### PR TITLE
feat: raster analysis tool pack — resample, IDW interpolate, mosaic (#2141)

### DIFF
--- a/docker/worker-gdal/Dockerfile
+++ b/docker/worker-gdal/Dockerfile
@@ -102,6 +102,9 @@ RUN apt-get update \
 # `pdal` must also be on PATH with the LAS reader + reprojection filter compiled
 # in (LAZ/COPC decompress + reproject, #1854).
 RUN command -v gdalwarp && command -v ogr2ogr && command -v gdalmdiminfo \
+ # gdal_grid backs the raster IDW interpolation tool (raster.interpolate-idw, #2141);
+ # gdalwarp backs raster.resample and raster.mosaic. Both ship in the ubuntu-full base.
+ && command -v gdal_grid \
  && gdalinfo --formats | grep -qi netCDF \
  && gdalinfo --formats | grep -qi GRIB \
  && command -v pdal \

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -651,7 +651,7 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         },
 
         // -----------------------------------------------------------------------
-        // Raster operations (5)
+        // Raster operations (9)
         // Raster analysis and mutation workflows implemented natively by the
         // heavyweight GDAL worker via the gdalwarp / gdalinfo CLI tools. Declared
         // RuntimeProfile = native so the submit path stamps the spec native and
@@ -732,6 +732,70 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 Param("statistics", "Statistics", "Comma-separated stat names. Allowed values: count, sum, mean, min, max, stddev, variance.", ProcessParameterValueType.Text, defaultValue: "count,mean,stddev,min,max,sum"),
             ],
             OutputArtifactKinds = [ArtifactKind.Table],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.resample",
+            Title = "Resample Raster",
+            Description = "Changes a raster's cell size using the requested resampling algorithm. Executed out-of-process by the heavyweight GDAL worker via gdalwarp -tr. Reads a base64-encoded GeoTIFF from 'source'; publishes the resampled GeoTIFF as a data-URI artifact.",
+            Category = "raster",
+            Parameters =
+            [
+                .. NativeRasterSourceParameters,
+                Param("cellSize", "Cell Size", "Target pixel size in the raster's georeferenced units. Must be > 0. Applied to both axes unless 'cellSizeY' is supplied.", ProcessParameterValueType.FloatingPoint, required: true),
+                Param("cellSizeY", "Cell Size Y", "Optional distinct vertical pixel size in georeferenced units. Must be > 0. Defaults to 'cellSize' (square pixels).", ProcessParameterValueType.FloatingPoint),
+                Param("resampling", "Resampling", "Resampling algorithm. Allowed values: nearestneighbor, bilinear, cubic, lanczos. Defaults to bilinear.", ProcessParameterValueType.Text, defaultValue: "bilinear"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.interpolate-idw",
+            Title = "Interpolate (IDW)",
+            Description = "Interpolates a continuous raster surface from scattered points using inverse-distance weighting. Executed out-of-process by the heavyweight GDAL worker via gdal_grid -a invdist. Reads a base64-encoded GeoJSON point FeatureCollection from 'points'; publishes the interpolated GeoTIFF as a data-URI artifact.",
+            Category = "raster",
+            Parameters =
+            [
+                Param("points", "Points", "Source points as a base64-encoded GeoJSON FeatureCollection. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("zField", "Z Field", "Attribute name holding the value to interpolate. When omitted, gdal_grid uses the geometry Z coordinate.", ProcessParameterValueType.Text),
+                Param("power", "Power", "Inverse-distance weighting exponent. Must be > 0. Defaults to 2.0.", ProcessParameterValueType.FloatingPoint, defaultValue: "2.0"),
+                Param("smoothing", "Smoothing", "Smoothing parameter applied during interpolation. Must be >= 0. Defaults to 0.", ProcessParameterValueType.FloatingPoint, defaultValue: "0"),
+                Param("radius", "Search Radius", "Optional search radius in georeferenced units. Must be > 0 when supplied. When omitted, all points contribute (global search).", ProcessParameterValueType.FloatingPoint),
+                Param("width", "Width", "Optional output raster width in pixels. Must be > 0 and supplied together with 'height'.", ProcessParameterValueType.WholeNumber),
+                Param("height", "Height", "Optional output raster height in pixels. Must be > 0 and supplied together with 'width'.", ProcessParameterValueType.WholeNumber),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.interpolate-kriging",
+            Title = "Interpolate (Kriging)",
+            Description = "FLAGGED / UNSUPPORTED in this build: kriging interpolation requires a kriging-capable numerical backend that the worker image does not bundle (stock GDAL gdal_grid has no kriging algorithm). The process is advertised so callers can discover the limitation; a submitted job FAILS with a clear message rather than silently substituting a different algorithm. Use raster.interpolate-idw for inverse-distance-weighted interpolation.",
+            Category = "raster",
+            Parameters =
+            [
+                Param("points", "Points", "Source points as a base64-encoded GeoJSON FeatureCollection.", ProcessParameterValueType.Text, required: true),
+                Param("zField", "Z Field", "Attribute name holding the value to interpolate.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.mosaic",
+            Title = "Mosaic Rasters",
+            Description = "Combines two or more input rasters into a single raster. Executed out-of-process by the heavyweight GDAL worker via gdalwarp. Reads a '|'-separated list of base64-encoded GeoTIFFs from 'sources'; publishes the mosaicked GeoTIFF as a data-URI artifact. The 'operator' selects overlap behavior (first/last); statistical operators (min/max/mean/sum) are not yet available on the native worker.",
+            Category = "raster",
+            Parameters =
+            [
+                Param("sources", "Sources", "Two or more source rasters as base64-encoded GeoTIFFs separated by '|'. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("operator", "Operator", "Overlap behavior. Allowed values: first, last. Defaults to last (later-listed source wins).", ProcessParameterValueType.Text, defaultValue: "last"),
+                Param("resampling", "Resampling", "Resampling algorithm. Allowed values: nearestneighbor, bilinear, cubic, lanczos. Defaults to nearestneighbor.", ProcessParameterValueType.Text, defaultValue: "nearestneighbor"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native
         },
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -67,6 +67,15 @@ internal static partial class ProcessPlanValidator
         "lanczos"
     };
 
+    // Mosaic overlap operators the native worker (GdalRasterMosaicJobExecutor) can
+    // express through gdalwarp source ordering. Statistical operators are not yet
+    // available and are rejected so a plan accepted here is also accepted by the
+    // worker rather than failing at the CLI boundary.
+    private static readonly HashSet<string> RasterMosaicOperatorValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "first", "last"
+    };
+
     private static readonly HashSet<string> RasterFormatValues = new(StringComparer.OrdinalIgnoreCase)
     {
         "gtiff", "geotiff", "tiff", "tif",
@@ -291,6 +300,23 @@ internal static partial class ProcessPlanValidator
                 break;
             case "raster.zonal-statistics":
                 ValidateRasterZonalStatisticsSemantics(step, violations);
+                break;
+            case "raster.resample":
+                ValidateRasterResampleSemantics(step, violations);
+                break;
+            case "raster.interpolate-idw":
+                ValidateRasterInterpolateIdwSemantics(step, violations);
+                break;
+            case "raster.interpolate-kriging":
+                // Kriging is advertised but flagged unsupported by the native worker
+                // (no kriging-capable backend is bundled). The plan is still
+                // shape-validated (the base type-validator enforces the required
+                // 'points' input); the worker FAILS the job at execution with a clear
+                // message rather than the validator blocking it, so the limitation is
+                // surfaced as a job failure rather than a submit-time rejection.
+                break;
+            case "raster.mosaic":
+                ValidateRasterMosaicSemantics(step, violations);
                 break;
             case "conversion.geometry-format":
                 ValidateGeometryFormatConversionSemantics(step, violations);
@@ -841,6 +867,56 @@ internal static partial class ProcessPlanValidator
         ValidateSharedRasterSourceSemantics(step, violations);
         RequireIntAtLeast(step, "band", 1, violations);
         ValidateEnumList(step, "statistics", RasterZonalStatisticValues, "count, sum, mean, min, max, stddev, variance", violations);
+    }
+
+    private static void ValidateRasterResampleSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        ValidateSharedRasterSourceSemantics(step, violations);
+        RequirePositiveFiniteDouble(step, "cellSize", violations);
+        RequirePositiveFiniteDouble(step, "cellSizeY", violations);
+
+        if (step.Inputs.TryGetValue("resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw)
+            && !RasterResamplingValues.Contains(resamplingRaw.Trim()))
+        {
+            AddEnumViolation(step, "resampling", resamplingRaw, "nearestneighbor, bilinear, cubic, lanczos", violations);
+        }
+    }
+
+    private static void ValidateRasterInterpolateIdwSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'points' is a declared-required base64 input enforced by the base
+        // type-validator. The IDW tuning parameters mirror gdal_grid's invdist
+        // options; range-check them so a plan accepted here is accepted by the CLI.
+        RequirePositiveFiniteDouble(step, "power", violations);
+        RequireNonNegativeFiniteDouble(step, "smoothing", violations);
+        RequirePositiveFiniteDouble(step, "radius", violations);
+        RequireIntAtLeast(step, "width", 1, violations);
+        RequireIntAtLeast(step, "height", 1, violations);
+    }
+
+    private static void ValidateRasterMosaicSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'sources' is a declared-required input enforced by the base type-validator.
+        if (step.Inputs.TryGetValue("operator", out var operatorRaw)
+            && !string.IsNullOrWhiteSpace(operatorRaw)
+            && !RasterMosaicOperatorValues.Contains(operatorRaw.Trim()))
+        {
+            AddEnumViolation(step, "operator", operatorRaw, "first, last", violations);
+        }
+
+        if (step.Inputs.TryGetValue("resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw)
+            && !RasterResamplingValues.Contains(resamplingRaw.Trim()))
+        {
+            AddEnumViolation(step, "resampling", resamplingRaw, "nearestneighbor, bilinear, cubic, lanczos", violations);
+        }
     }
 
     private static void ValidateGeometryFormatConversionSemantics(
@@ -1594,6 +1670,24 @@ internal static partial class ProcessPlanValidator
             || parsed <= 0d)
         {
             AddRangeViolationIfNew(step, parameter, $"expected positive number, got '{value}'", violations);
+        }
+    }
+
+    private static void RequireNonNegativeFiniteDouble(
+        AnalysisPlanStep step,
+        string parameter,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        if (!step.Inputs.TryGetValue(parameter, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed) || double.IsInfinity(parsed)
+            || parsed < 0d)
+        {
+            AddRangeViolationIfNew(step, parameter, $"expected non-negative number, got '{value}'", violations);
         }
     }
 

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterInterpolateJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterInterpolateJobExecutor.cs
@@ -1,0 +1,385 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the raster interpolation
+/// family: <c>raster.interpolate-idw</c> (inverse-distance-weighted) backed by the
+/// GDAL <c>gdal_grid</c> CLI, and <c>raster.interpolate-kriging</c>, which is
+/// FLAGGED as unsupported in this build.
+///
+/// <para>
+/// IDW reads a base64-encoded GeoJSON point FeatureCollection from <c>points</c>,
+/// grids it onto a raster surface using <c>gdal_grid -a invdist</c>, and publishes
+/// the GeoTIFF as a canonical data-URI artifact.
+/// </para>
+/// <para>
+/// Kriging requires a kriging-capable numerical backend that the worker image does
+/// NOT bundle (stock GDAL <c>gdal_grid</c> has no kriging algorithm). Rather than
+/// silently substitute a different algorithm, the executor FAILS the job with a
+/// clear message so the limitation is explicit (#2141).
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/>
+/// is <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterInterpolateJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterInterpolateJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>Process id for inverse-distance-weighted interpolation.</summary>
+    public const string IdwProcessId = "raster.interpolate-idw";
+
+    /// <summary>Process id for kriging interpolation (flagged unsupported).</summary>
+    public const string KrigingProcessId = "raster.interpolate-kriging";
+
+    /// <summary>
+    /// Stable message published when a kriging job is submitted. Surfaced as the
+    /// job's failure reason so callers see the unsupported-dependency limitation
+    /// rather than a silent no-op or a substituted algorithm.
+    /// </summary>
+    public const string KrigingUnsupportedMessage =
+        "Kriging interpolation is not available in this build: the worker image does not bundle a "
+        + "kriging-capable numerical backend (stock GDAL gdal_grid has no kriging algorithm). "
+        + "Use raster.interpolate-idw for inverse-distance-weighted interpolation.";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly FrozenSet<string> HandledProcessIds = new HashSet<string>(StringComparer.Ordinal)
+    {
+        IdwProcessId,
+        KrigingProcessId,
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <summary>Process ids this executor routes.</summary>
+    public static IReadOnlyCollection<string> SupportedProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (processId is null || !HandledProcessIds.Contains(processId))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the raster interpolation executor.");
+        }
+
+        // Kriging is advertised but flagged: fail fast with a clear message instead
+        // of substituting IDW or producing a silent stub (#2141 acceptance).
+        if (string.Equals(processId, KrigingProcessId, StringComparison.Ordinal))
+        {
+            Log.KrigingUnsupported(logger, job.OperationId);
+            return JobExecutionResult.Failed(KrigingUnsupportedMessage);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing interpolation inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!TryBuildAlgorithm(parameters, out var algorithm, out var algorithmError))
+        {
+            return JobExecutionResult.Failed($"Invalid interpolation inputs: {algorithmError}");
+        }
+
+        if (!TryReadOutputSize(parameters, out var width, out var height, out var sizeError))
+        {
+            return JobExecutionResult.Failed($"Invalid interpolation inputs: {sizeError}");
+        }
+
+        GdalJobInputReader.TryGetInput(parameters, "zField", out var zField);
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "points", opts.MaxArtifactBytes, out var pointsBytes, out var pointsError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, pointsError);
+            return JobExecutionResult.Failed($"Invalid interpolation inputs: {pointsError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            // gdal_grid derives the layer name from the file basename; write the
+            // input as points.geojson and reference layer "points" explicitly.
+            var inputPath = Path.Combine(workspace, "points.geojson");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, pointsBytes, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_grid interpolation", cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-a", algorithm,
+                "-of", "GTiff",
+                "-l", "points",
+            };
+            if (!string.IsNullOrWhiteSpace(zField))
+            {
+                args.Add("-zfield");
+                args.Add(zField.Trim());
+            }
+            if (width.HasValue && height.HasValue)
+            {
+                args.Add("-outsize");
+                args.Add(width.Value.ToString(CultureInfo.InvariantCulture));
+                args.Add(height.Value.ToString(CultureInfo.InvariantCulture));
+            }
+            args.Add(inputPath);
+            args.Add(outputPath);
+
+            await GdalCommandLog.LogCommandAsync(context, "gdal_grid", args, workspace, cancellationToken).ConfigureAwait(false);
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("gdal_grid", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"gdal_grid timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"gdal_grid exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed("gdal_grid reported success but produced no output raster.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding interpolated raster artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("gdal_grid produced an empty output raster.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Interpolated raster size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoTiffContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Interpolation completed", cancellationToken).ConfigureAwait(false);
+
+            Log.InterpolationCompleted(logger, job.OperationId, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Builds the <c>gdal_grid -a</c> algorithm spec for IDW. The parameter names
+    /// mirror gdal_grid's <c>invdist</c> options: power (default 2.0), smoothing
+    /// (default 0.0), and an optional search radius (omitted = global). Each value
+    /// is range-checked here so a plan that reaches the worker is also accepted by
+    /// the CLI rather than failing at the argument boundary.
+    /// </summary>
+    private static bool TryBuildAlgorithm(
+        IReadOnlyDictionary<string, string> parameters,
+        out string algorithm,
+        out string failure)
+    {
+        algorithm = "";
+        failure = "";
+
+        if (!TryReadDouble(parameters, "power", defaultValue: 2.0, requirePositive: true, out var power, out var powerError))
+        {
+            failure = powerError;
+            return false;
+        }
+
+        if (!TryReadDouble(parameters, "smoothing", defaultValue: 0.0, requirePositive: false, out var smoothing, out var smoothingError))
+        {
+            failure = smoothingError;
+            return false;
+        }
+
+        var spec = $"invdist:power={FormatDouble(power)}:smoothing={FormatDouble(smoothing)}";
+
+        if (GdalJobInputReader.TryGetInput(parameters, "radius", out var radiusRaw)
+            && !string.IsNullOrWhiteSpace(radiusRaw))
+        {
+            if (!TryReadDouble(parameters, "radius", defaultValue: 0.0, requirePositive: true, out var radius, out var radiusError))
+            {
+                failure = radiusError;
+                return false;
+            }
+            spec += $":radius={FormatDouble(radius)}";
+        }
+
+        algorithm = spec;
+        return true;
+    }
+
+    private static bool TryReadOutputSize(
+        IReadOnlyDictionary<string, string> parameters,
+        out int? width,
+        out int? height,
+        out string failure)
+    {
+        width = null;
+        height = null;
+        failure = "";
+
+        var hasWidth = TryReadOptionalPositiveInt(parameters, "width", out width, out var widthError);
+        if (!hasWidth && widthError.Length > 0)
+        {
+            failure = widthError;
+            return false;
+        }
+
+        var hasHeight = TryReadOptionalPositiveInt(parameters, "height", out height, out var heightError);
+        if (!hasHeight && heightError.Length > 0)
+        {
+            failure = heightError;
+            return false;
+        }
+
+        // gdal_grid -outsize requires BOTH dimensions; reject a half-specified grid
+        // so the contract is unambiguous (omit both to let gdal_grid pick a default).
+        if (width.HasValue ^ height.HasValue)
+        {
+            failure = "both 'width' and 'height' must be supplied together to set the output grid size";
+            width = null;
+            height = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadOptionalPositiveInt(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        out int? value,
+        out string failure)
+    {
+        value = null;
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed <= 0)
+        {
+            failure = $"{name} must be a positive integer; got '{raw}'";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    private static bool TryReadDouble(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        double defaultValue,
+        bool requirePositive,
+        out double value,
+        out string failure)
+    {
+        failure = "";
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            value = defaultValue;
+            return true;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed)
+            || double.IsInfinity(parsed)
+            || (requirePositive ? parsed <= 0d : parsed < 0d))
+        {
+            value = 0d;
+            failure = requirePositive
+                ? $"{name} must be a positive finite number; got '{raw}'"
+                : $"{name} must be a non-negative finite number; got '{raw}'";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    private static string FormatDouble(double value)
+        => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9320, LogLevel.Warning,
+            "GDAL raster interpolate executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9321, LogLevel.Warning,
+            "GDAL raster interpolate executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9322, LogLevel.Error,
+            "GDAL raster interpolate executor failed job {OperationId}: gdal_grid exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9323, LogLevel.Error,
+            "GDAL raster interpolate executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9324, LogLevel.Warning,
+            "GDAL raster interpolate executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9325, LogLevel.Information,
+            "GDAL raster interpolate executor completed job {OperationId}: bytes={Bytes}")]
+        public static partial void InterpolationCompleted(ILogger logger, string operationId, long bytes);
+
+        [LoggerMessage(9326, LogLevel.Warning,
+            "GDAL raster interpolate executor refused job {OperationId}: kriging is flagged unsupported in this build")]
+        public static partial void KrigingUnsupported(ILogger logger, string operationId);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
@@ -1,0 +1,316 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>raster.mosaic</c>
+/// process: combines multiple input rasters into one, backed by the GDAL
+/// <c>gdalwarp</c> CLI (which merges several sources into a single output grid).
+///
+/// <para>
+/// Inputs are supplied inline on the <c>sources</c> parameter as a
+/// <c>|</c>-separated list of base64-encoded GeoTIFFs (two or more). The
+/// <c>operator</c> parameter selects overlap behavior: <c>last</c> (default,
+/// later-listed source wins) or <c>first</c> (earlier-listed source wins,
+/// implemented by reversing source order). Statistical operators (min/max/mean/
+/// sum/blend) are not yet expressible through stock gdalwarp and are rejected with
+/// a clear message rather than silently approximated.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/>
+/// is <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterMosaicJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterMosaicJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "raster.mosaic";
+
+    /// <summary>Separator between base64 raster entries in the <c>sources</c> input.</summary>
+    public const string SourceSeparator = "|";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    // Mirrors ProcessPlanValidator.RasterResamplingValues so executor + validator
+    // agree on the accepted set.
+    private static readonly FrozenDictionary<string, string> ResamplingMap =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["nearestneighbor"] = "near",
+            ["nearest-neighbor"] = "near",
+            ["nearest"] = "near",
+            ["bilinear"] = "bilinear",
+            ["cubic"] = "cubic",
+            ["bicubic"] = "cubic",
+            ["lanczos"] = "lanczos",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    // Overlap operators expressible through stock gdalwarp source ordering.
+    private static readonly FrozenSet<string> SupportedOperators = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "first",
+        "last",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing mosaic inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        var mosaicOperator = "last";
+        if (GdalJobInputReader.TryGetInput(parameters, "operator", out var operatorRaw)
+            && !string.IsNullOrWhiteSpace(operatorRaw))
+        {
+            mosaicOperator = operatorRaw.Trim();
+            if (!SupportedOperators.Contains(mosaicOperator))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid mosaic inputs: 'operator' value '{operatorRaw}' is not supported by the native worker " +
+                    "(supported operators: first, last). Statistical operators (min, max, mean, sum) are not yet available.");
+            }
+        }
+
+        // Mosaic defaults to nearest-neighbor (gdalwarp's default) so aligned grids
+        // merge without resampling artifacts.
+        var resamplingFlag = "near";
+        if (GdalJobInputReader.TryGetInput(parameters, "resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw))
+        {
+            if (!ResamplingMap.TryGetValue(resamplingRaw.Trim(), out resamplingFlag))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid mosaic inputs: 'resampling' value '{resamplingRaw}' is not in the allowed set " +
+                    "(nearestneighbor, bilinear, cubic, lanczos).");
+            }
+        }
+
+        if (!TryDecodeSources(parameters, opts.MaxArtifactBytes, out var sources, out var sourcesError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourcesError);
+            return JobExecutionResult.Failed($"Invalid mosaic inputs: {sourcesError}");
+        }
+
+        // 'first' wins is achieved by reversing the source order so the desired
+        // source is written LAST into the output (gdalwarp later-source-wins).
+        if (string.Equals(mosaicOperator, "first", StringComparison.OrdinalIgnoreCase))
+        {
+            sources.Reverse();
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var outputPath = Path.Combine(workspace, "output.tif");
+            var inputPaths = new List<string>(sources.Count);
+            for (var i = 0; i < sources.Count; i++)
+            {
+                var inputPath = Path.Combine(workspace, $"input{i.ToString(CultureInfo.InvariantCulture)}.tif");
+                await File.WriteAllBytesAsync(inputPath, sources[i], cancellationToken).ConfigureAwait(false);
+                inputPaths.Add(inputPath);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdalwarp mosaic", cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-overwrite",
+                "-of", "GTiff",
+                "-r", resamplingFlag,
+            };
+            args.AddRange(inputPaths);
+            args.Add(outputPath);
+
+            await GdalCommandLog.LogCommandAsync(context, "gdalwarp", args, workspace, cancellationToken).ConfigureAwait(false);
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("gdalwarp", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"gdalwarp timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"gdalwarp exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed("gdalwarp reported success but produced no output raster.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding mosaic raster artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("gdalwarp produced an empty output raster.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Mosaic raster size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoTiffContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Mosaic completed", cancellationToken).ConfigureAwait(false);
+
+            Log.MosaicCompleted(logger, job.OperationId, sources.Count, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the <c>|</c>-separated base64 source list, enforcing the per-entry
+    /// MaxArtifactBytes ceiling and requiring at least two inputs (a mosaic of one
+    /// raster is a no-op the caller almost certainly did not intend).
+    /// </summary>
+    private static bool TryDecodeSources(
+        IReadOnlyDictionary<string, string> parameters,
+        long maxBytes,
+        out List<byte[]> sources,
+        out string failure)
+    {
+        sources = [];
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "sources", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            failure = "missing required input 'sources'";
+            return false;
+        }
+
+        var entries = raw.Split(SourceSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (entries.Length < 2)
+        {
+            failure = $"'sources' must list at least two base64 GeoTIFF rasters separated by '{SourceSeparator}'; got {entries.Length.ToString(CultureInfo.InvariantCulture)}";
+            return false;
+        }
+
+        var decoded = new List<byte[]>(entries.Length);
+        for (var i = 0; i < entries.Length; i++)
+        {
+            var entry = entries[i];
+            // Conservative upper bound on the decoded size before allocating.
+            if ((long)entry.Length / 4 * 3 > maxBytes)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(entry);
+            }
+            catch (FormatException)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} is not valid base64";
+                return false;
+            }
+
+            if (bytes.Length == 0)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} decoded to zero bytes";
+                return false;
+            }
+
+            if (bytes.Length > maxBytes)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} size {bytes.Length.ToString(CultureInfo.InvariantCulture)} bytes exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            decoded.Add(bytes);
+        }
+
+        sources = decoded;
+        return true;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9330, LogLevel.Warning,
+            "GDAL raster mosaic executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9331, LogLevel.Warning,
+            "GDAL raster mosaic executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9332, LogLevel.Error,
+            "GDAL raster mosaic executor failed job {OperationId}: gdalwarp exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9333, LogLevel.Error,
+            "GDAL raster mosaic executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9334, LogLevel.Warning,
+            "GDAL raster mosaic executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9335, LogLevel.Information,
+            "GDAL raster mosaic executor completed job {OperationId}: sources={SourceCount}, bytes={Bytes}")]
+        public static partial void MosaicCompleted(ILogger logger, string operationId, int sourceCount, long bytes);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterResampleJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterResampleJobExecutor.cs
@@ -1,0 +1,254 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>raster.resample</c>
+/// process: changes a raster's cell size using the requested resampling
+/// algorithm, backed by the GDAL <c>gdalwarp -tr</c> CLI.
+///
+/// Reads a base64-encoded GeoTIFF from the canonical <c>source</c> input and a
+/// target cell size from <c>cellSize</c> (optionally a distinct vertical size via
+/// <c>cellSizeY</c>), warps in an isolated scratch workspace, and publishes the
+/// resampled GeoTIFF as a canonical data-URI artifact. Runs only inside the GDAL
+/// worker image — <see cref="AcceptedRuntimeProfiles"/> is <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterResampleJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterResampleJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "raster.resample";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    // Maps the catalog's canonical resampling enum onto gdalwarp's -r flag value.
+    // Mirrors ProcessPlanValidator.RasterResamplingValues so executor + validator
+    // agree on the accepted set; unknown values are rejected at the executor
+    // boundary to defend against bypassed validation.
+    private static readonly FrozenDictionary<string, string> ResamplingMap =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["nearestneighbor"] = "near",
+            ["nearest-neighbor"] = "near",
+            ["nearest"] = "near",
+            ["bilinear"] = "bilinear",
+            ["cubic"] = "cubic",
+            ["bicubic"] = "cubic",
+            ["lanczos"] = "lanczos",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing resample inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!TryReadPositiveDouble(parameters, "cellSize", out var cellSizeX, out var cellError))
+        {
+            return JobExecutionResult.Failed($"Invalid resample inputs: {cellError}");
+        }
+
+        var cellSizeY = cellSizeX;
+        if (GdalJobInputReader.TryGetInput(parameters, "cellSizeY", out var cellSizeYRaw)
+            && !string.IsNullOrWhiteSpace(cellSizeYRaw))
+        {
+            if (!TryReadPositiveDouble(parameters, "cellSizeY", out cellSizeY, out var cellYError))
+            {
+                return JobExecutionResult.Failed($"Invalid resample inputs: {cellYError}");
+            }
+        }
+
+        var resamplingFlag = "bilinear";
+        if (GdalJobInputReader.TryGetInput(parameters, "resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw))
+        {
+            if (!ResamplingMap.TryGetValue(resamplingRaw.Trim(), out resamplingFlag))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid resample inputs: 'resampling' value '{resamplingRaw}' is not in the allowed set " +
+                    "(nearestneighbor, bilinear, cubic, lanczos).");
+            }
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid resample inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.tif");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdalwarp resample", cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-overwrite",
+                "-of", "GTiff",
+                "-tr", FormatDouble(cellSizeX), FormatDouble(cellSizeY),
+                "-r", resamplingFlag,
+                inputPath,
+                outputPath,
+            };
+
+            await GdalCommandLog.LogCommandAsync(context, "gdalwarp", args, workspace, cancellationToken).ConfigureAwait(false);
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("gdalwarp", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"gdalwarp timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"gdalwarp exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed("gdalwarp reported success but produced no output raster.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding resampled raster artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("gdalwarp produced an empty output raster.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Resampled raster size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoTiffContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Resample completed", cancellationToken).ConfigureAwait(false);
+
+            Log.ResampleCompleted(logger, job.OperationId, cellSizeX, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    private static bool TryReadPositiveDouble(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        out double value,
+        out string failure)
+    {
+        value = 0d;
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            failure = $"missing required input '{name}'";
+            return false;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed)
+            || double.IsInfinity(parsed)
+            || parsed <= 0d)
+        {
+            failure = $"{name} must be a positive finite number; got '{raw}'";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    private static string FormatDouble(double value)
+        => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9310, LogLevel.Warning,
+            "GDAL raster resample executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9311, LogLevel.Warning,
+            "GDAL raster resample executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9312, LogLevel.Error,
+            "GDAL raster resample executor failed job {OperationId}: gdalwarp exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9313, LogLevel.Error,
+            "GDAL raster resample executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9314, LogLevel.Warning,
+            "GDAL raster resample executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9315, LogLevel.Information,
+            "GDAL raster resample executor completed job {OperationId}: cellSize={CellSize}, bytes={Bytes}")]
+        public static partial void ResampleCompleted(ILogger logger, string operationId, double cellSize, long bytes);
+    }
+}

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -164,6 +164,9 @@ public static class GdalWorkerServiceCollectionExtensions
         RegisterGdalExecutor<GdalVectorReprojectJobExecutor>(services);
         RegisterGdalExecutor<GdalVectorSourceReadJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterReprojectJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterResampleJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterInterpolateJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterMosaicJobExecutor>(services);
         RegisterGdalExecutor<GdalSurfaceJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterClipJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterReprojectCatalogJobExecutor>(services);

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -166,6 +166,14 @@ public sealed class CatalogExecutableConformanceTests
         "raster.statistics",
         "raster.histogram",
         "raster.zonal-statistics",
+        // Raster analysis tool pack (#2141): resample / IDW interpolation / mosaic
+        // run out-of-process in the GDAL worker; kriging is advertised but flagged
+        // unsupported (the worker FAILS it with a clear message). All declare the
+        // native runtime profile and have NO lean-dispatcher executor.
+        "raster.resample",
+        "raster.interpolate-idw",
+        "raster.interpolate-kriging",
+        "raster.mosaic",
         "conversion.raster-format",
         "conversion.raster-reproject",
         // Point-cloud conversion (#1854): LAZ/COPC decompression + optional

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
@@ -19,9 +19,12 @@ public sealed class ProcessCatalogSurfaceRasterTests
     public void Catalog_SurfaceRasterAndConversionCategories_AreRegistered()
     {
         _catalog.GetProcessesByCategory("surface").Should().HaveCount(6);
-        // 5 native raster idioms + gdal.gdalwarp (the native-profile raster
-        // reproject executed out-of-process by the GDAL worker).
-        _catalog.GetProcessesByCategory("raster").Should().HaveCount(6);
+        // 5 native raster idioms (clip, reproject, statistics, histogram,
+        // zonal-statistics) + the raster analysis tool pack (resample,
+        // interpolate-idw, interpolate-kriging, mosaic; #2141) + gdal.gdalwarp
+        // (the native-profile raster reproject executed out-of-process by the
+        // GDAL worker).
+        _catalog.GetProcessesByCategory("raster").Should().HaveCount(10);
         // 4 managed conversion idioms + gdal.ogr2ogr (the native-profile vector
         // conversion executed out-of-process by the GDAL worker) + pcloud.translate
         // (the native-profile LAZ/COPC decompress + projected-CRS reproject, #1854).
@@ -364,6 +367,210 @@ public sealed class ProcessCatalogSurfaceRasterTests
         var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
 
         violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.targetFormat");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Catalog_RasterAnalyticToolPack_IsRegistered_WithNativeProfileAndRasterOutput()
+    {
+        // The #2141 raster analysis tool pack is executed out-of-process by the
+        // native GDAL worker, so each entry MUST declare the native runtime profile.
+        string[] toolPackIds =
+        [
+            "raster.resample", "raster.interpolate-idw",
+            "raster.interpolate-kriging", "raster.mosaic",
+        ];
+        foreach (var processId in toolPackIds)
+        {
+            var definition = _catalog.GetProcess(processId);
+            definition.Should().NotBeNull($"catalog must advertise raster tool '{processId}'");
+            definition!.Category.Should().Be("raster");
+            definition.RuntimeProfile.Should().Be(
+                Core.Features.ControlPlane.Domain.RuntimeProfiles.Native,
+                $"'{processId}' is executed by the native worker");
+            definition.OutputArtifactKinds.Should().ContainSingle().Which.Should().Be(ArtifactKind.Raster);
+        }
+
+        _catalog.GetProcess("raster.resample")!.Parameters
+            .Should().Contain(p => p.Name == "source" && p.Required)
+            .And.Contain(p => p.Name == "cellSize" && p.Required);
+        _catalog.GetProcess("raster.interpolate-idw")!.Parameters
+            .Should().Contain(p => p.Name == "points" && p.Required);
+        _catalog.GetProcess("raster.mosaic")!.Parameters
+            .Should().Contain(p => p.Name == "sources" && p.Required);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterResample_WithoutCellSize_ProducesMissingRequiredParameterViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.resample",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v =>
+            v.Code == "MISSING_REQUIRED_PARAMETER"
+            && v.FieldPath == "steps[s1].inputs.cellSize");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterResample_WithNonPositiveCellSize_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.resample",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["cellSize"] = "0",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.cellSize");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterResample_WithUnknownResampling_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.resample",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["cellSize"] = "30",
+                ["resampling"] = "spline",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.resampling");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateIdw_WithValidTuning_ProducesNoViolations()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-idw",
+            new Dictionary<string, string>
+            {
+                ["points"] = StubBase64,
+                ["zField"] = "elevation",
+                ["power"] = "2.5",
+                ["smoothing"] = "0",
+                ["width"] = "256",
+                ["height"] = "256",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateIdw_WithoutPoints_ProducesMissingRequiredParameterViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-idw",
+            new Dictionary<string, string>
+            {
+                ["power"] = "2",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v =>
+            v.Code == "MISSING_REQUIRED_PARAMETER"
+            && v.FieldPath == "steps[s1].inputs.points");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateIdw_WithNonPositivePower_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-idw",
+            new Dictionary<string, string>
+            {
+                ["points"] = StubBase64,
+                ["power"] = "-1",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.power");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateKriging_WithPoints_PassesValidation_AsFlaggedButShapeValid()
+    {
+        // Kriging is flagged unsupported at execution, but a shape-valid plan must
+        // still pass submit-time validation so the worker can surface the
+        // unsupported-dependency message as a job failure (not a submit rejection).
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-kriging",
+            new Dictionary<string, string>
+            {
+                ["points"] = StubBase64,
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterMosaic_WithUnsupportedOperator_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.mosaic",
+            new Dictionary<string, string>
+            {
+                ["sources"] = StubBase64,
+                ["operator"] = "mean",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.operator");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterMosaic_WithoutSources_ProducesMissingRequiredParameterViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.mosaic",
+            new Dictionary<string, string>
+            {
+                ["operator"] = "last",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v =>
+            v.Code == "MISSING_REQUIRED_PARAMETER"
+            && v.FieldPath == "steps[s1].inputs.sources");
     }
 
     private static AnalysisPlan CreateSingleStepPlan(

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -65,7 +65,10 @@ public sealed class ProcessCatalogTests
         // FeatureCollection canonicalization) added for the honua-worker-etl format
         // breadth (ADR-0038 roadmap F).
         // Round-5 (72) ∪ Round-4 (69) = 82 distinct processes (59 shared).
-        all.Should().HaveCount(82);
+        // + 4 native-profile raster analysis tool pack ops (raster.resample,
+        // raster.interpolate-idw, raster.interpolate-kriging, raster.mosaic) added
+        // by #2141.
+        all.Should().HaveCount(86);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
@@ -670,6 +670,14 @@ public sealed class GdalRasterExecutorTests
             "surface.rugosity-tri", "surface.rugosity-tpi", "surface.roughness",
             "raster.clip", "raster.reproject", "raster.statistics",
             "raster.histogram", "raster.zonal-statistics",
+            // Explicit raster CRS-conversion idiom, routed by the same
+            // GdalRasterReprojectCatalogJobExecutor that handles raster.reproject.
+            "conversion.raster-reproject",
+            // Raster analysis tool pack (#2141): resample / IDW + kriging interpolation
+            // / mosaic. Kriging is routed here too (the executor fails it fast with a
+            // flagged-unsupported message rather than the dispatcher rejecting it).
+            "raster.resample", "raster.interpolate-idw",
+            "raster.interpolate-kriging", "raster.mosaic",
             // Internal multidimensional-coverage metadata scan (ADR-0039 Path B).
             "coverage.multidim.metadata",
             // LAZ/COPC decompress + reproject (#1854).
@@ -731,6 +739,9 @@ public sealed class GdalRasterExecutorTests
             new GdalVectorReprojectJobExecutor(runner, options, NullLogger<GdalVectorReprojectJobExecutor>.Instance),
             new GdalVectorSourceReadJobExecutor(runner, options, NullLogger<GdalVectorSourceReadJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
+            new GdalRasterResampleJobExecutor(runner, options, NullLogger<GdalRasterResampleJobExecutor>.Instance),
+            new GdalRasterInterpolateJobExecutor(runner, options, NullLogger<GdalRasterInterpolateJobExecutor>.Instance),
+            new GdalRasterMosaicJobExecutor(runner, options, NullLogger<GdalRasterMosaicJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
             new GdalRasterClipJobExecutor(runner, options, NullLogger<GdalRasterClipJobExecutor>.Instance),
             new GdalRasterReprojectCatalogJobExecutor(runner, options, NullLogger<GdalRasterReprojectCatalogJobExecutor>.Instance),

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterInterpolateExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterInterpolateExecutorTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterInterpolateJobExecutor"/>: the
+/// gdal_grid IDW argument projection plus the flagged Kriging path that fails fast
+/// with a clear unsupported-dependency message (no silent stub, #2141).
+/// </summary>
+public sealed class GdalRasterInterpolateExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-interpolate-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalRasterInterpolateExecutor_DeclaresNativeRuntimeProfile_AndAdvertisesBothIds()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        GdalRasterInterpolateJobExecutor.SupportedProcessIds.Should().BeEquivalentTo(new[]
+        {
+            "raster.interpolate-idw",
+            "raster.interpolate-kriging",
+        });
+    }
+
+    [UnitTest]
+    public async Task Idw_Default_RunsGdalGridInvdist_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("idw-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.IdwProcessId,
+                ("points", Base64("{\"type\":\"FeatureCollection\",\"features\":[]}")),
+                ("zField", "elevation"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_grid");
+            invocation.Arguments.Should().ContainInOrder("-a", "invdist:power=2:smoothing=0");
+            invocation.Arguments.Should().ContainInOrder("-zfield", "elevation");
+            invocation.Arguments.Should().Contain("-l").And.Contain("points");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Idw_WithTuningAndOutsize_ProjectsAllArguments()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.IdwProcessId,
+                ("points", Base64("points")),
+                ("power", "3"),
+                ("smoothing", "0.5"),
+                ("radius", "100"),
+                ("width", "256"),
+                ("height", "128"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().ContainInOrder("-a", "invdist:power=3:smoothing=0.5:radius=100");
+            args.Should().ContainInOrder("-outsize", "256", "128");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Idw_WidthWithoutHeight_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.IdwProcessId,
+                ("points", Base64("points")),
+                ("width", "256"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("width").And.Contain("height");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Idw_MissingPoints_FailsWithClearMessage()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(GdalRasterInterpolateJobExecutor.IdwProcessId);
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("points");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Kriging_IsFlaggedUnsupported_FailsFastWithClearMessage_AndNeverRunsCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "should-not-run");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            // Even with valid inputs, kriging must fail fast with the unsupported
+            // message rather than silently substituting another algorithm.
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.KrigingProcessId,
+                ("points", Base64("points")),
+                ("zField", "elevation"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Be(GdalRasterInterpolateJobExecutor.KrigingUnsupportedMessage);
+            result.ErrorMessage.Should().Contain("not available in this build");
+            runner.Invocations.Should().BeEmpty();
+            context.Artifacts.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterInterpolateJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterInterpolateJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterInterpolateJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMosaicExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMosaicExecutorTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterMosaicJobExecutor"/>: multi-input
+/// gdalwarp argument projection, the first/last overlap-operator ordering, source
+/// list parsing guards, and the canonical data-URI artifact contract.
+/// </summary>
+public sealed class GdalRasterMosaicExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-mosaic-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    private static string Sources(params string[] entries)
+        => string.Join(GdalRasterMosaicJobExecutor.SourceSeparator, entries.Select(Base64));
+
+    [UnitTest]
+    public void GdalRasterMosaicExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("raster.mosaic");
+    }
+
+    [UnitTest]
+    public async Task Mosaic_TwoSources_RunsGdalwarpWithBothInputs_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("mosaic-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a", "raster-b")));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdalwarp");
+            invocation.Arguments.Should().Contain(a => a.EndsWith("input0.tif"));
+            invocation.Arguments.Should().Contain(a => a.EndsWith("input1.tif"));
+            invocation.Arguments.Should().ContainInOrder("-r", "near");
+            invocation.Arguments[^1].Should().EndWith("output.tif");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_FirstOperator_ReversesSourceOrderSoFirstSourceWins()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a", "raster-b")),
+                ("operator", "first"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+
+            // 'first' reverses the source order so the first-listed source is written
+            // LAST into the output (gdalwarp later-source-wins). The input paths are
+            // numbered by write order, so input0 (the reversed write) comes before
+            // input1 in the argument list.
+            var args = runner.Invocations.Single().Arguments;
+            var firstInputIndex = args.ToList().FindIndex(a => a.EndsWith("input0.tif"));
+            var secondInputIndex = args.ToList().FindIndex(a => a.EndsWith("input1.tif"));
+            firstInputIndex.Should().BeLessThan(secondInputIndex);
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_UnsupportedOperator_FailsWithClearMessage()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a", "raster-b")),
+                ("operator", "mean"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("operator").And.Contain("not supported");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_SingleSource_FailsBecauseAtLeastTwoAreRequired()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Base64("only-one")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("at least two");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_InvalidBase64Source_FailsWithClearMessage()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Base64("valid") + GdalRasterMosaicJobExecutor.SourceSeparator + "!!not-base64!!"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("not valid base64");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterMosaicJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterMosaicJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterMosaicJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterResampleExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterResampleExecutorTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterResampleJobExecutor"/>: gdalwarp
+/// -tr argument projection, resampling enum mapping, cell-size guards, and the
+/// canonical data-URI artifact contract.
+/// </summary>
+public sealed class GdalRasterResampleExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-resample-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalRasterResampleExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("raster.resample");
+    }
+
+    [UnitTest]
+    public async Task Resample_Default_RunsGdalwarpWithTargetResolution_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("resampled-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdalwarp");
+            invocation.Arguments.Should().ContainInOrder("-tr", "30", "30");
+            invocation.Arguments.Should().ContainInOrder("-r", "bilinear");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_DistinctCellSizeY_PassesBothAxes()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"),
+                ("cellSizeY", "20"),
+                ("resampling", "nearestneighbor"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().ContainInOrder("-tr", "30", "20");
+            args.Should().ContainInOrder("-r", "near");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_MissingCellSize_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("cellSize");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_UnknownResampling_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"),
+                ("resampling", "spline"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("resampling");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_ToolFailure_IsReportedAsJobFailure()
+    {
+        var runner = FakeGdalCommandRunner.Failing(2, "ERROR: warp failed");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("gdalwarp exited with code 2");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterResampleJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterResampleJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterResampleJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}


### PR DESCRIPTION
## Summary

Implements the first slice of the raster analysis GP tool pack (#2141) as
native-profile GDAL worker processes, following the existing `surface.*` /
`raster.*` executor pattern. Three tools execute end-to-end on the native
GDAL/PDAL worker path, Kriging is advertised but flagged unsupported (no silent
stub), and Reclassify is deferred.

Related to #2141

## Changes Made

- Added `raster.resample` (`GdalRasterResampleJobExecutor`) — changes cell size via `gdalwarp -tr` with a resampling method.
- Added `raster.interpolate-idw` (`GdalRasterInterpolateJobExecutor`) — grids scattered points to a raster via `gdal_grid -a invdist` (power / smoothing / radius / output-size controls).
- Added `raster.interpolate-kriging` (same executor) — advertised but FLAGGED: fails fast with a clear unsupported-dependency message (the worker image bundles no kriging-capable backend); no silent stub or substituted algorithm.
- Added `raster.mosaic` (`GdalRasterMosaicJobExecutor`) — combines two or more inputs via `gdalwarp` with `first`/`last` overlap operators; statistical operators are rejected with a clear message.
- Registered the three executors in the GDAL worker DI seam (`GdalWorkerServiceCollectionExtensions`).
- Added catalog entries (native runtime profile, raster artifact output) in `BuiltInProcessCatalog` and submit-time plan validation in `ProcessPlanValidator` mirroring each tool's CLI contract.
- Added `gdal_grid` to the worker image build-time sanity check.
- Added unit tests: worker executor argument projection / input guards / flagged-kriging path, plus catalog and validator semantics; updated catalog count/partition tests.
- Corrected a pre-existing red in `Dispatcher_RoutesAllSurfaceAndRasterIds` (its expected set omitted the already-routed `conversion.raster-reproject`).

## Breaking Changes

None.

## Known gaps

This is a coherent first slice of an effort/L ticket; the remaining scope is deferred:

- **Reclassify** (`raster.reclassify`) — not implemented. A correct value-remap needs `gdal_calc.py` (Python utility, not in the worker sanity-check set) or a VRT `<LUT>` (piecewise-linear, awkward for exact class remaps); deferred to a focused follow-up so the algorithm choice and image dependency can be settled cleanly.
- **Kriging execution** — only the flagged/unsupported path is implemented (per the ticket's acceptance criterion allowing a clear "flagged/unsupported" message). Real kriging needs a kriging-capable backend bundled in the worker image.
- **Real-CLI integration fixtures** — the new executors are covered by fake-runner unit tests; real `gdal_grid`/`gdalwarp` fixture tests (like the existing `[GdalCliFact]` slope test) are a follow-up.

## Gate Impact

- [x] No gate impact / internal only

## Testing

- [x] Ran affected build + unit tests (Release, `TreatWarningsAsErrors=true`)

- `dotnet build` (Release, warnings-as-errors): `Honua.Worker.Gdal`, `Honua.Geoprocessing`, `Honua.Worker.Gdal.Tests`, `Honua.Server.Tests` — all succeeded, 0 warnings.
- `dotnet test Honua.Worker.Gdal.Tests` — 119 passed, 3 skipped (real-GDAL-CLI gated), 0 failed.
- `dotnet test Honua.Server.Tests` (catalog/validator: `ProcessCatalogSurfaceRasterTests`, `ProcessCatalogTests`, `CatalogExecutableConformanceTests`) — 145 passed, 0 failed.
- Docker/Testcontainers-gated integration tests (e.g. `GrpcProcessServiceTests`) are skipped/failing only because no Docker daemon is available in this environment; they are unrelated to this change.

Opened as a draft because this lands one slice of a larger ticket (Reclassify + Kriging execution deferred).
