### PR TITLE
feat(federation): remote federated query executor with timeout and circuit breaker (#341)

### DIFF
--- a/src/Honua.Core/Features/Federation/Abstractions/IFederatedQueryExecutor.cs
+++ b/src/Honua.Core/Features/Federation/Abstractions/IFederatedQueryExecutor.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.Federation.Abstractions;
+
+/// <summary>
+/// Executes a federated query: it plans the push-down, fetches candidate rows from the remote
+/// source through a <see cref="IFederatedSourceConnector"/> under a per-source timeout and
+/// circuit breaker, then refines and combines the rows locally. This is the remote-execution
+/// layer that sits on top of the offline <see cref="IFederationQueryPlanner"/> (issue #341).
+/// </summary>
+public interface IFederatedQueryExecutor
+{
+    /// <summary>
+    /// Executes a federated query against a single source.
+    /// </summary>
+    /// <param name="source">The target federated source.</param>
+    /// <param name="query">The canonical query to execute.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The combined remote + locally refined result for the source.</returns>
+    /// <exception cref="FederatedSourceUnavailableException">
+    /// Thrown when the source times out, faults, has an open circuit, or has no registered connector.
+    /// </exception>
+    Task<FederatedQueryResult> ExecuteAsync(
+        FederatedSourceDescriptor source,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a federated query across multiple sources and merges the results. A source that
+    /// is unavailable is recorded as a failure rather than failing the whole request, so a
+    /// single failing source cannot cascade into a total outage.
+    /// </summary>
+    /// <param name="sources">The target federated sources. Disabled sources are skipped.</param>
+    /// <param name="query">The canonical query to execute against each source.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The merged result across all reachable sources, plus any per-source failures.</returns>
+    Task<FederatedCombinedResult> ExecuteAsync(
+        ImmutableArray<FederatedSourceDescriptor> sources,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Federation/Abstractions/IFederatedSourceConnector.cs
+++ b/src/Honua.Core/Features/Federation/Abstractions/IFederatedSourceConnector.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.Federation.Abstractions;
+
+/// <summary>
+/// Transport boundary for a single federated source kind. A connector is the only piece of
+/// the federation layer that performs remote I/O: it translates the pushed-down portion of a
+/// <see cref="FederatedFetchRequest"/> into a remote request (Honua gRPC, Esri REST, OGC API
+/// Features / WFS), executes it, and maps the response back to canonical
+/// <see cref="Feature"/> rows. The federation executor wraps every call in a per-source
+/// timeout and circuit breaker, so connectors should surface transport failures as exceptions
+/// rather than swallowing them.
+/// </summary>
+public interface IFederatedSourceConnector
+{
+    /// <summary>
+    /// Gets the transport family this connector services.
+    /// </summary>
+    FederatedSourceKind Kind { get; }
+
+    /// <summary>
+    /// Fetches the candidate rows for a federated fetch request. The connector applies the
+    /// predicates the plan marked as pushed-down; the federation executor refines the
+    /// remaining predicates locally.
+    /// </summary>
+    /// <param name="request">The fetch request, including the source, query, and plan.</param>
+    /// <param name="cancellationToken">A token that is cancelled when the per-source timeout elapses.</param>
+    /// <returns>The candidate rows fetched from the remote source.</returns>
+    Task<ImmutableArray<Feature>> FetchAsync(FederatedFetchRequest request, CancellationToken cancellationToken);
+}

--- a/src/Honua.Core/Features/Federation/Domain/FederatedFetchRequest.cs
+++ b/src/Honua.Core/Features/Federation/Domain/FederatedFetchRequest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.Federation.Domain;
+
+/// <summary>
+/// The request a <see cref="Abstractions.IFederatedSourceConnector"/> receives when the
+/// federation executor fetches candidate rows from a remote source. It pairs the canonical
+/// <see cref="FeatureQuery"/> with the <see cref="FederationQueryPlan"/> so a connector knows
+/// which predicates the planner decided to push down (and therefore must apply remotely) and
+/// which the federation layer will refine locally afterwards.
+/// </summary>
+/// <param name="Source">The descriptor for the target remote source.</param>
+/// <param name="Query">The canonical query whose pushed-down predicates the connector applies.</param>
+/// <param name="Plan">The push-down / local-refinement plan for this source.</param>
+public readonly record struct FederatedFetchRequest(
+    FederatedSourceDescriptor Source,
+    FeatureQuery Query,
+    FederationQueryPlan Plan)
+{
+    /// <summary>
+    /// Indicates whether a predicate family should be applied by the remote source. A
+    /// predicate that does not appear in the plan is absent from the query and therefore
+    /// nothing to apply.
+    /// </summary>
+    /// <param name="predicate">The predicate family to test.</param>
+    /// <returns><see langword="true"/> when the connector should apply the predicate remotely.</returns>
+    public bool ShouldPushDown(FederationPredicateKind predicate)
+    {
+        foreach (var decision in Plan.Decisions)
+        {
+            if (decision.Predicate == predicate)
+            {
+                return decision.PushedDown;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Honua.Core/Features/Federation/Domain/FederatedQueryResult.cs
+++ b/src/Honua.Core/Features/Federation/Domain/FederatedQueryResult.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.Federation.Domain;
+
+/// <summary>
+/// The outcome of executing a federated query against a single source: the combined rows
+/// (remote fetch plus local refinement), the plan that produced them, and lightweight
+/// per-call diagnostics. The diagnostics are a deliberate precursor to the per-source latency
+/// and error metrics tracked in issue #341.
+/// </summary>
+public sealed record FederatedQueryResult
+{
+    /// <summary>
+    /// Gets the identifier of the source this result came from.
+    /// </summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>
+    /// Gets the plan that drove push-down vs local refinement for this source.
+    /// </summary>
+    public required FederationQueryPlan Plan { get; init; }
+
+    /// <summary>
+    /// Gets the rows after the remote fetch and local refinement have been combined.
+    /// </summary>
+    public required QueryResult<Feature> Result { get; init; }
+
+    /// <summary>
+    /// Gets the wall-clock time spent on the remote fetch (including resilience handling).
+    /// </summary>
+    public required TimeSpan Elapsed { get; init; }
+
+    /// <summary>
+    /// Gets the local-refinement predicate families the plan required but the executor could
+    /// not yet apply (for example exact spatial-relationship refinement, which is deferred to
+    /// a later increment). When non-empty, the rows are an over-fetched superset for those
+    /// predicates rather than an exact result, so callers can decide how to surface them.
+    /// </summary>
+    public ImmutableArray<FederationPredicateKind> UnappliedLocalRefinements { get; init; } =
+        ImmutableArray<FederationPredicateKind>.Empty;
+}
+
+/// <summary>
+/// Records a source that failed during a multi-source federated query.
+/// </summary>
+/// <param name="SourceId">The identifier of the failed source.</param>
+/// <param name="Reason">Why the source was unavailable.</param>
+public readonly record struct FederatedSourceFailure(string SourceId, FederatedSourceUnavailableReason Reason);
+
+/// <summary>
+/// The outcome of executing a federated query across multiple sources. Successful sources are
+/// merged into a single <see cref="Combined"/> result; unavailable sources are recorded in
+/// <see cref="Failures"/> rather than failing the whole request, so a single failing source
+/// cannot cascade into a total outage.
+/// </summary>
+public sealed record FederatedCombinedResult
+{
+    /// <summary>
+    /// Gets the per-source results that completed successfully.
+    /// </summary>
+    public required ImmutableArray<FederatedQueryResult> Sources { get; init; }
+
+    /// <summary>
+    /// Gets the sources that were unavailable for this query.
+    /// </summary>
+    public required ImmutableArray<FederatedSourceFailure> Failures { get; init; }
+
+    /// <summary>
+    /// Gets the merged rows across all successful sources, after any cross-source ordering and
+    /// paging have been applied locally.
+    /// </summary>
+    public required QueryResult<Feature> Combined { get; init; }
+}

--- a/src/Honua.Core/Features/Federation/Domain/FederatedSourceUnavailableException.cs
+++ b/src/Honua.Core/Features/Federation/Domain/FederatedSourceUnavailableException.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Federation.Domain;
+
+/// <summary>
+/// Why a federated source could not be reached for a query.
+/// </summary>
+public enum FederatedSourceUnavailableReason
+{
+    /// <summary>The remote source returned an error or the transport faulted.</summary>
+    Faulted,
+
+    /// <summary>The remote call exceeded the source's configured request timeout.</summary>
+    TimedOut,
+
+    /// <summary>
+    /// The circuit breaker for the source is open, so the call fast-failed without
+    /// contacting the remote source. This bounds the blast radius of a failing source.
+    /// </summary>
+    CircuitOpen,
+
+    /// <summary>No connector is registered for the source's transport kind.</summary>
+    NoConnector,
+}
+
+/// <summary>
+/// Raised when the federation executor cannot obtain results from a single federated source.
+/// The <see cref="Reason"/> distinguishes a hard fault from a timeout or an open circuit so
+/// callers can decide whether to surface a partial result, retry later, or fail the request.
+/// </summary>
+public sealed class FederatedSourceUnavailableException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FederatedSourceUnavailableException"/> class.
+    /// </summary>
+    /// <param name="sourceId">The identifier of the source that was unavailable.</param>
+    /// <param name="reason">Why the source was unavailable.</param>
+    /// <param name="innerException">The underlying transport or resilience exception, if any.</param>
+    public FederatedSourceUnavailableException(
+        string sourceId,
+        FederatedSourceUnavailableReason reason,
+        Exception? innerException = null)
+        : base($"Federated source '{sourceId}' is unavailable ({reason}).", innerException)
+    {
+        SourceId = sourceId;
+        Reason = reason;
+    }
+
+    /// <summary>
+    /// Gets the identifier of the source that was unavailable.
+    /// </summary>
+    public string SourceId { get; }
+
+    /// <summary>
+    /// Gets the reason the source was unavailable.
+    /// </summary>
+    public FederatedSourceUnavailableReason Reason { get; }
+}

--- a/src/Honua.Core/Features/Federation/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Federation/ServiceCollectionExtensions.cs
@@ -3,25 +3,33 @@
 
 using Honua.Core.Features.Federation.Abstractions;
 using Honua.Core.Features.Federation.Services;
+using Honua.Core.Features.Infrastructure.Resilience;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Core.Features.Federation;
 
 /// <summary>
-/// Service registration helpers for the federated-query planning core (issue #341).
+/// Service registration helpers for the federated-query planning and execution core (issue #341).
 /// </summary>
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the federation query planner. The planner is pure and stateless, so it is
-    /// registered as a singleton.
+    /// Registers the federation query planner and the remote-execution layer (executor). The
+    /// planner is pure and stateless; the executor is a singleton because it caches per-source
+    /// circuit-breaker state across calls. Transport connectors
+    /// (<see cref="IFederatedSourceConnector"/>) are registered separately by the host.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddFederationCore(this IServiceCollection services)
     {
         services.TryAddSingleton<IFederationQueryPlanner, FederationQueryPlanner>();
+        services.TryAddSingleton<IFederatedQueryExecutor>(static sp => new FederatedQueryExecutor(
+            sp.GetRequiredService<IFederationQueryPlanner>(),
+            sp.GetServices<IFederatedSourceConnector>(),
+            sp.GetService<ResiliencePolicyOptions>() ?? ResiliencePolicyOptions.Default,
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<FederatedQueryExecutor>>()));
         return services;
     }
 }

--- a/src/Honua.Core/Features/Federation/Services/FederatedQueryExecutor.cs
+++ b/src/Honua.Core/Features/Federation/Services/FederatedQueryExecutor.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Infrastructure.Resilience;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.CircuitBreaker;
+
+namespace Honua.Core.Features.Federation.Services;
+
+/// <summary>
+/// Default <see cref="IFederatedQueryExecutor"/>. It plans the push-down with the offline
+/// <see cref="IFederationQueryPlanner"/>, fetches candidate rows through the registered
+/// <see cref="IFederatedSourceConnector"/> for the source kind, and refines/combines the rows
+/// locally. Every remote fetch runs under a per-source timeout and a circuit breaker so a slow
+/// or failing source fast-fails and cannot cascade into a total outage (issue #341).
+/// </summary>
+internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
+{
+    private readonly IFederationQueryPlanner _planner;
+    private readonly Dictionary<FederatedSourceKind, IFederatedSourceConnector> _connectors;
+    private readonly ResiliencePolicyOptions _resilienceOptions;
+    private readonly ILogger<FederatedQueryExecutor> _logger;
+
+    // Circuit-breaker state must persist across calls, so the per-source policy is cached.
+    private readonly ConcurrentDictionary<string, IAsyncPolicy> _policies = new(StringComparer.OrdinalIgnoreCase);
+
+    public FederatedQueryExecutor(
+        IFederationQueryPlanner planner,
+        IEnumerable<IFederatedSourceConnector> connectors,
+        ResiliencePolicyOptions resilienceOptions,
+        ILogger<FederatedQueryExecutor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(planner);
+        ArgumentNullException.ThrowIfNull(connectors);
+        ArgumentNullException.ThrowIfNull(resilienceOptions);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _planner = planner;
+        _resilienceOptions = resilienceOptions;
+        _logger = logger;
+
+        // Last writer wins when two connectors claim the same kind; this keeps registration
+        // deterministic without throwing during container build.
+        var map = new Dictionary<FederatedSourceKind, IFederatedSourceConnector>();
+        foreach (var connector in connectors)
+        {
+            map[connector.Kind] = connector;
+        }
+
+        _connectors = map;
+    }
+
+    public async Task<FederatedQueryResult> ExecuteAsync(
+        FederatedSourceDescriptor source,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (!_connectors.TryGetValue(source.Kind, out var connector))
+        {
+            throw new FederatedSourceUnavailableException(source.Id, FederatedSourceUnavailableReason.NoConnector);
+        }
+
+        var plan = _planner.Plan(source, in query, joinsLocalLayer: false);
+        var request = new FederatedFetchRequest(source, query, plan);
+
+        var stopwatch = Stopwatch.StartNew();
+        ImmutableArray<Feature> candidates;
+        try
+        {
+            candidates = await FetchWithResilienceAsync(source, connector, request, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            stopwatch.Stop();
+        }
+
+        var refinement = RefineLocally(query, plan, candidates);
+
+        FederationExecutionLog.SourceExecuted(_logger, source.Id, stopwatch.Elapsed.TotalMilliseconds, refinement.Result.Items.Length);
+
+        return new FederatedQueryResult
+        {
+            SourceId = source.Id,
+            Plan = plan,
+            Result = refinement.Result,
+            Elapsed = stopwatch.Elapsed,
+            UnappliedLocalRefinements = refinement.Unapplied,
+        };
+    }
+
+    public async Task<FederatedCombinedResult> ExecuteAsync(
+        ImmutableArray<FederatedSourceDescriptor> sources,
+        FeatureQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var results = ImmutableArray.CreateBuilder<FederatedQueryResult>();
+        var failures = ImmutableArray.CreateBuilder<FederatedSourceFailure>();
+
+        foreach (var source in sources)
+        {
+            if (source is null || !source.Enabled)
+            {
+                continue;
+            }
+
+            try
+            {
+                results.Add(await ExecuteAsync(source, query, cancellationToken).ConfigureAwait(false));
+            }
+            catch (FederatedSourceUnavailableException ex)
+            {
+                FederationExecutionLog.SourceUnavailable(_logger, source.Id, ex.Reason.ToString(), ex);
+                failures.Add(new FederatedSourceFailure(source.Id, ex.Reason));
+            }
+        }
+
+        var combined = Combine(query, results);
+
+        return new FederatedCombinedResult
+        {
+            Sources = results.ToImmutable(),
+            Failures = failures.ToImmutable(),
+            Combined = combined,
+        };
+    }
+
+    private async Task<ImmutableArray<Feature>> FetchWithResilienceAsync(
+        FederatedSourceDescriptor source,
+        IFederatedSourceConnector connector,
+        FederatedFetchRequest request,
+        CancellationToken cancellationToken)
+    {
+        var policy = _policies.GetOrAdd(source.Id, BuildPolicy);
+
+        try
+        {
+            return await policy.ExecuteAsync(
+                async ct =>
+                {
+                    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    timeoutCts.CancelAfter(source.RequestTimeout);
+
+                    try
+                    {
+                        return await connector.FetchAsync(request, timeoutCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (!ct.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+                    {
+                        // The per-source timeout fired (not the caller). Surface a fault the
+                        // resilience policy counts toward the circuit breaker.
+                        throw new TimeoutException($"Federated source '{source.Id}' timed out after {source.RequestTimeout}.");
+                    }
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (BrokenCircuitException ex)
+        {
+            throw new FederatedSourceUnavailableException(source.Id, FederatedSourceUnavailableReason.CircuitOpen, ex);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new FederatedSourceUnavailableException(source.Id, FederatedSourceUnavailableReason.TimedOut, ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new FederatedSourceUnavailableException(source.Id, FederatedSourceUnavailableReason.Faulted, ex);
+        }
+    }
+
+    private IAsyncPolicy BuildPolicy(string sourceId) =>
+        ResiliencePolicyFactory.CreateStandardPolicy(
+            // Caller cancellation must propagate unchanged, so it is excluded from retry/break.
+            Policy.Handle<Exception>(ex => ex is not OperationCanceledException),
+            _resilienceOptions,
+            onBreak: (_, breakDelay) => FederationExecutionLog.CircuitOpened(_logger, sourceId, breakDelay.TotalMilliseconds));
+
+    private static LocalRefinementOutcome RefineLocally(
+        in FeatureQuery query,
+        FederationQueryPlan plan,
+        ImmutableArray<Feature> candidates)
+    {
+        var features = candidates;
+        var unapplied = ImmutableArray.CreateBuilder<FederationPredicateKind>();
+
+        foreach (var decision in plan.Decisions)
+        {
+            if (decision.PushedDown)
+            {
+                continue;
+            }
+
+            switch (decision.Predicate)
+            {
+                case FederationPredicateKind.TemporalFilter when query.TemporalFilter is { } temporal:
+                    features = FederationLocalRefinement.ApplyTemporalFilter(features, in temporal);
+                    break;
+
+                case FederationPredicateKind.OrderBy when query.OrderBy is { IsDefaultOrEmpty: false } orderBy:
+                    features = FederationLocalRefinement.ApplyOrderBy(features, orderBy);
+                    break;
+
+                case FederationPredicateKind.Paging:
+                    // Paging is applied after ordering/temporal below so it pages the refined set.
+                    break;
+
+                default:
+                    // Attribute and exact spatial-relationship refinement are not implemented in
+                    // this slice; record them so callers know the rows are an unrefined superset.
+                    unapplied.Add(decision.Predicate);
+                    break;
+            }
+        }
+
+        var totalBeforePaging = features.Length;
+        var pagedLocally = plan.Decisions.Any(static d => d.Predicate == FederationPredicateKind.Paging && !d.PushedDown);
+
+        QueryResult<Feature> result;
+        if (pagedLocally)
+        {
+            var skip = query.Offset is > 0 ? query.Offset.Value : 0;
+            var page = FederationLocalRefinement.ApplyPaging(features, query.Offset, query.Limit);
+            result = new QueryResult<Feature>
+            {
+                TotalCount = totalBeforePaging,
+                Items = page,
+                HasMoreResults = skip + page.Length < totalBeforePaging,
+            };
+        }
+        else
+        {
+            result = new QueryResult<Feature>
+            {
+                TotalCount = totalBeforePaging,
+                Items = features,
+                HasMoreResults = false,
+            };
+        }
+
+        return new LocalRefinementOutcome(result, unapplied.ToImmutable());
+    }
+
+    private static QueryResult<Feature> Combine(in FeatureQuery query, ImmutableArray<FederatedQueryResult>.Builder results)
+    {
+        if (results.Count == 0)
+        {
+            return QueryResult<Feature>.Empty();
+        }
+
+        if (results.Count == 1)
+        {
+            return results[0].Result;
+        }
+
+        var merged = ImmutableArray.CreateBuilder<Feature>();
+        long total = 0;
+        foreach (var sourceResult in results)
+        {
+            merged.AddRange(sourceResult.Result.Items);
+            total += sourceResult.Result.TotalCount;
+        }
+
+        var features = merged.ToImmutable();
+
+        // Per-source ordering does not yield a global order, so re-apply it across the union.
+        if (query.OrderBy is { IsDefaultOrEmpty: false } orderBy)
+        {
+            features = FederationLocalRefinement.ApplyOrderBy(features, orderBy);
+        }
+
+        // Cross-source paging is best-effort over the merged candidate rows in this slice.
+        if (query.Offset is not null || query.Limit is not null)
+        {
+            var skip = query.Offset is > 0 ? query.Offset.Value : 0;
+            var page = FederationLocalRefinement.ApplyPaging(features, query.Offset, query.Limit);
+            return new QueryResult<Feature>
+            {
+                TotalCount = total,
+                Items = page,
+                HasMoreResults = skip + page.Length < features.Length,
+            };
+        }
+
+        return new QueryResult<Feature>
+        {
+            TotalCount = total,
+            Items = features,
+            HasMoreResults = false,
+        };
+    }
+
+    private readonly record struct LocalRefinementOutcome(
+        QueryResult<Feature> Result,
+        ImmutableArray<FederationPredicateKind> Unapplied);
+}

--- a/src/Honua.Core/Features/Federation/Services/FederationExecutionLog.cs
+++ b/src/Honua.Core/Features/Federation/Services/FederationExecutionLog.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Core.Features.Federation.Services;
+
+/// <summary>
+/// Source-generated structured logging for the federated-query executor (issue #341).
+/// </summary>
+internal static partial class FederationExecutionLog
+{
+    [LoggerMessage(EventId = 4510, Level = LogLevel.Debug,
+        Message = "Executed federated query against source '{SourceId}' in {ElapsedMs}ms ({Count} rows)")]
+    public static partial void SourceExecuted(ILogger logger, string sourceId, double elapsedMs, int count);
+
+    [LoggerMessage(EventId = 4511, Level = LogLevel.Warning,
+        Message = "Federated source '{SourceId}' unavailable ({Reason})")]
+    public static partial void SourceUnavailable(ILogger logger, string sourceId, string reason, Exception exception);
+
+    [LoggerMessage(EventId = 4512, Level = LogLevel.Warning,
+        Message = "Federated source '{SourceId}' circuit opened for {BreakMs}ms")]
+    public static partial void CircuitOpened(ILogger logger, string sourceId, double breakMs);
+}

--- a/src/Honua.Core/Features/Federation/Services/FederationLocalRefinement.cs
+++ b/src/Honua.Core/Features/Federation/Services/FederationLocalRefinement.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.Federation.Services;
+
+/// <summary>
+/// Pure, in-memory refinement of candidate rows that a federated source could not evaluate
+/// remotely. The executor fetches a candidate superset and then applies these refinements
+/// locally: temporal interval filtering, ordering, and paging. The helper is deterministic and
+/// performs no I/O, so it is exercised directly by unit tests.
+/// </summary>
+/// <remarks>
+/// Attribute (<c>WHERE</c>) and exact spatial-relationship refinement are intentionally not
+/// implemented here yet: the built-in source kinds always push attribute predicates down, and
+/// exact spatial refinement needs the geometry engine. Those are tracked as remaining work in
+/// issue #341; the executor reports any predicate it could not refine so callers are never
+/// silently handed an unrefined superset.
+/// </remarks>
+internal static class FederationLocalRefinement
+{
+    /// <summary>
+    /// Applies a temporal interval filter to the candidate rows, keeping only rows whose
+    /// temporal value (or interval) overlaps the requested window. Rows whose temporal value
+    /// is missing or unparseable are excluded.
+    /// </summary>
+    public static ImmutableArray<Feature> ApplyTemporalFilter(ImmutableArray<Feature> features, in TemporalFilter filter)
+    {
+        var start = filter.Start;
+        var end = filter.End;
+        var startProp = filter.PropertyName;
+        var endProp = filter.EndPropertyName;
+
+        var builder = ImmutableArray.CreateBuilder<Feature>(features.Length);
+        foreach (var feature in features)
+        {
+            if (!TryGetTimestamp(feature, startProp, out var rowStart))
+            {
+                continue;
+            }
+
+            var rowEnd = rowStart;
+            if (!string.IsNullOrEmpty(endProp) && TryGetTimestamp(feature, endProp!, out var parsedEnd))
+            {
+                rowEnd = parsedEnd;
+            }
+
+            // Interval-intersection: [rowStart, rowEnd] overlaps [start, end].
+            if (end is { } e && rowStart > e)
+            {
+                continue;
+            }
+
+            if (start is { } s && rowEnd < s)
+            {
+                continue;
+            }
+
+            builder.Add(feature);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Applies a stable multi-key ordering to the candidate rows.
+    /// </summary>
+    public static ImmutableArray<Feature> ApplyOrderBy(ImmutableArray<Feature> features, ImmutableArray<OrderByClause> orderBy)
+    {
+        if (orderBy.IsDefaultOrEmpty || features.Length <= 1)
+        {
+            return features;
+        }
+
+        // OrderBy/ThenBy is documented as a stable sort, which preserves remote order for ties.
+        IOrderedEnumerable<Feature>? ordered = null;
+        foreach (var clause in orderBy)
+        {
+            ordered = ordered is null
+                ? Sort(features, clause)
+                : Then(ordered, clause);
+        }
+
+        return ordered is null ? features : ordered.ToImmutableArray();
+
+        static IOrderedEnumerable<Feature> Sort(IEnumerable<Feature> source, OrderByClause clause) =>
+            clause.Ascending
+                ? source.OrderBy(f => GetValue(f, clause.Field), new FederationValueComparer(clause.NullOrdering, ascending: true))
+                : source.OrderByDescending(f => GetValue(f, clause.Field), new FederationValueComparer(clause.NullOrdering, ascending: false));
+
+        static IOrderedEnumerable<Feature> Then(IOrderedEnumerable<Feature> source, OrderByClause clause) =>
+            clause.Ascending
+                ? source.ThenBy(f => GetValue(f, clause.Field), new FederationValueComparer(clause.NullOrdering, ascending: true))
+                : source.ThenByDescending(f => GetValue(f, clause.Field), new FederationValueComparer(clause.NullOrdering, ascending: false));
+    }
+
+    /// <summary>
+    /// Applies offset/limit paging to the candidate rows.
+    /// </summary>
+    public static ImmutableArray<Feature> ApplyPaging(ImmutableArray<Feature> features, int? offset, int? limit)
+    {
+        var skip = offset is > 0 ? offset.Value : 0;
+        if (skip == 0 && limit is null)
+        {
+            return features;
+        }
+
+        if (skip >= features.Length)
+        {
+            return ImmutableArray<Feature>.Empty;
+        }
+
+        var remaining = features.Length - skip;
+        var take = limit is { } l && l < remaining ? l : remaining;
+        if (take <= 0)
+        {
+            return ImmutableArray<Feature>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<Feature>(take);
+        for (var i = skip; i < skip + take; i++)
+        {
+            builder.Add(features[i]);
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private static object? GetValue(in Feature feature, string field) =>
+        feature.Attributes.TryGetValue(field, out var value) ? value : null;
+
+    private static bool TryGetTimestamp(in Feature feature, string field, out DateTimeOffset value)
+    {
+        value = default;
+        if (!feature.Attributes.TryGetValue(field, out var raw) || raw is null)
+        {
+            return false;
+        }
+
+        switch (raw)
+        {
+            case DateTimeOffset dto:
+                value = dto;
+                return true;
+            case DateTime dt:
+                value = new DateTimeOffset(dt.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(dt, DateTimeKind.Utc) : dt);
+                return true;
+            case string s when DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed):
+                value = parsed;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Type-aware value comparer used for local ordering. Numbers compare numerically, dates
+    /// chronologically, and everything else by ordinal string comparison. Null placement
+    /// honours the clause's <see cref="NullOrdering"/>, defaulting to nulls-last for ascending
+    /// and nulls-first for descending.
+    /// </summary>
+    private sealed class FederationValueComparer(NullOrdering nullOrdering, bool ascending) : IComparer<object?>
+    {
+        public int Compare(object? x, object? y)
+        {
+            if (x is null && y is null)
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return NullSortValue();
+            }
+
+            if (y is null)
+            {
+                return -NullSortValue();
+            }
+
+            if (TryAsDouble(x, out var dx) && TryAsDouble(y, out var dy))
+            {
+                return dx.CompareTo(dy);
+            }
+
+            if (TryAsDateTimeOffset(x, out var tx) && TryAsDateTimeOffset(y, out var ty))
+            {
+                return tx.CompareTo(ty);
+            }
+
+            return string.CompareOrdinal(
+                Convert.ToString(x, CultureInfo.InvariantCulture),
+                Convert.ToString(y, CultureInfo.InvariantCulture));
+        }
+
+        // The framework inverts this comparer's result for OrderByDescending, so the value we
+        // return for a null operand must pre-compensate for that flip to land nulls in the
+        // intended final position.
+        private int NullSortValue()
+        {
+            // Final placement we want for a null vs a non-null value.
+            var nullsFirstInFinalOrder = nullOrdering switch
+            {
+                NullOrdering.NullsFirst => true,
+                NullOrdering.NullsLast => false,
+                // PostgreSQL-style default: nulls last when ascending, nulls first when descending.
+                _ => !ascending,
+            };
+
+            // Ascending uses the result as-is; descending inverts it.
+            return ascending
+                ? (nullsFirstInFinalOrder ? -1 : 1)
+                : (nullsFirstInFinalOrder ? 1 : -1);
+        }
+
+        private static bool TryAsDouble(object value, out double result)
+        {
+            switch (value)
+            {
+                case sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal:
+                    result = Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                    return true;
+                default:
+                    result = 0;
+                    return false;
+            }
+        }
+
+        private static bool TryAsDateTimeOffset(object value, out DateTimeOffset result)
+        {
+            switch (value)
+            {
+                case DateTimeOffset dto:
+                    result = dto;
+                    return true;
+                case DateTime dt:
+                    result = new DateTimeOffset(dt.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(dt, DateTimeKind.Utc) : dt);
+                    return true;
+                default:
+                    result = default;
+                    return false;
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Federation/FederatedQueryExecutorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Federation/FederatedQueryExecutorTests.cs
@@ -1,0 +1,293 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Core.Features.Federation;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.Federation.Services;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.Core.Tests.Features.Federation;
+
+/// <summary>
+/// Unit tests for the remote federated-query executor (issue #341). Remote I/O is provided by
+/// in-memory connectors, so these tests exercise the real executor behaviour — push-down vs
+/// local refinement, timeout, circuit breaker, and multi-source combination — without a live
+/// remote source.
+/// </summary>
+public sealed class FederatedQueryExecutorTests
+{
+    private static readonly ResiliencePolicyOptions FastFail = new()
+    {
+        MaxRetryAttempts = 0,
+        CircuitBreakerFailures = 2,
+        CircuitBreakDuration = TimeSpan.FromMinutes(5),
+    };
+
+    private static FederatedSourceDescriptor Source(
+        FederatedSourceKind kind,
+        TimeSpan? timeout = null) => new()
+        {
+            Id = $"src-{kind}",
+            DisplayName = kind.ToString(),
+            Kind = kind,
+            Endpoint = new Uri("https://remote.example.com/"),
+            RemoteLayer = "0",
+            RequestTimeout = timeout ?? TimeSpan.FromSeconds(30),
+        };
+
+    private static Feature Feature(long id, params (string Key, object? Value)[] attributes)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+        foreach (var (key, value) in attributes)
+        {
+            builder[key] = value;
+        }
+
+        return new Feature { Id = id, Geometry = null, Attributes = builder.ToImmutable() };
+    }
+
+    private static FederatedQueryExecutor BuildExecutor(
+        IFederatedSourceConnector connector,
+        ResiliencePolicyOptions? options = null)
+    {
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.AddFederationCore();
+        var planner = services.BuildServiceProvider().GetRequiredService<IFederationQueryPlanner>();
+
+        return new FederatedQueryExecutor(
+            planner,
+            new[] { connector },
+            options ?? ResiliencePolicyOptions.Default,
+            NullLogger<FederatedQueryExecutor>.Instance);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_NoConnector_ThrowsNoConnector()
+    {
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.HonuaGrpc, ImmutableArray<Feature>.Empty));
+
+        var ex = await Assert.ThrowsAsync<FederatedSourceUnavailableException>(
+            () => executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), new FeatureQuery()));
+
+        Assert.Equal(FederatedSourceUnavailableReason.NoConnector, ex.Reason);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_PushDownOnly_ReturnsCandidatesWithoutLocalRefinement()
+    {
+        var rows = ImmutableArray.Create(Feature(1, ("name", "b")), Feature(2, ("name", "a")));
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.HonuaGrpc, rows));
+
+        // HonuaGrpc pushes ordering down, so the executor must not re-sort locally.
+        var query = new FeatureQuery { OrderBy = ImmutableArray.Create(OrderByClause.Asc("name")) };
+        var result = await executor.ExecuteAsync(Source(FederatedSourceKind.HonuaGrpc), query);
+
+        Assert.Empty(result.UnappliedLocalRefinements);
+        Assert.Equal(new long[] { 1, 2 }, result.Result.Items.Select(f => f.Id).ToArray());
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_LocalOrderByAndPaging_SortsThenPages()
+    {
+        var rows = ImmutableArray.Create(
+            Feature(1, ("name", "charlie")),
+            Feature(2, ("name", "alpha")),
+            Feature(3, ("name", "bravo")));
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.OgcWfs, rows));
+
+        // OGC WFS does not push ordering down, which also forces paging to be applied locally.
+        var query = new FeatureQuery
+        {
+            OrderBy = ImmutableArray.Create(OrderByClause.Asc("name")),
+            Offset = 1,
+            Limit = 1,
+        };
+
+        var result = await executor.ExecuteAsync(Source(FederatedSourceKind.OgcWfs), query);
+
+        // Sorted -> alpha(2), bravo(3), charlie(1); offset 1, limit 1 -> bravo(3).
+        Assert.Equal(new long[] { 3 }, result.Result.Items.Select(f => f.Id).ToArray());
+        Assert.Equal(3, result.Result.TotalCount);
+        Assert.True(result.Result.HasMoreResults);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_LocalTemporalFilter_KeepsOnlyOverlappingRows()
+    {
+        var rows = ImmutableArray.Create(
+            Feature(1, ("t", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero))),
+            Feature(2, ("t", new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero))),
+            Feature(3, ("t", new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero))));
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.EsriRest, rows));
+
+        var query = new FeatureQuery
+        {
+            TemporalFilter = new TemporalFilter
+            {
+                PropertyName = "t",
+                PropertyType = TemporalPropertyType.DateTime,
+                Start = new DateTimeOffset(2023, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                End = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            },
+        };
+
+        var result = await executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), query);
+
+        Assert.Equal(new long[] { 2 }, result.Result.Items.Select(f => f.Id).ToArray());
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_ExactSpatialRelationship_RecordsUnappliedRefinement()
+    {
+        var rows = ImmutableArray.Create(Feature(1), Feature(2));
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.EsriRest, rows));
+
+        var query = FeatureQuery.WithSpatialFilter(new SpatialFilter
+        {
+            Geometry = Array.Empty<byte>(),
+            SpatialRelationship = SpatialRelationship.Within,
+        });
+
+        var result = await executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), query);
+
+        Assert.Contains(FederationPredicateKind.SpatialFilter, result.UnappliedLocalRefinements);
+        Assert.Equal(2, result.Result.Items.Length);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_CircuitBreaker_OpensAfterConsecutiveFailures()
+    {
+        var executor = BuildExecutor(new ThrowingConnector(FederatedSourceKind.EsriRest), FastFail);
+        var source = Source(FederatedSourceKind.EsriRest);
+
+        var reasons = new System.Collections.Generic.List<FederatedSourceUnavailableReason>();
+        for (var i = 0; i < 4; i++)
+        {
+            var ex = await Assert.ThrowsAsync<FederatedSourceUnavailableException>(
+                () => executor.ExecuteAsync(source, new FeatureQuery()));
+            reasons.Add(ex.Reason);
+        }
+
+        Assert.Equal(FederatedSourceUnavailableReason.Faulted, reasons[0]);
+        Assert.Contains(FederatedSourceUnavailableReason.CircuitOpen, reasons);
+        // Once open, the breaker fast-fails instead of contacting the source again.
+        Assert.Equal(FederatedSourceUnavailableReason.CircuitOpen, reasons[^1]);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_SlowSource_TranslatesToTimeout()
+    {
+        var executor = BuildExecutor(new SlowConnector(FederatedSourceKind.EsriRest), FastFail);
+        var source = Source(FederatedSourceKind.EsriRest, TimeSpan.FromMilliseconds(50));
+
+        var ex = await Assert.ThrowsAsync<FederatedSourceUnavailableException>(
+            () => executor.ExecuteAsync(source, new FeatureQuery()));
+
+        Assert.Equal(FederatedSourceUnavailableReason.TimedOut, ex.Reason);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_CallerCancellation_PropagatesWithoutWrapping()
+    {
+        var executor = BuildExecutor(new SlowConnector(FederatedSourceKind.EsriRest), FastFail);
+        var source = Source(FederatedSourceKind.EsriRest);
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => executor.ExecuteAsync(source, new FeatureQuery(), cts.Token));
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MultiSource_MergesResultsAndRecordsFailures()
+    {
+        var connectors = new MultiplexConnector(FederatedSourceKind.OgcWfs);
+        connectors.Rows["src-OgcWfs"] = ImmutableArray.Create(Feature(1, ("name", "z")), Feature(2, ("name", "a")));
+        connectors.Failures.Add("failing");
+
+        var executor = BuildExecutor(connectors, FastFail);
+
+        var ok = Source(FederatedSourceKind.OgcWfs);
+        var bad = ok with { Id = "failing" };
+
+        var query = new FeatureQuery { OrderBy = ImmutableArray.Create(OrderByClause.Asc("name")) };
+        var combined = await executor.ExecuteAsync(ImmutableArray.Create(ok, bad), query);
+
+        Assert.Single(combined.Sources);
+        var failure = Assert.Single(combined.Failures);
+        Assert.Equal("failing", failure.SourceId);
+        // Cross-source ordering is re-applied over the merged rows.
+        Assert.Equal(new long[] { 2, 1 }, combined.Combined.Items.Select(f => f.Id).ToArray());
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_MultiSource_SkipsDisabledSources()
+    {
+        var connector = new StubConnector(FederatedSourceKind.OgcWfs, ImmutableArray.Create(Feature(1)));
+        var executor = BuildExecutor(connector, FastFail);
+
+        var disabled = Source(FederatedSourceKind.OgcWfs) with { Enabled = false };
+        var combined = await executor.ExecuteAsync(ImmutableArray.Create(disabled), new FeatureQuery());
+
+        Assert.Empty(combined.Sources);
+        Assert.Empty(combined.Failures);
+        Assert.Empty(combined.Combined.Items);
+    }
+
+    private sealed class StubConnector(FederatedSourceKind kind, ImmutableArray<Feature> rows) : IFederatedSourceConnector
+    {
+        public FederatedSourceKind Kind => kind;
+
+        public Task<ImmutableArray<Feature>> FetchAsync(FederatedFetchRequest request, CancellationToken cancellationToken) =>
+            Task.FromResult(rows);
+    }
+
+    private sealed class ThrowingConnector(FederatedSourceKind kind) : IFederatedSourceConnector
+    {
+        public FederatedSourceKind Kind => kind;
+
+        public Task<ImmutableArray<Feature>> FetchAsync(FederatedFetchRequest request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("remote down");
+    }
+
+    private sealed class SlowConnector(FederatedSourceKind kind) : IFederatedSourceConnector
+    {
+        public FederatedSourceKind Kind => kind;
+
+        public async Task<ImmutableArray<Feature>> FetchAsync(FederatedFetchRequest request, CancellationToken cancellationToken)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
+            return ImmutableArray<Feature>.Empty;
+        }
+    }
+
+    private sealed class MultiplexConnector(FederatedSourceKind kind) : IFederatedSourceConnector
+    {
+        public FederatedSourceKind Kind => kind;
+
+        public System.Collections.Generic.Dictionary<string, ImmutableArray<Feature>> Rows { get; } = new();
+
+        public System.Collections.Generic.HashSet<string> Failures { get; } = new();
+
+        public Task<ImmutableArray<Feature>> FetchAsync(FederatedFetchRequest request, CancellationToken cancellationToken)
+        {
+            if (Failures.Contains(request.Source.Id))
+            {
+                throw new InvalidOperationException("remote down");
+            }
+
+            return Task.FromResult(Rows.TryGetValue(request.Source.Id, out var rows) ? rows : ImmutableArray<Feature>.Empty);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #341

## Summary
This adds the remote-execution slice of federated queries on top of the federation query
planner that already lives on `trunk`. Until now the federation feature could only plan
push-down vs local-refinement offline; it could not actually run a query against a remote
source. This PR adds `IFederatedQueryExecutor`, the layer that fetches candidate rows from a
remote source under a per-source timeout and circuit breaker, refines/combines them locally,
and merges multiple sources into a single result while isolating a failing source so it cannot
cascade into a total outage.

This is a deliberate first slice of an XL ticket; remaining scope is listed under Known gaps.

## Changes Made
- Add `IFederatedQueryExecutor` and `FederatedQueryExecutor`: plans push-down with the existing
  `IFederationQueryPlanner`, fetches through a connector, refines locally, and combines results.
- Add `IFederatedSourceConnector`, the per-kind transport boundary (Honua gRPC / Esri REST /
  OGC WFS) that performs the only remote I/O; the executor wraps every call in resilience.
- Add per-source timeout + Polly circuit breaker reusing `ResiliencePolicyFactory`; failures are
  surfaced as a typed `FederatedSourceUnavailableException` (Faulted / TimedOut / CircuitOpen /
  NoConnector). Circuit-breaker state is cached per source so it persists across calls.
- Add `FederationLocalRefinement`: deterministic in-memory temporal interval filtering, ordering
  (type-aware, null-placement aware), and paging applied to the candidate superset.
- Add result domain types (`FederatedFetchRequest`, `FederatedQueryResult`,
  `FederatedCombinedResult`, `FederatedSourceFailure`) including a precursor `Elapsed` latency
  measurement and `UnappliedLocalRefinements` so callers are never silently handed an unrefined
  superset.
- Register the executor in `AddFederationCore`; connectors are registered separately by the host.
- Add 10 unit tests covering push-down-only, local ordering/paging, local temporal filtering,
  unapplied exact-spatial refinement, circuit-breaker open-after-failures, timeout translation,
  caller-cancellation propagation, and multi-source merge/failure isolation.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Ran `dotnet build src/Honua.Core/Honua.Core.csproj -c Release /p:TreatWarningsAsErrors=true`
(succeeds) and `dotnet test tests/dotnet/Honua.Core.Tests --filter FullyQualifiedName~Federation`
which passes 22/22 (12 existing planner tests + 10 new executor tests). `dotnet format
--verify-no-changes` on the changed files reports no changes.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

## Known gaps (remaining for #341)
The following acceptance-criteria items are intentionally deferred to keep this slice clean and
well-tested; the issue stays open:
- Concrete transport connectors (Honua gRPC, Esri REST, OGC API Features / WFS). The executor and
  its connector seam are in place, but no real `IFederatedSourceConnector` implementations ship
  yet, so end-to-end remote execution is not wired into the query router.
- Exact spatial-relationship local refinement and attribute (`WHERE`) local refinement (needs the
  geometry/CQL engines). These are reported via `UnappliedLocalRefinements` rather than silently
  returning an unrefined superset.
- Multi-source join optimization (local PostGIS join remote). The planner already flags
  `RequiresLocalJoin`; the executor does not yet perform the join.
- Per-source latency/error metrics and the Admin UI surface for executing (not just planning)
  federated queries. `FederatedQueryResult.Elapsed` is the precursor hook.
- Cross-source paging/total counts are best-effort over the merged candidate set in this slice.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
