### PR TITLE
feat: raster analysis & terrain GP tool pack (#2141, #2239, #2240)

### DIFF
--- a/docker/worker-gdal/Dockerfile
+++ b/docker/worker-gdal/Dockerfile
@@ -105,6 +105,18 @@ RUN command -v gdalwarp && command -v ogr2ogr && command -v gdalmdiminfo \
  # gdal_grid backs the raster IDW interpolation tool (raster.interpolate-idw, #2141);
  # gdalwarp backs raster.resample and raster.mosaic. Both ship in the ubuntu-full base.
  && command -v gdal_grid \
+ # Raster analysis & terrain GP tool pack (#2239 / #2240). gdal_calc.py backs
+ # raster.map-algebra / raster.spectral-index / raster.reclassify; gdal_proximity.py
+ # backs proximity.euclidean-distance; gdal_polygonize.py backs conversion.polygonize
+ # (the GDAL Python utilities, shipped in the ubuntu-full base's python3-gdal layer).
+ # gdal_contour / gdal_viewshed / gdal_rasterize are C binaries backing
+ # surface.contour / surface.viewshed / conversion.rasterize.
+ && command -v gdal_calc.py \
+ && command -v gdal_proximity.py \
+ && command -v gdal_polygonize.py \
+ && command -v gdal_contour \
+ && command -v gdal_viewshed \
+ && command -v gdal_rasterize \
  && gdalinfo --formats | grep -qi netCDF \
  && gdalinfo --formats | grep -qi GRIB \
  && command -v pdal \

--- a/docker/worker-gdal/Dockerfile
+++ b/docker/worker-gdal/Dockerfile
@@ -102,6 +102,9 @@ RUN apt-get update \
 # `pdal` must also be on PATH with the LAS reader + reprojection filter compiled
 # in (LAZ/COPC decompress + reproject, #1854).
 RUN command -v gdalwarp && command -v ogr2ogr && command -v gdalmdiminfo \
+ # gdal_grid backs the raster IDW interpolation tool (raster.interpolate-idw, #2141);
+ # gdalwarp backs raster.resample and raster.mosaic. Both ship in the ubuntu-full base.
+ && command -v gdal_grid \
  && gdalinfo --formats | grep -qi netCDF \
  && gdalinfo --formats | grep -qi GRIB \
  && command -v pdal \

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -473,6 +473,42 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         },
 
         // -----------------------------------------------------------------------
+        // Euclidean proximity operations (#2240)
+        // Raster proximity products implemented natively by the heavyweight GDAL
+        // worker via gdal_proximity.py. Declared RuntimeProfile = native; the lean
+        // image validates these plans but never executes them.
+        // -----------------------------------------------------------------------
+        new ProcessDefinition
+        {
+            ProcessId = "proximity.euclidean-distance",
+            Title = "Euclidean Distance",
+            Description = "Computes a raster of the distance from each cell to the nearest source cell. Executed out-of-process by the heavyweight GDAL worker via gdal_proximity.py. Reads a base64-encoded GeoTIFF from 'source' whose non-zero (or 'values'-listed) pixels are the proximity targets; publishes the Float32 distance GeoTIFF as a data-URI artifact.",
+            Category = "proximity",
+            Parameters =
+            [
+                Param("source", "Source Raster", "Source raster as base64-encoded GeoTIFF bytes whose non-zero (or 'values'-listed) pixels are the proximity targets. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("maxDistance", "Max Distance", "Optional maximum distance to compute. Must be > 0 when supplied. Cells beyond it take the nodata value.", ProcessParameterValueType.FloatingPoint),
+                Param("distUnits", "Distance Units", "Distance units. Allowed values: GEO, PIXEL. Defaults to GEO.", ProcessParameterValueType.Text, defaultValue: "GEO"),
+                Param("values", "Target Values", "Optional comma-separated list of integer source pixel values to treat as targets. When omitted, all non-zero pixels are targets.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "proximity.euclidean-allocation",
+            Title = "Euclidean Allocation",
+            Description = "FLAGGED / UNSUPPORTED in this build: nearest-source allocation requires a mode that stock GDAL gdal_proximity does not provide (it computes distance only). The process is advertised so callers can discover the limitation; a submitted job FAILS with a clear message rather than silently substituting a distance raster. Use proximity.euclidean-distance for the distance raster.",
+            Category = "proximity",
+            Parameters =
+            [
+                Param("source", "Source Raster", "Source raster as base64-encoded GeoTIFF bytes. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+
+        // -----------------------------------------------------------------------
         // Statistics/summarization operations (#2140)
         // Managed table-producing aggregates over a single inline FeatureCollection.
         // Table outputs are null-geometry FeatureCollections (one feature per row).
@@ -555,9 +591,10 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         },
 
         // -----------------------------------------------------------------------
-        // Surface-analysis operations (6)
+        // Surface-analysis operations (8)
         // DEM-derived raster products implemented natively by the heavyweight GDAL
-        // worker via the gdaldem CLI. Declared RuntimeProfile = native so the
+        // worker via the gdaldem / gdal_contour / gdal_viewshed CLIs. Declared
+        // RuntimeProfile = native so the
         // submit path stamps ExecutionJobSpec.RuntimeProfile = "native" and the
         // claim fence routes the job to the GDAL worker and away from the lean
         // dispatcher. The lean image still validates these plans (parameter
@@ -649,9 +686,42 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
             OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native
         },
+        new ProcessDefinition
+        {
+            ProcessId = "surface.contour",
+            Title = "Contour",
+            Description = "Generates contour lines from an elevation source. Executed out-of-process by the heavyweight GDAL worker via gdal_contour. Reads a base64-encoded GeoTIFF DEM from 'source' and publishes a GeoJSON FeatureCollection of contour lines carrying an ELEV attribute as a data-URI artifact.",
+            Category = "surface",
+            Parameters =
+            [
+                .. NativeRasterSourceParameters,
+                Param("interval", "Interval", "Contour interval in the DEM's elevation units. Must be > 0. Required.", ProcessParameterValueType.FloatingPoint, required: true),
+                Param("base", "Base", "Optional elevation offset relative to which intervals are interpreted.", ProcessParameterValueType.FloatingPoint),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "surface.viewshed",
+            Title = "Viewshed",
+            Description = "Computes a binary visibility raster from a DEM and an observer location. Executed out-of-process by the heavyweight GDAL worker via gdal_viewshed. Reads a base64-encoded GeoTIFF DEM from 'source'; publishes the visibility GeoTIFF as a data-URI artifact. The observer is placed at (observerX, observerY) in the DEM's georeferenced units.",
+            Category = "surface",
+            Parameters =
+            [
+                .. NativeRasterSourceParameters,
+                Param("observerX", "Observer X", "Observer X coordinate in the DEM's georeferenced units. Required.", ProcessParameterValueType.FloatingPoint, required: true),
+                Param("observerY", "Observer Y", "Observer Y coordinate in the DEM's georeferenced units. Required.", ProcessParameterValueType.FloatingPoint, required: true),
+                Param("observerHeight", "Observer Height", "Observer height above the surface. Must be >= 0. Defaults to 2.", ProcessParameterValueType.FloatingPoint, defaultValue: "2"),
+                Param("targetHeight", "Target Height", "Target height above the surface. Must be >= 0. Defaults to 0.", ProcessParameterValueType.FloatingPoint, defaultValue: "0"),
+                Param("maxDistance", "Max Distance", "Optional maximum visibility distance in georeferenced units. Must be > 0 when supplied.", ProcessParameterValueType.FloatingPoint),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
 
         // -----------------------------------------------------------------------
-        // Raster operations (9)
+        // Raster operations (12)
         // Raster analysis and mutation workflows implemented natively by the
         // heavyweight GDAL worker via the gdalwarp / gdalinfo CLI tools. Declared
         // RuntimeProfile = native so the submit path stamps the spec native and
@@ -798,9 +868,60 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
             OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native
         },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.map-algebra",
+            Title = "Map Algebra",
+            Description = "Evaluates an allow-listed arithmetic/logical expression across one or more input rasters. Executed out-of-process by the heavyweight GDAL worker via gdal_calc.py. Reads a '|'-separated list of base64-encoded GeoTIFFs from 'sources' (bound to band variables A, B, C, …) and a validated 'expression'; publishes the result GeoTIFF as a data-URI artifact. The expression is restricted to single-letter band variables, numeric literals, a fixed operator set, and a small allow-list of NumPy functions; arbitrary input is never shell- or eval-evaluated.",
+            Category = "raster",
+            Parameters =
+            [
+                Param("sources", "Sources", "One or more source rasters as base64-encoded GeoTIFFs separated by '|', bound to band variables A, B, C, … in order. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("expression", "Expression", "Allow-listed map-algebra expression over the band variables (e.g. '(A-B)/(A+B)'). Required.", ProcessParameterValueType.Text, required: true),
+                Param("dataType", "Output Type", "Optional GDAL output data type. Allowed values: Byte, Int16, UInt16, Int32, UInt32, Float32, Float64.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.spectral-index",
+            Title = "Spectral Index",
+            Description = "Computes a named spectral index from band-role rasters, compiling down to the gdal_calc.py map-algebra core. Executed out-of-process by the heavyweight GDAL worker. Each required band role is supplied as its own base64-encoded GeoTIFF; publishes the Float32 index GeoTIFF as a data-URI artifact. Supported indices: NDVI (nir, red), NDWI (green, nir), NDBI (swir, nir), SAVI (nir, red), EVI (nir, red, blue).",
+            Category = "raster",
+            Parameters =
+            [
+                Param("index", "Index", "Spectral index preset. Allowed values: NDVI, NDWI, NDBI, SAVI, EVI.", ProcessParameterValueType.Text, required: true,
+                    allowedValues: ["NDVI", "NDWI", "NDBI", "SAVI", "EVI"]),
+                Param("red", "Red Band", "Red-band raster as a base64-encoded GeoTIFF. Required by NDVI, SAVI, EVI.", ProcessParameterValueType.Text),
+                Param("nir", "NIR Band", "Near-infrared-band raster as a base64-encoded GeoTIFF. Required by NDVI, NDWI, NDBI, SAVI, EVI.", ProcessParameterValueType.Text),
+                Param("green", "Green Band", "Green-band raster as a base64-encoded GeoTIFF. Required by NDWI.", ProcessParameterValueType.Text),
+                Param("swir", "SWIR Band", "Short-wave-infrared-band raster as a base64-encoded GeoTIFF. Required by NDBI.", ProcessParameterValueType.Text),
+                Param("blue", "Blue Band", "Blue-band raster as a base64-encoded GeoTIFF. Required by EVI.", ProcessParameterValueType.Text),
+                Param("L", "Soil Factor (SAVI)", "SAVI soil-adjustment factor in the closed range [0, 1]. Defaults to 0.5. Ignored by other indices.", ProcessParameterValueType.FloatingPoint, defaultValue: "0.5"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.reclassify",
+            Title = "Reclassify",
+            Description = "Remaps source pixel values per a supplied remap table. Executed out-of-process by the heavyweight GDAL worker via gdal_calc.py. Reads a base64-encoded GeoTIFF from 'source' and a 'remap' table; publishes the reclassified GeoTIFF as a data-URI artifact. Remap entries are ';'-separated 'key:value' pairs where key is a single number or a half-open range 'lo..hi' (lower-inclusive, upper-exclusive); unmatched pixels take 'defaultValue' or the original value.",
+            Category = "raster",
+            Parameters =
+            [
+                .. NativeRasterSourceParameters,
+                Param("remap", "Remap Table", "Reclassification table: ';'-separated 'value:newValue' or 'lo..hi:newValue' entries (e.g. '0..10:1;10..20:2'). Required.", ProcessParameterValueType.Text, required: true),
+                Param("defaultValue", "Default Value", "Optional output value for pixels matching no remap entry. When omitted, unmatched pixels keep their original value.", ProcessParameterValueType.FloatingPoint),
+                Param("dataType", "Output Type", "Optional GDAL output data type. Allowed values: Byte, Int16, UInt16, Int32, UInt32, Float32, Float64.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
 
         // -----------------------------------------------------------------------
-        // Conversion operations (4)
+        // Conversion operations (6)
         // Explicit format/CRS conversion idioms so adapters can expose them
         // without inventing a second semantic layer.
         // -----------------------------------------------------------------------
@@ -857,6 +978,41 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 .. NativeRasterSourceParameters,
                 Param("targetSrid", "Target SRID", "Target spatial reference identifier.", ProcessParameterValueType.Srid, required: true),
                 Param("resampling", "Resampling", "Resampling algorithm. Allowed values: nearestneighbor, bilinear, cubic, lanczos. Defaults to bilinear.", ProcessParameterValueType.Text, defaultValue: "bilinear"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "conversion.polygonize",
+            Title = "Polygonize Raster",
+            Description = "Vectorizes a raster into polygon features, one per connected region of equal pixel value. Executed out-of-process by the heavyweight GDAL worker via gdal_polygonize.py. Reads a base64-encoded GeoTIFF from 'source'; publishes a GeoJSON FeatureCollection carrying the pixel value in the 'fieldName' attribute as a data-URI artifact.",
+            Category = "conversion",
+            Parameters =
+            [
+                .. NativeRasterSourceParameters,
+                Param("band", "Band", "Source band to vectorize. Must be a positive integer. Defaults to 1.", ProcessParameterValueType.WholeNumber, defaultValue: "1"),
+                Param("connectedness", "Connectedness", "Pixel connectedness. Allowed values: 4, 8. Defaults to 4.", ProcessParameterValueType.Text, defaultValue: "4"),
+                Param("fieldName", "Field Name", "Output attribute holding the pixel value. Must match ^[A-Za-z_][A-Za-z0-9_]*$. Defaults to DN.", ProcessParameterValueType.Text, defaultValue: "DN"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "conversion.rasterize",
+            Title = "Rasterize Features",
+            Description = "Burns vector features into a new raster grid. Executed out-of-process by the heavyweight GDAL worker via gdal_rasterize. Reads a base64-encoded GeoJSON FeatureCollection from 'source' and burns either a fixed 'burnValue' or a numeric 'attribute'; publishes the GeoTIFF as a data-URI artifact. The output grid is defined by 'cellSize' (resolution) or 'width'+'height' (pixels); the extent is taken from the input layer.",
+            Category = "conversion",
+            Parameters =
+            [
+                Param("source", "Source Features", "Source features as a base64-encoded GeoJSON FeatureCollection. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("burnValue", "Burn Value", "Fixed value to burn into the raster. Supply exactly one of 'burnValue' or 'attribute'.", ProcessParameterValueType.FloatingPoint),
+                Param("attribute", "Attribute", "Numeric source attribute whose value is burned per feature. Must match ^[A-Za-z_][A-Za-z0-9_]*$. Supply exactly one of 'burnValue' or 'attribute'.", ProcessParameterValueType.Text),
+                Param("cellSize", "Cell Size", "Output pixel size in the source CRS units. Must be > 0. Supply either 'cellSize' or 'width'+'height'.", ProcessParameterValueType.FloatingPoint),
+                Param("width", "Width", "Output raster width in pixels. Must be > 0 and supplied together with 'height'.", ProcessParameterValueType.WholeNumber),
+                Param("height", "Height", "Output raster height in pixels. Must be > 0 and supplied together with 'width'.", ProcessParameterValueType.WholeNumber),
+                Param("nodata", "NoData", "Optional output nodata value.", ProcessParameterValueType.FloatingPoint),
             ],
             OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -651,7 +651,7 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         },
 
         // -----------------------------------------------------------------------
-        // Raster operations (5)
+        // Raster operations (9)
         // Raster analysis and mutation workflows implemented natively by the
         // heavyweight GDAL worker via the gdalwarp / gdalinfo CLI tools. Declared
         // RuntimeProfile = native so the submit path stamps the spec native and
@@ -732,6 +732,70 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 Param("statistics", "Statistics", "Comma-separated stat names. Allowed values: count, sum, mean, min, max, stddev, variance.", ProcessParameterValueType.Text, defaultValue: "count,mean,stddev,min,max,sum"),
             ],
             OutputArtifactKinds = [ArtifactKind.Table],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.resample",
+            Title = "Resample Raster",
+            Description = "Changes a raster's cell size using the requested resampling algorithm. Executed out-of-process by the heavyweight GDAL worker via gdalwarp -tr. Reads a base64-encoded GeoTIFF from 'source'; publishes the resampled GeoTIFF as a data-URI artifact.",
+            Category = "raster",
+            Parameters =
+            [
+                .. NativeRasterSourceParameters,
+                Param("cellSize", "Cell Size", "Target pixel size in the raster's georeferenced units. Must be > 0. Applied to both axes unless 'cellSizeY' is supplied.", ProcessParameterValueType.FloatingPoint, required: true),
+                Param("cellSizeY", "Cell Size Y", "Optional distinct vertical pixel size in georeferenced units. Must be > 0. Defaults to 'cellSize' (square pixels).", ProcessParameterValueType.FloatingPoint),
+                Param("resampling", "Resampling", "Resampling algorithm. Allowed values: nearestneighbor, bilinear, cubic, lanczos. Defaults to bilinear.", ProcessParameterValueType.Text, defaultValue: "bilinear"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.interpolate-idw",
+            Title = "Interpolate (IDW)",
+            Description = "Interpolates a continuous raster surface from scattered points using inverse-distance weighting. Executed out-of-process by the heavyweight GDAL worker via gdal_grid -a invdist. Reads a base64-encoded GeoJSON point FeatureCollection from 'points'; publishes the interpolated GeoTIFF as a data-URI artifact.",
+            Category = "raster",
+            Parameters =
+            [
+                Param("points", "Points", "Source points as a base64-encoded GeoJSON FeatureCollection. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("zField", "Z Field", "Attribute name holding the value to interpolate. When omitted, gdal_grid uses the geometry Z coordinate.", ProcessParameterValueType.Text),
+                Param("power", "Power", "Inverse-distance weighting exponent. Must be > 0. Defaults to 2.0.", ProcessParameterValueType.FloatingPoint, defaultValue: "2.0"),
+                Param("smoothing", "Smoothing", "Smoothing parameter applied during interpolation. Must be >= 0. Defaults to 0.", ProcessParameterValueType.FloatingPoint, defaultValue: "0"),
+                Param("radius", "Search Radius", "Optional search radius in georeferenced units. Must be > 0 when supplied. When omitted, all points contribute (global search).", ProcessParameterValueType.FloatingPoint),
+                Param("width", "Width", "Optional output raster width in pixels. Must be > 0 and supplied together with 'height'.", ProcessParameterValueType.WholeNumber),
+                Param("height", "Height", "Optional output raster height in pixels. Must be > 0 and supplied together with 'width'.", ProcessParameterValueType.WholeNumber),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.interpolate-kriging",
+            Title = "Interpolate (Kriging)",
+            Description = "FLAGGED / UNSUPPORTED in this build: kriging interpolation requires a kriging-capable numerical backend that the worker image does not bundle (stock GDAL gdal_grid has no kriging algorithm). The process is advertised so callers can discover the limitation; a submitted job FAILS with a clear message rather than silently substituting a different algorithm. Use raster.interpolate-idw for inverse-distance-weighted interpolation.",
+            Category = "raster",
+            Parameters =
+            [
+                Param("points", "Points", "Source points as a base64-encoded GeoJSON FeatureCollection.", ProcessParameterValueType.Text, required: true),
+                Param("zField", "Z Field", "Attribute name holding the value to interpolate.", ProcessParameterValueType.Text),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
+            RuntimeProfile = RuntimeProfiles.Native
+        },
+        new ProcessDefinition
+        {
+            ProcessId = "raster.mosaic",
+            Title = "Mosaic Rasters",
+            Description = "Combines two or more input rasters into a single raster. Executed out-of-process by the heavyweight GDAL worker via gdalwarp. Reads a '|'-separated list of base64-encoded GeoTIFFs from 'sources'; publishes the mosaicked GeoTIFF as a data-URI artifact. The 'operator' selects overlap behavior (first/last); statistical operators (min/max/mean/sum) are not yet available on the native worker.",
+            Category = "raster",
+            Parameters =
+            [
+                Param("sources", "Sources", "Two or more source rasters as base64-encoded GeoTIFFs separated by '|'. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("operator", "Operator", "Overlap behavior. Allowed values: first, last. Defaults to last (later-listed source wins).", ProcessParameterValueType.Text, defaultValue: "last"),
+                Param("resampling", "Resampling", "Resampling algorithm. Allowed values: nearestneighbor, bilinear, cubic, lanczos. Defaults to nearestneighbor.", ProcessParameterValueType.Text, defaultValue: "nearestneighbor"),
+            ],
+            OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native
         },
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -67,6 +67,15 @@ internal static partial class ProcessPlanValidator
         "lanczos"
     };
 
+    // Mosaic overlap operators the native worker (GdalRasterMosaicJobExecutor) can
+    // express through gdalwarp source ordering. Statistical operators are not yet
+    // available and are rejected so a plan accepted here is also accepted by the
+    // worker rather than failing at the CLI boundary.
+    private static readonly HashSet<string> RasterMosaicOperatorValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "first", "last"
+    };
+
     private static readonly HashSet<string> RasterFormatValues = new(StringComparer.OrdinalIgnoreCase)
     {
         "gtiff", "geotiff", "tiff", "tif",
@@ -291,6 +300,23 @@ internal static partial class ProcessPlanValidator
                 break;
             case "raster.zonal-statistics":
                 ValidateRasterZonalStatisticsSemantics(step, violations);
+                break;
+            case "raster.resample":
+                ValidateRasterResampleSemantics(step, violations);
+                break;
+            case "raster.interpolate-idw":
+                ValidateRasterInterpolateIdwSemantics(step, violations);
+                break;
+            case "raster.interpolate-kriging":
+                // Kriging is advertised but flagged unsupported by the native worker
+                // (no kriging-capable backend is bundled). The plan is still
+                // shape-validated (the base type-validator enforces the required
+                // 'points' input); the worker FAILS the job at execution with a clear
+                // message rather than the validator blocking it, so the limitation is
+                // surfaced as a job failure rather than a submit-time rejection.
+                break;
+            case "raster.mosaic":
+                ValidateRasterMosaicSemantics(step, violations);
                 break;
             case "conversion.geometry-format":
                 ValidateGeometryFormatConversionSemantics(step, violations);
@@ -841,6 +867,56 @@ internal static partial class ProcessPlanValidator
         ValidateSharedRasterSourceSemantics(step, violations);
         RequireIntAtLeast(step, "band", 1, violations);
         ValidateEnumList(step, "statistics", RasterZonalStatisticValues, "count, sum, mean, min, max, stddev, variance", violations);
+    }
+
+    private static void ValidateRasterResampleSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        ValidateSharedRasterSourceSemantics(step, violations);
+        RequirePositiveFiniteDouble(step, "cellSize", violations);
+        RequirePositiveFiniteDouble(step, "cellSizeY", violations);
+
+        if (step.Inputs.TryGetValue("resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw)
+            && !RasterResamplingValues.Contains(resamplingRaw.Trim()))
+        {
+            AddEnumViolation(step, "resampling", resamplingRaw, "nearestneighbor, bilinear, cubic, lanczos", violations);
+        }
+    }
+
+    private static void ValidateRasterInterpolateIdwSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'points' is a declared-required base64 input enforced by the base
+        // type-validator. The IDW tuning parameters mirror gdal_grid's invdist
+        // options; range-check them so a plan accepted here is accepted by the CLI.
+        RequirePositiveFiniteDouble(step, "power", violations);
+        RequireNonNegativeFiniteDouble(step, "smoothing", violations);
+        RequirePositiveFiniteDouble(step, "radius", violations);
+        RequireIntAtLeast(step, "width", 1, violations);
+        RequireIntAtLeast(step, "height", 1, violations);
+    }
+
+    private static void ValidateRasterMosaicSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'sources' is a declared-required input enforced by the base type-validator.
+        if (step.Inputs.TryGetValue("operator", out var operatorRaw)
+            && !string.IsNullOrWhiteSpace(operatorRaw)
+            && !RasterMosaicOperatorValues.Contains(operatorRaw.Trim()))
+        {
+            AddEnumViolation(step, "operator", operatorRaw, "first, last", violations);
+        }
+
+        if (step.Inputs.TryGetValue("resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw)
+            && !RasterResamplingValues.Contains(resamplingRaw.Trim()))
+        {
+            AddEnumViolation(step, "resampling", resamplingRaw, "nearestneighbor, bilinear, cubic, lanczos", violations);
+        }
     }
 
     private static void ValidateGeometryFormatConversionSemantics(
@@ -1594,6 +1670,24 @@ internal static partial class ProcessPlanValidator
             || parsed <= 0d)
         {
             AddRangeViolationIfNew(step, parameter, $"expected positive number, got '{value}'", violations);
+        }
+    }
+
+    private static void RequireNonNegativeFiniteDouble(
+        AnalysisPlanStep step,
+        string parameter,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        if (!step.Inputs.TryGetValue(parameter, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed) || double.IsInfinity(parsed)
+            || parsed < 0d)
+        {
+            AddRangeViolationIfNew(step, parameter, $"expected non-negative number, got '{value}'", violations);
         }
     }
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -959,6 +959,16 @@ internal static partial class ProcessPlanValidator
         RequirePositiveFiniteDouble(step, "radius", violations);
         RequireIntAtLeast(step, "width", 1, violations);
         RequireIntAtLeast(step, "height", 1, violations);
+
+        // gdal_grid -outsize requires BOTH dimensions; reject a half-specified grid up
+        // front so submit-time validation matches the executor (which fails the job for
+        // the same XOR), mirroring ValidateConversionRasterizeSemantics.
+        var hasWidth = step.Inputs.TryGetValue("width", out var width) && !string.IsNullOrWhiteSpace(width);
+        var hasHeight = step.Inputs.TryGetValue("height", out var height) && !string.IsNullOrWhiteSpace(height);
+        if (hasWidth ^ hasHeight)
+        {
+            AddRangeViolationIfNew(step, "width", "supply both 'width' and 'height' together to set the output grid size", violations);
+        }
     }
 
     private static void ValidateRasterMosaicSemantics(

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -84,6 +84,37 @@ internal static partial class ProcessPlanValidator
         "cog"
     };
 
+    // gdal_calc.py --type values accepted by the calc-family executors
+    // (raster.map-algebra / raster.spectral-index / raster.reclassify). Mirrors
+    // GdalCalcInputs.TryNormalizeDataType so a plan accepted here is accepted by
+    // the worker.
+    private static readonly HashSet<string> RasterCalcDataTypeValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "byte", "int16", "uint16", "int32", "uint32", "float32", "float64"
+    };
+
+    // Spectral-index presets the native worker (GdalRasterSpectralIndexJobExecutor)
+    // recognizes, with the band roles each requires.
+    private static readonly HashSet<string> SpectralIndexValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ndvi", "ndwi", "ndbi", "savi", "evi"
+    };
+
+    // Euclidean-distance units the native worker passes to gdal_proximity -distunits.
+    private static readonly HashSet<string> ProximityDistanceUnitValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "GEO", "PIXEL"
+    };
+
+    // NumPy element-wise functions the map-algebra allow-list admits. Mirrors
+    // MapAlgebraExpression.AllowedFunctions in the worker.
+    private static readonly HashSet<string> MapAlgebraFunctions = new(StringComparer.Ordinal)
+    {
+        "abs", "absolute", "minimum", "maximum", "sqrt", "exp", "log", "log10",
+        "power", "where", "clip", "sign", "floor", "ceil", "mod", "fmod",
+        "sin", "cos", "tan", "arctan", "nan_to_num"
+    };
+
     private static readonly HashSet<string> GeometryFormatValues = new(StringComparer.OrdinalIgnoreCase)
     {
         "wkt", "geojson", "wkb", "ewkt"
@@ -317,6 +348,37 @@ internal static partial class ProcessPlanValidator
                 break;
             case "raster.mosaic":
                 ValidateRasterMosaicSemantics(step, violations);
+                break;
+            case "raster.map-algebra":
+                ValidateRasterMapAlgebraSemantics(step, violations);
+                break;
+            case "raster.spectral-index":
+                ValidateRasterSpectralIndexSemantics(step, violations);
+                break;
+            case "raster.reclassify":
+                ValidateRasterReclassifySemantics(step, violations);
+                break;
+            case "proximity.euclidean-distance":
+                ValidateProximityEuclideanDistanceSemantics(step, violations);
+                break;
+            case "proximity.euclidean-allocation":
+                // Euclidean allocation is advertised but flagged unsupported by the
+                // native worker (stock gdal_proximity has no allocation mode). The
+                // plan is still shape-validated (the base type-validator enforces the
+                // required 'source' input); the worker FAILS the job at execution with
+                // a clear message rather than the validator blocking it.
+                break;
+            case "surface.contour":
+                ValidateSurfaceContourSemantics(step, violations);
+                break;
+            case "surface.viewshed":
+                ValidateSurfaceViewshedSemantics(step, violations);
+                break;
+            case "conversion.polygonize":
+                ValidateConversionPolygonizeSemantics(step, violations);
+                break;
+            case "conversion.rasterize":
+                ValidateConversionRasterizeSemantics(step, violations);
                 break;
             case "conversion.geometry-format":
                 ValidateGeometryFormatConversionSemantics(step, violations);
@@ -917,6 +979,361 @@ internal static partial class ProcessPlanValidator
         {
             AddEnumViolation(step, "resampling", resamplingRaw, "nearestneighbor, bilinear, cubic, lanczos", violations);
         }
+    }
+
+    private static void ValidateRasterMapAlgebraSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'sources' and 'expression' are declared-required inputs enforced by the
+        // base type-validator. Validate the expression against the same allow-list
+        // the worker (MapAlgebraExpression) enforces, since gdal_calc.py eval()'s it.
+        var bandCount = 0;
+        if (step.Inputs.TryGetValue("sources", out var sourcesRaw) && !string.IsNullOrWhiteSpace(sourcesRaw))
+        {
+            bandCount = sourcesRaw.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length;
+            if (bandCount > 26)
+            {
+                AddRangeViolationIfNew(step, "sources", $"at most 26 rasters may be supplied (one per band variable A–Z), got {bandCount}", violations);
+            }
+        }
+
+        if (step.Inputs.TryGetValue("expression", out var expression)
+            && !string.IsNullOrWhiteSpace(expression)
+            && !IsAllowedMapAlgebraExpression(expression, bandCount, out var expressionError))
+        {
+            AddRangeViolationIfNew(step, "expression", expressionError, violations);
+        }
+
+        ValidateCalcDataType(step, violations);
+    }
+
+    private static void ValidateRasterSpectralIndexSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        if (!step.Inputs.TryGetValue("index", out var indexRaw) || string.IsNullOrWhiteSpace(indexRaw))
+        {
+            return;
+        }
+
+        var index = indexRaw.Trim();
+        if (!SpectralIndexValues.Contains(index))
+        {
+            AddEnumViolation(step, "index", indexRaw, "NDVI, NDWI, NDBI, SAVI, EVI", violations);
+            return;
+        }
+
+        // Each preset requires a specific set of band-role rasters; reject a plan
+        // missing one so it does not route to the worker and fail there.
+        var required = index.ToUpperInvariant() switch
+        {
+            "NDVI" => new[] { "nir", "red" },
+            "NDWI" => new[] { "green", "nir" },
+            "NDBI" => new[] { "swir", "nir" },
+            "SAVI" => new[] { "nir", "red" },
+            "EVI" => new[] { "nir", "red", "blue" },
+            _ => [],
+        };
+        foreach (var role in required)
+        {
+            if (!step.Inputs.TryGetValue(role, out var roleValue) || string.IsNullOrWhiteSpace(roleValue))
+            {
+                RequireConditionalParameter(step, role, $"the '{index}' index requires it", violations);
+            }
+        }
+
+        RequireDoubleInClosedRange(step, "L", 0d, 1d, "(soil factor)", violations);
+    }
+
+    private static void ValidateRasterReclassifySemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'source' and 'remap' are declared-required inputs enforced by the base
+        // type-validator. Validate the remap table parses to numeric entries.
+        if (step.Inputs.TryGetValue("remap", out var remap)
+            && !string.IsNullOrWhiteSpace(remap)
+            && !IsParseableRemap(remap, out var remapError))
+        {
+            AddRangeViolationIfNew(step, "remap", remapError, violations);
+        }
+
+        RequireFiniteDouble(step, "defaultValue", violations);
+        ValidateCalcDataType(step, violations);
+    }
+
+    private static void ValidateProximityEuclideanDistanceSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'source' is a declared-required input enforced by the base type-validator.
+        RequirePositiveFiniteDouble(step, "maxDistance", violations);
+
+        if (step.Inputs.TryGetValue("distUnits", out var distUnits)
+            && !string.IsNullOrWhiteSpace(distUnits)
+            && !ProximityDistanceUnitValues.Contains(distUnits.Trim()))
+        {
+            AddEnumViolation(step, "distUnits", distUnits, "GEO, PIXEL", violations);
+        }
+
+        if (step.Inputs.TryGetValue("values", out var values) && !string.IsNullOrWhiteSpace(values))
+        {
+            var parts = values.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 0 || parts.Any(p => !long.TryParse(p, NumberStyles.Integer, CultureInfo.InvariantCulture, out _)))
+            {
+                AddRangeViolationIfNew(step, "values", "expected one or more comma-separated integer pixel values", violations);
+            }
+        }
+    }
+
+    private static void ValidateSurfaceContourSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'source' and 'interval' are declared-required inputs enforced by the base
+        // type-validator.
+        RequirePositiveFiniteDouble(step, "interval", violations);
+        RequireFiniteDouble(step, "base", violations);
+    }
+
+    private static void ValidateSurfaceViewshedSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'source', 'observerX', 'observerY' are declared-required inputs enforced by
+        // the base type-validator.
+        RequireFiniteDouble(step, "observerX", violations);
+        RequireFiniteDouble(step, "observerY", violations);
+        RequireNonNegativeFiniteDouble(step, "observerHeight", violations);
+        RequireNonNegativeFiniteDouble(step, "targetHeight", violations);
+        RequirePositiveFiniteDouble(step, "maxDistance", violations);
+    }
+
+    private static void ValidateConversionPolygonizeSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'source' is a declared-required input enforced by the base type-validator.
+        RequireIntAtLeast(step, "band", 1, violations);
+
+        if (step.Inputs.TryGetValue("connectedness", out var conn)
+            && !string.IsNullOrWhiteSpace(conn)
+            && conn.Trim() is not "4" and not "8")
+        {
+            AddEnumViolation(step, "connectedness", conn, "4, 8", violations);
+        }
+
+        if (step.Inputs.TryGetValue("fieldName", out var fieldName)
+            && !string.IsNullOrWhiteSpace(fieldName)
+            && !IsValidGdalFieldName(fieldName))
+        {
+            AddRangeViolationIfNew(step, "fieldName", "must match ^[A-Za-z_][A-Za-z0-9_]*$", violations);
+        }
+    }
+
+    private static void ValidateConversionRasterizeSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // 'source' is a declared-required input enforced by the base type-validator.
+        var hasBurn = step.Inputs.TryGetValue("burnValue", out var burn) && !string.IsNullOrWhiteSpace(burn);
+        var hasAttribute = step.Inputs.TryGetValue("attribute", out var attribute) && !string.IsNullOrWhiteSpace(attribute);
+        if (hasBurn == hasAttribute)
+        {
+            AddRangeViolationIfNew(step, "burnValue", "supply exactly one of 'burnValue' or 'attribute'", violations);
+        }
+
+        RequireFiniteDouble(step, "burnValue", violations);
+        if (hasAttribute && !IsValidGdalFieldName(attribute!))
+        {
+            AddRangeViolationIfNew(step, "attribute", "must match ^[A-Za-z_][A-Za-z0-9_]*$", violations);
+        }
+
+        var hasCellSize = step.Inputs.TryGetValue("cellSize", out var cell) && !string.IsNullOrWhiteSpace(cell);
+        var hasWidth = step.Inputs.TryGetValue("width", out var width) && !string.IsNullOrWhiteSpace(width);
+        var hasHeight = step.Inputs.TryGetValue("height", out var height) && !string.IsNullOrWhiteSpace(height);
+        if (hasCellSize && (hasWidth || hasHeight))
+        {
+            AddRangeViolationIfNew(step, "cellSize", "supply either 'cellSize' or 'width'+'height', not both", violations);
+        }
+        else if (!hasCellSize && !(hasWidth && hasHeight))
+        {
+            AddRangeViolationIfNew(step, "cellSize", "supply either 'cellSize' or both 'width' and 'height' to define the output grid", violations);
+        }
+
+        RequirePositiveFiniteDouble(step, "cellSize", violations);
+        RequireIntAtLeast(step, "width", 1, violations);
+        RequireIntAtLeast(step, "height", 1, violations);
+        RequireFiniteDouble(step, "nodata", violations);
+    }
+
+    private static void ValidateCalcDataType(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        if (step.Inputs.TryGetValue("dataType", out var dataType)
+            && !string.IsNullOrWhiteSpace(dataType)
+            && !RasterCalcDataTypeValues.Contains(dataType.Trim()))
+        {
+            AddEnumViolation(step, "dataType", dataType, "Byte, Int16, UInt16, Int32, UInt32, Float32, Float64", violations);
+        }
+    }
+
+    // Mirror of MapAlgebraExpression.IsAllowed in the worker: gdal_calc.py eval()'s
+    // the calc string, so an un-vetted expression is RCE. Admits only single-letter
+    // band variables (within the supplied band count), numeric literals, a fixed
+    // operator/grouping set, and an allow-list of NumPy functions.
+    private static bool IsAllowedMapAlgebraExpression(string expression, int bandCount, out string error)
+    {
+        error = "";
+        var expr = expression.Trim();
+        if (expr.Length == 0)
+        {
+            error = "must not be empty";
+            return false;
+        }
+        if (expr.Length > 2048)
+        {
+            error = "exceeds the maximum length of 2048 characters";
+            return false;
+        }
+
+        var i = 0;
+        var referencedAny = false;
+        while (i < expr.Length)
+        {
+            var c = expr[i];
+            if (char.IsWhiteSpace(c) || IsAllowedMapAlgebraSymbol(c))
+            {
+                i++;
+                continue;
+            }
+
+            if (char.IsDigit(c) || c == '.')
+            {
+                while (i < expr.Length && (char.IsDigit(expr[i]) || expr[i] is '.' or 'e' or 'E'))
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (char.IsAsciiLetter(c))
+            {
+                var start = i;
+                while (i < expr.Length && char.IsAsciiLetterOrDigit(expr[i]))
+                {
+                    i++;
+                }
+                var identifier = expr[start..i];
+                if (identifier.Length == 1 && identifier[0] is >= 'A' and <= 'Z')
+                {
+                    if (identifier[0] - 'A' >= bandCount)
+                    {
+                        error = $"references band variable '{identifier}' but only {bandCount} source raster(s) were supplied";
+                        return false;
+                    }
+                    referencedAny = true;
+                    continue;
+                }
+                if (MapAlgebraFunctions.Contains(identifier))
+                {
+                    continue;
+                }
+                error = $"contains a disallowed identifier '{identifier}'";
+                return false;
+            }
+
+            error = $"contains a disallowed character '{c}'";
+            return false;
+        }
+
+        if (!referencedAny)
+        {
+            error = "must reference at least one source band variable (A, B, …)";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsAllowedMapAlgebraSymbol(char c) => c switch
+    {
+        '+' or '-' or '*' or '/' or '%' or '(' or ')' or ',' or '.' => true,
+        '<' or '>' or '=' or '!' or '&' or '|' or '^' or '~' => true,
+        _ => false,
+    };
+
+    // Mirror of GdalRasterReclassifyJobExecutor.TryBuildCalc's table parser: every
+    // remap key/value must be numeric so the worker can fold it into a trusted calc.
+    private static bool IsParseableRemap(string remap, out string error)
+    {
+        error = "";
+        var entries = remap.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (entries.Length == 0)
+        {
+            error = "must list at least one 'value:newValue' or 'lo..hi:newValue' entry";
+            return false;
+        }
+
+        foreach (var entry in entries)
+        {
+            var colon = entry.IndexOf(':', StringComparison.Ordinal);
+            if (colon <= 0 || colon == entry.Length - 1)
+            {
+                error = $"entry '{entry}' must have the form 'value:newValue' or 'lo..hi:newValue'";
+                return false;
+            }
+
+            var keyPart = entry[..colon].Trim();
+            var valuePart = entry[(colon + 1)..].Trim();
+            if (!IsFiniteNumber(valuePart))
+            {
+                error = $"entry '{entry}' has a non-numeric output value";
+                return false;
+            }
+
+            var range = keyPart.IndexOf("..", StringComparison.Ordinal);
+            if (range >= 0)
+            {
+                var loRaw = keyPart[..range].Trim();
+                var hiRaw = keyPart[(range + 2)..].Trim();
+                if (!IsFiniteNumber(loRaw) || !IsFiniteNumber(hiRaw))
+                {
+                    error = $"entry '{entry}' has a non-numeric range bound";
+                    return false;
+                }
+                if (double.Parse(hiRaw, CultureInfo.InvariantCulture) <= double.Parse(loRaw, CultureInfo.InvariantCulture))
+                {
+                    error = $"entry '{entry}' must have lo < hi";
+                    return false;
+                }
+            }
+            else if (!IsFiniteNumber(keyPart))
+            {
+                error = $"entry '{entry}' has a non-numeric key";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsFiniteNumber(string raw)
+        => double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+            && !double.IsNaN(value) && !double.IsInfinity(value);
+
+    // Mirror of GdalFieldName.IsValid in the worker.
+    private static bool IsValidGdalFieldName(string value)
+    {
+        var token = value.Trim();
+        if (token.Length is 0 or > 128 || !(char.IsAsciiLetter(token[0]) || token[0] == '_'))
+        {
+            return false;
+        }
+
+        return token.All(c => char.IsAsciiLetterOrDigit(c) || c == '_');
     }
 
     private static void ValidateGeometryFormatConversionSemantics(
@@ -1688,6 +2105,23 @@ internal static partial class ProcessPlanValidator
             || parsed < 0d)
         {
             AddRangeViolationIfNew(step, parameter, $"expected non-negative number, got '{value}'", violations);
+        }
+    }
+
+    private static void RequireFiniteDouble(
+        AnalysisPlanStep step,
+        string parameter,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        if (!step.Inputs.TryGetValue(parameter, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed) || double.IsInfinity(parsed))
+        {
+            AddRangeViolationIfNew(step, parameter, $"expected a finite number, got '{value}'", violations);
         }
     }
 

--- a/src/Honua.Geoprocessing/Honua.Geoprocessing.csproj
+++ b/src/Honua.Geoprocessing/Honua.Geoprocessing.csproj
@@ -60,6 +60,10 @@
          registration to resolve the managed IProcessExecutor set Redis-free.
          Grant matches the CLI's AssemblyName (honua-gp), not its project name. -->
     <InternalsVisibleTo Include="honua-gp" />
+    <!-- Cross-project honesty check (#2253): the GDAL worker test asserts every
+         native-routed catalog process (BuiltInProcessCatalog) is routable by the
+         worker dispatcher, so it needs the internal catalog. -->
+    <InternalsVisibleTo Include="Honua.Worker.Gdal.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Honua.Worker.Gdal/Execution/GdalCalcInputs.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalCalcInputs.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Shared input helpers for the <c>gdal_calc.py</c>-backed executors
+/// (<c>raster.map-algebra</c>, <c>raster.spectral-index</c>, <c>raster.reclassify</c>;
+/// #2239): decoding the <c>|</c>-separated base64 source list and normalizing the
+/// optional output data-type token against a fixed allow-list. Centralized so the
+/// per-source <c>MaxArtifactBytes</c> ceiling and the accepted GDAL type set are
+/// enforced identically across the calc family.
+/// </summary>
+internal static class GdalCalcInputs
+{
+    /// <summary>Separator between base64 raster entries in a <c>sources</c> input.</summary>
+    public const string SourceSeparator = "|";
+
+    /// <summary>
+    /// GDAL output data types accepted by <c>gdal_calc.py --type</c>. Kept in sync
+    /// with <c>ProcessPlanValidator.RasterCalcDataTypeValues</c>.
+    /// </summary>
+    private static readonly FrozenDictionary<string, string> DataTypes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["byte"] = "Byte",
+            ["int16"] = "Int16",
+            ["uint16"] = "UInt16",
+            ["int32"] = "Int32",
+            ["uint32"] = "UInt32",
+            ["float32"] = "Float32",
+            ["float64"] = "Float64",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Decodes the <c>|</c>-separated base64 <c>sources</c> list, enforcing the
+    /// per-entry <c>MaxArtifactBytes</c> ceiling and requiring at least one input.
+    /// </summary>
+    public static bool TryDecodeSources(
+        IReadOnlyDictionary<string, string> parameters,
+        long maxBytes,
+        out List<byte[]> sources,
+        out string failure)
+    {
+        sources = [];
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "sources", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            failure = "missing required input 'sources'";
+            return false;
+        }
+
+        var entries = raw.Split(SourceSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (entries.Length == 0)
+        {
+            failure = $"'sources' must list at least one base64 GeoTIFF raster (separator '{SourceSeparator}')";
+            return false;
+        }
+
+        if (entries.Length > 26)
+        {
+            failure = $"'sources' must list at most 26 rasters (one per band variable A–Z); got {entries.Length.ToString(CultureInfo.InvariantCulture)}";
+            return false;
+        }
+
+        var decoded = new List<byte[]>(entries.Length);
+        for (var i = 0; i < entries.Length; i++)
+        {
+            var entry = entries[i];
+            if ((long)entry.Length / 4 * 3 > maxBytes)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(entry);
+            }
+            catch (FormatException)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} is not valid base64";
+                return false;
+            }
+
+            if (bytes.Length == 0)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} decoded to zero bytes";
+                return false;
+            }
+
+            if (bytes.Length > maxBytes)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} size {bytes.Length.ToString(CultureInfo.InvariantCulture)} bytes exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            decoded.Add(bytes);
+        }
+
+        sources = decoded;
+        return true;
+    }
+
+    /// <summary>
+    /// Normalizes a requested GDAL output data type onto its canonical
+    /// <c>gdal_calc.py --type</c> token, rejecting any value outside the allow-list.
+    /// </summary>
+    public static bool TryNormalizeDataType(string raw, out string? normalized, out string failure)
+    {
+        normalized = null;
+        failure = "";
+        if (!DataTypes.TryGetValue(raw.Trim(), out var mapped))
+        {
+            failure = $"'dataType' value '{raw}' is not in the allowed set (Byte, Int16, UInt16, Int32, UInt32, Float32, Float64)";
+            return false;
+        }
+
+        normalized = mapped;
+        return true;
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalCalcInputs.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalCalcInputs.cs
@@ -68,6 +68,7 @@ internal static class GdalCalcInputs
         }
 
         var decoded = new List<byte[]>(entries.Length);
+        long totalBytes = 0;
         for (var i = 0; i < entries.Length; i++)
         {
             var entry = entries[i];
@@ -97,6 +98,16 @@ internal static class GdalCalcInputs
             if (bytes.Length > maxBytes)
             {
                 failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} size {bytes.Length.ToString(CultureInfo.InvariantCulture)} bytes exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            // The decoder buffers every source in memory simultaneously, so bound the
+            // aggregate decoded size by the same MaxArtifactBytes ceiling used for the
+            // single output artifact rather than letting N×per-source slip through.
+            totalBytes += bytes.Length;
+            if (totalBytes > maxBytes)
+            {
+                failure = $"decoded sources total {totalBytes.ToString(CultureInfo.InvariantCulture)} bytes, exceeding configured MaxArtifactBytes={maxBytes}";
                 return false;
             }
 

--- a/src/Honua.Worker.Gdal/Execution/GdalContourJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalContourJobExecutor.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>surface.contour</c>
+/// process: generates contour LINES from a DEM, backed by the GDAL
+/// <c>gdal_contour</c> CLI (#2240).
+///
+/// <para>
+/// Reads a base64-encoded GeoTIFF DEM from <c>source</c> and emits a GeoJSON
+/// FeatureCollection of contour lines carrying an <c>ELEV</c> elevation attribute,
+/// at the requested <c>interval</c> and optional elevation <c>base</c> offset.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalContourJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalContourJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "surface.contour";
+
+    private const string GeoJsonContentType = "application/geo+json";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing contour inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "interval", out var intervalRaw) || string.IsNullOrWhiteSpace(intervalRaw))
+        {
+            return JobExecutionResult.Failed("Invalid contour inputs: missing required input 'interval'.");
+        }
+
+        if (!double.TryParse(intervalRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var interval)
+            || double.IsNaN(interval) || double.IsInfinity(interval) || interval <= 0d)
+        {
+            return JobExecutionResult.Failed(
+                $"Invalid contour inputs: 'interval' must be a positive finite number; got '{intervalRaw}'.");
+        }
+
+        double? offset = null;
+        if (GdalJobInputReader.TryGetInput(parameters, "base", out var baseRaw) && !string.IsNullOrWhiteSpace(baseRaw))
+        {
+            if (!double.TryParse(baseRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+                || double.IsNaN(parsed) || double.IsInfinity(parsed))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid contour inputs: 'base' must be a finite number; got '{baseRaw}'.");
+            }
+            offset = parsed;
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid contour inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.tif");
+            var outputPath = Path.Combine(workspace, "output.geojson");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-a", "ELEV",
+                "-i", interval.ToString("R", CultureInfo.InvariantCulture),
+                "-f", "GeoJSON",
+            };
+            if (offset.HasValue)
+            {
+                args.Add("-off");
+                args.Add(offset.Value.ToString("R", CultureInfo.InvariantCulture));
+            }
+            args.Add(inputPath);
+            args.Add(outputPath);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_contour", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_contour", args, workspace, outputPath,
+                GeoJsonContentType, "Contour vector",
+                "Encoding contour vector artifact", "Contour completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9380, LogLevel.Warning,
+            "GDAL contour executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9381, LogLevel.Warning,
+            "GDAL contour executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalDataUri.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalDataUri.cs
@@ -23,7 +23,10 @@ internal static class GdalDataUri
         ArgumentNullException.ThrowIfNull(contentType);
         ArgumentNullException.ThrowIfNull(payload);
 
-        var sb = new StringBuilder(payload.Length * 2 + contentType.Length + 32);
+        // base64 encodes 3 input bytes as 4 output chars (rounded up to a 4-char
+        // group), plus the "data:" + ";base64," envelope and the content type.
+        var base64Length = (payload.Length + 2) / 3 * 4;
+        var sb = new StringBuilder(base64Length + contentType.Length + 16);
         sb.Append("data:");
         sb.Append(contentType);
         sb.Append(";base64,");

--- a/src/Honua.Worker.Gdal/Execution/GdalFieldName.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalFieldName.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Shared attribute-name allow-shape for the raster&lt;-&gt;vector executors
+/// (<c>conversion.polygonize</c> field name, <c>conversion.rasterize</c> burn
+/// attribute; #2240). Restricts identifiers to <c>^[A-Za-z_][A-Za-z0-9_]*$</c> so a
+/// value cannot influence CLI flag parsing or downstream SQL/OGR field handling.
+/// </summary>
+internal static class GdalFieldName
+{
+    /// <summary>Returns whether <paramref name="value"/> is a safe attribute identifier.</summary>
+    public static bool IsValid(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var token = value.Trim();
+        if (token.Length > 128)
+        {
+            return false;
+        }
+
+        if (!(char.IsAsciiLetter(token[0]) || token[0] == '_'))
+        {
+            return false;
+        }
+
+        foreach (var c in token)
+        {
+            if (!(char.IsAsciiLetterOrDigit(c) || c == '_'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalPolygonizeJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalPolygonizeJobExecutor.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>conversion.polygonize</c>
+/// process: vectorizes a raster into polygon features (one per connected region of
+/// equal pixel value), backed by the GDAL <c>gdal_polygonize.py</c> CLI (#2240).
+///
+/// <para>
+/// Reads a base64-encoded GeoTIFF from <c>source</c> and publishes a GeoJSON
+/// FeatureCollection of polygons carrying the pixel value in the <c>fieldName</c>
+/// attribute (default <c>DN</c>), using the requested band and connectedness.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalPolygonizeJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalPolygonizeJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "conversion.polygonize";
+
+    private const string GeoJsonContentType = "application/geo+json";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing polygonize inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        var band = 1;
+        if (GdalJobInputReader.TryGetInput(parameters, "band", out var bandRaw) && !string.IsNullOrWhiteSpace(bandRaw))
+        {
+            if (!int.TryParse(bandRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out band) || band < 1)
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid polygonize inputs: 'band' must be a positive integer; got '{bandRaw}'.");
+            }
+        }
+
+        var eightConnected = false;
+        if (GdalJobInputReader.TryGetInput(parameters, "connectedness", out var connRaw) && !string.IsNullOrWhiteSpace(connRaw))
+        {
+            var conn = connRaw.Trim();
+            if (string.Equals(conn, "8", StringComparison.Ordinal))
+            {
+                eightConnected = true;
+            }
+            else if (!string.Equals(conn, "4", StringComparison.Ordinal))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid polygonize inputs: 'connectedness' must be 4 or 8; got '{connRaw}'.");
+            }
+        }
+
+        var fieldName = "DN";
+        if (GdalJobInputReader.TryGetInput(parameters, "fieldName", out var fieldRaw) && !string.IsNullOrWhiteSpace(fieldRaw))
+        {
+            if (!GdalFieldName.IsValid(fieldRaw))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid polygonize inputs: 'fieldName' must match ^[A-Za-z_][A-Za-z0-9_]*$; got '{fieldRaw}'.");
+            }
+            fieldName = fieldRaw.Trim();
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid polygonize inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.tif");
+            var outputPath = Path.Combine(workspace, "output.geojson");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            // gdal_polygonize.py [-8] -b band -f fmt -q raster out_file layer fieldname.
+            var args = new List<string>();
+            if (eightConnected)
+            {
+                args.Add("-8");
+            }
+            args.Add("-b");
+            args.Add(band.ToString(CultureInfo.InvariantCulture));
+            args.Add("-f");
+            args.Add("GeoJSON");
+            args.Add("-q");
+            args.Add(inputPath);
+            args.Add(outputPath);
+            args.Add("polygonized");
+            args.Add(fieldName);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_polygonize", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_polygonize.py", args, workspace, outputPath,
+                GeoJsonContentType, "Polygonized vector",
+                "Encoding polygonized vector artifact", "Polygonize completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9400, LogLevel.Warning,
+            "GDAL polygonize executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9401, LogLevel.Warning,
+            "GDAL polygonize executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalProximityJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalProximityJobExecutor.cs
@@ -1,0 +1,242 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the Euclidean-proximity family
+/// (#2240): <c>proximity.euclidean-distance</c>, a distance-to-nearest-source raster
+/// backed by the GDAL <c>gdal_proximity.py</c> CLI, and
+/// <c>proximity.euclidean-allocation</c>, which is FLAGGED unsupported in this build.
+///
+/// <para>
+/// Distance reads a base64-encoded source GeoTIFF whose non-zero (or
+/// <c>values</c>-listed) pixels are the proximity targets, and publishes a Float32
+/// distance raster honoring the requested distance units and optional maximum
+/// distance.
+/// </para>
+/// <para>
+/// Allocation (assigning each cell the value of its nearest source) has NO equivalent
+/// in stock <c>gdal_proximity.py</c> — the CLI computes distance only and has no
+/// nearest-source allocation mode. Rather than silently substitute a distance raster
+/// or a fixed-buffer value, the executor FAILS the job with a clear message so the
+/// limitation is explicit, mirroring the flagged-kriging contract (#2141).
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalProximityJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalProximityJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>Process id for the Euclidean distance raster.</summary>
+    public const string DistanceProcessId = "proximity.euclidean-distance";
+
+    /// <summary>Process id for Euclidean allocation (flagged unsupported).</summary>
+    public const string AllocationProcessId = "proximity.euclidean-allocation";
+
+    /// <summary>
+    /// Stable failure message published when an allocation job is submitted. Stock
+    /// <c>gdal_proximity.py</c> has no nearest-source allocation mode.
+    /// </summary>
+    public const string AllocationUnsupportedMessage =
+        "Euclidean allocation is not available in this build: stock GDAL gdal_proximity computes distance only and "
+        + "has no nearest-source allocation mode. Use proximity.euclidean-distance for the distance raster.";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly FrozenSet<string> HandledProcessIds = new HashSet<string>(StringComparer.Ordinal)
+    {
+        DistanceProcessId,
+        AllocationProcessId,
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    private static readonly FrozenSet<string> DistanceUnits = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "GEO",
+        "PIXEL",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Process ids this executor routes.</summary>
+    public static IReadOnlyCollection<string> SupportedProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (processId is null || !HandledProcessIds.Contains(processId))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the proximity executor.");
+        }
+
+        if (string.Equals(processId, AllocationProcessId, StringComparison.Ordinal))
+        {
+            Log.AllocationUnsupported(logger, job.OperationId);
+            return JobExecutionResult.Failed(AllocationUnsupportedMessage);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing proximity inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        var distUnits = "GEO";
+        if (GdalJobInputReader.TryGetInput(parameters, "distUnits", out var distUnitsRaw)
+            && !string.IsNullOrWhiteSpace(distUnitsRaw))
+        {
+            if (!DistanceUnits.Contains(distUnitsRaw.Trim()))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid proximity inputs: 'distUnits' value '{distUnitsRaw}' is not in the allowed set (GEO, PIXEL).");
+            }
+            distUnits = distUnitsRaw.Trim().ToUpperInvariant();
+        }
+
+        double? maxDistance = null;
+        if (GdalJobInputReader.TryGetInput(parameters, "maxDistance", out var maxRaw) && !string.IsNullOrWhiteSpace(maxRaw))
+        {
+            if (!TryParsePositive(maxRaw, out var parsed))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid proximity inputs: 'maxDistance' must be a positive finite number; got '{maxRaw}'.");
+            }
+            maxDistance = parsed;
+        }
+
+        string? values = null;
+        if (GdalJobInputReader.TryGetInput(parameters, "values", out var valuesRaw) && !string.IsNullOrWhiteSpace(valuesRaw))
+        {
+            if (!TryNormalizeValues(valuesRaw, out values, out var valuesError))
+            {
+                return JobExecutionResult.Failed($"Invalid proximity inputs: {valuesError}");
+            }
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid proximity inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.tif");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            // gdal_proximity.py [options] srcfile dstfile — keep the positional
+            // src/dst pair last so the output path is the final argument.
+            var args = new List<string>
+            {
+                "-of", "GTiff",
+                "-ot", "Float32",
+                "-distunits", distUnits,
+            };
+            if (maxDistance.HasValue)
+            {
+                args.Add("-maxdist");
+                args.Add(maxDistance.Value.ToString("R", CultureInfo.InvariantCulture));
+            }
+            if (values is not null)
+            {
+                args.Add("-values");
+                args.Add(values);
+            }
+            args.Add(inputPath);
+            args.Add(outputPath);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_proximity", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_proximity.py", args, workspace, outputPath,
+                GeoTiffContentType, "Proximity raster",
+                "Encoding proximity raster artifact", "Proximity completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Validates and re-serializes the comma-separated target pixel value list so
+    /// only finite integers reach the <c>-values</c> flag.
+    /// </summary>
+    private static bool TryNormalizeValues(string raw, out string? values, out string failure)
+    {
+        values = null;
+        failure = "";
+        var parts = raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+        {
+            failure = "'values' must list one or more comma-separated integer pixel values";
+            return false;
+        }
+
+        var normalized = new List<string>(parts.Length);
+        foreach (var part in parts)
+        {
+            if (!long.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            {
+                failure = $"'values' entry '{part}' is not an integer";
+                return false;
+            }
+            normalized.Add(value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        values = string.Join(',', normalized);
+        return true;
+    }
+
+    private static bool TryParsePositive(string raw, out double value)
+        => double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+            && !double.IsNaN(value) && !double.IsInfinity(value) && value > 0d;
+
+    private static partial class Log
+    {
+        [LoggerMessage(9370, LogLevel.Warning,
+            "GDAL proximity executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9371, LogLevel.Warning,
+            "GDAL proximity executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9372, LogLevel.Warning,
+            "GDAL proximity executor refused job {OperationId}: euclidean allocation is flagged unsupported in this build")]
+        public static partial void AllocationUnsupported(ILogger logger, string operationId);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterInterpolateJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterInterpolateJobExecutor.cs
@@ -1,0 +1,385 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the raster interpolation
+/// family: <c>raster.interpolate-idw</c> (inverse-distance-weighted) backed by the
+/// GDAL <c>gdal_grid</c> CLI, and <c>raster.interpolate-kriging</c>, which is
+/// FLAGGED as unsupported in this build.
+///
+/// <para>
+/// IDW reads a base64-encoded GeoJSON point FeatureCollection from <c>points</c>,
+/// grids it onto a raster surface using <c>gdal_grid -a invdist</c>, and publishes
+/// the GeoTIFF as a canonical data-URI artifact.
+/// </para>
+/// <para>
+/// Kriging requires a kriging-capable numerical backend that the worker image does
+/// NOT bundle (stock GDAL <c>gdal_grid</c> has no kriging algorithm). Rather than
+/// silently substitute a different algorithm, the executor FAILS the job with a
+/// clear message so the limitation is explicit (#2141).
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/>
+/// is <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterInterpolateJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterInterpolateJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>Process id for inverse-distance-weighted interpolation.</summary>
+    public const string IdwProcessId = "raster.interpolate-idw";
+
+    /// <summary>Process id for kriging interpolation (flagged unsupported).</summary>
+    public const string KrigingProcessId = "raster.interpolate-kriging";
+
+    /// <summary>
+    /// Stable message published when a kriging job is submitted. Surfaced as the
+    /// job's failure reason so callers see the unsupported-dependency limitation
+    /// rather than a silent no-op or a substituted algorithm.
+    /// </summary>
+    public const string KrigingUnsupportedMessage =
+        "Kriging interpolation is not available in this build: the worker image does not bundle a "
+        + "kriging-capable numerical backend (stock GDAL gdal_grid has no kriging algorithm). "
+        + "Use raster.interpolate-idw for inverse-distance-weighted interpolation.";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly FrozenSet<string> HandledProcessIds = new HashSet<string>(StringComparer.Ordinal)
+    {
+        IdwProcessId,
+        KrigingProcessId,
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <summary>Process ids this executor routes.</summary>
+    public static IReadOnlyCollection<string> SupportedProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds => HandledProcessIds;
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (processId is null || !HandledProcessIds.Contains(processId))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the raster interpolation executor.");
+        }
+
+        // Kriging is advertised but flagged: fail fast with a clear message instead
+        // of substituting IDW or producing a silent stub (#2141 acceptance).
+        if (string.Equals(processId, KrigingProcessId, StringComparison.Ordinal))
+        {
+            Log.KrigingUnsupported(logger, job.OperationId);
+            return JobExecutionResult.Failed(KrigingUnsupportedMessage);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing interpolation inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!TryBuildAlgorithm(parameters, out var algorithm, out var algorithmError))
+        {
+            return JobExecutionResult.Failed($"Invalid interpolation inputs: {algorithmError}");
+        }
+
+        if (!TryReadOutputSize(parameters, out var width, out var height, out var sizeError))
+        {
+            return JobExecutionResult.Failed($"Invalid interpolation inputs: {sizeError}");
+        }
+
+        GdalJobInputReader.TryGetInput(parameters, "zField", out var zField);
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "points", opts.MaxArtifactBytes, out var pointsBytes, out var pointsError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, pointsError);
+            return JobExecutionResult.Failed($"Invalid interpolation inputs: {pointsError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            // gdal_grid derives the layer name from the file basename; write the
+            // input as points.geojson and reference layer "points" explicitly.
+            var inputPath = Path.Combine(workspace, "points.geojson");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, pointsBytes, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_grid interpolation", cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-a", algorithm,
+                "-of", "GTiff",
+                "-l", "points",
+            };
+            if (!string.IsNullOrWhiteSpace(zField))
+            {
+                args.Add("-zfield");
+                args.Add(zField.Trim());
+            }
+            if (width.HasValue && height.HasValue)
+            {
+                args.Add("-outsize");
+                args.Add(width.Value.ToString(CultureInfo.InvariantCulture));
+                args.Add(height.Value.ToString(CultureInfo.InvariantCulture));
+            }
+            args.Add(inputPath);
+            args.Add(outputPath);
+
+            await GdalCommandLog.LogCommandAsync(context, "gdal_grid", args, workspace, cancellationToken).ConfigureAwait(false);
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("gdal_grid", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"gdal_grid timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"gdal_grid exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed("gdal_grid reported success but produced no output raster.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding interpolated raster artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("gdal_grid produced an empty output raster.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Interpolated raster size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoTiffContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Interpolation completed", cancellationToken).ConfigureAwait(false);
+
+            Log.InterpolationCompleted(logger, job.OperationId, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Builds the <c>gdal_grid -a</c> algorithm spec for IDW. The parameter names
+    /// mirror gdal_grid's <c>invdist</c> options: power (default 2.0), smoothing
+    /// (default 0.0), and an optional search radius (omitted = global). Each value
+    /// is range-checked here so a plan that reaches the worker is also accepted by
+    /// the CLI rather than failing at the argument boundary.
+    /// </summary>
+    private static bool TryBuildAlgorithm(
+        IReadOnlyDictionary<string, string> parameters,
+        out string algorithm,
+        out string failure)
+    {
+        algorithm = "";
+        failure = "";
+
+        if (!TryReadDouble(parameters, "power", defaultValue: 2.0, requirePositive: true, out var power, out var powerError))
+        {
+            failure = powerError;
+            return false;
+        }
+
+        if (!TryReadDouble(parameters, "smoothing", defaultValue: 0.0, requirePositive: false, out var smoothing, out var smoothingError))
+        {
+            failure = smoothingError;
+            return false;
+        }
+
+        var spec = $"invdist:power={FormatDouble(power)}:smoothing={FormatDouble(smoothing)}";
+
+        if (GdalJobInputReader.TryGetInput(parameters, "radius", out var radiusRaw)
+            && !string.IsNullOrWhiteSpace(radiusRaw))
+        {
+            if (!TryReadDouble(parameters, "radius", defaultValue: 0.0, requirePositive: true, out var radius, out var radiusError))
+            {
+                failure = radiusError;
+                return false;
+            }
+            spec += $":radius={FormatDouble(radius)}";
+        }
+
+        algorithm = spec;
+        return true;
+    }
+
+    private static bool TryReadOutputSize(
+        IReadOnlyDictionary<string, string> parameters,
+        out int? width,
+        out int? height,
+        out string failure)
+    {
+        width = null;
+        height = null;
+        failure = "";
+
+        var hasWidth = TryReadOptionalPositiveInt(parameters, "width", out width, out var widthError);
+        if (!hasWidth && widthError.Length > 0)
+        {
+            failure = widthError;
+            return false;
+        }
+
+        var hasHeight = TryReadOptionalPositiveInt(parameters, "height", out height, out var heightError);
+        if (!hasHeight && heightError.Length > 0)
+        {
+            failure = heightError;
+            return false;
+        }
+
+        // gdal_grid -outsize requires BOTH dimensions; reject a half-specified grid
+        // so the contract is unambiguous (omit both to let gdal_grid pick a default).
+        if (width.HasValue ^ height.HasValue)
+        {
+            failure = "both 'width' and 'height' must be supplied together to set the output grid size";
+            width = null;
+            height = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadOptionalPositiveInt(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        out int? value,
+        out string failure)
+    {
+        value = null;
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed <= 0)
+        {
+            failure = $"{name} must be a positive integer; got '{raw}'";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    private static bool TryReadDouble(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        double defaultValue,
+        bool requirePositive,
+        out double value,
+        out string failure)
+    {
+        failure = "";
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            value = defaultValue;
+            return true;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed)
+            || double.IsInfinity(parsed)
+            || (requirePositive ? parsed <= 0d : parsed < 0d))
+        {
+            value = 0d;
+            failure = requirePositive
+                ? $"{name} must be a positive finite number; got '{raw}'"
+                : $"{name} must be a non-negative finite number; got '{raw}'";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    private static string FormatDouble(double value)
+        => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9320, LogLevel.Warning,
+            "GDAL raster interpolate executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9321, LogLevel.Warning,
+            "GDAL raster interpolate executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9322, LogLevel.Error,
+            "GDAL raster interpolate executor failed job {OperationId}: gdal_grid exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9323, LogLevel.Error,
+            "GDAL raster interpolate executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9324, LogLevel.Warning,
+            "GDAL raster interpolate executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9325, LogLevel.Information,
+            "GDAL raster interpolate executor completed job {OperationId}: bytes={Bytes}")]
+        public static partial void InterpolationCompleted(ILogger logger, string operationId, long bytes);
+
+        [LoggerMessage(9326, LogLevel.Warning,
+            "GDAL raster interpolate executor refused job {OperationId}: kriging is flagged unsupported in this build")]
+        public static partial void KrigingUnsupported(ILogger logger, string operationId);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterInterpolateJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterInterpolateJobExecutor.cs
@@ -116,6 +116,12 @@ internal sealed partial class GdalRasterInterpolateJobExecutor(
         }
 
         GdalJobInputReader.TryGetInput(parameters, "zField", out var zField);
+        if (!string.IsNullOrWhiteSpace(zField) && !GdalFieldName.IsValid(zField))
+        {
+            Log.InvalidInputs(logger, job.OperationId, $"'zField' value '{zField}' is not a valid attribute name");
+            return JobExecutionResult.Failed(
+                "Invalid interpolation inputs: 'zField' must match ^[A-Za-z_][A-Za-z0-9_]*$.");
+        }
 
         if (!GdalJobInputReader.TryGetBase64Input(parameters, "points", opts.MaxArtifactBytes, out var pointsBytes, out var pointsError))
         {

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterMapAlgebraJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterMapAlgebraJobExecutor.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>raster.map-algebra</c>
+/// process: evaluates an ALLOW-LISTED arithmetic/logical expression across one or
+/// more input rasters, backed by the GDAL <c>gdal_calc.py</c> CLI (#2239).
+///
+/// <para>
+/// Inputs are supplied inline on the <c>sources</c> parameter as a <c>|</c>-separated
+/// list of base64-encoded GeoTIFFs (1–26). Each source is bound to a single-letter
+/// band variable A, B, C, … in list order. The <c>expression</c> is validated against
+/// a strict allow-list (single-uppercase band variables, numeric literals, a fixed set
+/// of arithmetic/logical operators, and a small allow-list of safe NumPy functions)
+/// BEFORE it ever reaches the CLI — <c>gdal_calc.py</c> evaluates the calc string with
+/// <c>eval()</c>, so an un-vetted expression would be remote code execution. The
+/// allow-list never shell-evaluates arbitrary input.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterMapAlgebraJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterMapAlgebraJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "raster.map-algebra";
+
+    /// <summary>Separator between base64 raster entries in the <c>sources</c> input.</summary>
+    public const string SourceSeparator = "|";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing map-algebra inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!GdalCalcInputs.TryDecodeSources(parameters, opts.MaxArtifactBytes, out var sources, out var sourcesError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourcesError);
+            return JobExecutionResult.Failed($"Invalid map-algebra inputs: {sourcesError}");
+        }
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "expression", out var expression)
+            || string.IsNullOrWhiteSpace(expression))
+        {
+            return JobExecutionResult.Failed("Invalid map-algebra inputs: missing required input 'expression'.");
+        }
+
+        if (!MapAlgebraExpression.IsAllowed(expression, sources.Count, out var expressionError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, expressionError);
+            return JobExecutionResult.Failed($"Invalid map-algebra inputs: {expressionError}");
+        }
+
+        string? dataType = null;
+        if (GdalJobInputReader.TryGetInput(parameters, "dataType", out var dataTypeRaw)
+            && !string.IsNullOrWhiteSpace(dataTypeRaw))
+        {
+            if (!GdalCalcInputs.TryNormalizeDataType(dataTypeRaw, out dataType, out var dataTypeError))
+            {
+                return JobExecutionResult.Failed($"Invalid map-algebra inputs: {dataTypeError}");
+            }
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var outputPath = Path.Combine(workspace, "output.tif");
+            var args = new List<string>(sources.Count * 2 + 8);
+            for (var i = 0; i < sources.Count; i++)
+            {
+                var letter = (char)('A' + i);
+                var inputPath = Path.Combine(workspace, $"input{i.ToString(CultureInfo.InvariantCulture)}.tif");
+                await File.WriteAllBytesAsync(inputPath, sources[i], cancellationToken).ConfigureAwait(false);
+                args.Add($"-{letter}");
+                args.Add(inputPath);
+            }
+
+            args.Add("--calc");
+            args.Add(expression.Trim());
+            if (dataType is not null)
+            {
+                args.Add("--type");
+                args.Add(dataType);
+            }
+            args.Add("--overwrite");
+            args.Add("--quiet");
+            args.Add("--outfile");
+            args.Add(outputPath);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_calc map algebra", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_calc.py", args, workspace, outputPath,
+                GeoTiffContentType, "Map-algebra raster",
+                "Encoding map-algebra raster artifact", "Map algebra completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9340, LogLevel.Warning,
+            "GDAL map-algebra executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9341, LogLevel.Warning,
+            "GDAL map-algebra executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterMapAlgebraJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterMapAlgebraJobExecutor.cs
@@ -119,8 +119,10 @@ internal sealed partial class GdalRasterMapAlgebraJobExecutor(
                 args.Add(inputPath);
             }
 
-            args.Add("--calc");
-            args.Add(expression.Trim());
+            // Pass the calc as a single "--calc=<expr>" token so an expression with a
+            // leading unary minus (e.g. "-A") is not mistaken for a separate option by
+            // gdal_calc.py's argparse.
+            args.Add($"--calc={expression.Trim()}");
             if (dataType is not null)
             {
                 args.Add("--type");

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
@@ -1,0 +1,316 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>raster.mosaic</c>
+/// process: combines multiple input rasters into one, backed by the GDAL
+/// <c>gdalwarp</c> CLI (which merges several sources into a single output grid).
+///
+/// <para>
+/// Inputs are supplied inline on the <c>sources</c> parameter as a
+/// <c>|</c>-separated list of base64-encoded GeoTIFFs (two or more). The
+/// <c>operator</c> parameter selects overlap behavior: <c>last</c> (default,
+/// later-listed source wins) or <c>first</c> (earlier-listed source wins,
+/// implemented by reversing source order). Statistical operators (min/max/mean/
+/// sum/blend) are not yet expressible through stock gdalwarp and are rejected with
+/// a clear message rather than silently approximated.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/>
+/// is <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterMosaicJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterMosaicJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "raster.mosaic";
+
+    /// <summary>Separator between base64 raster entries in the <c>sources</c> input.</summary>
+    public const string SourceSeparator = "|";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    // Mirrors ProcessPlanValidator.RasterResamplingValues so executor + validator
+    // agree on the accepted set.
+    private static readonly FrozenDictionary<string, string> ResamplingMap =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["nearestneighbor"] = "near",
+            ["nearest-neighbor"] = "near",
+            ["nearest"] = "near",
+            ["bilinear"] = "bilinear",
+            ["cubic"] = "cubic",
+            ["bicubic"] = "cubic",
+            ["lanczos"] = "lanczos",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    // Overlap operators expressible through stock gdalwarp source ordering.
+    private static readonly FrozenSet<string> SupportedOperators = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "first",
+        "last",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing mosaic inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        var mosaicOperator = "last";
+        if (GdalJobInputReader.TryGetInput(parameters, "operator", out var operatorRaw)
+            && !string.IsNullOrWhiteSpace(operatorRaw))
+        {
+            mosaicOperator = operatorRaw.Trim();
+            if (!SupportedOperators.Contains(mosaicOperator))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid mosaic inputs: 'operator' value '{operatorRaw}' is not supported by the native worker " +
+                    "(supported operators: first, last). Statistical operators (min, max, mean, sum) are not yet available.");
+            }
+        }
+
+        // Mosaic defaults to nearest-neighbor (gdalwarp's default) so aligned grids
+        // merge without resampling artifacts.
+        var resamplingFlag = "near";
+        if (GdalJobInputReader.TryGetInput(parameters, "resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw))
+        {
+            if (!ResamplingMap.TryGetValue(resamplingRaw.Trim(), out resamplingFlag))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid mosaic inputs: 'resampling' value '{resamplingRaw}' is not in the allowed set " +
+                    "(nearestneighbor, bilinear, cubic, lanczos).");
+            }
+        }
+
+        if (!TryDecodeSources(parameters, opts.MaxArtifactBytes, out var sources, out var sourcesError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourcesError);
+            return JobExecutionResult.Failed($"Invalid mosaic inputs: {sourcesError}");
+        }
+
+        // 'first' wins is achieved by reversing the source order so the desired
+        // source is written LAST into the output (gdalwarp later-source-wins).
+        if (string.Equals(mosaicOperator, "first", StringComparison.OrdinalIgnoreCase))
+        {
+            sources.Reverse();
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var outputPath = Path.Combine(workspace, "output.tif");
+            var inputPaths = new List<string>(sources.Count);
+            for (var i = 0; i < sources.Count; i++)
+            {
+                var inputPath = Path.Combine(workspace, $"input{i.ToString(CultureInfo.InvariantCulture)}.tif");
+                await File.WriteAllBytesAsync(inputPath, sources[i], cancellationToken).ConfigureAwait(false);
+                inputPaths.Add(inputPath);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdalwarp mosaic", cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-overwrite",
+                "-of", "GTiff",
+                "-r", resamplingFlag,
+            };
+            args.AddRange(inputPaths);
+            args.Add(outputPath);
+
+            await GdalCommandLog.LogCommandAsync(context, "gdalwarp", args, workspace, cancellationToken).ConfigureAwait(false);
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("gdalwarp", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"gdalwarp timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"gdalwarp exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed("gdalwarp reported success but produced no output raster.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding mosaic raster artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("gdalwarp produced an empty output raster.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Mosaic raster size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoTiffContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Mosaic completed", cancellationToken).ConfigureAwait(false);
+
+            Log.MosaicCompleted(logger, job.OperationId, sources.Count, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Decodes the <c>|</c>-separated base64 source list, enforcing the per-entry
+    /// MaxArtifactBytes ceiling and requiring at least two inputs (a mosaic of one
+    /// raster is a no-op the caller almost certainly did not intend).
+    /// </summary>
+    private static bool TryDecodeSources(
+        IReadOnlyDictionary<string, string> parameters,
+        long maxBytes,
+        out List<byte[]> sources,
+        out string failure)
+    {
+        sources = [];
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "sources", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            failure = "missing required input 'sources'";
+            return false;
+        }
+
+        var entries = raw.Split(SourceSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (entries.Length < 2)
+        {
+            failure = $"'sources' must list at least two base64 GeoTIFF rasters separated by '{SourceSeparator}'; got {entries.Length.ToString(CultureInfo.InvariantCulture)}";
+            return false;
+        }
+
+        var decoded = new List<byte[]>(entries.Length);
+        for (var i = 0; i < entries.Length; i++)
+        {
+            var entry = entries[i];
+            // Conservative upper bound on the decoded size before allocating.
+            if ((long)entry.Length / 4 * 3 > maxBytes)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(entry);
+            }
+            catch (FormatException)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} is not valid base64";
+                return false;
+            }
+
+            if (bytes.Length == 0)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} decoded to zero bytes";
+                return false;
+            }
+
+            if (bytes.Length > maxBytes)
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} size {bytes.Length.ToString(CultureInfo.InvariantCulture)} bytes exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            decoded.Add(bytes);
+        }
+
+        sources = decoded;
+        return true;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9330, LogLevel.Warning,
+            "GDAL raster mosaic executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9331, LogLevel.Warning,
+            "GDAL raster mosaic executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9332, LogLevel.Error,
+            "GDAL raster mosaic executor failed job {OperationId}: gdalwarp exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9333, LogLevel.Error,
+            "GDAL raster mosaic executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9334, LogLevel.Warning,
+            "GDAL raster mosaic executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9335, LogLevel.Information,
+            "GDAL raster mosaic executor completed job {OperationId}: sources={SourceCount}, bytes={Bytes}")]
+        public static partial void MosaicCompleted(ILogger logger, string operationId, int sourceCount, long bytes);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
@@ -38,6 +38,13 @@ internal sealed partial class GdalRasterMosaicJobExecutor(
     /// <summary>Separator between base64 raster entries in the <c>sources</c> input.</summary>
     public const string SourceSeparator = "|";
 
+    /// <summary>
+    /// Upper bound on the number of mosaic sources. gdalwarp can merge many tiles, but
+    /// the worker decodes them all into memory and writes them to the scratch workspace
+    /// first, so the count is bounded to keep a single job from exhausting the host.
+    /// </summary>
+    public const int MaxSources = 256;
+
     private const string GeoTiffContentType = "image/tiff; application=geotiff";
 
     private static readonly IReadOnlySet<string> NativeProfileSet =
@@ -246,7 +253,14 @@ internal sealed partial class GdalRasterMosaicJobExecutor(
             return false;
         }
 
+        if (entries.Length > MaxSources)
+        {
+            failure = $"'sources' must list at most {MaxSources.ToString(CultureInfo.InvariantCulture)} rasters; got {entries.Length.ToString(CultureInfo.InvariantCulture)}";
+            return false;
+        }
+
         var decoded = new List<byte[]>(entries.Length);
+        long totalBytes = 0;
         for (var i = 0; i < entries.Length; i++)
         {
             var entry = entries[i];
@@ -277,6 +291,16 @@ internal sealed partial class GdalRasterMosaicJobExecutor(
             if (bytes.Length > maxBytes)
             {
                 failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} size {bytes.Length.ToString(CultureInfo.InvariantCulture)} bytes exceeds configured MaxArtifactBytes={maxBytes}";
+                return false;
+            }
+
+            // Bound the aggregate decoded size: every source is buffered in memory and
+            // staged to scratch before gdalwarp runs, so cap the total by the same
+            // MaxArtifactBytes ceiling used for the merged output artifact.
+            totalBytes += bytes.Length;
+            if (totalBytes > maxBytes)
+            {
+                failure = $"decoded sources total {totalBytes.ToString(CultureInfo.InvariantCulture)} bytes, exceeding configured MaxArtifactBytes={maxBytes}";
                 return false;
             }
 

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReclassifyJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReclassifyJobExecutor.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>raster.reclassify</c>
+/// process: remaps source pixel values per a supplied remap table, backed by the
+/// GDAL <c>gdal_calc.py</c> CLI (#2239). This closes the reclassify gap the #2141
+/// slice explicitly deferred.
+///
+/// <para>
+/// The <c>remap</c> table is a <c>;</c>-separated list of entries, each
+/// <c>key:value</c> where the key is either a single number (<c>v</c>) or a half-open
+/// range (<c>lo..hi</c>, lower-inclusive / upper-exclusive) and the value is the
+/// output number. Unmatched pixels take the optional <c>defaultValue</c>, or the
+/// original value when omitted. Every token is parsed as a number BEFORE it is
+/// folded into the trusted nested-<c>where</c> calc expression, so no caller text
+/// reaches the <c>eval()</c>'d calc string.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterReclassifyJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterReclassifyJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "raster.reclassify";
+
+    /// <summary>Separator between remap entries.</summary>
+    public const string EntrySeparator = ";";
+
+    /// <summary>Separator between the lower and upper bound of a range key.</summary>
+    public const string RangeSeparator = "..";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing reclassify inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "remap", out var remap) || string.IsNullOrWhiteSpace(remap))
+        {
+            return JobExecutionResult.Failed("Invalid reclassify inputs: missing required input 'remap'.");
+        }
+
+        if (!TryBuildCalc(remap, parameters, out var calc, out var remapError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, remapError);
+            return JobExecutionResult.Failed($"Invalid reclassify inputs: {remapError}");
+        }
+
+        string? dataType = null;
+        if (GdalJobInputReader.TryGetInput(parameters, "dataType", out var dataTypeRaw)
+            && !string.IsNullOrWhiteSpace(dataTypeRaw))
+        {
+            if (!GdalCalcInputs.TryNormalizeDataType(dataTypeRaw, out dataType, out var dataTypeError))
+            {
+                return JobExecutionResult.Failed($"Invalid reclassify inputs: {dataTypeError}");
+            }
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid reclassify inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.tif");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-A", inputPath,
+                "--calc", calc,
+            };
+            if (dataType is not null)
+            {
+                args.Add("--type");
+                args.Add(dataType);
+            }
+            args.Add("--overwrite");
+            args.Add("--quiet");
+            args.Add("--outfile");
+            args.Add(outputPath);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_calc reclassify", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_calc.py", args, workspace, outputPath,
+                GeoTiffContentType, "Reclassified raster",
+                "Encoding reclassified raster artifact", "Reclassify completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Parses the remap table and folds it into a trusted nested-<c>where</c> NumPy
+    /// expression. Every bound and output value is parsed as a finite number, so the
+    /// resulting calc string contains only digits, the band variable <c>A</c>, and a
+    /// fixed operator/function vocabulary — no caller text survives parsing.
+    /// </summary>
+    public static bool TryBuildCalc(
+        string remap,
+        IReadOnlyDictionary<string, string> parameters,
+        out string calc,
+        out string failure)
+    {
+        calc = "";
+        failure = "";
+
+        var defaultExpr = "A";
+        if (GdalJobInputReader.TryGetInput(parameters, "defaultValue", out var defaultRaw)
+            && !string.IsNullOrWhiteSpace(defaultRaw))
+        {
+            if (!TryParseNumber(defaultRaw, out var defaultValue))
+            {
+                failure = $"'defaultValue' must be a finite number; got '{defaultRaw}'";
+                return false;
+            }
+            defaultExpr = Literal(defaultValue);
+        }
+
+        var entries = remap.Split(EntrySeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (entries.Length == 0)
+        {
+            failure = $"'remap' must list at least one 'key:value' entry separated by '{EntrySeparator}'";
+            return false;
+        }
+
+        var conditions = new List<(string Condition, string Output)>(entries.Length);
+        foreach (var entry in entries)
+        {
+            var colon = entry.IndexOf(':', StringComparison.Ordinal);
+            if (colon <= 0 || colon == entry.Length - 1)
+            {
+                failure = $"remap entry '{entry}' must have the form 'value:newValue' or 'lo..hi:newValue'";
+                return false;
+            }
+
+            var keyPart = entry[..colon].Trim();
+            var valuePart = entry[(colon + 1)..].Trim();
+
+            if (!TryParseNumber(valuePart, out var output))
+            {
+                failure = $"remap entry '{entry}' has a non-numeric output value '{valuePart}'";
+                return false;
+            }
+
+            string condition;
+            var rangeIndex = keyPart.IndexOf(RangeSeparator, StringComparison.Ordinal);
+            if (rangeIndex >= 0)
+            {
+                var loRaw = keyPart[..rangeIndex].Trim();
+                var hiRaw = keyPart[(rangeIndex + RangeSeparator.Length)..].Trim();
+                if (!TryParseNumber(loRaw, out var lo) || !TryParseNumber(hiRaw, out var hi))
+                {
+                    failure = $"remap entry '{entry}' has a non-numeric range bound";
+                    return false;
+                }
+                if (hi <= lo)
+                {
+                    failure = $"remap entry '{entry}' must have lo < hi";
+                    return false;
+                }
+                condition = $"(A>={Literal(lo)})&(A<{Literal(hi)})";
+            }
+            else
+            {
+                if (!TryParseNumber(keyPart, out var value))
+                {
+                    failure = $"remap entry '{entry}' has a non-numeric key '{keyPart}'";
+                    return false;
+                }
+                condition = $"(A=={Literal(value)})";
+            }
+
+            conditions.Add((condition, Literal(output)));
+        }
+
+        // Fold right-to-left into nested where(cond, output, <rest>).
+        var builder = new StringBuilder(defaultExpr);
+        for (var i = conditions.Count - 1; i >= 0; i--)
+        {
+            var (condition, output) = conditions[i];
+            builder.Insert(0, $"where({condition},{output},");
+            builder.Append(')');
+        }
+
+        calc = builder.ToString();
+        return true;
+    }
+
+    private static bool TryParseNumber(string raw, out double value)
+        => double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+            && !double.IsNaN(value) && !double.IsInfinity(value);
+
+    private static string Literal(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9360, LogLevel.Warning,
+            "GDAL reclassify executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9361, LogLevel.Warning,
+            "GDAL reclassify executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterResampleJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterResampleJobExecutor.cs
@@ -1,0 +1,254 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>raster.resample</c>
+/// process: changes a raster's cell size using the requested resampling
+/// algorithm, backed by the GDAL <c>gdalwarp -tr</c> CLI.
+///
+/// Reads a base64-encoded GeoTIFF from the canonical <c>source</c> input and a
+/// target cell size from <c>cellSize</c> (optionally a distinct vertical size via
+/// <c>cellSizeY</c>), warps in an isolated scratch workspace, and publishes the
+/// resampled GeoTIFF as a canonical data-URI artifact. Runs only inside the GDAL
+/// worker image — <see cref="AcceptedRuntimeProfiles"/> is <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterResampleJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterResampleJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "raster.resample";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    // Maps the catalog's canonical resampling enum onto gdalwarp's -r flag value.
+    // Mirrors ProcessPlanValidator.RasterResamplingValues so executor + validator
+    // agree on the accepted set; unknown values are rejected at the executor
+    // boundary to defend against bypassed validation.
+    private static readonly FrozenDictionary<string, string> ResamplingMap =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["nearestneighbor"] = "near",
+            ["nearest-neighbor"] = "near",
+            ["nearest"] = "near",
+            ["bilinear"] = "bilinear",
+            ["cubic"] = "cubic",
+            ["bicubic"] = "cubic",
+            ["lanczos"] = "lanczos",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing resample inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!TryReadPositiveDouble(parameters, "cellSize", out var cellSizeX, out var cellError))
+        {
+            return JobExecutionResult.Failed($"Invalid resample inputs: {cellError}");
+        }
+
+        var cellSizeY = cellSizeX;
+        if (GdalJobInputReader.TryGetInput(parameters, "cellSizeY", out var cellSizeYRaw)
+            && !string.IsNullOrWhiteSpace(cellSizeYRaw))
+        {
+            if (!TryReadPositiveDouble(parameters, "cellSizeY", out cellSizeY, out var cellYError))
+            {
+                return JobExecutionResult.Failed($"Invalid resample inputs: {cellYError}");
+            }
+        }
+
+        var resamplingFlag = "bilinear";
+        if (GdalJobInputReader.TryGetInput(parameters, "resampling", out var resamplingRaw)
+            && !string.IsNullOrWhiteSpace(resamplingRaw))
+        {
+            if (!ResamplingMap.TryGetValue(resamplingRaw.Trim(), out resamplingFlag))
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid resample inputs: 'resampling' value '{resamplingRaw}' is not in the allowed set " +
+                    "(nearestneighbor, bilinear, cubic, lanczos).");
+            }
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid resample inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.tif");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdalwarp resample", cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-overwrite",
+                "-of", "GTiff",
+                "-tr", FormatDouble(cellSizeX), FormatDouble(cellSizeY),
+                "-r", resamplingFlag,
+                inputPath,
+                outputPath,
+            };
+
+            await GdalCommandLog.LogCommandAsync(context, "gdalwarp", args, workspace, cancellationToken).ConfigureAwait(false);
+
+            using var timeoutCts = new CancellationTokenSource(opts.ToolTimeout);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            GdalCommandResult result;
+            try
+            {
+                result = await runner.RunAsync("gdalwarp", args, workspace, linked.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                Log.ToolTimedOut(logger, job.OperationId, opts.ToolTimeout);
+                return JobExecutionResult.Failed($"gdalwarp timed out after {opts.ToolTimeout}.");
+            }
+
+            if (!result.Succeeded)
+            {
+                Log.ToolFailed(logger, job.OperationId, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+                return JobExecutionResult.Failed(
+                    $"gdalwarp exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+            }
+
+            if (!File.Exists(outputPath))
+            {
+                return JobExecutionResult.Failed("gdalwarp reported success but produced no output raster.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(80, "Encoding resampled raster artifact", cancellationToken).ConfigureAwait(false);
+
+            var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+            if (outputBytes.Length == 0)
+            {
+                return JobExecutionResult.Failed("gdalwarp produced an empty output raster.");
+            }
+
+            if (outputBytes.Length > opts.MaxArtifactBytes)
+            {
+                Log.ArtifactTooLarge(logger, job.OperationId, outputBytes.Length, opts.MaxArtifactBytes);
+                return JobExecutionResult.Failed(
+                    $"Resampled raster size {outputBytes.Length} bytes exceeds configured " +
+                    $"MaxArtifactBytes={opts.MaxArtifactBytes}.");
+            }
+
+            var artifactUri = GdalDataUri.Build(GeoTiffContentType, outputBytes);
+            await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Resample completed", cancellationToken).ConfigureAwait(false);
+
+            Log.ResampleCompleted(logger, job.OperationId, cellSizeX, outputBytes.Length);
+            return JobExecutionResult.Succeeded();
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    private static bool TryReadPositiveDouble(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        out double value,
+        out string failure)
+    {
+        value = 0d;
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            failure = $"missing required input '{name}'";
+            return false;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed)
+            || double.IsInfinity(parsed)
+            || parsed <= 0d)
+        {
+            failure = $"{name} must be a positive finite number; got '{raw}'";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    private static string FormatDouble(double value)
+        => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static partial class Log
+    {
+        [LoggerMessage(9310, LogLevel.Warning,
+            "GDAL raster resample executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9311, LogLevel.Warning,
+            "GDAL raster resample executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+
+        [LoggerMessage(9312, LogLevel.Error,
+            "GDAL raster resample executor failed job {OperationId}: gdalwarp exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, int exitCode, string error);
+
+        [LoggerMessage(9313, LogLevel.Error,
+            "GDAL raster resample executor timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, TimeSpan timeout);
+
+        [LoggerMessage(9314, LogLevel.Warning,
+            "GDAL raster resample executor refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9315, LogLevel.Information,
+            "GDAL raster resample executor completed job {OperationId}: cellSize={CellSize}, bytes={Bytes}")]
+        public static partial void ResampleCompleted(ILogger logger, string operationId, double cellSize, long bytes);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterSpectralIndexJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterSpectralIndexJobExecutor.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>raster.spectral-index</c>
+/// process: computes a named spectral index (NDVI, NDWI, NDBI, SAVI, EVI) from
+/// band-role rasters, compiling down to the <c>gdal_calc.py</c> map-algebra core
+/// (#2239).
+///
+/// <para>
+/// Each required band role (<c>red</c>, <c>nir</c>, <c>green</c>, <c>swir</c>,
+/// <c>blue</c>) is supplied as its own base64-encoded single-band GeoTIFF. The
+/// executor binds the roles needed by the requested index to band variables and
+/// builds a TRUSTED calc expression (constructed here, never user-supplied), forcing
+/// a <c>Float32</c> output so the normalized-difference ratios are not truncated.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterSpectralIndexJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterSpectralIndexJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "raster.spectral-index";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <summary>Spectral index presets keyed by canonical name.</summary>
+    public static readonly FrozenSet<string> SupportedIndices = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "ndvi", "ndwi", "ndbi", "savi", "evi",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing spectral-index inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!GdalJobInputReader.TryGetInput(parameters, "index", out var indexRaw)
+            || string.IsNullOrWhiteSpace(indexRaw))
+        {
+            return JobExecutionResult.Failed("Invalid spectral-index inputs: missing required input 'index'.");
+        }
+
+        var index = indexRaw.Trim().ToLowerInvariant();
+        if (!SupportedIndices.Contains(index))
+        {
+            return JobExecutionResult.Failed(
+                $"Invalid spectral-index inputs: 'index' value '{indexRaw}' is not supported (NDVI, NDWI, NDBI, SAVI, EVI).");
+        }
+
+        // Each preset declares the ordered band roles it needs (bound to A, B, C…)
+        // and a builder for the trusted calc expression.
+        if (!TryBuildIndex(index, parameters, out var roles, out var calc, out var buildError))
+        {
+            return JobExecutionResult.Failed($"Invalid spectral-index inputs: {buildError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var outputPath = Path.Combine(workspace, "output.tif");
+            var args = new List<string>(roles.Count * 2 + 8);
+            for (var i = 0; i < roles.Count; i++)
+            {
+                var letter = (char)('A' + i);
+                if (!GdalJobInputReader.TryGetBase64Input(parameters, roles[i], opts.MaxArtifactBytes, out var bytes, out var roleError))
+                {
+                    Log.InvalidInputs(logger, job.OperationId, roleError);
+                    return JobExecutionResult.Failed($"Invalid spectral-index inputs: {roleError}");
+                }
+
+                var inputPath = Path.Combine(workspace, $"{roles[i]}.tif");
+                await File.WriteAllBytesAsync(inputPath, bytes, cancellationToken).ConfigureAwait(false);
+                args.Add($"-{letter}");
+                args.Add(inputPath);
+            }
+
+            args.Add("--calc");
+            args.Add(calc);
+            args.Add("--type");
+            args.Add("Float32");
+            args.Add("--overwrite");
+            args.Add("--quiet");
+            args.Add("--outfile");
+            args.Add(outputPath);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, $"Running gdal_calc {index}", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_calc.py", args, workspace, outputPath,
+                GeoTiffContentType, "Spectral-index raster",
+                "Encoding spectral-index raster artifact", "Spectral index completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Maps the requested index onto its ordered band roles (bound to A, B, C…) and
+    /// the TRUSTED calc expression. A <c>1.0*</c> coefficient forces float division
+    /// so integer surface-reflectance inputs do not truncate the ratio. SAVI reads an
+    /// optional soil-adjustment factor <c>L</c> (default 0.5), substituted as a
+    /// validated numeric literal.
+    /// </summary>
+    private static bool TryBuildIndex(
+        string index,
+        IReadOnlyDictionary<string, string> parameters,
+        out IReadOnlyList<string> roles,
+        out string calc,
+        out string failure)
+    {
+        roles = [];
+        calc = "";
+        failure = "";
+
+        switch (index)
+        {
+            case "ndvi":
+                roles = ["nir", "red"];
+                calc = "(1.0*A-B)/(1.0*A+B)";
+                return true;
+            case "ndwi":
+                roles = ["green", "nir"];
+                calc = "(1.0*A-B)/(1.0*A+B)";
+                return true;
+            case "ndbi":
+                roles = ["swir", "nir"];
+                calc = "(1.0*A-B)/(1.0*A+B)";
+                return true;
+            case "savi":
+                {
+                    if (!TryReadL(parameters, out var l, out failure))
+                    {
+                        return false;
+                    }
+                    var lLiteral = l.ToString("R", CultureInfo.InvariantCulture);
+                    roles = ["nir", "red"];
+                    calc = $"((1.0*A-B)/(1.0*A+B+{lLiteral}))*(1.0+{lLiteral})";
+                    return true;
+                }
+            case "evi":
+                roles = ["nir", "red", "blue"];
+                calc = "2.5*((1.0*A-B)/(1.0*A+6.0*B-7.5*C+1.0))";
+                return true;
+            default:
+                failure = $"unsupported index '{index}'";
+                return false;
+        }
+    }
+
+    private static bool TryReadL(IReadOnlyDictionary<string, string> parameters, out double l, out string failure)
+    {
+        l = 0.5;
+        failure = "";
+        if (!GdalJobInputReader.TryGetInput(parameters, "L", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed) || double.IsInfinity(parsed) || parsed < 0d || parsed > 1d)
+        {
+            failure = $"SAVI soil factor 'L' must be in the closed range [0, 1]; got '{raw}'";
+            return false;
+        }
+
+        l = parsed;
+        return true;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9350, LogLevel.Warning,
+            "GDAL spectral-index executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9351, LogLevel.Warning,
+            "GDAL spectral-index executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterizeJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterizeJobExecutor.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>conversion.rasterize</c>
+/// process: burns vector features into a new raster grid, backed by the GDAL
+/// <c>gdal_rasterize</c> CLI (#2240).
+///
+/// <para>
+/// Reads a base64-encoded GeoJSON FeatureCollection from <c>source</c> and burns
+/// either a fixed <c>burnValue</c> or a numeric <c>attribute</c> into a GeoTIFF whose
+/// grid is defined by <c>cellSize</c> (resolution) or <c>width</c>+<c>height</c>
+/// (pixel dimensions). The output extent is taken from the input layer.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalRasterizeJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalRasterizeJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "conversion.rasterize";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing rasterize inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!TryBuildBurnArgs(parameters, out var burnArgs, out var burnError))
+        {
+            return JobExecutionResult.Failed($"Invalid rasterize inputs: {burnError}");
+        }
+
+        if (!TryBuildGridArgs(parameters, out var gridArgs, out var gridError))
+        {
+            return JobExecutionResult.Failed($"Invalid rasterize inputs: {gridError}");
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid rasterize inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.geojson");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string> { "-of", "GTiff" };
+            args.AddRange(burnArgs);
+            args.AddRange(gridArgs);
+
+            if (GdalJobInputReader.TryGetInput(parameters, "nodata", out var nodataRaw) && !string.IsNullOrWhiteSpace(nodataRaw))
+            {
+                if (!double.TryParse(nodataRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var nodata)
+                    || double.IsNaN(nodata) || double.IsInfinity(nodata))
+                {
+                    return JobExecutionResult.Failed(
+                        $"Invalid rasterize inputs: 'nodata' must be a finite number; got '{nodataRaw}'.");
+                }
+                args.Add("-a_nodata");
+                args.Add(nodata.ToString("R", CultureInfo.InvariantCulture));
+            }
+
+            args.Add(inputPath);
+            args.Add(outputPath);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_rasterize", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_rasterize", args, workspace, outputPath,
+                GeoTiffContentType, "Rasterized raster",
+                "Encoding rasterized raster artifact", "Rasterize completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    /// <summary>
+    /// Requires exactly one of <c>burnValue</c> (fixed value) or <c>attribute</c>
+    /// (numeric source field) and projects it onto <c>-burn</c> / <c>-a</c>.
+    /// </summary>
+    private static bool TryBuildBurnArgs(
+        IReadOnlyDictionary<string, string> parameters,
+        out List<string> args,
+        out string failure)
+    {
+        args = [];
+        failure = "";
+
+        var hasBurn = GdalJobInputReader.TryGetInput(parameters, "burnValue", out var burnRaw) && !string.IsNullOrWhiteSpace(burnRaw);
+        var hasAttribute = GdalJobInputReader.TryGetInput(parameters, "attribute", out var attrRaw) && !string.IsNullOrWhiteSpace(attrRaw);
+
+        if (hasBurn == hasAttribute)
+        {
+            failure = "supply exactly one of 'burnValue' or 'attribute'";
+            return false;
+        }
+
+        if (hasBurn)
+        {
+            if (!double.TryParse(burnRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var burn)
+                || double.IsNaN(burn) || double.IsInfinity(burn))
+            {
+                failure = $"'burnValue' must be a finite number; got '{burnRaw}'";
+                return false;
+            }
+            args.Add("-burn");
+            args.Add(burn.ToString("R", CultureInfo.InvariantCulture));
+            return true;
+        }
+
+        if (!GdalFieldName.IsValid(attrRaw))
+        {
+            failure = $"'attribute' must match ^[A-Za-z_][A-Za-z0-9_]*$; got '{attrRaw}'";
+            return false;
+        }
+        args.Add("-a");
+        args.Add(attrRaw.Trim());
+        return true;
+    }
+
+    /// <summary>
+    /// Requires exactly one of <c>cellSize</c> (<c>-tr</c>) or <c>width</c>+<c>height</c>
+    /// (<c>-ts</c>) so the output grid is unambiguous. The extent is inferred from the
+    /// input layer by gdal_rasterize.
+    /// </summary>
+    private static bool TryBuildGridArgs(
+        IReadOnlyDictionary<string, string> parameters,
+        out List<string> args,
+        out string failure)
+    {
+        args = [];
+        failure = "";
+
+        var hasCellSize = GdalJobInputReader.TryGetInput(parameters, "cellSize", out var cellRaw) && !string.IsNullOrWhiteSpace(cellRaw);
+        var hasWidth = GdalJobInputReader.TryGetInput(parameters, "width", out var widthRaw) && !string.IsNullOrWhiteSpace(widthRaw);
+        var hasHeight = GdalJobInputReader.TryGetInput(parameters, "height", out var heightRaw) && !string.IsNullOrWhiteSpace(heightRaw);
+
+        if (hasCellSize)
+        {
+            if (hasWidth || hasHeight)
+            {
+                failure = "supply either 'cellSize' or 'width'+'height', not both";
+                return false;
+            }
+            if (!double.TryParse(cellRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var cell)
+                || double.IsNaN(cell) || double.IsInfinity(cell) || cell <= 0d)
+            {
+                failure = $"'cellSize' must be a positive finite number; got '{cellRaw}'";
+                return false;
+            }
+            var cellLiteral = cell.ToString("R", CultureInfo.InvariantCulture);
+            args.Add("-tr");
+            args.Add(cellLiteral);
+            args.Add(cellLiteral);
+            return true;
+        }
+
+        if (hasWidth && hasHeight)
+        {
+            if (!int.TryParse(widthRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var width) || width < 1
+                || !int.TryParse(heightRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var height) || height < 1)
+            {
+                failure = "'width' and 'height' must be positive integers";
+                return false;
+            }
+            args.Add("-ts");
+            args.Add(width.ToString(CultureInfo.InvariantCulture));
+            args.Add(height.ToString(CultureInfo.InvariantCulture));
+            return true;
+        }
+
+        failure = "supply either 'cellSize' or both 'width' and 'height' to define the output grid";
+        return false;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9410, LogLevel.Warning,
+            "GDAL rasterize executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9411, LogLevel.Warning,
+            "GDAL rasterize executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalToolExecution.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalToolExecution.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Shared "run a GDAL/OGR CLI tool and publish its single file output" tail used
+/// by the raster-analysis / terrain-derivative / raster&lt;-&gt;vector executors
+/// (#2239, #2240). Centralizes the identical timeout fence, exit-code handling,
+/// output-existence / empty / size guards, and canonical data-URI artifact
+/// publication so every executor enforces the same cross-cutting behavior (error
+/// sanitization, MaxArtifactBytes ceiling, structured run logging) rather than
+/// each copy-pasting the boilerplate.
+///
+/// <para>
+/// Each executor remains responsible for the genuinely per-tool work — parsing /
+/// guarding its inputs and projecting them onto the CLI argument list — and then
+/// hands the assembled command here for execution.
+/// </para>
+/// </summary>
+internal static partial class GdalToolExecution
+{
+    /// <summary>
+    /// Runs <paramref name="tool"/> with the supplied arguments inside the scratch
+    /// <paramref name="workspace"/>, then publishes <paramref name="outputPath"/> as
+    /// a canonical <c>data:&lt;contentType&gt;;base64,...</c> artifact. The command
+    /// is logged (scratch-redacted) before execution and bounded by the worker's
+    /// <see cref="GdalWorkerOptions.ToolTimeout"/> and
+    /// <see cref="GdalWorkerOptions.MaxArtifactBytes"/>.
+    /// </summary>
+    public static async Task<JobExecutionResult> RunAndPublishAsync(
+        IGdalCommandRunner runner,
+        IJobExecutionContext context,
+        GdalWorkerOptions options,
+        ILogger logger,
+        string operationId,
+        string tool,
+        IReadOnlyList<string> args,
+        string workspace,
+        string outputPath,
+        string contentType,
+        string artifactLabel,
+        string encodingPhase,
+        string completedPhase,
+        CancellationToken cancellationToken)
+    {
+        await GdalCommandLog.LogCommandAsync(context, tool, args, workspace, cancellationToken).ConfigureAwait(false);
+
+        using var timeoutCts = new CancellationTokenSource(options.ToolTimeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        GdalCommandResult result;
+        try
+        {
+            result = await runner.RunAsync(tool, args, workspace, linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            Log.ToolTimedOut(logger, operationId, tool, options.ToolTimeout);
+            return JobExecutionResult.Failed($"{tool} timed out after {options.ToolTimeout}.");
+        }
+
+        if (!result.Succeeded)
+        {
+            Log.ToolFailed(logger, operationId, tool, result.ExitCode, GdalErrorSanitizer.TruncateForLog(result.StandardError));
+            return JobExecutionResult.Failed(
+                $"{tool} exited with code {result.ExitCode}: {GdalErrorSanitizer.Sanitize(result.StandardError, workspace)}");
+        }
+
+        if (!File.Exists(outputPath))
+        {
+            return JobExecutionResult.Failed($"{tool} reported success but produced no output.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(80, encodingPhase, cancellationToken).ConfigureAwait(false);
+
+        var outputBytes = await File.ReadAllBytesAsync(outputPath, cancellationToken).ConfigureAwait(false);
+        if (outputBytes.Length == 0)
+        {
+            return JobExecutionResult.Failed($"{tool} produced an empty output.");
+        }
+
+        if (outputBytes.Length > options.MaxArtifactBytes)
+        {
+            Log.ArtifactTooLarge(logger, operationId, tool, outputBytes.Length, options.MaxArtifactBytes);
+            return JobExecutionResult.Failed(
+                $"{artifactLabel} size {outputBytes.Length} bytes exceeds configured MaxArtifactBytes={options.MaxArtifactBytes}.");
+        }
+
+        var artifactUri = GdalDataUri.Build(contentType, outputBytes);
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, completedPhase, cancellationToken).ConfigureAwait(false);
+
+        Log.ToolCompleted(logger, operationId, tool, outputBytes.Length);
+        return JobExecutionResult.Succeeded();
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9290, LogLevel.Error,
+            "GDAL tool {Tool} failed job {OperationId}: exit {ExitCode}: {Error}")]
+        public static partial void ToolFailed(ILogger logger, string operationId, string tool, int exitCode, string error);
+
+        [LoggerMessage(9291, LogLevel.Error,
+            "GDAL tool {Tool} timed out job {OperationId} after {Timeout}")]
+        public static partial void ToolTimedOut(ILogger logger, string operationId, string tool, TimeSpan timeout);
+
+        [LoggerMessage(9292, LogLevel.Warning,
+            "GDAL tool {Tool} refused job {OperationId}: artifact size {ActualBytes} exceeds limit {MaxBytes}")]
+        public static partial void ArtifactTooLarge(ILogger logger, string operationId, string tool, long actualBytes, long maxBytes);
+
+        [LoggerMessage(9293, LogLevel.Information,
+            "GDAL tool {Tool} completed job {OperationId}: bytes={Bytes}")]
+        public static partial void ToolCompleted(ILogger logger, string operationId, string tool, long bytes);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalViewshedJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalViewshedJobExecutor.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Native-profile <see cref="IProcessExecutor"/> for the <c>surface.viewshed</c>
+/// process: computes a binary visibility raster from a DEM and an observer location,
+/// backed by the GDAL <c>gdal_viewshed</c> CLI (#2240).
+///
+/// <para>
+/// Reads a base64-encoded GeoTIFF DEM from <c>source</c>, places the observer at
+/// (<c>observerX</c>, <c>observerY</c>) in the DEM's georeferenced units at
+/// <c>observerHeight</c> above the surface, and publishes the visibility GeoTIFF,
+/// optionally bounded by <c>maxDistance</c> and using a <c>targetHeight</c> offset.
+/// </para>
+/// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
+/// <c>{ "native" }</c>.
+/// </summary>
+internal sealed partial class GdalViewshedJobExecutor(
+    IGdalCommandRunner runner,
+    IOptionsMonitor<GdalWorkerOptions> options,
+    ILogger<GdalViewshedJobExecutor> logger) : IProcessExecutor
+{
+    /// <summary>The canonical process id this executor handles.</summary>
+    public const string HandledProcessId = "surface.viewshed";
+
+    private const string GeoTiffContentType = "image/tiff; application=geotiff";
+
+    private static readonly IReadOnlySet<string> NativeProfileSet =
+        new HashSet<string>(StringComparer.Ordinal) { RuntimeProfiles.Native };
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds { get; } =
+        new HashSet<string>(StringComparer.Ordinal) { HandledProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> AcceptedRuntimeProfiles => NativeProfileSet;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var parameters = job.Spec.Parameters;
+        var processId = GdalJobInputReader.ResolveProcessId(parameters);
+        if (!string.Equals(processId, HandledProcessId, StringComparison.Ordinal))
+        {
+            Log.UnsupportedProcessId(logger, job.OperationId, processId ?? "<none>");
+            return JobExecutionResult.Failed(
+                $"Process id '{processId ?? "<none>"}' is not handled by the {HandledProcessId} executor.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, "Parsing viewshed inputs", cancellationToken).ConfigureAwait(false);
+
+        var opts = options.CurrentValue;
+
+        if (!TryReadFinite(parameters, "observerX", out var observerX, out var oxError))
+        {
+            return JobExecutionResult.Failed($"Invalid viewshed inputs: {oxError}");
+        }
+
+        if (!TryReadFinite(parameters, "observerY", out var observerY, out var oyError))
+        {
+            return JobExecutionResult.Failed($"Invalid viewshed inputs: {oyError}");
+        }
+
+        if (!TryReadOptionalNonNegative(parameters, "observerHeight", 2.0, out var observerHeight, out var ohError))
+        {
+            return JobExecutionResult.Failed($"Invalid viewshed inputs: {ohError}");
+        }
+
+        if (!TryReadOptionalNonNegative(parameters, "targetHeight", 0.0, out var targetHeight, out var thError))
+        {
+            return JobExecutionResult.Failed($"Invalid viewshed inputs: {thError}");
+        }
+
+        double? maxDistance = null;
+        if (GdalJobInputReader.TryGetInput(parameters, "maxDistance", out var maxRaw) && !string.IsNullOrWhiteSpace(maxRaw))
+        {
+            if (!double.TryParse(maxRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+                || double.IsNaN(parsed) || double.IsInfinity(parsed) || parsed <= 0d)
+            {
+                return JobExecutionResult.Failed(
+                    $"Invalid viewshed inputs: 'maxDistance' must be a positive finite number; got '{maxRaw}'.");
+            }
+            maxDistance = parsed;
+        }
+
+        if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
+        {
+            Log.InvalidInputs(logger, job.OperationId, sourceError);
+            return JobExecutionResult.Failed($"Invalid viewshed inputs: {sourceError}");
+        }
+
+        var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
+        try
+        {
+            var inputPath = Path.Combine(workspace, "input.tif");
+            var outputPath = Path.Combine(workspace, "output.tif");
+            await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            var args = new List<string>
+            {
+                "-of", "GTiff",
+                "-ox", observerX.ToString("R", CultureInfo.InvariantCulture),
+                "-oy", observerY.ToString("R", CultureInfo.InvariantCulture),
+                "-oz", observerHeight.ToString("R", CultureInfo.InvariantCulture),
+                "-tz", targetHeight.ToString("R", CultureInfo.InvariantCulture),
+            };
+            if (maxDistance.HasValue)
+            {
+                args.Add("-md");
+                args.Add(maxDistance.Value.ToString("R", CultureInfo.InvariantCulture));
+            }
+            args.Add(inputPath);
+            args.Add(outputPath);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await context.ReportProgressAsync(40, "Running gdal_viewshed", cancellationToken).ConfigureAwait(false);
+
+            return await GdalToolExecution.RunAndPublishAsync(
+                runner, context, opts, logger, job.OperationId,
+                "gdal_viewshed", args, workspace, outputPath,
+                GeoTiffContentType, "Viewshed raster",
+                "Encoding viewshed raster artifact", "Viewshed completed",
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            GdalScratch.TryCleanup(workspace, logger);
+        }
+    }
+
+    private static bool TryReadFinite(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        out double value,
+        out string failure)
+    {
+        value = 0d;
+        failure = "";
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            failure = $"missing required input '{name}'";
+            return false;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+            || double.IsNaN(value) || double.IsInfinity(value))
+        {
+            failure = $"{name} must be a finite number; got '{raw}'";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadOptionalNonNegative(
+        IReadOnlyDictionary<string, string> parameters,
+        string name,
+        double defaultValue,
+        out double value,
+        out string failure)
+    {
+        value = defaultValue;
+        failure = "";
+        if (!GdalJobInputReader.TryGetInput(parameters, name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+            || double.IsNaN(value) || double.IsInfinity(value) || value < 0d)
+        {
+            failure = $"{name} must be a non-negative finite number; got '{raw}'";
+            value = defaultValue;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(9390, LogLevel.Warning,
+            "GDAL viewshed executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
+        public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9391, LogLevel.Warning,
+            "GDAL viewshed executor rejected job {OperationId}: {Reason}")]
+        public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalVsiPath.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalVsiPath.cs
@@ -23,6 +23,10 @@ internal static class GdalVsiPath
     /// <returns>A path GDAL can open, e.g. <c>/vsis3/bucket/key.nc</c>.</returns>
     /// <exception cref="ArgumentException">Bucket or key is null/empty.</exception>
     /// <exception cref="NotSupportedException">The provider has no GDAL VSI handler.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// A <see cref="CloudStorageProvider.Local"/> key escapes the configured bucket root
+    /// (rooted segment or <c>..</c> traversal).
+    /// </exception>
     public static string Build(CloudStorageProvider provider, string bucket, string objectKey)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(bucket);
@@ -40,6 +44,31 @@ internal static class GdalVsiPath
         };
     }
 
+    /// <summary>
+    /// Combines a Local-provider bucket root with a relative object key, rejecting any
+    /// key that escapes the root. Mirrors the root-prefix containment check in
+    /// <see cref="GdalScratch.CreateWorkspace"/>: a rooted segment or a <c>..</c>
+    /// traversal must never resolve outside the configured bucket directory.
+    /// </summary>
     private static string CombineLocal(string directory, string key)
-        => Path.Combine(directory, key.Replace('/', Path.DirectorySeparatorChar));
+    {
+        var normalizedKey = key.Replace('/', Path.DirectorySeparatorChar);
+        if (Path.IsPathRooted(normalizedKey))
+        {
+            throw new InvalidOperationException("Local object key must be a relative path under the bucket root.");
+        }
+
+        var root = Path.GetFullPath(directory);
+        var combined = Path.GetFullPath(Path.Combine(root, normalizedKey));
+        var rootPrefix = Path.EndsInDirectorySeparator(root)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!combined.StartsWith(rootPrefix, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Local object key must resolve to a path under the bucket root.");
+        }
+
+        return combined;
+    }
 }

--- a/src/Honua.Worker.Gdal/Execution/MapAlgebraExpression.cs
+++ b/src/Honua.Worker.Gdal/Execution/MapAlgebraExpression.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Strict allow-list validator for the user-supplied <c>raster.map-algebra</c>
+/// expression (#2239). <c>gdal_calc.py</c> evaluates the <c>--calc</c> string with
+/// Python <c>eval()</c> in a NumPy namespace, so an un-vetted expression is remote
+/// code execution. This validator admits ONLY:
+/// <list type="bullet">
+/// <item>single-uppercase band variables A–Z, each within the supplied band count;</item>
+/// <item>a fixed set of arithmetic / comparison / logical operators and grouping;</item>
+/// <item>numeric literals; and</item>
+/// <item>a small allow-list of safe NumPy element-wise functions.</item>
+/// </list>
+/// Underscores, quotes, attribute access, indexing, and any other character are
+/// rejected, which blocks dunder / import / attribute-traversal escapes.
+///
+/// <para>
+/// The same rule is mirrored at submit time in
+/// <c>ProcessPlanValidator.ValidateRasterMapAlgebraSemantics</c> so a plan accepted
+/// at submit is also accepted by the executor.
+/// </para>
+/// </summary>
+internal static class MapAlgebraExpression
+{
+    /// <summary>Defensive upper bound on the expression length.</summary>
+    public const int MaxLength = 2048;
+
+    // Element-wise NumPy functions safe to expose in the calc namespace. No I/O,
+    // attribute traversal, or object construction primitives are included.
+    private static readonly FrozenSet<string> AllowedFunctions = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "abs", "absolute", "minimum", "maximum", "sqrt", "exp", "log", "log10",
+        "power", "where", "clip", "sign", "floor", "ceil", "mod", "fmod",
+        "sin", "cos", "tan", "arctan", "nan_to_num",
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Validates <paramref name="expression"/> against the allow-list for a calc
+    /// with <paramref name="bandCount"/> source rasters (band variables A …
+    /// A+bandCount-1).
+    /// </summary>
+    public static bool IsAllowed(string expression, int bandCount, out string error)
+    {
+        error = "";
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            error = "'expression' must not be empty";
+            return false;
+        }
+
+        var expr = expression.Trim();
+        if (expr.Length > MaxLength)
+        {
+            error = $"'expression' exceeds the maximum length of {MaxLength} characters";
+            return false;
+        }
+
+        var i = 0;
+        var referencedAny = false;
+        while (i < expr.Length)
+        {
+            var c = expr[i];
+
+            if (char.IsWhiteSpace(c) || IsAllowedSymbol(c))
+            {
+                i++;
+                continue;
+            }
+
+            if (char.IsDigit(c) || c == '.')
+            {
+                // Skip a numeric literal (digits, decimal point, exponent sign).
+                while (i < expr.Length && (char.IsDigit(expr[i]) || expr[i] == '.' || expr[i] == 'e' || expr[i] == 'E'))
+                {
+                    i++;
+                }
+                continue;
+            }
+
+            if (char.IsAsciiLetter(c))
+            {
+                var start = i;
+                while (i < expr.Length && (char.IsAsciiLetterOrDigit(expr[i])))
+                {
+                    i++;
+                }
+
+                var identifier = expr[start..i];
+                if (identifier.Length == 1 && identifier[0] is >= 'A' and <= 'Z')
+                {
+                    var bandIndex = identifier[0] - 'A';
+                    if (bandIndex >= bandCount)
+                    {
+                        error = $"'expression' references band variable '{identifier}' but only {bandCount} source raster(s) were supplied";
+                        return false;
+                    }
+                    referencedAny = true;
+                    continue;
+                }
+
+                if (AllowedFunctions.Contains(identifier))
+                {
+                    continue;
+                }
+
+                error = $"'expression' contains a disallowed identifier '{identifier}'";
+                return false;
+            }
+
+            error = $"'expression' contains a disallowed character '{c}'";
+            return false;
+        }
+
+        if (!referencedAny)
+        {
+            error = "'expression' must reference at least one source band variable (A, B, …)";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsAllowedSymbol(char c) => c switch
+    {
+        '+' or '-' or '*' or '/' or '%' or '(' or ')' or ',' or '.' => true,
+        '<' or '>' or '=' or '!' or '&' or '|' or '^' or '~' => true,
+        _ => false,
+    };
+}

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -164,6 +164,9 @@ public static class GdalWorkerServiceCollectionExtensions
         RegisterGdalExecutor<GdalVectorReprojectJobExecutor>(services);
         RegisterGdalExecutor<GdalVectorSourceReadJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterReprojectJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterResampleJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterInterpolateJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterMosaicJobExecutor>(services);
         RegisterGdalExecutor<GdalSurfaceJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterClipJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterReprojectCatalogJobExecutor>(services);

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -167,6 +167,14 @@ public static class GdalWorkerServiceCollectionExtensions
         RegisterGdalExecutor<GdalRasterResampleJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterInterpolateJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterMosaicJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterMapAlgebraJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterSpectralIndexJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterReclassifyJobExecutor>(services);
+        RegisterGdalExecutor<GdalProximityJobExecutor>(services);
+        RegisterGdalExecutor<GdalContourJobExecutor>(services);
+        RegisterGdalExecutor<GdalViewshedJobExecutor>(services);
+        RegisterGdalExecutor<GdalPolygonizeJobExecutor>(services);
+        RegisterGdalExecutor<GdalRasterizeJobExecutor>(services);
         RegisterGdalExecutor<GdalSurfaceJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterClipJobExecutor>(services);
         RegisterGdalExecutor<GdalRasterReprojectCatalogJobExecutor>(services);

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -311,22 +311,11 @@ public sealed class CatalogExecutableConformanceTests
         // routes these ids; here we lock in the catalog declaration AND that
         // the lean dispatcher has no executor for them, so the routing decision
         // and the GDAL-free baseline agree.
-        var nativeExecutableProcessIds = new[]
-        {
-            "gdal.gdalwarp",
-            "gdal.ogr2ogr",
-            "surface.slope",
-            "surface.aspect",
-            "surface.hillshade",
-            "surface.rugosity-tri",
-            "surface.rugosity-tpi",
-            "surface.roughness",
-            "raster.clip",
-            "raster.reproject",
-            "raster.statistics",
-            "raster.histogram",
-            "raster.zonal-statistics",
-        };
+        // Derive the native-profile assertion set from the classification source of
+        // truth so a newly added native-routed id (the #2141 / #2239 / #2240 raster &
+        // terrain GP packs) is covered automatically instead of drifting away from a
+        // hand-maintained list.
+        var nativeExecutableProcessIds = RoutedToNativeProcessIds;
         var managedExecutable = DispatcherSupportedProcessIds();
 
         foreach (var processId in nativeExecutableProcessIds)

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -166,6 +166,14 @@ public sealed class CatalogExecutableConformanceTests
         "raster.statistics",
         "raster.histogram",
         "raster.zonal-statistics",
+        // Raster analysis tool pack (#2141): resample / IDW interpolation / mosaic
+        // run out-of-process in the GDAL worker; kriging is advertised but flagged
+        // unsupported (the worker FAILS it with a clear message). All declare the
+        // native runtime profile and have NO lean-dispatcher executor.
+        "raster.resample",
+        "raster.interpolate-idw",
+        "raster.interpolate-kriging",
+        "raster.mosaic",
         "conversion.raster-format",
         "conversion.raster-reproject",
         // Point-cloud conversion (#1854): LAZ/COPC decompression + optional

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -174,6 +174,21 @@ public sealed class CatalogExecutableConformanceTests
         "raster.interpolate-idw",
         "raster.interpolate-kriging",
         "raster.mosaic",
+        // Raster analysis & terrain GP tool pack (#2239 / #2240): all run
+        // out-of-process in the GDAL worker (gdal_calc.py / gdal_proximity.py /
+        // gdal_contour / gdal_viewshed / gdal_polygonize.py / gdal_rasterize).
+        // proximity.euclidean-allocation is advertised but flagged unsupported
+        // (the worker FAILS it with a clear message). All declare the native
+        // runtime profile and have NO lean-dispatcher executor.
+        "raster.map-algebra",
+        "raster.spectral-index",
+        "raster.reclassify",
+        "proximity.euclidean-distance",
+        "proximity.euclidean-allocation",
+        "surface.contour",
+        "surface.viewshed",
+        "conversion.polygonize",
+        "conversion.rasterize",
         "conversion.raster-format",
         "conversion.raster-reproject",
         // Point-cloud conversion (#1854): LAZ/COPC decompression + optional

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
@@ -18,17 +18,21 @@ public sealed class ProcessCatalogSurfaceRasterTests
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
     public void Catalog_SurfaceRasterAndConversionCategories_AreRegistered()
     {
-        _catalog.GetProcessesByCategory("surface").Should().HaveCount(6);
+        // 6 gdaldem-backed surface products + surface.contour / surface.viewshed
+        // (gdal_contour / gdal_viewshed; #2240).
+        _catalog.GetProcessesByCategory("surface").Should().HaveCount(8);
         // 5 native raster idioms (clip, reproject, statistics, histogram,
         // zonal-statistics) + the raster analysis tool pack (resample,
         // interpolate-idw, interpolate-kriging, mosaic; #2141) + gdal.gdalwarp
         // (the native-profile raster reproject executed out-of-process by the
-        // GDAL worker).
-        _catalog.GetProcessesByCategory("raster").Should().HaveCount(10);
+        // GDAL worker) + the map-algebra tool pack (map-algebra, spectral-index,
+        // reclassify; #2239).
+        _catalog.GetProcessesByCategory("raster").Should().HaveCount(13);
         // 4 managed conversion idioms + gdal.ogr2ogr (the native-profile vector
         // conversion executed out-of-process by the GDAL worker) + pcloud.translate
-        // (the native-profile LAZ/COPC decompress + projected-CRS reproject, #1854).
-        _catalog.GetProcessesByCategory("conversion").Should().HaveCount(6);
+        // (the native-profile LAZ/COPC decompress + projected-CRS reproject, #1854)
+        // + conversion.polygonize / conversion.rasterize (#2240).
+        _catalog.GetProcessesByCategory("conversion").Should().HaveCount(8);
     }
 
     [UnitTest]
@@ -571,6 +575,172 @@ public sealed class ProcessCatalogSurfaceRasterTests
         violations.Should().Contain(v =>
             v.Code == "MISSING_REQUIRED_PARAMETER"
             && v.FieldPath == "steps[s1].inputs.sources");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Catalog_RasterAnalysisAndTerrainToolPack_DeclaresNativeProfile()
+    {
+        // The #2239/#2240 tool pack is executed out-of-process by the native GDAL
+        // worker, so each entry MUST declare the native runtime profile.
+        string[] toolPackIds =
+        [
+            "raster.map-algebra", "raster.spectral-index", "raster.reclassify",
+            "proximity.euclidean-distance", "proximity.euclidean-allocation",
+            "surface.contour", "surface.viewshed",
+            "conversion.polygonize", "conversion.rasterize",
+        ];
+        foreach (var processId in toolPackIds)
+        {
+            var definition = _catalog.GetProcess(processId);
+            definition.Should().NotBeNull($"catalog must advertise GP tool '{processId}'");
+            definition!.RuntimeProfile.Should().Be(
+                Core.Features.ControlPlane.Domain.RuntimeProfiles.Native,
+                $"'{processId}' is executed by the native worker");
+        }
+
+        _catalog.GetProcess("raster.map-algebra")!.Parameters
+            .Should().Contain(p => p.Name == "sources" && p.Required)
+            .And.Contain(p => p.Name == "expression" && p.Required);
+        _catalog.GetProcess("raster.reclassify")!.Parameters
+            .Should().Contain(p => p.Name == "remap" && p.Required);
+        _catalog.GetProcess("conversion.polygonize")!.OutputArtifactKinds
+            .Should().ContainSingle().Which.Should().Be(ArtifactKind.FeatureLayer);
+        _catalog.GetProcess("surface.contour")!.OutputArtifactKinds
+            .Should().ContainSingle().Which.Should().Be(ArtifactKind.FeatureLayer);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterMapAlgebra_WithDisallowedExpression_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.map-algebra",
+            new Dictionary<string, string>
+            {
+                ["sources"] = StubBase64,
+                ["expression"] = "__import__('os')",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.expression");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterReclassify_WithNonNumericRemap_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.reclassify",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["remap"] = "lo..hi:1",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.remap");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterSpectralIndex_MissingRequiredBand_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.spectral-index",
+            new Dictionary<string, string>
+            {
+                ["index"] = "NDVI",
+                ["nir"] = StubBase64,
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v => v.FieldPath == "steps[s1].inputs.red");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_ProximityEuclideanAllocation_ShapeValid_PassesValidation_AsFlagged()
+    {
+        // Allocation is flagged unsupported at execution, but a shape-valid plan must
+        // pass submit-time validation so the worker surfaces the unsupported message
+        // as a job failure (not a submit rejection).
+        var plan = CreateSingleStepPlan(
+            "proximity.euclidean-allocation",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_SurfaceContour_WithoutInterval_ProducesMissingRequiredParameterViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "surface.contour",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v =>
+            v.Code == "MISSING_REQUIRED_PARAMETER"
+            && v.FieldPath == "steps[s1].inputs.interval");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_ConversionRasterize_WithBothBurnAndAttribute_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "conversion.rasterize",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["burnValue"] = "1",
+                ["attribute"] = "pop",
+                ["cellSize"] = "0.001",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v => v.FieldPath == "steps[s1].inputs.burnValue");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_ConversionRasterize_WithGridAndBurn_ProducesNoViolations()
+    {
+        var plan = CreateSingleStepPlan(
+            "conversion.rasterize",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["burnValue"] = "1",
+                ["cellSize"] = "0.001",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().BeEmpty();
     }
 
     private static AnalysisPlan CreateSingleStepPlan(

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
@@ -523,6 +523,26 @@ public sealed class ProcessCatalogSurfaceRasterTests
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateIdw_WithWidthWithoutHeight_ProducesViolation()
+    {
+        // gdal_grid -outsize needs both dimensions; the executor rejects a
+        // half-specified grid, so submit-time validation must too.
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-idw",
+            new Dictionary<string, string>
+            {
+                ["points"] = StubBase64,
+                ["width"] = "256",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v => v.FieldPath == "steps[s1].inputs.width");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
     public void Validator_RasterInterpolateKriging_WithPoints_PassesValidation_AsFlaggedButShapeValid()
     {
         // Kriging is flagged unsupported at execution, but a shape-valid plan must

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
@@ -19,9 +19,12 @@ public sealed class ProcessCatalogSurfaceRasterTests
     public void Catalog_SurfaceRasterAndConversionCategories_AreRegistered()
     {
         _catalog.GetProcessesByCategory("surface").Should().HaveCount(6);
-        // 5 native raster idioms + gdal.gdalwarp (the native-profile raster
-        // reproject executed out-of-process by the GDAL worker).
-        _catalog.GetProcessesByCategory("raster").Should().HaveCount(6);
+        // 5 native raster idioms (clip, reproject, statistics, histogram,
+        // zonal-statistics) + the raster analysis tool pack (resample,
+        // interpolate-idw, interpolate-kriging, mosaic; #2141) + gdal.gdalwarp
+        // (the native-profile raster reproject executed out-of-process by the
+        // GDAL worker).
+        _catalog.GetProcessesByCategory("raster").Should().HaveCount(10);
         // 4 managed conversion idioms + gdal.ogr2ogr (the native-profile vector
         // conversion executed out-of-process by the GDAL worker) + pcloud.translate
         // (the native-profile LAZ/COPC decompress + projected-CRS reproject, #1854).
@@ -364,6 +367,210 @@ public sealed class ProcessCatalogSurfaceRasterTests
         var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
 
         violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.targetFormat");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Catalog_RasterAnalyticToolPack_IsRegistered_WithNativeProfileAndRasterOutput()
+    {
+        // The #2141 raster analysis tool pack is executed out-of-process by the
+        // native GDAL worker, so each entry MUST declare the native runtime profile.
+        string[] toolPackIds =
+        [
+            "raster.resample", "raster.interpolate-idw",
+            "raster.interpolate-kriging", "raster.mosaic",
+        ];
+        foreach (var processId in toolPackIds)
+        {
+            var definition = _catalog.GetProcess(processId);
+            definition.Should().NotBeNull($"catalog must advertise raster tool '{processId}'");
+            definition!.Category.Should().Be("raster");
+            definition.RuntimeProfile.Should().Be(
+                Core.Features.ControlPlane.Domain.RuntimeProfiles.Native,
+                $"'{processId}' is executed by the native worker");
+            definition.OutputArtifactKinds.Should().ContainSingle().Which.Should().Be(ArtifactKind.Raster);
+        }
+
+        _catalog.GetProcess("raster.resample")!.Parameters
+            .Should().Contain(p => p.Name == "source" && p.Required)
+            .And.Contain(p => p.Name == "cellSize" && p.Required);
+        _catalog.GetProcess("raster.interpolate-idw")!.Parameters
+            .Should().Contain(p => p.Name == "points" && p.Required);
+        _catalog.GetProcess("raster.mosaic")!.Parameters
+            .Should().Contain(p => p.Name == "sources" && p.Required);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterResample_WithoutCellSize_ProducesMissingRequiredParameterViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.resample",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v =>
+            v.Code == "MISSING_REQUIRED_PARAMETER"
+            && v.FieldPath == "steps[s1].inputs.cellSize");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterResample_WithNonPositiveCellSize_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.resample",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["cellSize"] = "0",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.cellSize");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterResample_WithUnknownResampling_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.resample",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["cellSize"] = "30",
+                ["resampling"] = "spline",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.resampling");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateIdw_WithValidTuning_ProducesNoViolations()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-idw",
+            new Dictionary<string, string>
+            {
+                ["points"] = StubBase64,
+                ["zField"] = "elevation",
+                ["power"] = "2.5",
+                ["smoothing"] = "0",
+                ["width"] = "256",
+                ["height"] = "256",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateIdw_WithoutPoints_ProducesMissingRequiredParameterViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-idw",
+            new Dictionary<string, string>
+            {
+                ["power"] = "2",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v =>
+            v.Code == "MISSING_REQUIRED_PARAMETER"
+            && v.FieldPath == "steps[s1].inputs.points");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateIdw_WithNonPositivePower_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-idw",
+            new Dictionary<string, string>
+            {
+                ["points"] = StubBase64,
+                ["power"] = "-1",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.power");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterInterpolateKriging_WithPoints_PassesValidation_AsFlaggedButShapeValid()
+    {
+        // Kriging is flagged unsupported at execution, but a shape-valid plan must
+        // still pass submit-time validation so the worker can surface the
+        // unsupported-dependency message as a job failure (not a submit rejection).
+        var plan = CreateSingleStepPlan(
+            "raster.interpolate-kriging",
+            new Dictionary<string, string>
+            {
+                ["points"] = StubBase64,
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterMosaic_WithUnsupportedOperator_ProducesViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.mosaic",
+            new Dictionary<string, string>
+            {
+                ["sources"] = StubBase64,
+                ["operator"] = "mean",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().ContainSingle(v => v.FieldPath == "steps[s1].inputs.operator");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_RasterMosaic_WithoutSources_ProducesMissingRequiredParameterViolation()
+    {
+        var plan = CreateSingleStepPlan(
+            "raster.mosaic",
+            new Dictionary<string, string>
+            {
+                ["operator"] = "last",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v =>
+            v.Code == "MISSING_REQUIRED_PARAMETER"
+            && v.FieldPath == "steps[s1].inputs.sources");
     }
 
     private static AnalysisPlan CreateSingleStepPlan(

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -68,7 +68,12 @@ public sealed class ProcessCatalogTests
         // + 4 native-profile raster analysis tool pack ops (raster.resample,
         // raster.interpolate-idw, raster.interpolate-kriging, raster.mosaic) added
         // by #2141.
-        all.Should().HaveCount(86);
+        // + 9 native-profile raster analysis & terrain ops added by #2239/#2240:
+        // raster.map-algebra, raster.spectral-index, raster.reclassify (#2239);
+        // proximity.euclidean-distance, proximity.euclidean-allocation,
+        // surface.contour, surface.viewshed, conversion.polygonize,
+        // conversion.rasterize (#2240).
+        all.Should().HaveCount(95);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -65,7 +65,10 @@ public sealed class ProcessCatalogTests
         // FeatureCollection canonicalization) added for the honua-worker-etl format
         // breadth (ADR-0038 roadmap F).
         // Round-5 (72) ∪ Round-4 (69) = 82 distinct processes (59 shared).
-        all.Should().HaveCount(82);
+        // + 4 native-profile raster analysis tool pack ops (raster.resample,
+        // raster.interpolate-idw, raster.interpolate-kriging, raster.mosaic) added
+        // by #2141.
+        all.Should().HaveCount(86);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalContourExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalContourExecutorTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalContourJobExecutor"/>: gdal_contour
+/// interval/base argument projection and the GeoJSON vector artifact contract (#2240).
+/// </summary>
+public sealed class GdalContourExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-contour-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalContourExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("surface.contour");
+    }
+
+    [UnitTest]
+    public async Task Contour_Default_RunsGdalContour_AndPublishesGeoJson()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("{\"type\":\"FeatureCollection\"}"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalContourJobExecutor.HandledProcessId,
+                ("source", Base64("fake-dem")),
+                ("interval", "10"),
+                ("base", "5"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:application/geo+json");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_contour");
+            invocation.Arguments.Should().ContainInOrder("-a", "ELEV");
+            invocation.Arguments.Should().ContainInOrder("-i", "10");
+            invocation.Arguments.Should().ContainInOrder("-off", "5");
+            invocation.Arguments.Should().ContainInOrder("-f", "GeoJSON");
+            invocation.Arguments[^1].Should().EndWith("output.geojson");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Contour_MissingInterval_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalContourJobExecutor.HandledProcessId,
+                ("source", Base64("fake-dem")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("interval");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Contour_NonPositiveInterval_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalContourJobExecutor.HandledProcessId,
+                ("source", Base64("fake-dem")),
+                ("interval", "0"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("interval");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalContourJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalContourJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalContourJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalJobFactory.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalJobFactory.cs
@@ -44,11 +44,11 @@ internal static class GdalJobFactory
         };
     }
 
-    public static IOptionsMonitor<GdalWorkerOptions> Options(string scratchRoot)
+    public static IOptionsMonitor<GdalWorkerOptions> Options(string scratchRoot, long maxArtifactBytes = 50L * 1024L * 1024L)
         => new StaticOptionsMonitor<GdalWorkerOptions>(new GdalWorkerOptions
         {
             ScratchRoot = scratchRoot,
-            MaxArtifactBytes = 50L * 1024L * 1024L,
+            MaxArtifactBytes = maxArtifactBytes,
             ToolTimeout = TimeSpan.FromMinutes(1),
         });
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalMultidimCoverageExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalMultidimCoverageExecutorTests.cs
@@ -188,4 +188,28 @@ public sealed class GdalMultidimCoverageExecutorTests
         var act = () => GdalVsiPath.Build((CloudStorageProvider)999, "bucket", "k.nc");
         act.Should().Throw<NotSupportedException>();
     }
+
+    [UnitTest]
+    public void VsiPath_LocalProvider_KeyUnderRoot_StaysUnderBucket()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "honua-vsi-root");
+        GdalVsiPath.Build(CloudStorageProvider.Local, root, "sub/dir/file.nc")
+            .Should().Be(Path.GetFullPath(Path.Combine(root, "sub", "dir", "file.nc")));
+    }
+
+    [UnitTest]
+    public void VsiPath_LocalProvider_ParentTraversal_IsRejected()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "honua-vsi-root");
+        var act = () => GdalVsiPath.Build(CloudStorageProvider.Local, root, "../../etc/passwd");
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [UnitTest]
+    public void VsiPath_LocalProvider_EmbeddedTraversal_IsRejected()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "honua-vsi-root");
+        var act = () => GdalVsiPath.Build(CloudStorageProvider.Local, root, "sub/../../escape.nc");
+        act.Should().Throw<InvalidOperationException>();
+    }
 }

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalPolygonizeExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalPolygonizeExecutorTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalPolygonizeJobExecutor"/>: gdal_polygonize.py
+/// band/connectedness/field argument projection and the GeoJSON vector artifact
+/// contract (#2240).
+/// </summary>
+public sealed class GdalPolygonizeExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-polygonize-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    // gdal_polygonize.py positional layout is "raster out_file layer fieldname", so
+    // the output path is NOT the last argument; write to whichever arg names it.
+    private static FakeGdalCommandRunner SucceedingGeoJson(byte[] bytes)
+        => new((_, args, _) =>
+        {
+            var outputPath = args.First(a => a.EndsWith("output.geojson", StringComparison.Ordinal));
+            File.WriteAllBytes(outputPath, bytes);
+            return new GdalCommandResult { ExitCode = 0 };
+        });
+
+    [UnitTest]
+    public void GdalPolygonizeExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("conversion.polygonize");
+    }
+
+    [UnitTest]
+    public async Task Polygonize_EightConnected_ProjectsFlagsAndField_AndPublishesGeoJson()
+    {
+        var runner = SucceedingGeoJson(Encoding.UTF8.GetBytes("{\"type\":\"FeatureCollection\"}"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalPolygonizeJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("band", "2"),
+                ("connectedness", "8"),
+                ("fieldName", "value"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:application/geo+json");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_polygonize.py");
+            invocation.Arguments.Should().Contain("-8");
+            invocation.Arguments.Should().ContainInOrder("-b", "2");
+            invocation.Arguments.Should().ContainInOrder("-f", "GeoJSON");
+            invocation.Arguments[^1].Should().Be("value");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Polygonize_InvalidFieldName_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalPolygonizeJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("fieldName", "bad name!"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("fieldName");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Polygonize_InvalidConnectedness_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalPolygonizeJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("connectedness", "6"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("connectedness");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalPolygonizeJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalPolygonizeJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalPolygonizeJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProcessExecutorModeRegistrationTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProcessExecutorModeRegistrationTests.cs
@@ -3,6 +3,8 @@
 
 using FluentAssertions;
 using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Honua.Worker.Gdal.Execution;
 using Microsoft.Extensions.Configuration;
@@ -80,6 +82,94 @@ public sealed class GdalProcessExecutorModeRegistrationTests
             .Value;
 
         options.Image.Should().Be(customImage);
+    }
+
+    [UnitTest]
+    public void AddGdalProcessExecutors_RegistersExactlyTheExpectedNativeProcessIdSet()
+    {
+        using var provider = BuildProvider(static (services, config) =>
+            services.AddGdalProcessExecutors(config));
+
+        var registeredIds = provider
+            .GetServices<IProcessExecutor>()
+            .SelectMany(e => e.ProcessIds)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // The full process-id surface the GDAL worker exposes. Asserting the exact set
+        // (not just mode-to-mode equality) makes adding or dropping an executor a
+        // deliberate, reviewed change rather than a silent drift.
+        registeredIds.Should().BeEquivalentTo(new[]
+        {
+            // Vector / raster passthrough + canonicalization.
+            "gdal.ogr2ogr",
+            "gdal.gdalwarp",
+            "transform.reproject",
+            "source.ogr",
+            // Raster analysis tool pack (#2141).
+            "raster.resample",
+            "raster.interpolate-idw",
+            "raster.interpolate-kriging",
+            "raster.mosaic",
+            // Raster analysis & terrain GP tool packs (#2239, #2240).
+            "raster.map-algebra",
+            "raster.spectral-index",
+            "raster.reclassify",
+            "proximity.euclidean-distance",
+            "proximity.euclidean-allocation",
+            "surface.contour",
+            "surface.viewshed",
+            "conversion.polygonize",
+            "conversion.rasterize",
+            // Surface / terrain derivatives.
+            "surface.slope",
+            "surface.aspect",
+            "surface.hillshade",
+            "surface.rugosity-tri",
+            "surface.rugosity-tpi",
+            "surface.roughness",
+            // Raster clip / reproject / format conversion.
+            "raster.clip",
+            "raster.reproject",
+            "conversion.raster-reproject",
+            "conversion.raster-format",
+            // Raster statistics.
+            "raster.statistics",
+            "raster.histogram",
+            "raster.zonal-statistics",
+            // Coverage metadata + point-cloud translate.
+            "coverage.multidim.metadata",
+            "pcloud.translate",
+        });
+    }
+
+    [UnitTest]
+    public void AddGdalProcessExecutors_RoutesEveryNativeRoutedCatalogProcess()
+    {
+        // Cross-project honesty: the managed-side CatalogExecutableConformanceTests
+        // proves these native-routed ids are ABSENT from the lean dispatcher; here we
+        // prove the GDAL worker actually routes every native-profile catalog process,
+        // so a catalog entry can never claim native execution with no worker executor.
+        using var provider = BuildProvider(static (services, config) =>
+            services.AddGdalProcessExecutors(config));
+
+        var supported = provider
+            .GetServices<IProcessExecutor>()
+            .SelectMany(e => e.ProcessIds)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var catalog = new BuiltInProcessCatalog();
+        var nativeRouted = catalog.ListProcesses()
+            .Where(p => RuntimeProfiles.Normalize(p.RuntimeProfile) == RuntimeProfiles.Native)
+            .Select(p => p.ProcessId)
+            .ToList();
+
+        nativeRouted.Should().NotBeEmpty("the catalog advertises native-routed processes");
+        foreach (var processId in nativeRouted)
+        {
+            supported.Should().Contain(
+                processId,
+                $"the catalog advertises native-routed '{processId}', so the GDAL worker dispatcher must route it");
+        }
     }
 
     private static string[] ExecutorTypeNames(IServiceProvider provider)

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProximityExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProximityExecutorTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalProximityJobExecutor"/>: the
+/// gdal_proximity.py distance argument projection plus the flagged allocation path
+/// that fails fast with a clear unsupported-dependency message (#2240).
+/// </summary>
+public sealed class GdalProximityExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-proximity-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalProximityExecutor_DeclaresNativeRuntimeProfile_AndAdvertisesBothIds()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        GdalProximityJobExecutor.SupportedProcessIds.Should().BeEquivalentTo(new[]
+        {
+            "proximity.euclidean-distance",
+            "proximity.euclidean-allocation",
+        });
+    }
+
+    [UnitTest]
+    public async Task Distance_Default_RunsGdalProximity_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("dist-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalProximityJobExecutor.DistanceProcessId,
+                ("source", Base64("fake-raster")),
+                ("maxDistance", "500"),
+                ("distUnits", "GEO"),
+                ("values", "1,2"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_proximity.py");
+            invocation.Arguments.Should().ContainInOrder("-distunits", "GEO");
+            invocation.Arguments.Should().ContainInOrder("-maxdist", "500");
+            invocation.Arguments.Should().ContainInOrder("-values", "1,2");
+            invocation.Arguments[^1].Should().EndWith("output.tif");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Distance_InvalidUnits_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalProximityJobExecutor.DistanceProcessId,
+                ("source", Base64("fake-raster")),
+                ("distUnits", "MILES"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("distUnits");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Allocation_IsFlaggedUnsupported_AndFailsFast()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalProximityJobExecutor.AllocationProcessId,
+                ("source", Base64("fake-raster")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Be(GdalProximityJobExecutor.AllocationUnsupportedMessage);
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalProximityJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalProximityJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalProximityJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
@@ -678,6 +678,15 @@ public sealed class GdalRasterExecutorTests
             // flagged-unsupported message rather than the dispatcher rejecting it).
             "raster.resample", "raster.interpolate-idw",
             "raster.interpolate-kriging", "raster.mosaic",
+            // Raster analysis & terrain GP tool pack (#2239 / #2240). map-algebra /
+            // spectral-index / reclassify compile to gdal_calc.py; euclidean distance
+            // runs gdal_proximity.py (allocation is routed here too but fails fast as
+            // flagged-unsupported); contour / viewshed / polygonize / rasterize run
+            // gdal_contour / gdal_viewshed / gdal_polygonize.py / gdal_rasterize.
+            "raster.map-algebra", "raster.spectral-index", "raster.reclassify",
+            "proximity.euclidean-distance", "proximity.euclidean-allocation",
+            "surface.contour", "surface.viewshed",
+            "conversion.polygonize", "conversion.rasterize",
             // Internal multidimensional-coverage metadata scan (ADR-0039 Path B).
             "coverage.multidim.metadata",
             // LAZ/COPC decompress + reproject (#1854).
@@ -742,6 +751,14 @@ public sealed class GdalRasterExecutorTests
             new GdalRasterResampleJobExecutor(runner, options, NullLogger<GdalRasterResampleJobExecutor>.Instance),
             new GdalRasterInterpolateJobExecutor(runner, options, NullLogger<GdalRasterInterpolateJobExecutor>.Instance),
             new GdalRasterMosaicJobExecutor(runner, options, NullLogger<GdalRasterMosaicJobExecutor>.Instance),
+            new GdalRasterMapAlgebraJobExecutor(runner, options, NullLogger<GdalRasterMapAlgebraJobExecutor>.Instance),
+            new GdalRasterSpectralIndexJobExecutor(runner, options, NullLogger<GdalRasterSpectralIndexJobExecutor>.Instance),
+            new GdalRasterReclassifyJobExecutor(runner, options, NullLogger<GdalRasterReclassifyJobExecutor>.Instance),
+            new GdalProximityJobExecutor(runner, options, NullLogger<GdalProximityJobExecutor>.Instance),
+            new GdalContourJobExecutor(runner, options, NullLogger<GdalContourJobExecutor>.Instance),
+            new GdalViewshedJobExecutor(runner, options, NullLogger<GdalViewshedJobExecutor>.Instance),
+            new GdalPolygonizeJobExecutor(runner, options, NullLogger<GdalPolygonizeJobExecutor>.Instance),
+            new GdalRasterizeJobExecutor(runner, options, NullLogger<GdalRasterizeJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
             new GdalRasterClipJobExecutor(runner, options, NullLogger<GdalRasterClipJobExecutor>.Instance),
             new GdalRasterReprojectCatalogJobExecutor(runner, options, NullLogger<GdalRasterReprojectCatalogJobExecutor>.Instance),

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterExecutorTests.cs
@@ -670,6 +670,14 @@ public sealed class GdalRasterExecutorTests
             "surface.rugosity-tri", "surface.rugosity-tpi", "surface.roughness",
             "raster.clip", "raster.reproject", "raster.statistics",
             "raster.histogram", "raster.zonal-statistics",
+            // Explicit raster CRS-conversion idiom, routed by the same
+            // GdalRasterReprojectCatalogJobExecutor that handles raster.reproject.
+            "conversion.raster-reproject",
+            // Raster analysis tool pack (#2141): resample / IDW + kriging interpolation
+            // / mosaic. Kriging is routed here too (the executor fails it fast with a
+            // flagged-unsupported message rather than the dispatcher rejecting it).
+            "raster.resample", "raster.interpolate-idw",
+            "raster.interpolate-kriging", "raster.mosaic",
             // Internal multidimensional-coverage metadata scan (ADR-0039 Path B).
             "coverage.multidim.metadata",
             // LAZ/COPC decompress + reproject (#1854).
@@ -731,6 +739,9 @@ public sealed class GdalRasterExecutorTests
             new GdalVectorReprojectJobExecutor(runner, options, NullLogger<GdalVectorReprojectJobExecutor>.Instance),
             new GdalVectorSourceReadJobExecutor(runner, options, NullLogger<GdalVectorSourceReadJobExecutor>.Instance),
             new GdalRasterReprojectJobExecutor(runner, options, NullLogger<GdalRasterReprojectJobExecutor>.Instance),
+            new GdalRasterResampleJobExecutor(runner, options, NullLogger<GdalRasterResampleJobExecutor>.Instance),
+            new GdalRasterInterpolateJobExecutor(runner, options, NullLogger<GdalRasterInterpolateJobExecutor>.Instance),
+            new GdalRasterMosaicJobExecutor(runner, options, NullLogger<GdalRasterMosaicJobExecutor>.Instance),
             new GdalSurfaceJobExecutor(runner, options, NullLogger<GdalSurfaceJobExecutor>.Instance),
             new GdalRasterClipJobExecutor(runner, options, NullLogger<GdalRasterClipJobExecutor>.Instance),
             new GdalRasterReprojectCatalogJobExecutor(runner, options, NullLogger<GdalRasterReprojectCatalogJobExecutor>.Instance),

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterInterpolateExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterInterpolateExecutorTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterInterpolateJobExecutor"/>: the
+/// gdal_grid IDW argument projection plus the flagged Kriging path that fails fast
+/// with a clear unsupported-dependency message (no silent stub, #2141).
+/// </summary>
+public sealed class GdalRasterInterpolateExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-interpolate-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalRasterInterpolateExecutor_DeclaresNativeRuntimeProfile_AndAdvertisesBothIds()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        GdalRasterInterpolateJobExecutor.SupportedProcessIds.Should().BeEquivalentTo(new[]
+        {
+            "raster.interpolate-idw",
+            "raster.interpolate-kriging",
+        });
+    }
+
+    [UnitTest]
+    public async Task Idw_Default_RunsGdalGridInvdist_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("idw-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.IdwProcessId,
+                ("points", Base64("{\"type\":\"FeatureCollection\",\"features\":[]}")),
+                ("zField", "elevation"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_grid");
+            invocation.Arguments.Should().ContainInOrder("-a", "invdist:power=2:smoothing=0");
+            invocation.Arguments.Should().ContainInOrder("-zfield", "elevation");
+            invocation.Arguments.Should().Contain("-l").And.Contain("points");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Idw_WithTuningAndOutsize_ProjectsAllArguments()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.IdwProcessId,
+                ("points", Base64("points")),
+                ("power", "3"),
+                ("smoothing", "0.5"),
+                ("radius", "100"),
+                ("width", "256"),
+                ("height", "128"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().ContainInOrder("-a", "invdist:power=3:smoothing=0.5:radius=100");
+            args.Should().ContainInOrder("-outsize", "256", "128");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Idw_WidthWithoutHeight_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.IdwProcessId,
+                ("points", Base64("points")),
+                ("width", "256"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("width").And.Contain("height");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Idw_MissingPoints_FailsWithClearMessage()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(GdalRasterInterpolateJobExecutor.IdwProcessId);
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("points");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Kriging_IsFlaggedUnsupported_FailsFastWithClearMessage_AndNeverRunsCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "should-not-run");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            // Even with valid inputs, kriging must fail fast with the unsupported
+            // message rather than silently substituting another algorithm.
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.KrigingProcessId,
+                ("points", Base64("points")),
+                ("zField", "elevation"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Be(GdalRasterInterpolateJobExecutor.KrigingUnsupportedMessage);
+            result.ErrorMessage.Should().Contain("not available in this build");
+            runner.Invocations.Should().BeEmpty();
+            context.Artifacts.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterInterpolateJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterInterpolateJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterInterpolateJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterInterpolateExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterInterpolateExecutorTests.cs
@@ -120,6 +120,30 @@ public sealed class GdalRasterInterpolateExecutorTests
     }
 
     [UnitTest]
+    public async Task Idw_InvalidZField_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterInterpolateJobExecutor.IdwProcessId,
+                ("points", Base64("points")),
+                ("zField", "elev; rm -rf /"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("zField");
+            runner.Invocations.Should().BeEmpty("an invalid attribute name must never reach the CLI");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
     public async Task Idw_MissingPoints_FailsWithClearMessage()
     {
         var runner = FakeGdalCommandRunner.Failing(1, "n/a");

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMapAlgebraExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMapAlgebraExecutorTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterMapAlgebraJobExecutor"/>: gdal_calc.py
+/// band-variable argument projection, the expression allow-list guard, and the
+/// canonical data-URI artifact contract (#2239).
+/// </summary>
+public sealed class GdalRasterMapAlgebraExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-mapalgebra-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    private static string Sources(params string[] entries)
+        => string.Join(GdalRasterMapAlgebraJobExecutor.SourceSeparator, entries.Select(Base64));
+
+    [UnitTest]
+    public void GdalRasterMapAlgebraExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("raster.map-algebra");
+    }
+
+    [UnitTest]
+    public async Task MapAlgebra_TwoSources_ProjectsBandVariables_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("calc-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a", "raster-b")),
+                ("expression", "(A-B)/(A+B)"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_calc.py");
+            invocation.Arguments.Should().Contain(a => a.StartsWith("-A"));
+            invocation.Arguments.Should().Contain(a => a.StartsWith("-B"));
+            invocation.Arguments.Should().ContainInOrder("--calc", "(A-B)/(A+B)");
+            invocation.Arguments.Should().Contain("--overwrite");
+            invocation.Arguments[^1].Should().EndWith("output.tif");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task MapAlgebra_DataType_PassesTypeFlag()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a")),
+                ("expression", "A*2"),
+                ("dataType", "float32"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            runner.Invocations.Single().Arguments.Should().ContainInOrder("--type", "Float32");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task MapAlgebra_DisallowedExpression_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a")),
+                ("expression", "__import__('os').system('id')"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("expression");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task MapAlgebra_ExpressionReferencesUndefinedBand_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a")),
+                ("expression", "A+B"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("B");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task MapAlgebra_MissingExpression_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("expression");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterMapAlgebraJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterMapAlgebraJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterMapAlgebraJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMapAlgebraExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMapAlgebraExecutorTests.cs
@@ -57,9 +57,38 @@ public sealed class GdalRasterMapAlgebraExecutorTests
             invocation.Tool.Should().Be("gdal_calc.py");
             invocation.Arguments.Should().Contain(a => a.StartsWith("-A"));
             invocation.Arguments.Should().Contain(a => a.StartsWith("-B"));
-            invocation.Arguments.Should().ContainInOrder("--calc", "(A-B)/(A+B)");
+            invocation.Arguments.Should().Contain("--calc=(A-B)/(A+B)");
             invocation.Arguments.Should().Contain("--overwrite");
             invocation.Arguments[^1].Should().EndWith("output.tif");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task MapAlgebra_LeadingUnaryMinus_PassesCalcAsSingleToken()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("calc-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a")),
+                ("expression", "-A"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+
+            var args = runner.Invocations.Single().Arguments;
+            // The expression is a single "--calc=-A" token so argparse cannot mistake
+            // the leading minus for a separate option. (The band-variable flag "-A" is
+            // a separate, expected argument.)
+            args.Should().Contain("--calc=-A");
+            args.Should().NotContain("--calc");
         }
         finally
         {
@@ -154,6 +183,34 @@ public sealed class GdalRasterMapAlgebraExecutorTests
 
             result.Status.Should().Be(ExecutionJobStatus.Failed);
             result.ErrorMessage.Should().Contain("expression");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task MapAlgebra_AggregateDecodedBytesExceedCeiling_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        // Each source decodes to 4 bytes (under the 6-byte ceiling), but the aggregate
+        // exceeds it, so GdalCalcInputs must reject before the CLI is reached.
+        var executor = new GdalRasterMapAlgebraJobExecutor(
+            runner, GdalJobFactory.Options(scratch, maxArtifactBytes: 6), NullLogger<GdalRasterMapAlgebraJobExecutor>.Instance);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("ABCD", "EFGH")),
+                ("expression", "A+B"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("total");
             runner.Invocations.Should().BeEmpty();
         }
         finally

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMosaicExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMosaicExecutorTests.cs
@@ -166,6 +166,60 @@ public sealed class GdalRasterMosaicExecutorTests
         }
     }
 
+    [UnitTest]
+    public async Task Mosaic_TooManySources_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var entries = Enumerable
+                .Range(0, GdalRasterMosaicJobExecutor.MaxSources + 1)
+                .Select(i => "tile" + i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .ToArray();
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources(entries)));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("at most");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_AggregateDecodedBytesExceedCeiling_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        // Each source decodes to 4 bytes (under the 6-byte ceiling) but together they
+        // exceed it, so the aggregate guard must reject before any decode reaches scratch.
+        var executor = new GdalRasterMosaicJobExecutor(
+            runner, GdalJobFactory.Options(scratch, maxArtifactBytes: 6), NullLogger<GdalRasterMosaicJobExecutor>.Instance);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources("ABCD", "EFGH")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("total");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
     private static GdalRasterMosaicJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
     {
         scratch = GdalCli.NewScratch(ScratchSuite);

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMosaicExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMosaicExecutorTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterMosaicJobExecutor"/>: multi-input
+/// gdalwarp argument projection, the first/last overlap-operator ordering, source
+/// list parsing guards, and the canonical data-URI artifact contract.
+/// </summary>
+public sealed class GdalRasterMosaicExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-mosaic-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    private static string Sources(params string[] entries)
+        => string.Join(GdalRasterMosaicJobExecutor.SourceSeparator, entries.Select(Base64));
+
+    [UnitTest]
+    public void GdalRasterMosaicExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("raster.mosaic");
+    }
+
+    [UnitTest]
+    public async Task Mosaic_TwoSources_RunsGdalwarpWithBothInputs_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("mosaic-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a", "raster-b")));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdalwarp");
+            invocation.Arguments.Should().Contain(a => a.EndsWith("input0.tif"));
+            invocation.Arguments.Should().Contain(a => a.EndsWith("input1.tif"));
+            invocation.Arguments.Should().ContainInOrder("-r", "near");
+            invocation.Arguments[^1].Should().EndWith("output.tif");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_FirstOperator_ReversesSourceOrderSoFirstSourceWins()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a", "raster-b")),
+                ("operator", "first"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+
+            // 'first' reverses the source order so the first-listed source is written
+            // LAST into the output (gdalwarp later-source-wins). The input paths are
+            // numbered by write order, so input0 (the reversed write) comes before
+            // input1 in the argument list.
+            var args = runner.Invocations.Single().Arguments;
+            var firstInputIndex = args.ToList().FindIndex(a => a.EndsWith("input0.tif"));
+            var secondInputIndex = args.ToList().FindIndex(a => a.EndsWith("input1.tif"));
+            firstInputIndex.Should().BeLessThan(secondInputIndex);
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_UnsupportedOperator_FailsWithClearMessage()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a", "raster-b")),
+                ("operator", "mean"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("operator").And.Contain("not supported");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_SingleSource_FailsBecauseAtLeastTwoAreRequired()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Base64("only-one")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("at least two");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Mosaic_InvalidBase64Source_FailsWithClearMessage()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMosaicJobExecutor.HandledProcessId,
+                ("sources", Base64("valid") + GdalRasterMosaicJobExecutor.SourceSeparator + "!!not-base64!!"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("not valid base64");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterMosaicJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterMosaicJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterMosaicJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterReclassifyExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterReclassifyExecutorTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterReclassifyJobExecutor"/>: remap-table
+/// folding into a trusted nested-where gdal_calc.py expression, plus the parse guards
+/// (#2239).
+/// </summary>
+public sealed class GdalRasterReclassifyExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-reclassify-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalRasterReclassifyExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("raster.reclassify");
+    }
+
+    [UnitTest]
+    public async Task Reclassify_RangeTable_BuildsNestedWhere_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("reclassified"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterReclassifyJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("remap", "0..10:1;10..20:2"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:image/tiff");
+
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().Contain("-A");
+            var calcIndex = args.ToList().IndexOf("--calc");
+            var calc = args[calcIndex + 1];
+            calc.Should().StartWith("where(");
+            calc.Should().Contain("(A>=0)&(A<10)");
+            calc.Should().EndWith("A))");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Reclassify_SingleValuesAndDefault_FoldsDefaultLast()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterReclassifyJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("remap", "1:100;2:200"),
+                ("defaultValue", "0"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var args = runner.Invocations.Single().Arguments;
+            var calc = args[args.ToList().IndexOf("--calc") + 1];
+            calc.Should().Contain("(A==1)");
+            calc.Should().Contain("(A==2)");
+            calc.Should().EndWith(",0))");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Reclassify_NonNumericRemap_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterReclassifyJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("remap", "low..high:1"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("remap");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Reclassify_MissingRemap_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterReclassifyJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("remap");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterReclassifyJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterReclassifyJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterReclassifyJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterResampleExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterResampleExecutorTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterResampleJobExecutor"/>: gdalwarp
+/// -tr argument projection, resampling enum mapping, cell-size guards, and the
+/// canonical data-URI artifact contract.
+/// </summary>
+public sealed class GdalRasterResampleExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-resample-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalRasterResampleExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("raster.resample");
+    }
+
+    [UnitTest]
+    public async Task Resample_Default_RunsGdalwarpWithTargetResolution_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("resampled-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Should().ContainSingle();
+            context.Artifacts[0].Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdalwarp");
+            invocation.Arguments.Should().ContainInOrder("-tr", "30", "30");
+            invocation.Arguments.Should().ContainInOrder("-r", "bilinear");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_DistinctCellSizeY_PassesBothAxes()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"),
+                ("cellSizeY", "20"),
+                ("resampling", "nearestneighbor"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().ContainInOrder("-tr", "30", "20");
+            args.Should().ContainInOrder("-r", "near");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_MissingCellSize_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("cellSize");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_UnknownResampling_FailsBeforeReachingTheCli()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"),
+                ("resampling", "spline"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("resampling");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Resample_ToolFailure_IsReportedAsJobFailure()
+    {
+        var runner = FakeGdalCommandRunner.Failing(2, "ERROR: warp failed");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterResampleJobExecutor.HandledProcessId,
+                ("source", Base64("fake-raster")),
+                ("cellSize", "30"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("gdalwarp exited with code 2");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterResampleJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterResampleJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterResampleJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterSpectralIndexExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterSpectralIndexExecutorTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterSpectralIndexJobExecutor"/>: preset
+/// band-role binding, the trusted Float32 calc expression projection, and the
+/// required-band guards (#2239).
+/// </summary>
+public sealed class GdalRasterSpectralIndexExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-spectral-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalRasterSpectralIndexExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("raster.spectral-index");
+    }
+
+    [UnitTest]
+    public async Task Ndvi_BindsNirAndRed_AndForcesFloat32()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ndvi-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterSpectralIndexJobExecutor.HandledProcessId,
+                ("index", "NDVI"),
+                ("nir", Base64("nir-raster")),
+                ("red", Base64("red-raster")));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:image/tiff");
+
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().Contain(a => a.StartsWith("-A")).And.Contain(a => a.StartsWith("-B"));
+            args.Should().ContainInOrder("--calc", "(1.0*A-B)/(1.0*A+B)");
+            args.Should().ContainInOrder("--type", "Float32");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Savi_AppliesSoilFactorLiteral()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("savi"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterSpectralIndexJobExecutor.HandledProcessId,
+                ("index", "SAVI"),
+                ("nir", Base64("nir")),
+                ("red", Base64("red")),
+                ("L", "0.25"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var args = runner.Invocations.Single().Arguments;
+            var calcIndex = args.ToList().IndexOf("--calc");
+            args[calcIndex + 1].Should().Contain("0.25");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Evi_MissingBlueBand_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterSpectralIndexJobExecutor.HandledProcessId,
+                ("index", "EVI"),
+                ("nir", Base64("nir")),
+                ("red", Base64("red")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("blue");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task UnknownIndex_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterSpectralIndexJobExecutor.HandledProcessId,
+                ("index", "NDXX"),
+                ("nir", Base64("nir")));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("index");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterSpectralIndexJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterSpectralIndexJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterSpectralIndexJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterizeExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterizeExecutorTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalRasterizeJobExecutor"/>: gdal_rasterize
+/// burn/grid argument projection, the burn/grid XOR guards, and the GeoTIFF artifact
+/// contract (#2240).
+/// </summary>
+public sealed class GdalRasterizeExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-rasterize-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalRasterizeExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("conversion.rasterize");
+    }
+
+    [UnitTest]
+    public async Task Rasterize_BurnValueAndCellSize_ProjectsArguments_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("rasterized"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterizeJobExecutor.HandledProcessId,
+                ("source", Base64("{\"type\":\"FeatureCollection\",\"features\":[]}")),
+                ("burnValue", "1"),
+                ("cellSize", "0.001"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_rasterize");
+            invocation.Arguments.Should().ContainInOrder("-burn", "1");
+            invocation.Arguments.Should().ContainInOrder("-tr", "0.001", "0.001");
+            invocation.Arguments[^1].Should().EndWith("output.tif");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Rasterize_AttributeAndSize_ProjectsArguments()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterizeJobExecutor.HandledProcessId,
+                ("source", Base64("{\"type\":\"FeatureCollection\",\"features\":[]}")),
+                ("attribute", "pop"),
+                ("width", "256"),
+                ("height", "128"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var args = runner.Invocations.Single().Arguments;
+            args.Should().ContainInOrder("-a", "pop");
+            args.Should().ContainInOrder("-ts", "256", "128");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Rasterize_BothBurnAndAttribute_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterizeJobExecutor.HandledProcessId,
+                ("source", Base64("fc")),
+                ("burnValue", "1"),
+                ("attribute", "pop"),
+                ("cellSize", "1"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("exactly one");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Rasterize_NoGrid_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterizeJobExecutor.HandledProcessId,
+                ("source", Base64("fc")),
+                ("burnValue", "1"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("grid");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalRasterizeJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalRasterizeJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalRasterizeJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalViewshedExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalViewshedExecutorTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Fake-runner coverage for <see cref="GdalViewshedJobExecutor"/>: gdal_viewshed
+/// observer/distance argument projection and the GeoTIFF artifact contract (#2240).
+/// </summary>
+public sealed class GdalViewshedExecutorTests
+{
+    private const string ScratchSuite = "honua-gdal-viewshed-test";
+
+    private static string Base64(string text) => GdalCli.Base64(text);
+
+    [UnitTest]
+    public void GdalViewshedExecutor_DeclaresNativeRuntimeProfile()
+    {
+        var executor = NewExecutor(FakeGdalCommandRunner.Failing(1, "n/a"), out _);
+
+        executor.Kind.Should().Be(ExecutionJobKind.Geoprocessing);
+        executor.AcceptedRuntimeProfiles.Should().ContainSingle().Which.Should().Be(RuntimeProfiles.Native);
+        executor.ProcessIds.Should().ContainSingle().Which.Should().Be("surface.viewshed");
+    }
+
+    [UnitTest]
+    public async Task Viewshed_Default_RunsGdalViewshed_AndPublishesGeoTiff()
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("viewshed"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalViewshedJobExecutor.HandledProcessId,
+                ("source", Base64("fake-dem")),
+                ("observerX", "100.5"),
+                ("observerY", "200.25"),
+                ("observerHeight", "1.8"),
+                ("maxDistance", "5000"));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("gdal_viewshed");
+            invocation.Arguments.Should().ContainInOrder("-ox", "100.5");
+            invocation.Arguments.Should().ContainInOrder("-oy", "200.25");
+            invocation.Arguments.Should().ContainInOrder("-oz", "1.8");
+            invocation.Arguments.Should().ContainInOrder("-md", "5000");
+            invocation.Arguments[^1].Should().EndWith("output.tif");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Viewshed_MissingObserver_Fails()
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalViewshedJobExecutor.HandledProcessId,
+                ("source", Base64("fake-dem")),
+                ("observerX", "100"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("observerY");
+            runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    private static GdalViewshedJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
+    {
+        scratch = GdalCli.NewScratch(ScratchSuite);
+        return new GdalViewshedJobExecutor(
+            runner, GdalJobFactory.Options(scratch), NullLogger<GdalViewshedJobExecutor>.Instance);
+    }
+
+    private static void CleanupScratch(string scratch) => GdalCli.CleanupScratch(scratch);
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
@@ -61,6 +61,27 @@ public sealed class GdalWorkerExecutorTests
             .Which.Should().Be(RuntimeProfiles.Native);
         dispatcher.AcceptedRuntimeProfiles.Should().NotContain(RuntimeProfiles.Managed);
         dispatcher.SupportedProcessIds.Should().Contain(new[] { "gdal.ogr2ogr", "gdal.gdalwarp" });
+
+        // The raster analysis & terrain GP tool packs (#2141, #2239, #2240) must all be
+        // routable by the worker dispatcher, including the flagged-but-routed ids
+        // (interpolate-kriging, euclidean-allocation) that fail fast with a clear
+        // message inside the executor.
+        dispatcher.SupportedProcessIds.Should().Contain(new[]
+        {
+            "raster.resample",
+            "raster.interpolate-idw",
+            "raster.interpolate-kriging",
+            "raster.mosaic",
+            "raster.map-algebra",
+            "raster.spectral-index",
+            "raster.reclassify",
+            "proximity.euclidean-distance",
+            "proximity.euclidean-allocation",
+            "surface.contour",
+            "surface.viewshed",
+            "conversion.polygonize",
+            "conversion.rasterize",
+        });
     }
 
     [UnitTest]
@@ -92,6 +113,18 @@ public sealed class GdalWorkerExecutorTests
             new GdalRasterZonalStatisticsJobExecutor(runner, options, NullLogger<GdalRasterZonalStatisticsJobExecutor>.Instance),
             new GdalMultidimCoverageMetadataJobExecutor(runner, options, NullLogger<GdalMultidimCoverageMetadataJobExecutor>.Instance),
             new PdalPointCloudConvertJobExecutor(runner, options, NullLogger<PdalPointCloudConvertJobExecutor>.Instance),
+            // Raster analysis & terrain GP tool packs (#2141, #2239, #2240).
+            new GdalRasterResampleJobExecutor(runner, options, NullLogger<GdalRasterResampleJobExecutor>.Instance),
+            new GdalRasterInterpolateJobExecutor(runner, options, NullLogger<GdalRasterInterpolateJobExecutor>.Instance),
+            new GdalRasterMosaicJobExecutor(runner, options, NullLogger<GdalRasterMosaicJobExecutor>.Instance),
+            new GdalRasterMapAlgebraJobExecutor(runner, options, NullLogger<GdalRasterMapAlgebraJobExecutor>.Instance),
+            new GdalRasterSpectralIndexJobExecutor(runner, options, NullLogger<GdalRasterSpectralIndexJobExecutor>.Instance),
+            new GdalRasterReclassifyJobExecutor(runner, options, NullLogger<GdalRasterReclassifyJobExecutor>.Instance),
+            new GdalProximityJobExecutor(runner, options, NullLogger<GdalProximityJobExecutor>.Instance),
+            new GdalContourJobExecutor(runner, options, NullLogger<GdalContourJobExecutor>.Instance),
+            new GdalViewshedJobExecutor(runner, options, NullLogger<GdalViewshedJobExecutor>.Instance),
+            new GdalPolygonizeJobExecutor(runner, options, NullLogger<GdalPolygonizeJobExecutor>.Instance),
+            new GdalRasterizeJobExecutor(runner, options, NullLogger<GdalRasterizeJobExecutor>.Instance),
         };
 
         return new GdalDispatchJobExecutor(


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2141
Closes #2239
Closes #2240

## Summary
Delivers the full native-profile GDAL worker geoprocessing tool pack as ONE PR. It
includes and supersedes the #2141 slice (`raster.resample`, `raster.interpolate-idw`,
flagged `raster.interpolate-kriging`, `raster.mosaic`) that was previously open as draft
PR #2246, and adds the remaining raster-analysis (#2239) and proximity / terrain-derivative
/ raster↔vector (#2240) tools on top, following the established `surface.*`/`raster.*`
executor pattern (executor → DI registration → `BuiltInProcessCatalog` entry → submit-time
`ProcessPlanValidator` rules → worker dispatcher routing → unit tests).

Every new process runs out-of-process in the heavyweight GDAL worker (`RuntimeProfile =
native`) and is absent from the lean managed dispatcher, so the GDAL-free serving image
stays unchanged. Two operations remain flagged-unsupported by design (fail fast with a
clear message, no silent stub): `raster.interpolate-kriging` (per #2141's acceptance —
stock GDAL bundles no kriging backend) and `proximity.euclidean-allocation` (stock
`gdal_proximity` computes distance only and has no nearest-source allocation mode).

## Changes Made
- #2239: `raster.map-algebra` (allow-listed `gdal_calc.py` expression — never eval's
  arbitrary input), `raster.spectral-index` (NDVI/NDWI/NDBI/SAVI/EVI presets compiling to
  a trusted `gdal_calc.py` Float32 calc), `raster.reclassify` (value/range remap folded
  into a trusted nested-`where` calc — closes the gap #2141/#2246 deferred).
- #2240: `proximity.euclidean-distance` (`gdal_proximity.py`), `proximity.euclidean-allocation`
  (flagged unsupported), `surface.contour` (`gdal_contour` → GeoJSON), `surface.viewshed`
  (`gdal_viewshed`), `conversion.polygonize` (`gdal_polygonize.py` → GeoJSON),
  `conversion.rasterize` (`gdal_rasterize`).
- Registered all new executors in the GDAL worker DI seam and the worker dispatcher routing test.
- Added catalog entries (native runtime profile; raster / feature-layer outputs) and
  submit-time plan-validation rules mirroring each tool's CLI contract.
- Extended the worker image build-time sanity check to include `gdal_calc.py`,
  `gdal_proximity.py`, `gdal_polygonize.py`, `gdal_contour`, `gdal_viewshed`,
  `gdal_rasterize` (the GDAL Python utilities ship in the `ubuntu-full` base's
  `python3-gdal` layer; the C binaries ship in the base).
- Added shared worker helpers (`GdalToolExecution` run/publish tail, `GdalCalcInputs`,
  `MapAlgebraExpression` allow-list, `GdalFieldName`) to remove per-executor boilerplate.
- Updated catalog count / category-partition / conformance / dispatcher assertions and
  added focused unit tests for argument projection, input guards, and the flagged paths.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes

(The `honua-worker-etl` GDAL image gains six additional CLI dependencies — all already
present in the pinned `ubuntu-full` GDAL base; the change is the build-time sanity check
that asserts them.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

<!--
Note for reviewers: pre-pr-check build (warnings-as-errors Release), dotnet format
verification, affected unit tests, and the architecture suite all pass locally. The
Testcontainers-gated integration shards (Honua.Postgres.Tests, etc.) cannot run in this
environment because no Docker daemon is available; they are exercised by CI. This PR adds
no integration tests.
-->
