### PR TITLE
feat: enforce per-map authorization on saved-map op-log endpoints (#972)

### DIFF
--- a/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationEndpoints.cs
+++ b/src/Honua.Server/Features/Collaboration/Operations/SavedMapOperationEndpoints.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using Honua.Core.Features.Collaboration.Operations;
 using Honua.Infrastructure.Models;
+using Honua.Server.Features.Collaboration.Sessions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Server.Features.Collaboration.Operations;
@@ -51,8 +52,15 @@ internal static class SavedMapOperationEndpoints
         string mapId,
         [FromBody] SavedMapOperationAppendApiRequest request,
         [FromServices] ISavedMapOperationLogRepository repository,
+        [FromServices] ISavedMapCollaborationAuthorizer authorizer,
         HttpContext context)
     {
+        var authorizationError = await AuthorizeAsync(mapId, authorizer, context).ConfigureAwait(false);
+        if (authorizationError is not null)
+        {
+            return authorizationError;
+        }
+
         if (!TryValidate(request, out var validationError) ||
             string.IsNullOrWhiteSpace(request.OperationId) ||
             request.Kind is null)
@@ -119,9 +127,16 @@ internal static class SavedMapOperationEndpoints
     private static async Task<IResult> HandleReplay(
         string mapId,
         [FromServices] ISavedMapOperationLogRepository repository,
+        [FromServices] ISavedMapCollaborationAuthorizer authorizer,
         HttpContext context,
         [FromQuery] long? since = null)
     {
+        var authorizationError = await AuthorizeAsync(mapId, authorizer, context).ConfigureAwait(false);
+        if (authorizationError is not null)
+        {
+            return authorizationError;
+        }
+
         var sinceCursor = since.GetValueOrDefault(0);
         if (sinceCursor < 0)
         {
@@ -147,6 +162,33 @@ internal static class SavedMapOperationEndpoints
         return Results.Json(
             ApiResponse<SavedMapOperationReplayApiResponse>.CreateSuccess(response),
             SavedMapOperationJsonContext.Default.ApiResponseSavedMapOperationReplayApiResponse);
+    }
+
+    // Fail-closed per-map capability check shared with the session transport (#971/#972): a
+    // generally authenticated principal must still be permitted on THIS saved map before its
+    // edits enter the durable op-log. Reusing the join authorizer keeps presence and durable
+    // edits on a single identity/RBAC seam. The middleware-level RequireAuthorization already
+    // rejected anonymous callers, so this maps capability decisions to typed 401/403 results.
+    private static async Task<IResult?> AuthorizeAsync(
+        string mapId,
+        ISavedMapCollaborationAuthorizer authorizer,
+        HttpContext context)
+    {
+        var authorization = await authorizer
+            .AuthorizeJoinAsync(mapId, context.User, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        return authorization.Status switch
+        {
+            SavedMapCollaborationAuthorizationStatus.Authorized => null,
+            SavedMapCollaborationAuthorizationStatus.RequiresAuthentication =>
+                StandardErrorHelpers.CreateUnauthorized(
+                    context,
+                    authorization.Detail ?? "Authentication is required to edit this saved map."),
+            _ => StandardErrorHelpers.CreateForbidden(
+                context,
+                authorization.Detail ?? "You are not allowed to edit this saved map.")
+        };
     }
 
     private static string ToWireStatus(SavedMapOperationAppendStatus status) => status switch

--- a/tests/dotnet/Honua.Server.Tests/Features/Collaboration/OperationLog/SavedMapOperationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Collaboration/OperationLog/SavedMapOperationEndpointsTests.cs
@@ -3,13 +3,18 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Server.Features.Collaboration.Sessions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Server.Tests.Features.Collaboration.OperationLog;
 
@@ -30,7 +35,7 @@ public sealed class SavedMapOperationEndpointsTests
     [Endpoint("GET /api/v1/saved-maps/{mapId}/collaboration/operations")]
     public async Task Append_AssignsMonotonicCursors_AndReplayReturnsThem()
     {
-        using var factory = CreateFactory();
+        using var factory = CreateFactory(allowEdit: true);
         using var client = CreateAdminClient(factory);
 
         var first = await AppendAsync(client, "op-1", baseCursor: 0);
@@ -57,7 +62,7 @@ public sealed class SavedMapOperationEndpointsTests
     [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/operations")]
     public async Task Append_DuplicateOperationId_IsIdempotent()
     {
-        using var factory = CreateFactory();
+        using var factory = CreateFactory(allowEdit: true);
         using var client = CreateAdminClient(factory);
 
         var first = await AppendAsync(client, "op-dupe", baseCursor: 0);
@@ -77,11 +82,36 @@ public sealed class SavedMapOperationEndpointsTests
     [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/operations")]
     public async Task Append_WithoutAuthentication_ReturnsUnauthorized()
     {
-        using var factory = CreateFactory();
+        using var factory = CreateFactory(allowEdit: true);
         using var client = factory.CreateClient();
 
         var response = await AppendAsync(client, "op-anon", baseCursor: 0);
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/saved-maps/{mapId}/collaboration/operations")]
+    public async Task Append_WithoutSavedMapCapability_ReturnsForbidden()
+    {
+        // No permissive authorizer registered, so the default fail-closed authorizer denies an
+        // otherwise-authenticated principal: durable edits must be permission-checked per map.
+        using var factory = CreateFactory(allowEdit: false);
+        using var client = CreateAdminClient(factory);
+
+        var response = await AppendAsync(client, "op-forbidden", baseCursor: 0);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/saved-maps/{mapId}/collaboration/operations")]
+    public async Task Replay_WithoutSavedMapCapability_ReturnsForbidden()
+    {
+        using var factory = CreateFactory(allowEdit: false);
+        using var client = CreateAdminClient(factory);
+
+        using var response = await client.GetAsync(
+            $"/api/v1/saved-maps/{MapId}/collaboration/operations?since=0");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     private static async Task<HttpResponseMessage> AppendAsync(HttpClient client, string operationId, long baseCursor)
@@ -105,7 +135,7 @@ public sealed class SavedMapOperationEndpointsTests
         return document.RootElement.Clone();
     }
 
-    private static WebApplicationFactory<Program> CreateFactory()
+    private static WebApplicationFactory<Program> CreateFactory(bool allowEdit)
     {
         return new TestWebApplicationFactory()
             .WithWebHostBuilder(builder =>
@@ -118,6 +148,17 @@ public sealed class SavedMapOperationEndpointsTests
                         ["HONUA_ADMIN_PASSWORD"] = AdminPassword
                     });
                 });
+
+                if (allowEdit)
+                {
+                    // The default authorizer is fail-closed, so happy-path durable edits need an
+                    // explicit permissive capability grant just like the session join tests.
+                    builder.ConfigureTestServices(services =>
+                    {
+                        services.RemoveAll<ISavedMapCollaborationAuthorizer>();
+                        services.AddSingleton<ISavedMapCollaborationAuthorizer, AllowSavedMapCollaborationAuthorizer>();
+                    });
+                }
             });
     }
 
@@ -126,5 +167,14 @@ public sealed class SavedMapOperationEndpointsTests
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword);
         return client;
+    }
+
+    private sealed class AllowSavedMapCollaborationAuthorizer : ISavedMapCollaborationAuthorizer
+    {
+        public ValueTask<SavedMapCollaborationAuthorizationResult> AuthorizeJoinAsync(
+            string mapId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken) =>
+            ValueTask.FromResult(SavedMapCollaborationAuthorizationResult.Allow());
     }
 }


### PR DESCRIPTION
## Summary

The saved-map collaborative edit operation-log endpoints (#972) existed on trunk (envelopes/families/kinds in `SavedMapOperationModels.cs`, `InMemorySavedMapOperationLogRepository` with idempotency/conflict/replay/retention, `MvpSavedMapOperationConflictPolicy`, append/replay HTTP adapter, API DTOs, DI registration, and tests). The one remaining gap against the ticket's acceptance criteria was authorization: the append/replay endpoints only called `RequireAuthorization()` (any authenticated principal) and never invoked the per-map capability authorizer that the sibling collaboration session endpoints use — even though the endpoint XML doc claimed a shared identity/RBAC seam.

This PR closes that gap so durable saved-map edits are permission-checked per map.

## Changes Made

- Wire `ISavedMapCollaborationAuthorizer` into both the append and replay handlers in `SavedMapOperationEndpoints`, reusing the same fail-closed authorizer the session join/stream use, and mapping capability decisions to typed `401`/`403` responses via `StandardErrorHelpers`.
- Add a shared `AuthorizeAsync` helper that runs before validation so unauthorized callers cannot probe op-log behavior.
- Add endpoint integration tests for forbidden append and forbidden replay under the default fail-closed authorizer; register a permissive authorizer for the existing append/replay/idempotency happy-path tests (mirroring the session endpoint test pattern).

## Breaking Changes

None. Callers already had to be authenticated; they now additionally must be authorized for the specific saved map. The default authorizer remains fail-closed, consistent with the session transport.

## Gate Impact

- [x] No gate-tier impact (behavior-compatible authorization hardening within the collaboration feature slice)

## Testing

- [x] Ran the affected Release build (`dotnet build src/Honua.Server/Honua.Server.csproj -c Release /p:TreatWarningsAsErrors=true`) — 0 warnings, 0 errors.
- [x] Ran `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj -c Release --filter FullyQualifiedName~SavedMapOperationEndpointsTests` — 5/5 passed (monotonic cursors + replay, idempotent duplicate, unauthenticated 401, forbidden append 403, forbidden replay 403).
- [x] `dotnet format --verify-no-changes` clean on the changed files.
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Closes #972
