### PR TITLE
feat: add retry/resilience to Databricks statement client (#1719)

### DIFF
--- a/docs/reference/configuration/data-sources/databricks.md
+++ b/docs/reference/configuration/data-sources/databricks.md
@@ -53,6 +53,8 @@ Bound from the `Databricks` configuration section (environment variables shown w
 | `Databricks__Schema` | no | Schema (database) used to qualify tables when a layer does not override it. |
 | `Databricks__CommandTimeoutSeconds` | no (default `120`) | Overall submit + poll budget. |
 | `Databricks__PollIntervalMilliseconds` | no (default `750`) | Delay between status polls. |
+| `Databricks__MaxRetryAttempts` | no (default `3`) | Automatic retries per Statement Execution HTTP call (submit, poll, chunk) on transient failures (HTTP 408/429/5xx, transient network faults). Set `0` to disable. |
+| `Databricks__RetryBaseDelayMilliseconds` | no (default `500`) | Base delay for the exponential backoff (with jitter) applied between retries. |
 
 ### Layer mappings
 
@@ -107,6 +109,13 @@ attribute identifiers are validated against a simple-identifier allow-list at st
 - **No writes.** The provider exposes no `IFeatureWriter`; all edit paths are rejected.
 - **No native .NET driver.** Communication is over the REST Statement Execution API, so
   every request incurs submit + poll latency rather than a persistent connection.
+- **Transient failures are retried automatically.** Each outbound Statement Execution call
+  (submit, status poll, and result-chunk fetch) is fronted by the shared HTTP resilience
+  policy: transient responses (HTTP 408/429/5xx) and transient network faults are retried
+  with exponential backoff + jitter (`Databricks__MaxRetryAttempts`,
+  `Databricks__RetryBaseDelayMilliseconds`), and a per-provider circuit breaker isolates
+  Databricks failures from other backends. Non-transient errors (e.g. HTTP 400) are not
+  retried.
 - **Spatial-function availability is environment-dependent.** `ST_AsBinary`,
   `ST_GeomFromText`, `ST_Intersects`, and the `ST_*min/max` aggregates require a
   Databricks runtime / DBSQL build that ships the spatial functions. On warehouses
@@ -127,8 +136,7 @@ attribute identifiers are validated against a simple-identifier allow-list at st
 - **No schema introspection.** Attribute columns must be listed explicitly per layer.
 - **Deferred to the hardening follow-up (#1719):** Metadata-v2 binding
   (`IBindableFeatureDataProvider`) so layers resolve from secure connections rather than
-  static config, and a retry/resilience policy on the submit/poll loop. Top-features,
-  date/value bins, and H3 aggregation remain unsupported.
+  static config. Top-features, date/value bins, and H3 aggregation remain unsupported.
 
 Provider selection variables are listed in the
 [environment variable reference](../environment-variables.md#database-and-providers).

--- a/src/Honua.Databricks/DatabricksOptions.cs
+++ b/src/Honua.Databricks/DatabricksOptions.cs
@@ -72,6 +72,22 @@ public sealed class DatabricksOptions
     /// </summary>
     public int PollIntervalMilliseconds { get; set; } = 750;
 
+    /// <summary>
+    /// Maximum number of automatic retries applied to each outbound Statement Execution
+    /// HTTP call (statement submit, status poll, and result-chunk fetch) when the workspace
+    /// returns a transient failure (HTTP 408/429/5xx) or the request faults with a transient
+    /// network error. Retries use exponential backoff with jitter. Set to <c>0</c> to disable
+    /// retries. Defaults to <c>3</c>.
+    /// </summary>
+    public int MaxRetryAttempts { get; set; } = 3;
+
+    /// <summary>
+    /// Base delay in milliseconds for the exponential backoff applied between retry attempts
+    /// (see <see cref="MaxRetryAttempts"/>). The effective delay grows exponentially per
+    /// attempt and has jitter applied. Defaults to <c>500</c>.
+    /// </summary>
+    public int RetryBaseDelayMilliseconds { get; set; } = 500;
+
     /// <summary>Configured layer definitions.</summary>
     public DatabricksLayerOptions[] Layers { get; set; } = [];
 }

--- a/src/Honua.Databricks/DatabricksOptionsValidator.cs
+++ b/src/Honua.Databricks/DatabricksOptionsValidator.cs
@@ -61,6 +61,16 @@ internal static class DatabricksOptionsValidator
             throw new InvalidOperationException("Databricks:PollIntervalMilliseconds must be positive.");
         }
 
+        if (options.MaxRetryAttempts < 0)
+        {
+            throw new InvalidOperationException("Databricks:MaxRetryAttempts must not be negative.");
+        }
+
+        if (options.RetryBaseDelayMilliseconds <= 0)
+        {
+            throw new InvalidOperationException("Databricks:RetryBaseDelayMilliseconds must be positive.");
+        }
+
         foreach (var layer in options.Layers)
         {
             DatabricksIdentifier.ValidateIdentifier(layer.Table);

--- a/src/Honua.Databricks/Features/Infrastructure/DatabricksStatementClient.cs
+++ b/src/Honua.Databricks/Features/Infrastructure/DatabricksStatementClient.cs
@@ -237,4 +237,10 @@ internal static class DatabricksServiceClientName
 {
     /// <summary>Logical HttpClient name for Databricks Statement Execution outbound calls.</summary>
     public const string Default = "Honua.Databricks.Statements";
+
+    /// <summary>
+    /// Service-type identifier used to isolate this provider's resilience (retry +
+    /// circuit-breaker) state from other external dependencies.
+    /// </summary>
+    public const string ResilienceServiceType = "databricks-sql";
 }

--- a/src/Honua.Databricks/ServiceCollectionExtensions.cs
+++ b/src/Honua.Databricks/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Infrastructure.Resilience;
 using Honua.Core.Queries.Filters;
 using Honua.Databricks.Features.FeatureStore;
 using Honua.Databricks.Features.FeatureStore.Services;
@@ -54,20 +55,25 @@ public static class ServiceCollectionExtensions
 
         // Typed-HttpClient registration: the BaseAddress points at the workspace host so
         // host applications can attach resilience / retry / telemetry handlers via the
-        // well-known name without depending on this provider's internals.
-        services.AddHttpClient<IDatabricksStatementClient, DatabricksStatementClient>(
-            DatabricksServiceClientName.Default,
-            client =>
-            {
-                if (Uri.TryCreate(options.Host, UriKind.Absolute, out var host))
+        // well-known name without depending on this provider's internals. A standard
+        // retry + circuit-breaker policy is attached below so the Statement Execution
+        // submit/poll/chunk loop survives transient workspace failures (HTTP 408/429/5xx
+        // and transient network faults) with exponential backoff and jitter.
+        services
+            .AddHttpClient<IDatabricksStatementClient, DatabricksStatementClient>(
+                DatabricksServiceClientName.Default,
+                client =>
                 {
-                    client.BaseAddress = host;
-                }
+                    if (Uri.TryCreate(options.Host, UriKind.Absolute, out var host))
+                    {
+                        client.BaseAddress = host;
+                    }
 
-                // Generous client timeout; the statement client enforces the finer-grained
-                // CommandTimeout budget across the submit/poll loop.
-                client.Timeout = TimeSpan.FromSeconds(Math.Max(options.CommandTimeoutSeconds + 30, 60));
-            });
+                    // Generous client timeout; the statement client enforces the finer-grained
+                    // CommandTimeout budget across the submit/poll loop.
+                    client.Timeout = TimeSpan.FromSeconds(Math.Max(options.CommandTimeoutSeconds + 30, 60));
+                })
+            .AddHttpResiliencePolicy(DatabricksServiceClientName.ResilienceServiceType, BuildResilienceOptions(options));
 
         services.AddSingleton<IDatabricksFeatureQueryBuilder, DatabricksFeatureQueryBuilder>();
         services.AddScoped<IDatabricksFeatureDataAccess, DatabricksFeatureDataAccess>();
@@ -82,6 +88,19 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Maps the Databricks retry options onto the shared HTTP resilience policy options so the
+    /// Statement Execution client reuses the canonical retry + circuit-breaker pipeline.
+    /// </summary>
+    private static ResiliencePolicyOptions BuildResilienceOptions(DatabricksOptions options)
+        => new()
+        {
+            MaxRetryAttempts = options.MaxRetryAttempts,
+            BaseDelay = TimeSpan.FromMilliseconds(options.RetryBaseDelayMilliseconds),
+            BackoffExponent = 2.0,
+            JitterPercentage = 0.2,
+        };
 
     private static List<DatabricksLayerMapping> BuildLayerMappings(DatabricksOptions options)
     {

--- a/tests/dotnet/Honua.Databricks.Tests/DatabricksOptionsValidatorTests.cs
+++ b/tests/dotnet/Honua.Databricks.Tests/DatabricksOptionsValidatorTests.cs
@@ -79,4 +79,31 @@ public class DatabricksOptionsValidatorTests
         options.Layers = [new DatabricksLayerOptions { Id = 1, Table = "t", GeometryColumn = "geom", PrimaryKeyColumn = "id", GeometryType = "Hyperbola" }];
         Assert.Throws<InvalidOperationException>(() => DatabricksOptionsValidator.ThrowIfInvalid(options));
     }
+
+    [Fact]
+    public void ThrowIfInvalid_NegativeMaxRetryAttempts_Throws()
+    {
+        var options = Valid();
+        options.MaxRetryAttempts = -1;
+        Assert.Throws<InvalidOperationException>(() => DatabricksOptionsValidator.ThrowIfInvalid(options));
+    }
+
+    [Fact]
+    public void ThrowIfInvalid_ZeroMaxRetryAttempts_DoesNotThrow()
+    {
+        // Zero is valid and disables retries.
+        var options = Valid();
+        options.MaxRetryAttempts = 0;
+        DatabricksOptionsValidator.ThrowIfInvalid(options);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-100)]
+    public void ThrowIfInvalid_NonPositiveRetryBaseDelay_Throws(int delayMs)
+    {
+        var options = Valid();
+        options.RetryBaseDelayMilliseconds = delayMs;
+        Assert.Throws<InvalidOperationException>(() => DatabricksOptionsValidator.ThrowIfInvalid(options));
+    }
 }

--- a/tests/dotnet/Honua.Databricks.Tests/DatabricksStatementResilienceTests.cs
+++ b/tests/dotnet/Honua.Databricks.Tests/DatabricksStatementResilienceTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.Databricks.Features.FeatureStore.Services;
+using Honua.Databricks.Features.Infrastructure;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Databricks.Tests;
+
+/// <summary>
+/// Verifies the Statement Execution submit/poll loop transparently retries transient
+/// workspace failures when the HTTP client is fronted by the shared resilience policy
+/// (mirroring the production DI registration), without retrying non-transient errors.
+/// </summary>
+public class DatabricksStatementResilienceTests
+{
+    private const string SucceededJson = """
+    {
+      "statement_id": "abc",
+      "status": { "state": "SUCCEEDED" },
+      "manifest": { "schema": { "columns": [ { "name": "c", "position": 0 } ] } },
+      "result": { "data_array": [ ["42"] ] }
+    }
+    """;
+
+    private static DatabricksStatementClient CreateClient(StubHttpMessageHandler handler, int maxRetries)
+    {
+        // A fresh service type per test isolates the cached circuit-breaker state so tests
+        // do not interfere with one another; tiny delays keep the backoff fast.
+        var options = new ResiliencePolicyOptions
+        {
+            MaxRetryAttempts = maxRetries,
+            BaseDelay = TimeSpan.FromMilliseconds(1),
+            BackoffExponent = 2.0,
+            JitterPercentage = 0,
+        };
+        var policy = HttpResiliencePolicies.GetHttpPolicy($"databricks-test-{Guid.NewGuid():N}", options);
+        var policyHandler = new PolicyHttpMessageHandler(policy) { InnerHandler = handler };
+
+        var httpClient = new HttpClient(policyHandler) { BaseAddress = new Uri("https://example.cloud.databricks.com") };
+        var databricksOptions = Options.Create(new DatabricksOptions
+        {
+            Host = "https://example.cloud.databricks.com",
+            WarehouseId = "wh123",
+            Token = "secret-token",
+            CommandTimeoutSeconds = 30,
+            PollIntervalMilliseconds = 1,
+        });
+        return new DatabricksStatementClient(httpClient, databricksOptions);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TransientServerErrorThenSuccess_RetriesAndCompletes()
+    {
+        var handler = new StubHttpMessageHandler()
+            .EnqueueJson("{}", HttpStatusCode.ServiceUnavailable)
+            .EnqueueJson(SucceededJson);
+        var client = CreateClient(handler, maxRetries: 3);
+
+        var result = await client.ExecuteAsync(DatabricksSqlStatement.WithoutParameters("SELECT 1"), CancellationToken.None);
+
+        Assert.Single(result.Rows);
+        // First submit got 503; the policy retried, and the second submit succeeded.
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TooManyRequestsThenSuccess_RetriesAndCompletes()
+    {
+        var handler = new StubHttpMessageHandler()
+            .EnqueueJson("{}", HttpStatusCode.TooManyRequests)
+            .EnqueueJson(SucceededJson);
+        var client = CreateClient(handler, maxRetries: 3);
+
+        var result = await client.ExecuteAsync(DatabricksSqlStatement.WithoutParameters("SELECT 1"), CancellationToken.None);
+
+        Assert.Single(result.Rows);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonTransientError_DoesNotRetry()
+    {
+        var handler = new StubHttpMessageHandler()
+            .EnqueueJson("{}", HttpStatusCode.BadRequest);
+        var client = CreateClient(handler, maxRetries: 3);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.ExecuteAsync(DatabricksSqlStatement.WithoutParameters("SELECT 1"), CancellationToken.None));
+
+        // 400 is not transient: the single submit is surfaced without any retry.
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PersistentTransientError_ExhaustsRetriesThenThrows()
+    {
+        var handler = new StubHttpMessageHandler()
+            .EnqueueJson("{}", HttpStatusCode.ServiceUnavailable)
+            .EnqueueJson("{}", HttpStatusCode.ServiceUnavailable)
+            .EnqueueJson("{}", HttpStatusCode.ServiceUnavailable);
+        var client = CreateClient(handler, maxRetries: 2);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.ExecuteAsync(DatabricksSqlStatement.WithoutParameters("SELECT 1"), CancellationToken.None));
+
+        // 1 initial attempt + 2 retries = 3 requests, all 503.
+        Assert.Equal(3, handler.Requests.Count);
+    }
+}

--- a/tests/dotnet/Honua.Databricks.Tests/Honua.Databricks.Tests.csproj
+++ b/tests/dotnet/Honua.Databricks.Tests/Honua.Databricks.Tests.csproj
@@ -13,6 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" />
+    <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
## Summary

Hardens the read-only Databricks provider with the resilience slice of #1719: the SQL Statement Execution HTTP client is now fronted by the shared retry + circuit-breaker resilience policy, so the submit → poll → result-chunk loop survives transient SQL Warehouse failures instead of failing on the first blip.

This delivers the **"Retry/resilience policy on the Statement Execution submit/poll loop"** acceptance criterion. Filter translation and statistics already shipped on trunk; Metadata-v2 binding (`IBindableFeatureDataProvider`) and the remaining analytics aggregations are intentionally left for follow-up (see Known gaps), so this PR lands one slice and leaves the issue open.

Related to #1719

## Changes Made

- Wire the typed `IDatabricksStatementClient` HttpClient registration to the canonical `AddHttpResiliencePolicy` extension (`Honua.Core` resilience infrastructure) under a dedicated `databricks-sql` service type so retry + circuit-breaker state is isolated per provider.
- Retries apply to every outbound Statement Execution call (submit POST, status GET poll, result-chunk GET) on transient failures (HTTP 408/429/5xx and transient network faults) with exponential backoff + jitter; non-transient errors (e.g. HTTP 400) are not retried.
- Add `Databricks:MaxRetryAttempts` (default `3`, `0` disables) and `Databricks:RetryBaseDelayMilliseconds` (default `500`) options, mapped onto `ResiliencePolicyOptions` and validated fail-fast at startup.
- Document the new keys and resilience behaviour in `docs/reference/configuration/data-sources/databricks.md` and update the #1719 deferred note.
- Add unit tests for retry-then-success (503 and 429), no-retry on non-transient 400, retry exhaustion, and the new option validation.

## Breaking Changes

None. New options have backwards-compatible defaults; the resilience policy is transparent to callers.

## Gate Impact

- [x] PR gates (build, test, governance)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Equivalent checks run locally:
- `dotnet build src/Honua.Databricks/Honua.Databricks.csproj --configuration Release /p:TreatWarningsAsErrors=true` — succeeded, 0 warnings / 0 errors.
- `dotnet test tests/dotnet/Honua.Databricks.Tests/Honua.Databricks.Tests.csproj` — Passed: 56, Failed: 0 (4 new resilience tests + 3 new validator tests).
- `dotnet format --verify-no-changes` on the changed source and test files — no changes.

## Known gaps

The following #1719 acceptance criteria remain open and are deferred to follow-up PRs (issue stays open):
- Metadata-v2 binding via `IBindableFeatureDataProvider` so layers resolve from secure connections rather than static `Databricks:Layers` config.
- Remaining analytics aggregations (top-features, date/value bins, H3) and schema introspection.
