### PR TITLE
feat: SAML SLO + SCIM discovery for IdP conformance matrix (#2154)

### DIFF
--- a/docs/reference/compatibility/idp-conformance-matrix.md
+++ b/docs/reference/compatibility/idp-conformance-matrix.md
@@ -20,7 +20,12 @@ the main per-provider variable and is exercised by the conformance matrix tests.
   signature or attribute-mapping path fails the build.
 - **SCIM provisioning** — `ScimProvisioningEndpointsTests` exercises the RFC 7643/7644
   user/group lifecycle (create / replace / patch-active / patch-membership / deprovision)
-  that every listed IdP's SCIM client drives.
+  that every listed IdP's SCIM client drives, plus the RFC 7643 §5-7 discovery documents
+  (`/ServiceProviderConfig`, `/ResourceTypes`, `/Schemas`).
+- **SAML Single Logout** — `SamlBridgeEndpointsTests` drives the `/saml/slo` endpoint with a
+  signed, IdP-initiated `LogoutRequest`, asserting the local session is terminated and a
+  `LogoutResponse` relayed; `IdpConformanceMatrixTests` proves the SLO signature path verifies
+  each provider's signed logout and rejects an unsigned one.
 - **Live-IdP runs** are out of scope for CI (they require tenant credentials) and are tracked
   as a follow-up; see _Deferred_ below.
 
@@ -34,7 +39,8 @@ the main per-provider variable and is exercised by the conformance matrix tests.
 | Email / display-name attribute mapping | Supported | Supported | Supported | Supported |
 | Role/group attribute mapping | Supported | Supported | Supported | Supported |
 | Default-role fallback when no role claim is present | Supported | Supported | Supported | Supported |
-| Single Logout (SLO) | Unsupported (deferred) | Unsupported (deferred) | Unsupported (deferred) | Unsupported (deferred) |
+| Single Logout (SLO) — IdP-initiated, HTTP-POST, signed `LogoutRequest` | Supported | Supported | Supported | Supported |
+| Single Logout (SLO) — SP-initiated / HTTP-Redirect binding | Partial (deferred) | Partial (deferred) | Partial (deferred) | Partial (deferred) |
 
 ### Per-provider attribute configuration
 
@@ -50,6 +56,17 @@ the attribute `Name` your IdP emits:
 
 The validator resolves an attribute by both its `Name` and `FriendlyName`, so either form
 works when an IdP emits both.
+
+### Single Logout (SLO) configuration
+
+Set `Saml:SingleLogoutServiceUrl` to the SP's own `/saml/slo` endpoint to advertise a
+`SingleLogoutService` (HTTP-POST binding) in SP metadata. When the IdP front-channels a signed
+`LogoutRequest` there, Honua verifies the signature against `Saml:IdpSigningCertificate`,
+terminates the local admin session (store record + cookie), and emits a `LogoutResponse`. Set
+`Saml:IdpSingleLogoutServiceUrl` to relay that `LogoutResponse` back to the IdP via an
+auto-submitting HTTP-POST form; leave it unset to return the `LogoutResponse` directly. Only
+signed `LogoutRequest`s are honored — unsigned or forged logout requests are rejected so they
+cannot terminate a session.
 
 ### Known quirks
 
@@ -76,6 +93,7 @@ works when an IdP emits both.
 | Group membership PATCH (add / remove) | Supported | Supported | Supported | Supported |
 | Filtering + pagination (`filter`, `startIndex`, `count`) | Supported | Supported | Supported | Supported |
 | Bearer-token authentication | Supported | Supported | Supported | Supported |
+| Discovery documents (`/ServiceProviderConfig`, `/ResourceTypes`, `/Schemas`) | Supported | Supported | Supported | Supported |
 
 ### Known quirks
 
@@ -87,9 +105,10 @@ works when an IdP emits both.
   group display name (each SCIM group maps to a Honua role).
 - **PingFederate** — uses standard RFC 7644 PUT/PATCH; no Honua-specific deviation observed.
 
-## Deferred (tracked under #2154)
+## Deferred
 
-- SAML Single Logout (SLO) endpoint and front/back-channel logout flows.
+- SP-initiated SAML logout (Honua generating and signing its own `LogoutRequest`) and the
+  HTTP-Redirect SLO binding (with its query-string signature scheme). IdP-initiated,
+  HTTP-POST, signed Single Logout is supported today.
 - Live-IdP conformance runs gated behind tenant credentials (skippable in CI), with recorded
   real-world assertion/metadata fixtures captured per provider.
-- SCIM `/ServiceProviderConfig`, `/ResourceTypes`, and `/Schemas` discovery documents.

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -265,9 +265,17 @@ public static class EndpointRegistry
         new("PATCH", "/scim/v2/Groups/{id}"),
         new("DELETE", "/scim/v2/Groups/{id}"),
 
-        // SAML 2.0 Service Provider endpoints (#508)
+        // SCIM 2.0 discovery documents (#2154, RFC 7643 §5-7)
+        new("GET", "/scim/v2/ServiceProviderConfig"),
+        new("GET", "/scim/v2/ResourceTypes"),
+        new("GET", "/scim/v2/ResourceTypes/{id}"),
+        new("GET", "/scim/v2/Schemas"),
+        new("GET", "/scim/v2/Schemas/{id}"),
+
+        // SAML 2.0 Service Provider endpoints (#508; SLO #2154)
         new("GET", "/saml/metadata"),
         new("POST", "/saml/acs"),
+        new("POST", "/saml/slo"),
 
         // v1 console metadata v2 content + RBAC baseline (#1162)
         new("GET", "/api/v1/console/session"),

--- a/src/Honua.Server/Features/Identity/Saml/ExclusiveCanonicalizer.cs
+++ b/src/Honua.Server/Features/Identity/Saml/ExclusiveCanonicalizer.cs
@@ -58,7 +58,7 @@ internal static class ExclusiveCanonicalizer
         var namespacesToOutput = new SortedDictionary<string, string>(PrefixComparer.Instance);
 
         // (a) the element's own namespace.
-        ConsiderNamespace(element.Name, localRendered, namespacesToOutput);
+        ConsiderNamespace(element.Name, element, localRendered, namespacesToOutput);
 
         // (a) namespaces used by qualified attributes.
         foreach (var attribute in element.Attributes())
@@ -70,7 +70,7 @@ internal static class ExclusiveCanonicalizer
 
             if (attribute.Name.Namespace != XNamespace.None)
             {
-                ConsiderNamespace(attribute.Name, localRendered, namespacesToOutput);
+                ConsiderNamespace(attribute.Name, element, localRendered, namespacesToOutput);
             }
         }
 
@@ -148,17 +148,22 @@ internal static class ExclusiveCanonicalizer
 
     private static void ConsiderNamespace(
         XName name,
+        XElement scope,
         Dictionary<string, string> rendered,
         SortedDictionary<string, string> toOutput)
     {
         var uri = name.NamespaceName;
-        var prefix = NamespacePrefix(name);
 
         // The XML namespace is implicitly declared and never rendered.
         if (string.Equals(uri, XmlNs.NamespaceName, StringComparison.Ordinal))
         {
             return;
         }
+
+        // Resolve the real prefix from the element scope. XName does not carry the prefix, so a
+        // prefixed name (e.g. a root <samlp:LogoutRequest>) must render xmlns:<prefix>, not the
+        // default namespace — resolving via the scope is what distinguishes the two.
+        var prefix = scope.GetPrefixOfNamespace(name.Namespace) ?? string.Empty;
 
         // Attributes in no namespace contribute nothing; an element in no namespace only needs
         // a default-namespace undeclaration if an ancestor rendered one (handled below).
@@ -190,18 +195,6 @@ internal static class ExclusiveCanonicalizer
             : element.GetNamespaceOfPrefix(prefix);
         var uri = xname?.NamespaceName;
         return string.IsNullOrEmpty(uri) ? null : uri;
-    }
-
-    private static string NamespacePrefix(XName name)
-    {
-        if (name.Namespace == XNamespace.None)
-        {
-            return string.Empty;
-        }
-
-        // Resolve the prefix from the declaring element where possible; XName itself does not
-        // carry the prefix, so callers pass through QualifiedName which uses the element scope.
-        return string.Empty;
     }
 
     private static string QualifiedName(XName name, XElement scope)

--- a/src/Honua.Server/Features/Identity/Saml/SamlAuthenticationOptions.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlAuthenticationOptions.cs
@@ -39,6 +39,21 @@ public sealed class SamlAuthenticationOptions
     public string? AssertionConsumerServiceUrl { get; set; }
 
     /// <summary>
+    /// The SP's own Single Logout (SLO) service URL (the endpoint the IdP sends a
+    /// <c>LogoutRequest</c> to over the HTTP-POST binding). Advertised in SP metadata as a
+    /// <c>SingleLogoutService</c> when set; leaving it null omits the SLO declaration so an IdP
+    /// will not attempt single-logout against an unconfigured SP.
+    /// </summary>
+    public string? SingleLogoutServiceUrl { get; set; }
+
+    /// <summary>
+    /// The IdP's Single Logout service URL the SP posts its <c>LogoutResponse</c> back to after
+    /// terminating the local session. When null the SP terminates the session and returns the
+    /// <c>LogoutResponse</c> directly rather than relaying it to the IdP.
+    /// </summary>
+    public string? IdpSingleLogoutServiceUrl { get; set; }
+
+    /// <summary>
     /// The IdP's signing certificate, base64-encoded DER (the inner text of an
     /// <c>&lt;X509Certificate&gt;</c> element). Required: signatures are verified against this
     /// certificate's public key, and unsigned assertions are rejected.

--- a/src/Honua.Server/Features/Identity/Saml/SamlEndpoints.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlEndpoints.cs
@@ -1,11 +1,16 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
+using System.Net;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml;
+using System.Xml.Linq;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Helpers;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -39,6 +44,7 @@ internal static partial class SamlEndpoints
 
         group.MapGet("/metadata", HandleMetadata).WithDisplayName("SAML SP Metadata");
         group.MapPost("/acs", HandleAssertionConsumerService).WithDisplayName("SAML Assertion Consumer Service");
+        group.MapPost("/slo", HandleSingleLogout).WithDisplayName("SAML Single Logout Service");
     }
 
     private static IResult HandleMetadata(
@@ -169,6 +175,218 @@ internal static partial class SamlEndpoints
         return TypedResults.NoContent();
     }
 
+    /// <summary>
+    /// Handles SAML 2.0 Single Logout (SLO) over the HTTP-POST binding. Consumes an
+    /// IdP-initiated, signed <c>LogoutRequest</c>, verifies its signature against the configured
+    /// IdP certificate (reusing the assertion signature path), terminates the local Honua admin
+    /// session (store record + cookie), and emits a <c>LogoutResponse</c> — relayed back to the
+    /// IdP's SLO endpoint via an auto-submitting form when configured, or returned directly.
+    /// </summary>
+    private static async Task<IResult> HandleSingleLogout(
+        HttpContext context,
+        [FromServices] IOptions<SamlAuthenticationOptions> options,
+        [FromServices] AdminAuthSessionStore sessionStore,
+        [FromServices] ILogger<SamlEndpointsLog> logger)
+    {
+        var opts = options.Value;
+        if (!opts.Enabled)
+        {
+            return Results.Problem(
+                title: "SAML not enabled",
+                detail: "The SAML SP bridge is not enabled.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (!context.Request.HasFormContentType)
+        {
+            return BadRequest(context, "Expected an HTTP-POST SAML logout form.");
+        }
+
+        var form = await context.Request.ReadFormAsync(context.RequestAborted).ConfigureAwait(false);
+        var relayState = form["RelayState"].ToString();
+
+        // A SAMLResponse here is the IdP acknowledging an SP-initiated logout: clear any local
+        // session and finish. No signed request to validate in this direction.
+        if (string.IsNullOrWhiteSpace(form["SAMLRequest"]) && !string.IsNullOrWhiteSpace(form["SAMLResponse"]))
+        {
+            await TerminateLocalSessionAsync(context, sessionStore).ConfigureAwait(false);
+            SamlLog.SingleLogoutProcessed(logger, "(sp-initiated)");
+            return TypedResults.NoContent();
+        }
+
+        var encodedRequest = form["SAMLRequest"].ToString();
+        if (string.IsNullOrWhiteSpace(encodedRequest))
+        {
+            return BadRequest(context, "Missing SAMLRequest.");
+        }
+
+        string requestXml;
+        try
+        {
+            requestXml = Encoding.UTF8.GetString(Convert.FromBase64String(encodedRequest));
+        }
+        catch (FormatException)
+        {
+            return BadRequest(context, "SAMLRequest is not valid base64.");
+        }
+
+        XDocument document;
+        try
+        {
+            document = SecureXmlDocumentParser.Parse(requestXml, LoadOptions.None);
+        }
+        catch (XmlException)
+        {
+            return BadRequest(context, "Malformed SAML logout request XML.");
+        }
+
+        var logoutRequest = document.Root;
+        if (logoutRequest is null || logoutRequest.Name.LocalName != "LogoutRequest")
+        {
+            return BadRequest(context, "Expected a samlp:LogoutRequest.");
+        }
+
+        if (string.IsNullOrWhiteSpace(opts.IdpSigningCertificate))
+        {
+            SamlLog.SingleLogoutRejected(logger, "no signing certificate configured");
+            return LogoutRejected(context, "No IdP signing certificate configured.");
+        }
+
+        X509Certificate2 certificate;
+        try
+        {
+            certificate = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(opts.IdpSigningCertificate!.Trim()));
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException)
+        {
+            SamlLog.SingleLogoutRejected(logger, "invalid signing certificate");
+            return LogoutRejected(context, "IdP signing certificate is not valid base64 DER.");
+        }
+
+        using (certificate)
+        {
+            var signatureResult = SamlSignatureVerifier.Verify(logoutRequest, certificate);
+            if (!signatureResult.Verified)
+            {
+                // Unsigned or forged LogoutRequests must not be able to terminate sessions.
+                SamlLog.SingleLogoutRejected(logger, signatureResult.Reason ?? "signature verification failed");
+                return LogoutRejected(context, signatureResult.Reason ?? "The SAML logout request could not be validated.");
+            }
+        }
+
+        var issuer = logoutRequest.Element(XName.Get("Issuer", SamlAssertionNs))?.Value?.Trim();
+        if (!string.IsNullOrEmpty(opts.IdpEntityId) &&
+            !string.Equals(issuer, opts.IdpEntityId, StringComparison.Ordinal))
+        {
+            SamlLog.SingleLogoutRejected(logger, "issuer mismatch");
+            return LogoutRejected(context, "SAML logout request issuer does not match the configured IdP.");
+        }
+
+        await TerminateLocalSessionAsync(context, sessionStore).ConfigureAwait(false);
+
+        var nameId = logoutRequest.Element(XName.Get("NameID", SamlAssertionNs))?.Value?.Trim();
+        SamlLog.SingleLogoutProcessed(logger, string.IsNullOrEmpty(nameId) ? "(unknown)" : nameId);
+
+        var requestId = logoutRequest.Attribute("ID")?.Value;
+        var logoutResponse = BuildLogoutResponse(opts, requestId);
+        var encodedResponse = Convert.ToBase64String(Encoding.UTF8.GetBytes(logoutResponse));
+
+        // Relay the LogoutResponse back to the IdP via an auto-submitting HTML form (HTTP-POST
+        // binding). With no IdP SLO endpoint configured, return the response payload directly.
+        if (string.IsNullOrWhiteSpace(opts.IdpSingleLogoutServiceUrl))
+        {
+            return Results.Content(logoutResponse, "application/samlp+xml", Encoding.UTF8);
+        }
+
+        var formHtml = BuildAutoPostForm(opts.IdpSingleLogoutServiceUrl!, encodedResponse, relayState);
+        return Results.Content(formHtml, "text/html", Encoding.UTF8);
+    }
+
+    private const string SamlAssertionNs = "urn:oasis:names:tc:SAML:2.0:assertion";
+    private const string SamlProtocolNs = "urn:oasis:names:tc:SAML:2.0:protocol";
+
+    private static async Task TerminateLocalSessionAsync(HttpContext context, AdminAuthSessionStore sessionStore)
+    {
+        if (context.Request.Cookies.TryGetValue(AdminAuthSessionStore.AuthSessionCookieName, out var sessionId) &&
+            !string.IsNullOrWhiteSpace(sessionId))
+        {
+            await sessionStore.RemoveAuthenticatedSessionAsync(sessionId, context.RequestAborted).ConfigureAwait(false);
+        }
+
+        context.Response.Cookies.Delete(
+            AdminAuthSessionStore.AuthSessionCookieName,
+            new CookieOptions
+            {
+                HttpOnly = true,
+                IsEssential = true,
+                SameSite = SameSiteMode.Lax,
+                Secure = context.Request.IsHttps,
+                Path = "/",
+            });
+    }
+
+    private static string BuildLogoutResponse(SamlAuthenticationOptions opts, string? inResponseTo)
+    {
+        var settings = new XmlWriterSettings
+        {
+            Encoding = new UTF8Encoding(false),
+            Indent = false,
+            OmitXmlDeclaration = false,
+        };
+
+        var output = new StringWriterUtf8();
+        using (var writer = XmlWriter.Create(output, settings))
+        {
+            writer.WriteStartElement("samlp", "LogoutResponse", SamlProtocolNs);
+            writer.WriteAttributeString("ID", "_" + Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant());
+            writer.WriteAttributeString("Version", "2.0");
+            writer.WriteAttributeString("IssueInstant", DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
+            if (!string.IsNullOrWhiteSpace(inResponseTo))
+            {
+                writer.WriteAttributeString("InResponseTo", inResponseTo);
+            }
+
+            if (!string.IsNullOrWhiteSpace(opts.EntityId))
+            {
+                writer.WriteStartElement("Issuer", SamlAssertionNs);
+                writer.WriteString(opts.EntityId);
+                writer.WriteEndElement();
+            }
+
+            writer.WriteStartElement("Status", SamlProtocolNs);
+            writer.WriteStartElement("StatusCode", SamlProtocolNs);
+            writer.WriteAttributeString("Value", "urn:oasis:names:tc:SAML:2.0:status:Success");
+            writer.WriteEndElement(); // StatusCode
+            writer.WriteEndElement(); // Status
+
+            writer.WriteEndElement(); // LogoutResponse
+        }
+
+        return output.ToString();
+    }
+
+    private static string BuildAutoPostForm(string destination, string encodedResponse, string? relayState)
+    {
+        var relayInput = string.IsNullOrEmpty(relayState)
+            ? string.Empty
+            : $"<input type=\"hidden\" name=\"RelayState\" value=\"{WebUtility.HtmlEncode(relayState)}\"/>";
+
+        return $"""
+            <!DOCTYPE html>
+            <html><head><title>SAML Single Logout</title></head>
+            <body onload="document.forms[0].submit()">
+            <form method="post" action="{WebUtility.HtmlEncode(destination)}">
+            <input type="hidden" name="SAMLResponse" value="{WebUtility.HtmlEncode(encodedResponse)}"/>
+            {relayInput}
+            <noscript><button type="submit">Continue</button></noscript>
+            </form>
+            </body></html>
+            """;
+    }
+
+    private static IResult LogoutRejected(HttpContext context, string detail)
+        => Results.Problem(title: "SAML logout request rejected", detail: detail, statusCode: StatusCodes.Status401Unauthorized);
+
     private static string BuildSpMetadata(SamlAuthenticationOptions opts)
     {
         // Emit minimal, valid SP metadata describing the ACS endpoint and supported NameID
@@ -191,6 +409,16 @@ internal static partial class SamlEndpoints
             writer.WriteAttributeString("AuthnRequestsSigned", "false");
             writer.WriteAttributeString("WantAssertionsSigned", "true");
             writer.WriteAttributeString("protocolSupportEnumeration", "urn:oasis:names:tc:SAML:2.0:protocol");
+
+            // SingleLogoutService advertises SP-side support for SAML 2.0 Single Logout (SLO).
+            // Schema order places it before NameIDFormat within an SSODescriptor.
+            if (!string.IsNullOrWhiteSpace(opts.SingleLogoutServiceUrl))
+            {
+                writer.WriteStartElement("SingleLogoutService", md);
+                writer.WriteAttributeString("Binding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST");
+                writer.WriteAttributeString("Location", opts.SingleLogoutServiceUrl);
+                writer.WriteEndElement(); // SingleLogoutService
+            }
 
             writer.WriteStartElement("NameIDFormat", md);
             writer.WriteString("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent");

--- a/src/Honua.Server/Features/Identity/Saml/SamlLog.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlLog.cs
@@ -17,4 +17,12 @@ internal static partial class SamlLog
     [LoggerMessage(EventId = 4621, Level = LogLevel.Information,
         Message = "SAML session established for subject '{NameId}' with {RoleCount} role(s).")]
     public static partial void SessionEstablished(ILogger logger, string nameId, int roleCount);
+
+    [LoggerMessage(EventId = 4622, Level = LogLevel.Information,
+        Message = "SAML single-logout processed for subject '{NameId}'.")]
+    public static partial void SingleLogoutProcessed(ILogger logger, string nameId);
+
+    [LoggerMessage(EventId = 4623, Level = LogLevel.Warning,
+        Message = "SAML single-logout request rejected. Reason={Reason}")]
+    public static partial void SingleLogoutRejected(ILogger logger, string reason);
 }

--- a/src/Honua.Server/Features/Identity/Scim/Models/ScimModels.cs
+++ b/src/Honua.Server/Features/Identity/Scim/Models/ScimModels.cs
@@ -25,8 +25,186 @@ internal static class ScimSchemas
     /// <summary>Error message schema URI.</summary>
     public const string Error = "urn:ietf:params:scim:api:messages:2.0:Error";
 
+    /// <summary>ServiceProviderConfig resource schema URI.</summary>
+    public const string ServiceProviderConfig = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
+
+    /// <summary>ResourceType resource schema URI.</summary>
+    public const string ResourceType = "urn:ietf:params:scim:schemas:core:2.0:ResourceType";
+
+    /// <summary>Schema-definition resource schema URI.</summary>
+    public const string Schema = "urn:ietf:params:scim:schemas:core:2.0:Schema";
+
     /// <summary>SCIM JSON content type.</summary>
     public const string ContentType = "application/scim+json";
+}
+
+/// <summary>
+/// SCIM 2.0 ServiceProviderConfig resource (RFC 7643 §5). Advertises the optional features the
+/// service provider supports so an IdP can adapt its provisioning behavior.
+/// </summary>
+public sealed class ScimServiceProviderConfig
+{
+    /// <summary>Schema URIs for this resource.</summary>
+    public IReadOnlyList<string> Schemas { get; init; } = [ScimSchemas.ServiceProviderConfig];
+
+    /// <summary>HTTP-addressable documentation describing the service provider.</summary>
+    public string? DocumentationUri { get; init; }
+
+    /// <summary>PATCH support (RFC 7644 §3.5.2).</summary>
+    public required ScimSupported Patch { get; init; }
+
+    /// <summary>Bulk-operation support (RFC 7644 §3.7).</summary>
+    public required ScimBulkConfig Bulk { get; init; }
+
+    /// <summary>Filtering support (RFC 7644 §3.4.2.2).</summary>
+    public required ScimFilterConfig Filter { get; init; }
+
+    /// <summary>Change-password support.</summary>
+    public required ScimSupported ChangePassword { get; init; }
+
+    /// <summary>Sorting support (RFC 7644 §3.4.2.3).</summary>
+    public required ScimSupported Sort { get; init; }
+
+    /// <summary>ETag support.</summary>
+    public required ScimSupported Etag { get; init; }
+
+    /// <summary>Supported authentication schemes.</summary>
+    public IReadOnlyList<ScimAuthenticationScheme> AuthenticationSchemes { get; init; } = [];
+
+    /// <summary>Resource metadata (read-only).</summary>
+    public ScimMeta? Meta { get; init; }
+}
+
+/// <summary>A simple supported/unsupported feature flag (RFC 7643 §5).</summary>
+public sealed class ScimSupported
+{
+    /// <summary>Whether the feature is supported.</summary>
+    public bool Supported { get; init; }
+}
+
+/// <summary>Bulk-operation capability descriptor (RFC 7643 §5).</summary>
+public sealed class ScimBulkConfig
+{
+    /// <summary>Whether bulk operations are supported.</summary>
+    public bool Supported { get; init; }
+
+    /// <summary>Maximum number of operations per bulk request.</summary>
+    public int MaxOperations { get; init; }
+
+    /// <summary>Maximum bulk-request payload size in bytes.</summary>
+    public int MaxPayloadSize { get; init; }
+}
+
+/// <summary>Filtering capability descriptor (RFC 7643 §5).</summary>
+public sealed class ScimFilterConfig
+{
+    /// <summary>Whether filtering is supported.</summary>
+    public bool Supported { get; init; }
+
+    /// <summary>Maximum number of resources returned by a filtered query.</summary>
+    public int MaxResults { get; init; }
+}
+
+/// <summary>An authentication scheme advertised by the service provider (RFC 7643 §5).</summary>
+public sealed class ScimAuthenticationScheme
+{
+    /// <summary>Scheme type (e.g. "oauthbearertoken", "httpbasic").</summary>
+    public string? Type { get; init; }
+
+    /// <summary>Human-readable name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Human-readable description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>HTTP-addressable specification document for the scheme.</summary>
+    public string? SpecUri { get; init; }
+
+    /// <summary>Whether this is the primary/preferred scheme.</summary>
+    public bool? Primary { get; init; }
+}
+
+/// <summary>
+/// SCIM 2.0 ResourceType resource (RFC 7643 §6). Describes an endpoint resource (User/Group),
+/// the schema that backs it, and where it is hosted.
+/// </summary>
+public sealed class ScimResourceType
+{
+    /// <summary>Schema URIs for this resource.</summary>
+    public IReadOnlyList<string> Schemas { get; init; } = [ScimSchemas.ResourceType];
+
+    /// <summary>Resource type identifier (e.g. "User").</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Resource type name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Relative endpoint the resource is hosted at (e.g. "/Users").</summary>
+    public string? Endpoint { get; init; }
+
+    /// <summary>The primary schema URI for this resource type.</summary>
+    public string? Schema { get; init; }
+
+    /// <summary>Human-readable description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Resource metadata (read-only).</summary>
+    public ScimMeta? Meta { get; init; }
+}
+
+/// <summary>
+/// SCIM 2.0 Schema resource (RFC 7643 §7) describing the attributes of a resource type.
+/// </summary>
+public sealed class ScimSchemaResource
+{
+    /// <summary>The schema URI this definition describes.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Schema name (e.g. "User").</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Human-readable description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Attribute definitions for the schema.</summary>
+    public IReadOnlyList<ScimAttributeDefinition> Attributes { get; init; } = [];
+
+    /// <summary>Resource metadata (read-only).</summary>
+    public ScimMeta? Meta { get; init; }
+}
+
+/// <summary>A SCIM attribute definition (RFC 7643 §7).</summary>
+public sealed class ScimAttributeDefinition
+{
+    /// <summary>Attribute name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Data type (e.g. "string", "boolean", "complex", "reference").</summary>
+    public string? Type { get; init; }
+
+    /// <summary>Whether the attribute is multi-valued.</summary>
+    public bool MultiValued { get; init; }
+
+    /// <summary>Human-readable description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Whether the attribute is required.</summary>
+    public bool Required { get; init; }
+
+    /// <summary>Whether string comparison is case-sensitive.</summary>
+    public bool CaseExact { get; init; }
+
+    /// <summary>Mutability ("readOnly", "readWrite", "immutable", "writeOnly").</summary>
+    public string? Mutability { get; init; }
+
+    /// <summary>Return characteristics ("always", "never", "default", "request").</summary>
+    public string? Returned { get; init; }
+
+    /// <summary>Uniqueness constraint ("none", "server", "global").</summary>
+    public string? Uniqueness { get; init; }
+
+    /// <summary>Sub-attribute definitions for a complex attribute.</summary>
+    public IReadOnlyList<ScimAttributeDefinition>? SubAttributes { get; init; }
 }
 
 /// <summary>
@@ -196,6 +374,11 @@ public sealed class ScimError
 [JsonSerializable(typeof(ScimListResponse<ScimGroupResource>))]
 [JsonSerializable(typeof(ScimPatchRequest))]
 [JsonSerializable(typeof(ScimError))]
+[JsonSerializable(typeof(ScimServiceProviderConfig))]
+[JsonSerializable(typeof(ScimResourceType))]
+[JsonSerializable(typeof(ScimSchemaResource))]
+[JsonSerializable(typeof(ScimListResponse<ScimResourceType>))]
+[JsonSerializable(typeof(ScimListResponse<ScimSchemaResource>))]
 internal sealed partial class ScimJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Identity/Scim/ScimDiscoveryEndpoints.cs
+++ b/src/Honua.Server/Features/Identity/Scim/ScimDiscoveryEndpoints.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Server.Features.Identity.Scim.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Identity.Scim;
+
+/// <summary>
+/// SCIM 2.0 service-provider discovery documents (#2154, RFC 7643 §5-7): the
+/// <c>/ServiceProviderConfig</c>, <c>/ResourceTypes</c>, and <c>/Schemas</c> endpoints an IdP
+/// queries to learn which optional features, resource types, and attribute schemas Honua
+/// supports. These are static, provider-agnostic descriptions of the implemented surface and
+/// are gated by the same bearer token as the rest of the SCIM API.
+/// </summary>
+internal static partial class ScimEndpoints
+{
+    // ---- ServiceProviderConfig --------------------------------------------------------
+
+    private static IResult HandleServiceProviderConfig(
+        HttpContext context,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        return ScimJson(ServiceProviderConfig, ScimJsonContext.Default.ScimServiceProviderConfig, StatusCodes.Status200OK);
+    }
+
+    // ---- ResourceTypes ----------------------------------------------------------------
+
+    private static IResult HandleResourceTypes(
+        HttpContext context,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var response = new ScimListResponse<ScimResourceType>
+        {
+            TotalResults = ResourceTypes.Count,
+            StartIndex = 1,
+            ItemsPerPage = ResourceTypes.Count,
+            Resources = ResourceTypes,
+        };
+
+        return ScimJson(response, ScimJsonContext.Default.ScimListResponseScimResourceType, StatusCodes.Status200OK);
+    }
+
+    private static IResult HandleResourceType(
+        string id,
+        HttpContext context,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var match = ResourceTypes.FirstOrDefault(rt => string.Equals(rt.Id, id, StringComparison.OrdinalIgnoreCase));
+        return match is null
+            ? ScimErrorResult(StatusCodes.Status404NotFound, "ResourceType not found.")
+            : ScimJson(match, ScimJsonContext.Default.ScimResourceType, StatusCodes.Status200OK);
+    }
+
+    // ---- Schemas ----------------------------------------------------------------------
+
+    private static IResult HandleSchemas(
+        HttpContext context,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var response = new ScimListResponse<ScimSchemaResource>
+        {
+            TotalResults = SchemaDefinitions.Count,
+            StartIndex = 1,
+            ItemsPerPage = SchemaDefinitions.Count,
+            Resources = SchemaDefinitions,
+        };
+
+        return ScimJson(response, ScimJsonContext.Default.ScimListResponseScimSchemaResource, StatusCodes.Status200OK);
+    }
+
+    private static IResult HandleSchema(
+        string id,
+        HttpContext context,
+        [FromServices] IOptions<ScimProvisioningOptions> options)
+    {
+        if (!Authenticate(context, options.Value))
+        {
+            return Unauthorized();
+        }
+
+        var match = SchemaDefinitions.FirstOrDefault(s => string.Equals(s.Id, id, StringComparison.OrdinalIgnoreCase));
+        return match is null
+            ? ScimErrorResult(StatusCodes.Status404NotFound, "Schema not found.")
+            : ScimJson(match, ScimJsonContext.Default.ScimSchemaResource, StatusCodes.Status200OK);
+    }
+
+    // ---- Static discovery documents ---------------------------------------------------
+
+    private static readonly ScimServiceProviderConfig ServiceProviderConfig = new()
+    {
+        DocumentationUri = "https://docs.honua.io/reference/compatibility/idp-conformance-matrix",
+        Patch = new ScimSupported { Supported = true },
+        Bulk = new ScimBulkConfig { Supported = false, MaxOperations = 0, MaxPayloadSize = 0 },
+        Filter = new ScimFilterConfig { Supported = true, MaxResults = MaxPageSize },
+        ChangePassword = new ScimSupported { Supported = false },
+        Sort = new ScimSupported { Supported = false },
+        Etag = new ScimSupported { Supported = false },
+        AuthenticationSchemes =
+        [
+            new ScimAuthenticationScheme
+            {
+                Type = "oauthbearertoken",
+                Name = "OAuth Bearer Token",
+                Description = "Authentication via the OAuth 2.0 Bearer Token standard.",
+                SpecUri = "https://www.rfc-editor.org/info/rfc6750",
+                Primary = true,
+            },
+        ],
+        Meta = new ScimMeta
+        {
+            ResourceType = "ServiceProviderConfig",
+            Location = "/scim/v2/ServiceProviderConfig",
+        },
+    };
+
+    private static readonly IReadOnlyList<ScimResourceType> ResourceTypes =
+    [
+        new ScimResourceType
+        {
+            Id = "User",
+            Name = "User",
+            Endpoint = "/Users",
+            Schema = ScimSchemas.User,
+            Description = "User Account",
+            Meta = new ScimMeta { ResourceType = "ResourceType", Location = "/scim/v2/ResourceTypes/User" },
+        },
+        new ScimResourceType
+        {
+            Id = "Group",
+            Name = "Group",
+            Endpoint = "/Groups",
+            Schema = ScimSchemas.Group,
+            Description = "Group",
+            Meta = new ScimMeta { ResourceType = "ResourceType", Location = "/scim/v2/ResourceTypes/Group" },
+        },
+    ];
+
+    private static readonly IReadOnlyList<ScimSchemaResource> SchemaDefinitions =
+    [
+        new ScimSchemaResource
+        {
+            Id = ScimSchemas.User,
+            Name = "User",
+            Description = "User Account",
+            Meta = new ScimMeta { ResourceType = "Schema", Location = "/scim/v2/Schemas/" + ScimSchemas.User },
+            Attributes =
+            [
+                StringAttribute("userName", required: true, uniqueness: "server"),
+                StringAttribute("displayName"),
+                new ScimAttributeDefinition
+                {
+                    Name = "active",
+                    Type = "boolean",
+                    MultiValued = false,
+                    Description = "A Boolean value indicating the user's administrative status.",
+                    Required = false,
+                    CaseExact = false,
+                    Mutability = "readWrite",
+                    Returned = "default",
+                    Uniqueness = "none",
+                },
+                new ScimAttributeDefinition
+                {
+                    Name = "emails",
+                    Type = "complex",
+                    MultiValued = true,
+                    Description = "Email addresses for the user.",
+                    Required = false,
+                    CaseExact = false,
+                    Mutability = "readWrite",
+                    Returned = "default",
+                    Uniqueness = "none",
+                    SubAttributes =
+                    [
+                        StringAttribute("value"),
+                        StringAttribute("type"),
+                        new ScimAttributeDefinition
+                        {
+                            Name = "primary",
+                            Type = "boolean",
+                            MultiValued = false,
+                            Required = false,
+                            CaseExact = false,
+                            Mutability = "readWrite",
+                            Returned = "default",
+                            Uniqueness = "none",
+                        },
+                    ],
+                },
+            ],
+        },
+        new ScimSchemaResource
+        {
+            Id = ScimSchemas.Group,
+            Name = "Group",
+            Description = "Group",
+            Meta = new ScimMeta { ResourceType = "Schema", Location = "/scim/v2/Schemas/" + ScimSchemas.Group },
+            Attributes =
+            [
+                StringAttribute("displayName", required: true),
+                new ScimAttributeDefinition
+                {
+                    Name = "members",
+                    Type = "complex",
+                    MultiValued = true,
+                    Description = "A list of members of the Group.",
+                    Required = false,
+                    CaseExact = false,
+                    Mutability = "readWrite",
+                    Returned = "default",
+                    Uniqueness = "none",
+                    SubAttributes =
+                    [
+                        StringAttribute("value"),
+                        StringAttribute("display"),
+                    ],
+                },
+            ],
+        },
+    ];
+
+    private static ScimAttributeDefinition StringAttribute(string name, bool required = false, string uniqueness = "none")
+        => new()
+        {
+            Name = name,
+            Type = "string",
+            MultiValued = false,
+            Required = required,
+            CaseExact = false,
+            Mutability = "readWrite",
+            Returned = "default",
+            Uniqueness = uniqueness,
+        };
+}

--- a/src/Honua.Server/Features/Identity/Scim/ScimEndpoints.cs
+++ b/src/Honua.Server/Features/Identity/Scim/ScimEndpoints.cs
@@ -57,6 +57,18 @@ internal static partial class ScimEndpoints
         groups.MapPut("/{id}", HandleReplaceGroup).WithDisplayName("SCIM Replace Group");
         groups.MapPatch("/{id}", HandlePatchGroup).WithDisplayName("SCIM Patch Group");
         groups.MapDelete("/{id}", HandleDeleteGroup).WithDisplayName("SCIM Delete Group");
+
+        // RFC 7643 service-provider discovery documents (#2154). These let an IdP probe the
+        // optional features, resource types, and attribute schemas Honua supports.
+        var discovery = endpoints.MapGroup("/scim/v2")
+            .WithTags("Identity", "SCIM")
+            .AllowAnonymous();
+
+        discovery.MapGet("/ServiceProviderConfig", HandleServiceProviderConfig).WithDisplayName("SCIM ServiceProviderConfig");
+        discovery.MapGet("/ResourceTypes", HandleResourceTypes).WithDisplayName("SCIM ResourceTypes");
+        discovery.MapGet("/ResourceTypes/{id}", HandleResourceType).WithDisplayName("SCIM ResourceType");
+        discovery.MapGet("/Schemas", HandleSchemas).WithDisplayName("SCIM Schemas");
+        discovery.MapGet("/Schemas/{id}", HandleSchema).WithDisplayName("SCIM Schema");
     }
 
     // ---- Users ------------------------------------------------------------------------

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/IdpConformanceMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/IdpConformanceMatrixTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Infrastructure.Helpers;
 using Honua.Server.Features.Identity.Saml;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -199,5 +200,37 @@ public sealed class IdpConformanceMatrixTests
         Assert.True(result.Succeeded, result.FailureReason);
         Assert.Single(result.Subject!.Roles);
         Assert.Contains("viewer", result.Subject.Roles);
+    }
+
+    [UnitTest]
+    public void Slo_SignedLogoutRequest_IsAcceptedForEachProvider()
+    {
+        // Single Logout (SLO) consumes an IdP-initiated, signed samlp:LogoutRequest. The signature
+        // path is provider-agnostic — every IdP signs the LogoutRequest with the same XML-DSig
+        // profile the SP verifies — so each provider's signed logout must verify against its own
+        // signing certificate.
+        foreach (var subject in new[] { "okta", "entra", "auth0", "ping" })
+        {
+            using var cert = SamlTestAssertions.CreateSigningCertificate();
+            var signed = SamlTestAssertions.CreateSignedLogoutRequest(cert, subject + ".user@example.com");
+            var logoutRequest = SecureXmlDocumentParser.Parse(Decode(signed)).Root!;
+
+            var result = SamlSignatureVerifier.Verify(logoutRequest, cert);
+
+            Assert.True(result.Verified, $"{subject}: {result.Reason}");
+        }
+    }
+
+    [UnitTest]
+    public void Slo_UnsignedLogoutRequest_IsRejected()
+    {
+        // An unsigned (or forged) LogoutRequest must never be able to terminate a session.
+        using var cert = SamlTestAssertions.CreateSigningCertificate();
+        var unsigned = SamlTestAssertions.CreateUnsignedLogoutRequest("attacker@example.com");
+        var logoutRequest = SecureXmlDocumentParser.Parse(Decode(unsigned)).Root!;
+
+        var result = SamlSignatureVerifier.Verify(logoutRequest, cert);
+
+        Assert.False(result.Verified);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Honua.Infrastructure.Authentication;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Server.Tests.Features.Identity;
 
@@ -38,6 +41,8 @@ public class SamlBridgeEndpointsTests : IAsyncLifetime
                 builder.UseSetting("Saml:EntityId", SamlTestAssertions.Audience);
                 builder.UseSetting("Saml:IdpEntityId", SamlTestAssertions.Issuer);
                 builder.UseSetting("Saml:AssertionConsumerServiceUrl", SamlTestAssertions.Audience + "/saml/acs");
+                builder.UseSetting("Saml:SingleLogoutServiceUrl", SamlTestAssertions.Audience + "/saml/slo");
+                builder.UseSetting("Saml:IdpSingleLogoutServiceUrl", "https://idp.example.com/slo");
                 builder.UseSetting("Saml:IdpSigningCertificate", base64Cert);
             });
     }
@@ -66,6 +71,87 @@ public class SamlBridgeEndpointsTests : IAsyncLifetime
         Assert.Contains("EntityDescriptor", body, StringComparison.Ordinal);
         Assert.Contains("AssertionConsumerService", body, StringComparison.Ordinal);
         Assert.Contains(SamlTestAssertions.Audience, body, StringComparison.Ordinal);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /saml/metadata")]
+    public async Task Metadata_WhenSloConfigured_AdvertisesSingleLogoutService()
+    {
+        var response = await _client.GetAsync("/saml/metadata");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("SingleLogoutService", body, StringComparison.Ordinal);
+        Assert.Contains(SamlTestAssertions.Audience + "/saml/slo", body, StringComparison.Ordinal);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/slo")]
+    public async Task Slo_ValidSignedLogoutRequest_TerminatesSessionAndRelaysResponse()
+    {
+        // Seed an authenticated SAML session, then drive an IdP-initiated single logout.
+        string sessionId;
+        await using (var scope = _fixture.Services.CreateAsyncScope())
+        {
+            var sessionStore = scope.ServiceProvider.GetRequiredService<AdminAuthSessionStore>();
+            sessionId = await sessionStore.CreateAuthenticatedSessionAsync(
+                "saml",
+                "opaque-token",
+                idToken: null,
+                [new AdminAuthSessionClaim { Type = ClaimTypes.NameIdentifier, Value = "slo-user@example.com" }],
+                DateTimeOffset.UtcNow.AddMinutes(5),
+                CancellationToken.None);
+        }
+
+        var samlRequest = SamlTestAssertions.CreateSignedLogoutRequest(_certificate, "slo-user@example.com");
+        using var client = _fixture.CreateClient(
+            c => c.DefaultRequestHeaders.Add("Cookie", $"{AdminAuthSessionStore.AuthSessionCookieName}={sessionId}"));
+
+        var response = await client.PostAsync(
+            "/saml/slo",
+            new FormUrlEncodedContent(new Dictionary<string, string> { ["SAMLRequest"] = samlRequest }));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // The LogoutResponse is relayed back to the IdP via an auto-submitting HTTP-POST form.
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("https://idp.example.com/slo", body, StringComparison.Ordinal);
+        Assert.Contains("SAMLResponse", body, StringComparison.Ordinal);
+
+        // The local session cookie is expired.
+        Assert.Contains(
+            response.Headers.GetValues("Set-Cookie"),
+            c => c.Contains(AdminAuthSessionStore.AuthSessionCookieName, StringComparison.Ordinal)
+                 && c.Contains("01 Jan 1970", StringComparison.Ordinal));
+
+        // The session record is removed from the store.
+        await using var verifyScope = _fixture.Services.CreateAsyncScope();
+        var verifyStore = verifyScope.ServiceProvider.GetRequiredService<AdminAuthSessionStore>();
+        Assert.Null(await verifyStore.GetAuthenticatedSessionAsync(sessionId, CancellationToken.None));
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/slo")]
+    public async Task Slo_UnsignedLogoutRequest_IsRejected()
+    {
+        var samlRequest = SamlTestAssertions.CreateUnsignedLogoutRequest("attacker@example.com");
+
+        var response = await _client.PostAsync(
+            "/saml/slo",
+            new FormUrlEncodedContent(new Dictionary<string, string> { ["SAMLRequest"] = samlRequest }));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /saml/slo")]
+    public async Task Slo_MissingSamlRequest_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsync(
+            "/saml/slo",
+            new FormUrlEncodedContent(new Dictionary<string, string> { ["RelayState"] = "x" }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlTestAssertions.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlTestAssertions.cs
@@ -98,6 +98,43 @@ internal static class SamlTestAssertions
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(signed));
     }
 
+    /// <summary>
+    /// Produces a signed SAML 2.0 <c>LogoutRequest</c> (base64-encoded, HTTP-POST binding) as an
+    /// IdP emits for IdP-initiated Single Logout (#2154). The <c>LogoutRequest</c> element is
+    /// signed with the in-box <see cref="SignedXml"/> oracle so the server's hand-rolled verifier
+    /// must accept it.
+    /// </summary>
+    public static string CreateSignedLogoutRequest(X509Certificate2 certificate, string nameId)
+    {
+        var xml = BuildLogoutRequestXml(nameId);
+        var signed = SignElement(xml, "_logout1", certificate);
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(signed));
+    }
+
+    /// <summary>
+    /// Produces an UNSIGNED SAML 2.0 <c>LogoutRequest</c> (base64-encoded). Used to prove the
+    /// server rejects an unauthenticated single-logout that would otherwise terminate a session.
+    /// </summary>
+    public static string CreateUnsignedLogoutRequest(string nameId)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(BuildLogoutRequestXml(nameId)));
+
+    private static string BuildLogoutRequestXml(string nameId)
+    {
+        const string saml = "urn:oasis:names:tc:SAML:2.0:assertion";
+        const string samlp = "urn:oasis:names:tc:SAML:2.0:protocol";
+        var issueInstant = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        // Realistic IdP shape: a prefixed samlp:LogoutRequest root with samlp-prefixed and
+        // assertion-default-namespace children, exercising exclusive-C14N prefix rendering.
+        return $"""
+            <samlp:LogoutRequest xmlns:samlp="{samlp}" xmlns="{saml}" ID="_logout1" Version="2.0" IssueInstant="{issueInstant}">
+              <Issuer>{Issuer}</Issuer>
+              <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">{nameId}</NameID>
+              <samlp:SessionIndex>_session1</samlp:SessionIndex>
+            </samlp:LogoutRequest>
+            """;
+    }
+
     private static string BuildResponseXml(
         string nameId,
         string email,
@@ -173,20 +210,28 @@ internal static class SamlTestAssertions
     /// RSA-SHA256, mirroring what a real IdP emits.
     /// </summary>
     private static string SignAssertion(string responseXml, X509Certificate2 certificate)
+        => SignElement(responseXml, "_assertion1", certificate);
+
+    /// <summary>
+    /// Signs the element bearing the supplied <c>ID</c> with an enveloped XML-DSig signature
+    /// (Exclusive C14N, RSA-SHA256), inserting the signature after the element's saml:Issuer
+    /// child. Shared by the assertion and LogoutRequest signers.
+    /// </summary>
+    private static string SignElement(string xml, string referenceId, X509Certificate2 certificate)
     {
         var document = new XmlDocument { PreserveWhitespace = true };
-        document.LoadXml(responseXml);
+        document.LoadXml(xml);
 
         var nsmgr = new XmlNamespaceManager(document.NameTable);
         nsmgr.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
-        var assertion = (XmlElement)document.SelectSingleNode("//saml:Assertion", nsmgr)!;
+        var element = (XmlElement)document.SelectSingleNode($"//*[@ID='{referenceId}']")!;
 
         using var rsa = certificate.GetRSAPrivateKey()!;
-        var signedXml = new SignedXml(assertion) { SigningKey = rsa };
+        var signedXml = new SignedXml(element) { SigningKey = rsa };
         signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
         signedXml.SignedInfo.SignatureMethod = SignedXml.XmlDsigRSASHA256Url;
 
-        var reference = new Reference("#_assertion1");
+        var reference = new Reference("#" + referenceId);
         reference.DigestMethod = SignedXml.XmlDsigSHA256Url;
         reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
         reference.AddTransform(new XmlDsigExcC14NTransform());
@@ -195,9 +240,9 @@ internal static class SamlTestAssertions
         signedXml.ComputeSignature();
         var signatureElement = signedXml.GetXml();
 
-        // Insert the signature as the first child of the assertion (after Issuer is also valid;
-        // the verifier locates it as a direct child regardless of position).
-        assertion.InsertAfter(signatureElement, assertion.SelectSingleNode("saml:Issuer", nsmgr));
+        // Insert the signature as a direct child after the Issuer; the verifier locates it as a
+        // direct child regardless of position.
+        element.InsertAfter(signatureElement, element.SelectSingleNode("saml:Issuer", nsmgr));
 
         return document.OuterXml;
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs
@@ -254,6 +254,98 @@ public class ScimProvisioningEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /scim/v2/ServiceProviderConfig")]
+    public async Task ServiceProviderConfig_ReturnsSupportedFeatures()
+    {
+        var response = await _client.GetAsync("/scim/v2/ServiceProviderConfig");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var config = await ReadAsync(response);
+        Assert.Contains(
+            "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig",
+            config.GetProperty("schemas").EnumerateArray().Select(s => s.GetString()));
+        Assert.True(config.GetProperty("patch").GetProperty("supported").GetBoolean());
+        Assert.True(config.GetProperty("filter").GetProperty("supported").GetBoolean());
+
+        var schemes = config.GetProperty("authenticationSchemes");
+        Assert.Equal("oauthbearertoken", schemes[0].GetProperty("type").GetString());
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/ServiceProviderConfig")]
+    public async Task ServiceProviderConfig_WithoutToken_ReturnsUnauthorized()
+    {
+        using var anon = _fixture.CreateClient();
+        var response = await anon.GetAsync("/scim/v2/ServiceProviderConfig");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/ResourceTypes")]
+    public async Task ResourceTypes_ReturnsUserAndGroup()
+    {
+        var response = await _client.GetAsync("/scim/v2/ResourceTypes");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await ReadAsync(response);
+        Assert.Equal(2, body.GetProperty("totalResults").GetInt32());
+        var ids = body.GetProperty("resources").EnumerateArray()
+            .Select(r => r.GetProperty("id").GetString()).ToList();
+        Assert.Contains("User", ids);
+        Assert.Contains("Group", ids);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/ResourceTypes/{id}")]
+    public async Task ResourceType_ById_ReturnsUser()
+    {
+        var response = await _client.GetAsync("/scim/v2/ResourceTypes/User");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await ReadAsync(response);
+        Assert.Equal("User", body.GetProperty("id").GetString());
+        Assert.Equal("/Users", body.GetProperty("endpoint").GetString());
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/ResourceTypes/{id}")]
+    public async Task ResourceType_UnknownId_ReturnsNotFound()
+    {
+        var response = await _client.GetAsync("/scim/v2/ResourceTypes/Nope");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Schemas")]
+    public async Task Schemas_ReturnsUserAndGroupDefinitions()
+    {
+        var response = await _client.GetAsync("/scim/v2/Schemas");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await ReadAsync(response);
+        Assert.Equal(2, body.GetProperty("totalResults").GetInt32());
+        var ids = body.GetProperty("resources").EnumerateArray()
+            .Select(r => r.GetProperty("id").GetString()).ToList();
+        Assert.Contains("urn:ietf:params:scim:schemas:core:2.0:User", ids);
+        Assert.Contains("urn:ietf:params:scim:schemas:core:2.0:Group", ids);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Schemas/{id}")]
+    public async Task Schema_ById_ReturnsUserSchema()
+    {
+        var response = await _client.GetAsync("/scim/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await ReadAsync(response);
+        Assert.Equal("urn:ietf:params:scim:schemas:core:2.0:User", body.GetProperty("id").GetString());
+        var attrNames = body.GetProperty("attributes").EnumerateArray()
+            .Select(a => a.GetProperty("name").GetString()).ToList();
+        Assert.Contains("userName", attrNames);
+        Assert.Contains("active", attrNames);
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /scim/v2/Users")]
     public async Task Request_WithoutBearerToken_ReturnsUnauthorized()
     {


### PR DESCRIPTION
## Related Issue

Closes #2154

## Summary

Completes the deferred enterprise-identity slice from #2110: SAML 2.0 Single Logout (SLO), SCIM 2.0 service-provider discovery documents, and the conformance tests/docs that prove them. Also fixes a latent exclusive-C14N bug that blocked verifying signatures on prefixed root elements (which is exactly the shape real IdPs send for `LogoutRequest`).

## Changes Made

- Add `POST /saml/slo`: consumes an IdP-initiated, signed `samlp:LogoutRequest` (HTTP-POST binding), verifies its XML-DSig signature against the configured IdP certificate, terminates the local admin session (session-store record + cookie), and emits a `LogoutResponse` — relayed to the IdP's SLO endpoint via an auto-submitting form when configured, else returned directly. Unsigned/forged logout requests are rejected.
- Advertise `SingleLogoutService` (HTTP-POST) in SP metadata when `Saml:SingleLogoutServiceUrl` is set; add `Saml:SingleLogoutServiceUrl` and `Saml:IdpSingleLogoutServiceUrl` options.
- Fix `ExclusiveCanonicalizer` namespace-prefix rendering: the prefix was never resolved from the element scope (`NamespacePrefix` always returned ""), so a prefixed signed root such as `<samlp:LogoutRequest>` was mis-canonicalized and failed verification. The assertion path never hit this because the signed `<Assertion>` uses the default namespace.
- Add SCIM 2.0 discovery documents (RFC 7643 §5-7): `GET /scim/v2/ServiceProviderConfig`, `/ResourceTypes`, `/ResourceTypes/{id}`, `/Schemas`, `/Schemas/{id}`, gated by the existing SCIM bearer token.
- Register the new routes in `EndpointRegistry`; add SLO + discovery integration tests and per-IdP SLO signature-verification conformance tests; update `docs/reference/compatibility/idp-conformance-matrix.md`.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact / not applicable

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

`dotnet build src/Honua.Server/Honua.Server.csproj -c Release /p:TreatWarningsAsErrors=true` — succeeds (0 warnings). `dotnet format --verify-no-changes` on changed files — clean. `dotnet test Honua.Server.Tests --filter IdpConformanceMatrixTests|SamlAssertionValidatorTests` — 14/14 pass, including the new per-IdP SLO signature tests (realistic prefixed `<samlp:LogoutRequest>`) and the pre-existing assertion-signature tests (confirming the canonicalizer fix does not regress the ACS path).

The Docker-gated integration tests (`SamlBridgeEndpointsTests` SLO cases, `ScimProvisioningEndpointsTests` discovery cases) compile and follow the existing passing patterns; they require a Docker daemon (Testcontainers/PostGIS) which is unavailable in this worktree, so they run in CI.

## Known gaps / deferred

- SP-initiated logout (Honua generating/signing its own `LogoutRequest`) and the HTTP-Redirect SLO binding (query-string signature scheme).
- Live-IdP conformance runs gated behind tenant credentials.
