### PR TITLE
docs(grpc): document FeatureQueryResult REST-parity contract (#2252)

### DIFF
--- a/docs/reference/protocols/grpc.md
+++ b/docs/reference/protocols/grpc.md
@@ -31,6 +31,34 @@ grpcurl -plaintext -d '{"serviceId":"roads","layerId":0,"where":"1=1"}' \
   server.example.com:8081 geospatial.v1.FeatureService/QueryFeatures
 ```
 
+## Feature query result contract (REST parity)
+
+`QueryFeatures` (`QueryFeaturesResponse`) and `QueryFeaturesStream` (the first
+`FeaturePage`) carry the same descriptive metadata that the GeoServices REST
+`query` response returns inline, so clients reach result parity without a
+separate layer-metadata round trip:
+
+| Field | Meaning |
+| --- | --- |
+| `spatial_reference` | The spatial reference of the returned geometries. Reflects the requested `out_sr` when supplied, otherwise the layer's spatial reference. |
+| `geometry_type` | The layer geometry type (`POINT`, `POLYLINE`/line, `POLYGON`, multi variants, or `NONE` for tables). |
+| `object_id_field_name` | The primary object-id field name (defaults to `objectid`). |
+| `fields` | Field definitions (name, type, length, nullability) for every non-geometry attribute field. |
+
+Notes:
+
+- For streaming queries the metadata is populated **only on the first
+  `FeaturePage`**; subsequent pages set `is_last_page` and feature payloads only.
+- `fields` is emitted for full feature payloads. The `return_count_only`,
+  `return_ids_only`, and `return_extent_only` shapes return the relevant scalar
+  (`count`, `object_ids`, `extent`) and still carry `spatial_reference` /
+  `geometry_type`, but omit `fields`.
+- Metadata-fallback contract: if a client is pinned to an older `Geospatial.Grpc`
+  package whose `geospatial.v1` messages predate one of these fields, that field
+  is absent (proto3 implicit default) and the client should fall back to the
+  layer metadata surface (`FeatureService` reflection / the REST layer document)
+  for the missing descriptor. Current `geospatial.v1` carries all four fields.
+
 ## Versioning and deprecation policy
 
 Every protobuf package carries a major-version suffix (`geospatial.v1`, future `geospatial.v2`); a service lives under exactly one major version, and versions are hosted side by side.

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/GrpcFeatureServiceTests.cs
@@ -536,6 +536,41 @@ public sealed class GrpcFeatureServiceTests
 
     [UnitTest]
     [Endpoint("POST /grpc/geospatial.v1.FeatureService/QueryFeatures")]
+    public async Task QueryFeatures_ReturnsSpatialReferenceGeometryTypeAndFieldsFromMetadata()
+    {
+        // REST-parity contract (#2252): a standard feature query response carries the
+        // layer's spatial reference, geometry type, object-id field name, and field
+        // definitions so gRPC clients do not have to fall back to a separate metadata
+        // lookup. The fixture layer is WGS84 / Point with objectid + name fields.
+        var features = ImmutableArray.Create(Feature.Create(1, null));
+        _featureReader.QueryAsync(0, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(QueryResult<Feature>.Create(1, features));
+
+        var request = new Proto.QueryFeaturesRequest
+        {
+            ServiceId = "test",
+            LayerId = 0,
+            Where = "1=1"
+        };
+
+        var response = await _sut.QueryFeatures(request, CreateCallContext());
+
+        response.ObjectIdFieldName.Should().Be("objectid");
+        response.GeometryType.Should().Be(Proto.GeometryType.Point);
+        response.SpatialReference.Should().NotBeNull();
+        response.SpatialReference.Wkid.Should().Be(SpatialReference.WGS84.Wkid);
+
+        response.Fields.Should().HaveCount(2);
+        response.Fields.Select(field => field.Name)
+            .Should().BeEquivalentTo(["objectid", "name"]);
+        var nameField = response.Fields.Single(field => field.Name == "name");
+        nameField.FieldType.Should().Be(Proto.FieldType.String);
+        nameField.Length.Should().Be(255);
+        nameField.Nullable.Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Endpoint("POST /grpc/geospatial.v1.FeatureService/QueryFeatures")]
     public async Task QueryFeatures_CountOnly_ReturnsCountWithNoFeatures()
     {
         _featureReader.CountAsync(0, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary

Resolves the gRPC release-dependency #2252 for the `honua-server` side. Investigation found the proto is **external** (consumed from the published `Geospatial.Grpc` package; canonical `.proto` lives in `geospatial-grpc`, per the repo's Proto Ownership rule), so the message is not editable here. It also found that the current `geospatial.v1` feature-query responses **already carry** the descriptive metadata the ticket asks for: `HonuaFeatureService.QueryFeatures` populates `QueryFeaturesResponse.spatial_reference`, `geometry_type`, `object_id_field_name`, and `fields`, and the streaming path populates the same on the first `FeaturePage`. The ticket's "FeatureQueryResult carries nothing" reflected an older/SDK-side view.

This PR therefore locks and documents that REST-parity contract from the `honua-server` side rather than vendoring a proto change.

## Changes Made

- Documented the feature-query result contract in `docs/reference/protocols/grpc.md`: `spatial_reference`, `geometry_type`, `object_id_field_name`, and `fields` on `QueryFeatures`/first `FeaturePage`, including the count/ids/extent shape differences and the metadata-fallback contract for clients pinned to older `geospatial.v1` packages.
- Added a `GrpcFeatureServiceTests` unit test (`QueryFeatures_ReturnsSpatialReferenceGeometryTypeAndFieldsFromMetadata`) asserting the non-streaming query response carries the layer spatial reference, geometry type, object-id field name, and field definitions (name/type/length/nullable). The streaming-path metadata was already covered by `QueryFeaturesStream_StreamsPages`.

## Breaking Changes

None. No proto/wire change; documentation and test only.

## Notes / cross-repo

The cross-repo gRPC v1 contract lock continues to be tracked in `geospatial-grpc#47`; no proto edit is made here (canonical protos stay in `geospatial-grpc`).

## Gate Impact

- [x] No gate impact (docs + test only)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Built `tests/dotnet/Honua.Server.Tests` in Release with `TreatWarningsAsErrors=true` (0 warnings, 0 errors) and ran `--filter FullyQualifiedName~GrpcFeatureServiceTests`: 39/39 passed, including the new parity test.

Closes #2252
