### PR TITLE
feat: server-side idempotency for applyEdits adds (#2250)

### DIFF
--- a/docs/reference/compatibility/geoservices-parity.md
+++ b/docs/reference/compatibility/geoservices-parity.md
@@ -67,6 +67,33 @@ Esri spec: [Feature Service](https://developers.arcgis.com/rest/services-referen
 `editsUploadId`, ...) are silently ignored. queryRelatedRecords rejects
 `gdbVersion` and `historicMoment` with 400 and accepts/ignores `returnTrueCurves`.
 
+#### Idempotency (at-most-once edits)
+
+`applyEdits`, `addFeatures`, `updateFeatures`, and `deleteFeatures` (layer-level) honour
+an optional `Idempotency-Key` request header so a client can retry an edit on a transient
+failure without creating duplicate features (#2250). When the header is present, the first
+request that commits at least one row records its full response keyed by the
+`(principal, serviceId, layerId, key)` tuple; any later request that repeats the same key
+within the dedupe window (24 hours) replays that original response — the same `objectId`s,
+with `success: true` — instead of re-applying the edit. This is the server-side contract the
+Honua SDKs and field clients rely on for true at-most-once semantics.
+
+Contract details:
+
+- The key is a client-generated, stable string of at most 200 characters with no control
+  characters; an empty, oversized, or malformed header is rejected with a 400.
+- The key is scoped to the authenticated principal, service, and layer — one caller's key
+  can never replay another caller's response, and the same key on a different layer is a
+  distinct edit.
+- Only requests that committed rows are recorded; a fully-failed/no-op request is not
+  recorded, so it can be retried fresh.
+- The store is Redis-backed when an `IDistributedCache` is configured (durable across
+  replicas) and falls back to an in-process window on a single node. Because
+  `IDistributedCache` exposes no atomic reserve, two *truly concurrent* identical requests
+  can both miss the window before either records its response; the header guarantees
+  at-most-once for the common *sequential-retry* pattern, not for simultaneous in-flight
+  duplicates.
+
 ## MapServer + WMS / WMTS
 
 Esri spec: [Map Service](https://developers.arcgis.com/rest/services-reference/enterprise/map-service/).

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsDependencies.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsDependencies.cs
@@ -25,7 +25,8 @@ internal sealed class FeatureServerEditsDependencies
         IFilterExpressionService filterExpressionService,
         IHttpContextAccessor httpContextAccessor,
         FeatureMutationEventService mutationEventService,
-        IPluginEditPipeline pluginPipeline)
+        IPluginEditPipeline pluginPipeline,
+        IApplyEditsIdempotencyStore idempotencyStore)
     {
         ResourceValidator = resourceValidator ?? throw new ArgumentNullException(nameof(resourceValidator));
         FeatureWriter = featureWriter ?? throw new ArgumentNullException(nameof(featureWriter));
@@ -38,6 +39,7 @@ internal sealed class FeatureServerEditsDependencies
         HttpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         MutationEventService = mutationEventService ?? throw new ArgumentNullException(nameof(mutationEventService));
         PluginPipeline = pluginPipeline ?? throw new ArgumentNullException(nameof(pluginPipeline));
+        IdempotencyStore = idempotencyStore ?? throw new ArgumentNullException(nameof(idempotencyStore));
     }
 
     public IResourceValidator ResourceValidator { get; }
@@ -51,4 +53,5 @@ internal sealed class FeatureServerEditsDependencies
     public IHttpContextAccessor HttpContextAccessor { get; }
     public FeatureMutationEventService MutationEventService { get; }
     public IPluginEditPipeline PluginPipeline { get; }
+    public IApplyEditsIdempotencyStore IdempotencyStore { get; }
 }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -51,6 +51,7 @@ internal sealed class FeatureServerEditsHandler(
     private readonly IHttpContextAccessor _httpContextAccessor = dependencies.HttpContextAccessor;
     private readonly FeatureMutationEventService _mutationEventService = dependencies.MutationEventService;
     private readonly IPluginEditPipeline _pluginPipeline = dependencies.PluginPipeline;
+    private readonly IApplyEditsIdempotencyStore _idempotencyStore = dependencies.IdempotencyStore;
     private readonly ILogger<FeatureServerEditsHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <summary>
@@ -74,6 +75,13 @@ internal sealed class FeatureServerEditsHandler(
         if (editsGate is not null)
         {
             return editsGate;
+        }
+
+        // Server-side at-most-once (#2250): validate the optional Idempotency-Key header up front so a
+        // malformed header fails fast with a 400 before any edit work, rather than being silently ignored.
+        if (!ApplyEditsIdempotency.TryResolveKey(httpContext, out var idempotencyKey, out var idempotencyError))
+        {
+            return StandardErrorHelpers.CreateBadRequest(httpContext, idempotencyError!);
         }
 
         using var scope = HonuaTelemetryScope.StartFeature(
@@ -162,6 +170,29 @@ internal sealed class FeatureServerEditsHandler(
             // shared edit pipeline rather than by caller discipline.
             var editPrincipal = ResolveEditPrincipal(httpContext);
 
+            // At-most-once replay (#2250): a retry carrying a previously-seen Idempotency-Key returns the
+            // original response without re-applying the edit, so a retried add cannot create a duplicate
+            // feature. The key is scoped to (principal, service, layer) inside the store.
+            ApplyEditsIdempotencyScope? idempotencyScope = idempotencyKey is null
+                ? null
+                : new ApplyEditsIdempotencyScope(
+                    serviceId,
+                    layerId,
+                    string.IsNullOrEmpty(editPrincipal.Name) ? "anonymous" : editPrincipal.Name,
+                    idempotencyKey);
+
+            if (idempotencyScope is { } replayScope)
+            {
+                var replay = await _idempotencyStore.TryGetAsync(replayScope, cancellationToken).ConfigureAwait(false);
+                if (replay is not null)
+                {
+                    FeatureServerLog.ApplyEditsReplayed(_logger, serviceId, layerId);
+                    scope.SetSuccess(0);
+                    return Results.Json(replay, FeatureServerJsonContext.Default.ApplyEditsResponse,
+                        contentType: "application/json");
+                }
+            }
+
             // Process edit operations
             var editContext = await ProcessEditOperationsAsync(request, resource, storageLayerId.Value, editPrincipal, cancellationToken);
 
@@ -193,7 +224,19 @@ internal sealed class FeatureServerEditsHandler(
             // Build and return final response
             var featureCount = editResult.CreatedCount + editResult.UpdatedCount + editResult.DeletedCount;
             scope.SetSuccess(featureCount);
-            return CreateFinalResponse(editContext, editResult, serviceId, layerId);
+            var finalResponse = BuildFinalResponse(editContext, editResult);
+            FeatureServerLog.ApplyEditsCompleted(_logger, serviceId, layerId, finalResponse.Success);
+
+            // Record the response for at-most-once replay (#2250) only when the edit actually committed
+            // rows. A fully-failed/no-op request is intentionally not recorded so a genuine retry is
+            // re-attempted rather than replaying a no-op failure. Best-effort: the store swallows errors.
+            if (idempotencyScope is { } recordScope && !editResult.WasRolledBack && featureCount > 0)
+            {
+                await _idempotencyStore.SetAsync(recordScope, finalResponse, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            return Results.Json(finalResponse, FeatureServerJsonContext.Default.ApplyEditsResponse,
+                contentType: "application/json");
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -691,9 +734,11 @@ internal sealed class FeatureServerEditsHandler(
     }
 
     /// <summary>
-    /// Creates the final response after all operations complete
+    /// Builds the final response after all operations complete. Returns the response object (rather than
+    /// an <see cref="IResult"/>) so the caller can record it in the idempotency store (#2250) before
+    /// serializing it.
     /// </summary>
-    private IResult CreateFinalResponse(EditOperationContext context, FeatureEditResult editResult, string serviceId, int layerId)
+    private static ApplyEditsResponse BuildFinalResponse(EditOperationContext context, FeatureEditResult editResult)
     {
         var finalAddResults = FinalizeResults(context.AddResults);
         var finalUpdateResults = FinalizeResults(context.UpdateResults);
@@ -704,18 +749,13 @@ internal sealed class FeatureServerEditsHandler(
                          !editResult.WasRolledBack &&
                          !context.HasValidationErrors;
 
-        var finalResponse = new ApplyEditsResponse
+        return new ApplyEditsResponse
         {
             AddResults = finalAddResults,
             UpdateResults = finalUpdateResults,
             DeleteResults = finalDeleteResults,
             Success = allSuccess
         };
-
-        FeatureServerLog.ApplyEditsCompleted(_logger, serviceId, layerId, allSuccess);
-
-        return Results.Json(finalResponse, FeatureServerJsonContext.Default.ApplyEditsResponse,
-            contentType: "application/json");
     }
 
     private async Task PublishFeatureChangeEventsAsync(

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
@@ -254,6 +254,27 @@ internal static partial class FeatureServerLog
     public static partial void ApplyEditsFailed(ILogger logger, string serviceId, int layerId, string errorMessage, Exception exception);
 
     /// <summary>
+    /// Logs when an ApplyEdits request is replayed from the idempotency store (#2250): a retry carrying
+    /// a previously-seen Idempotency-Key returns the original response without re-applying the edit.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer identifier.</param>
+    [LoggerMessage(EventId = 2406, Level = LogLevel.Information, Message = "ApplyEdits replayed from idempotency store for service '{ServiceId}' layer {LayerId}")]
+    public static partial void ApplyEditsReplayed(ILogger logger, string serviceId, int layerId);
+
+    /// <summary>
+    /// Logs when the ApplyEdits idempotency store is unavailable (#2250). Best-effort: the edit still
+    /// proceeds, but a retry may be re-applied rather than deduplicated.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer identifier.</param>
+    /// <param name="exception">The exception raised by the store.</param>
+    [LoggerMessage(EventId = 2407, Level = LogLevel.Warning, Message = "ApplyEdits idempotency store unavailable for service '{ServiceId}' layer {LayerId}; retry deduplication is degraded")]
+    public static partial void ApplyEditsIdempotencyStoreUnavailable(ILogger logger, string serviceId, int layerId, Exception exception);
+
+    /// <summary>
     /// Logs when adding a feature fails.
     /// </summary>
     /// <param name="logger">The logger instance.</param>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerServiceCollectionExtensions.cs
@@ -42,6 +42,14 @@ internal static class FeatureServerServiceCollectionExtensions
             serviceProvider.GetRequiredService<FeatureServerQueryHandler>());
         services.AddScoped<FeatureServerRelatedRecordsDependencies>();
         services.AddScoped<FeatureServerRelatedRecordsHandler>();
+        // At-most-once applyEdits store (#2250). Distributed (Redis) when an IDistributedCache is
+        // configured, otherwise an in-process fallback — mirroring DistributedReplicaStore. Singleton so
+        // the in-process fallback dictionary survives across requests.
+        services.TryAddSingleton<IApplyEditsIdempotencyStore>(static serviceProvider =>
+            new DistributedApplyEditsIdempotencyStore(
+                serviceProvider.GetService<Microsoft.Extensions.Caching.Distributed.IDistributedCache>(),
+                serviceProvider.GetRequiredService<ILogger<DistributedApplyEditsIdempotencyStore>>()));
+
         services.AddScoped<FeatureServerEditsDependencies>();
         services.AddScoped<FeatureServerEditsHandler>();
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Honua.Protocols.GeoServices.FeatureServer.Services;
+
+/// <summary>
+/// Server-side at-most-once store for FeatureServer <c>applyEdits</c> requests (#2250). A client that
+/// retries an edit (transient failure, re-sync) supplies a stable <c>Idempotency-Key</c>; the first
+/// completed request's response is recorded keyed by that key so a replayed request returns the original
+/// result (the original objectIds) without re-applying the edit and creating duplicate features.
+/// </summary>
+internal interface IApplyEditsIdempotencyStore
+{
+    /// <summary>
+    /// Returns the previously-recorded response for an idempotency key within the dedupe window, or
+    /// <see langword="null"/> when this is the first time the key has been seen.
+    /// </summary>
+    Task<ApplyEditsResponse?> TryGetAsync(
+        ApplyEditsIdempotencyScope scope,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records the response for an idempotency key so a later retry replays it instead of re-applying
+    /// the edit. Best-effort: a store failure is swallowed so it can never fail an already-applied edit
+    /// (the only consequence is the retry is re-applied rather than deduped).
+    /// </summary>
+    Task SetAsync(
+        ApplyEditsIdempotencyScope scope,
+        ApplyEditsResponse response,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Identifies a single idempotent edit. The key is scoped to the principal, service, and layer so one
+/// caller's key can never replay another caller's response, and the same key on different layers does
+/// not collide.
+/// </summary>
+/// <param name="ServiceId">The service the edit targets.</param>
+/// <param name="LayerId">The layer the edit targets.</param>
+/// <param name="Principal">The authenticated principal name, or <c>anonymous</c> when unauthenticated.</param>
+/// <param name="IdempotencyKey">The validated client-supplied idempotency key.</param>
+internal readonly record struct ApplyEditsIdempotencyScope(
+    string ServiceId,
+    int LayerId,
+    string Principal,
+    string IdempotencyKey);
+
+/// <summary>
+/// Distributed (Redis-backed) at-most-once store for applyEdits with an in-process fallback when no
+/// <see cref="IDistributedCache"/> is configured, mirroring <see cref="DistributedReplicaStore"/>. The
+/// distributed path is a plain keyed write with a dedupe-window TTL: it gives at-most-once for the common
+/// retry pattern (a retry that arrives after the first request completed replays the stored response).
+/// Two truly-concurrent identical requests can both miss the window before either records its response;
+/// closing that race needs an atomic reserve, which <see cref="IDistributedCache"/> does not expose, so it
+/// is intentionally out of scope for this slice.
+/// </summary>
+internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempotencyStore
+{
+    private const string KeyPrefix = "featureserver:applyedits:idem:";
+    private const int MaxFallbackEntries = 10_000;
+
+    /// <summary>
+    /// Default dedupe window. A retry within this window of the original request replays the stored
+    /// response; after it the key is forgotten and a re-submission is treated as a fresh edit.
+    /// </summary>
+    internal static readonly TimeSpan DedupeWindow = TimeSpan.FromHours(24);
+
+    private readonly IDistributedCache? _cache;
+    private readonly ILogger<DistributedApplyEditsIdempotencyStore> _logger;
+    private readonly ConcurrentDictionary<string, FallbackEntry> _fallback = new(StringComparer.Ordinal);
+
+    public DistributedApplyEditsIdempotencyStore(
+        IDistributedCache? cache,
+        ILogger<DistributedApplyEditsIdempotencyStore> logger)
+    {
+        _cache = cache;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ApplyEditsResponse?> TryGetAsync(
+        ApplyEditsIdempotencyScope scope,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var key = BuildKey(scope);
+        var now = DateTimeOffset.UtcNow;
+
+        if (_cache == null)
+        {
+            if (_fallback.TryGetValue(key, out var entry) && entry.ExpiresAt > now)
+            {
+                return Deserialize(entry.Payload);
+            }
+
+            return null;
+        }
+
+        try
+        {
+            var payload = await _cache.GetAsync(key, cancellationToken).ConfigureAwait(false);
+            return payload is null ? null : Deserialize(payload);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a lookup failure simply means the retry is re-applied rather than deduped.
+            FeatureServerLog.ApplyEditsIdempotencyStoreUnavailable(_logger, scope.ServiceId, scope.LayerId, ex);
+            return null;
+        }
+    }
+
+    public async Task SetAsync(
+        ApplyEditsIdempotencyScope scope,
+        ApplyEditsResponse response,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var key = BuildKey(scope);
+        var payload = Serialize(response);
+        var now = DateTimeOffset.UtcNow;
+
+        if (_cache == null)
+        {
+            _fallback[key] = new FallbackEntry(payload, now.Add(DedupeWindow));
+            CleanupFallback(now);
+            return;
+        }
+
+        try
+        {
+            await _cache.SetAsync(key, payload, new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = DedupeWindow
+            }, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: failing to record the response must not fail an already-applied edit.
+            FeatureServerLog.ApplyEditsIdempotencyStoreUnavailable(_logger, scope.ServiceId, scope.LayerId, ex);
+        }
+    }
+
+    private static string BuildKey(ApplyEditsIdempotencyScope scope)
+        => string.Concat(
+            KeyPrefix,
+            scope.ServiceId,
+            ":",
+            scope.LayerId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ":",
+            scope.Principal,
+            ":",
+            scope.IdempotencyKey);
+
+    private static byte[] Serialize(ApplyEditsResponse response)
+        => JsonSerializer.SerializeToUtf8Bytes(response, FeatureServerJsonContext.Default.ApplyEditsResponse);
+
+    private static ApplyEditsResponse? Deserialize(byte[] payload)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize(payload, FeatureServerJsonContext.Default.ApplyEditsResponse);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private void CleanupFallback(DateTimeOffset now)
+    {
+        foreach (var pair in _fallback)
+        {
+            if (pair.Value.ExpiresAt <= now)
+            {
+                _fallback.TryRemove(pair.Key, out _);
+            }
+        }
+
+        if (_fallback.Count <= MaxFallbackEntries)
+        {
+            return;
+        }
+
+        // Bound memory growth on the no-cache path by evicting the soonest-to-expire entries.
+        foreach (var pair in _fallback.OrderBy(static p => p.Value.ExpiresAt).Take(_fallback.Count - MaxFallbackEntries))
+        {
+            _fallback.TryRemove(pair.Key, out _);
+        }
+    }
+
+    private readonly record struct FallbackEntry(byte[] Payload, DateTimeOffset ExpiresAt);
+}
+
+/// <summary>
+/// Reads and validates the <c>Idempotency-Key</c> request header for FeatureServer edits.
+/// </summary>
+internal static class ApplyEditsIdempotency
+{
+    /// <summary>
+    /// HTTP request header carrying the client-supplied at-most-once key.
+    /// </summary>
+    public const string HeaderName = "Idempotency-Key";
+
+    /// <summary>
+    /// Maximum accepted key length. Bounds cache-key size and rejects abusive payloads.
+    /// </summary>
+    public const int MaxKeyLength = 200;
+
+    /// <summary>
+    /// Reads the <c>Idempotency-Key</c> header and returns the trimmed key when present and valid.
+    /// Returns <see langword="null"/> when the header is absent. Returns <see langword="false"/> via
+    /// <paramref name="error"/> when the header is present but malformed (empty, too long, or contains
+    /// control characters) so the caller can reject it with a 400 rather than silently ignoring it.
+    /// </summary>
+    public static bool TryResolveKey(HttpContext httpContext, out string? key, out string? error)
+    {
+        key = null;
+        error = null;
+
+        if (!httpContext.Request.Headers.TryGetValue(HeaderName, out var values))
+        {
+            return true;
+        }
+
+        var raw = values.Count > 0 ? values[0] : null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            error = $"{HeaderName} header must not be empty.";
+            return false;
+        }
+
+        var trimmed = raw.Trim();
+        if (trimmed.Length > MaxKeyLength)
+        {
+            error = $"{HeaderName} header must be at most {MaxKeyLength} characters.";
+            return false;
+        }
+
+        foreach (var ch in trimmed)
+        {
+            if (char.IsControl(ch))
+            {
+                error = $"{HeaderName} header must not contain control characters.";
+                return false;
+            }
+        }
+
+        key = trimmed;
+        return true;
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
+using Honua.Protocols.GeoServices.FeatureServer.Services;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Unit coverage for the server-side at-most-once applyEdits store and Idempotency-Key header parsing
+/// (#2250): a recorded response is replayed for a repeated key, keys are isolated by principal/service/
+/// layer, and a malformed header is rejected.
+/// </summary>
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class ApplyEditsIdempotencyStoreTests
+{
+    private static ApplyEditsResponse SampleResponse(long objectId = 42)
+        => new()
+        {
+            Success = true,
+            AddResults = [new EditResult { ObjectId = objectId, Success = true }]
+        };
+
+    private static ApplyEditsIdempotencyScope Scope(
+        string key = "key-1",
+        string service = "svc",
+        int layer = 0,
+        string principal = "alice")
+        => new(service, layer, principal, key);
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public async Task TryGetAsync_BeforeSet_ReturnsNull()
+    {
+        var store = new DistributedApplyEditsIdempotencyStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var result = await store.TryGetAsync(Scope());
+
+        result.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public async Task SetThenTryGet_WithDistributedCache_ReplaysOriginalObjectId()
+    {
+        var store = new DistributedApplyEditsIdempotencyStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        await store.SetAsync(Scope(), SampleResponse(objectId: 99));
+
+        var replay = await store.TryGetAsync(Scope());
+
+        replay.Should().NotBeNull();
+        replay!.Success.Should().BeTrue();
+        replay.AddResults.Should().ContainSingle();
+        replay.AddResults![0].ObjectId.Should().Be(99);
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public async Task SetThenTryGet_WithInProcessFallback_ReplaysOriginalObjectId()
+    {
+        // No IDistributedCache configured -> the in-process fallback dictionary is exercised.
+        var store = new DistributedApplyEditsIdempotencyStore(
+            cache: null,
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        await store.SetAsync(Scope(), SampleResponse(objectId: 7));
+
+        var replay = await store.TryGetAsync(Scope());
+
+        replay.Should().NotBeNull();
+        replay!.AddResults![0].ObjectId.Should().Be(7);
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public async Task TryGetAsync_DifferentPrincipal_DoesNotReplay()
+    {
+        var store = new DistributedApplyEditsIdempotencyStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        await store.SetAsync(Scope(principal: "alice"), SampleResponse());
+
+        var replay = await store.TryGetAsync(Scope(principal: "mallory"));
+
+        replay.Should().BeNull("an idempotency key must not replay another principal's response");
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public async Task TryGetAsync_DifferentLayer_DoesNotReplay()
+    {
+        var store = new DistributedApplyEditsIdempotencyStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        await store.SetAsync(Scope(layer: 0), SampleResponse());
+
+        var replay = await store.TryGetAsync(Scope(layer: 1));
+
+        replay.Should().BeNull("the same key on a different layer is a distinct edit");
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public void TryResolveKey_NoHeader_ReturnsNullKeyWithoutError()
+    {
+        var context = new DefaultHttpContext();
+
+        var ok = ApplyEditsIdempotency.TryResolveKey(context, out var key, out var error);
+
+        ok.Should().BeTrue();
+        key.Should().BeNull();
+        error.Should().BeNull();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public void TryResolveKey_ValidHeader_ReturnsTrimmedKey()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[ApplyEditsIdempotency.HeaderName] = "  abc-123  ";
+
+        var ok = ApplyEditsIdempotency.TryResolveKey(context, out var key, out var error);
+
+        ok.Should().BeTrue();
+        error.Should().BeNull();
+        key.Should().Be("abc-123");
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public void TryResolveKey_EmptyHeader_ReturnsError()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[ApplyEditsIdempotency.HeaderName] = "   ";
+
+        var ok = ApplyEditsIdempotency.TryResolveKey(context, out var key, out var error);
+
+        ok.Should().BeFalse();
+        key.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public void TryResolveKey_TooLongHeader_ReturnsError()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[ApplyEditsIdempotency.HeaderName] =
+            new string('x', ApplyEditsIdempotency.MaxKeyLength + 1);
+
+        var ok = ApplyEditsIdempotency.TryResolveKey(context, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public void TryResolveKey_ControlCharacter_ReturnsError()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[ApplyEditsIdempotency.HeaderName] = "abcdef";
+
+        var ok = ApplyEditsIdempotency.TryResolveKey(context, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -3111,6 +3111,84 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.ApplyEdits)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_RetriedAddWithSameIdempotencyKey_CreatesExactlyOneFeature()
+    {
+        // Server-side at-most-once (#2250): a client that retries an add carrying the same
+        // Idempotency-Key must not create a duplicate feature; the retry replays the original
+        // response (the same objectId) and the layer ends up with exactly one new row.
+        var uniqueName = $"Idempotent-{Guid.NewGuid():n}";
+        var idempotencyKey = Guid.NewGuid().ToString("n");
+
+        var editsRequest = new ApplyEditsRequest
+        {
+            Adds = new[]
+            {
+                new GeoServicesFeature
+                {
+                    Attributes = new Dictionary<string, object?>
+                    {
+                        ["name"] = uniqueName,
+                        ["description"] = "Added via idempotent ApplyEdits test"
+                    },
+                    Geometry = new GeoServicesGeometry
+                    {
+                        X = -122.4194,
+                        Y = 37.7749
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(editsRequest, FeatureServerJsonContext.Default.ApplyEditsRequest);
+
+        var firstResponse = await PostApplyEditsWithIdempotencyKeyAsync(json, idempotencyKey);
+        firstResponse.Be200Ok();
+        var first = JsonSerializer.Deserialize<ApplyEditsResponse>(
+            await firstResponse.Content.ReadAsStringAsync(), FeatureServerJsonContext.Default.ApplyEditsResponse);
+        first.Should().NotBeNull();
+        first!.Success.Should().BeTrue();
+        first.AddResults.Should().HaveCount(1);
+        first.AddResults![0].Success.Should().BeTrue();
+        var originalObjectId = first.AddResults[0].ObjectId;
+        originalObjectId.Should().BeGreaterThan(0);
+
+        // Retry the identical add with the same Idempotency-Key.
+        var secondResponse = await PostApplyEditsWithIdempotencyKeyAsync(json, idempotencyKey);
+        secondResponse.Be200Ok();
+        var second = JsonSerializer.Deserialize<ApplyEditsResponse>(
+            await secondResponse.Content.ReadAsStringAsync(), FeatureServerJsonContext.Default.ApplyEditsResponse);
+        second.Should().NotBeNull();
+        second!.Success.Should().BeTrue();
+        second.AddResults.Should().HaveCount(1);
+        second.AddResults![0].Success.Should().BeTrue();
+        second.AddResults[0].ObjectId.Should().Be(originalObjectId,
+            "a replayed idempotent add must return the original objectId");
+
+        // Exactly one feature with the unique name must exist.
+        var countResponse = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=name='{uniqueName}'&returnCountOnly=true&f=json");
+        countResponse.Be200Ok();
+        var countQuery = JsonSerializer.Deserialize<QueryResponse>(
+            await countResponse.Content.ReadAsStringAsync(), FeatureServerJsonContext.Default.QueryResponse);
+        countQuery.Should().NotBeNull();
+        countQuery!.Count.Should().Be(1, "the retried add must not create a duplicate feature");
+    }
+
+    private Task<HttpResponseMessage> PostApplyEditsWithIdempotencyKeyAsync(string json, string idempotencyKey)
+    {
+        var requestMessage = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/applyEdits")
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+        };
+        requestMessage.Headers.Add("Idempotency-Key", idempotencyKey);
+        return _fixture.Client.SendAsync(requestMessage);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
     public async Task ApplyEdits_WithCalculationRule_PopulatesTargetFieldOnAdd()
     {
         // honua-server#1271: a calculation attribute rule attached to the resource must


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2250

## Summary
Makes FeatureServer `applyEdits` adds idempotent (server-side at-most-once). A client
that retries an edit on a transient failure can now supply a stable `Idempotency-Key`
request header; the first request that commits at least one row records its full response
keyed by `(principal, serviceId, layerId, key)`, and any later request that repeats the
same key within a 24-hour window replays that original response (the same `objectId`s,
`success: true`) instead of re-applying the edit and creating duplicate features. This is
the server-side contract the client repos already shipped at-least-once mitigations
against (honua-collect#102/#103, honua-sdk-dotnet#224, honua-mobile#311).

The header is read inside the shared `HandleApplyEditsAsync` funnel, so it covers
layer-level `applyEdits`/`addFeatures`/`updateFeatures`/`deleteFeatures` and the
service-level multi-layer `applyEdits` (each layer scoped independently).

## Changes Made
- Add `DistributedApplyEditsIdempotencyStore` + `IApplyEditsIdempotencyStore`: a
  Redis-backed (via `IDistributedCache`) at-most-once store with an in-process fallback,
  mirroring the existing `DistributedReplicaStore` pattern. Stores the serialized
  `ApplyEditsResponse` under a `(principal, service, layer, key)`-scoped cache key with a
  24h dedupe-window TTL.
- Add `ApplyEditsIdempotency` header parser/validator (`Idempotency-Key`, <=200 chars, no
  control characters; malformed -> 400).
- Wire the store through `FeatureServerEditsDependencies` and register it in
  `AddFeatureServer`. In `HandleApplyEditsAsync`: validate the header up front, short-circuit
  with a replay on a recorded key, and record the response after a committed edit.
- Refactor `CreateFinalResponse` into `BuildFinalResponse` so the response can be recorded
  before serialization.
- Document the at-most-once contract in `docs/reference/compatibility/geoservices-parity.md`.
- Tests: unit coverage for the store (replay, principal/layer isolation, in-process
  fallback) and header parsing; an `applyEdits` double-submit conformance integration test
  asserting exactly one feature and a replayed objectId.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

What was run:
- `dotnet build` (Release, `TreatWarningsAsErrors=true`) on `Honua.Protocols.GeoServices`
  and `Honua.Server.Tests` — both succeed, 0 warnings / 0 errors.
- `dotnet test Honua.Protocols.GeoServices.Tests` — 10 new idempotency unit tests pass;
  the broader unit-tier slice (425 tests) is green.
- The new `ApplyEdits_RetriedAddWithSameIdempotencyKey_CreatesExactlyOneFeature`
  integration test compiles but was NOT executed locally because the Docker daemon is
  unavailable in this environment (Testcontainers/PostGIS required). CI will run it.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The `Idempotency-Key` header is optional; behavior is unchanged when it is absent.

## Known gaps
- The integration conformance test was not executed locally (no Docker daemon); it is
  expected to run in CI.
- `IDistributedCache` exposes no atomic reserve, so two *truly concurrent* identical
  requests can both miss the window before either records its response. The header
  guarantees at-most-once for the common *sequential-retry* pattern, not for simultaneous
  in-flight duplicates; closing that race needs an atomic reserve and is deferred.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
