### PR TITLE
feat: stable applyEdits per-feature conflict classification codes (#2251)

### DIFF
--- a/docs/internal/evidence/editing-parity-conformance.md
+++ b/docs/internal/evidence/editing-parity-conformance.md
@@ -30,6 +30,30 @@ conformance matrix so a regression fails CI.
 | VersionManagementServer — reconcile withPost | Post after clean reconcile | Separate reconcile + post operations | Partial (withPost auto-post pending #2135) |
 | VersionManagementServer — inspect/resolveConflicts shapes | Esri conflict descriptors + resolution echo | Per-object/per-field descriptors served | Partial (resolution echo + byAttribute pending #2135) |
 | Replica sync — directional sync | Bidirectional/up/down sync | Branch-versioned sync via VersionManagementServer | See branch-versioning evidence |
+| applyEdits per-feature conflict codes (#2251) | Per-edit `error.code` lets clients classify failures | Stable `GeoServicesEditErrorCodes` taxonomy on the HTTP-200 envelope | Supported |
+
+## applyEdits per-feature conflict classification (#2251)
+
+`applyEdits` returns HTTP 200 with a per-feature `error.{code,description}` for each failed
+edit. The `code` is a **stable, machine-readable classification** (`GeoServicesEditErrorCodes`)
+so clients (honua-mobile `ConflictType`, honua-collect sync) branch deterministically rather
+than guessing from the description. Codes are derived from the edit pipeline's typed outcome,
+never by parsing the message.
+
+| Code | Class | Trigger |
+|---:|---|---|
+| `1000` | Generic | Unclassified / fallback failure |
+| `1001` | Invalid object id | Missing/non-numeric object id or unresolvable object-id field |
+| `1002` | Not found | `update` target row absent (or RLS-hidden) |
+| `1003` | Delete conflict (delete-delete) | `delete` target already removed |
+| `1004` | Update conflict (update-update) | Optimistic-concurrency / version mismatch (writer precondition failure) |
+| `1005` | Locked | Feature locked by another editor/session (HTTP 423; reserved for lock-aware providers) |
+| `1006` | Validation failed | Invalid attributes/geometry, attribute-rule or contingent-value violation |
+| `1007` | Not permitted | Owner-based edit-policy denial |
+| `1008` | Rolled back | Sibling operation failed under `rollbackOnFailure=true` |
+
+- **Conformance test:** `tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerApplyEditsConflictCodeTests.cs`
+  exercises the classification per conflict class.
 
 ## Non-Postgres / unsupported caveats
 

--- a/docs/reference/compatibility/geoservices-parity.md
+++ b/docs/reference/compatibility/geoservices-parity.md
@@ -67,6 +67,33 @@ Esri spec: [Feature Service](https://developers.arcgis.com/rest/services-referen
 `editsUploadId`, ...) are silently ignored. queryRelatedRecords rejects
 `gdbVersion` and `historicMoment` with 400 and accepts/ignores `returnTrueCurves`.
 
+### applyEdits per-feature error codes
+
+`applyEdits` (and the standalone `addFeatures`/`updateFeatures`/`deleteFeatures`
+endpoints) return HTTP 200 with a per-feature result in `addResults`/`updateResults`/
+`deleteResults`. A failed result carries `success:false` and an `error` object
+`{ "code": <int>, "description": "<safe message>" }`. The `code` is a **stable,
+machine-readable classification** so clients can branch on the *kind* of failure without
+parsing `description` (descriptions are sanitized free-form text and may change). These
+codes are the contract; once published, a code does not change meaning.
+
+| `error.code` | Class | Meaning |
+| ---: | --- | --- |
+| `1000` | Generic | Unclassified / fallback failure (unexpected provider error). |
+| `1001` | Invalid object id | Update/delete object id missing, non-numeric, or the object-id field could not be resolved (request-shape error). |
+| `1002` | Not found | The `update` target feature does not exist (or is hidden by row-level security). |
+| `1003` | Delete conflict (delete-delete) | The `delete` target was already removed, typically by another writer. |
+| `1004` | Update conflict (update-update) | Optimistic-concurrency / version mismatch: the row changed since the caller read it. Clients may re-read and retry. |
+| `1005` | Locked | The feature is locked by another editor/session (HTTP 423 semantics). Reserved for lock-aware providers; the default edit path produces no locks yet. |
+| `1006` | Validation failed | Invalid attributes/geometry, attribute-rule violation, or invalid contingent-value combination (request-shape error). |
+| `1007` | Not permitted | Denied by an owner-based edit policy (non-owning/non-admin or anonymous caller). |
+| `1008` | Rolled back | The operation was otherwise applicable but the transaction rolled back because a sibling operation failed under `rollbackOnFailure=true`. |
+
+The classification is deterministic: it is derived from the edit pipeline's typed outcome
+(e.g. a writer precondition failure → `1004`), never from the error message. The codes are
+defined in `GeoServicesEditErrorCodes` and exercised per class by
+`FeatureServerApplyEditsConflictCodeTests`.
+
 ## MapServer + WMS / WMTS
 
 Esri spec: [Map Service](https://developers.arcgis.com/rest/services-reference/enterprise/map-service/).

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -317,11 +317,18 @@ internal sealed class FeatureServerEditsHandler(
                     ? responseObjectId
                     : null);
             }
+            catch (EditNotPermittedException ex)
+            {
+                context.HasValidationErrors = true;
+                context.AddResults![i] = CreateFailureResult(
+                    code: GeoServicesEditErrorCodes.NotPermitted,
+                    description: SanitizeEditErrorMessage(ex.Message, "Edit not permitted."));
+            }
             catch (ArgumentException ex)
             {
                 context.HasValidationErrors = true;
                 context.AddResults![i] = CreateFailureResult(
-                    code: 1000,
+                    code: GeoServicesEditErrorCodes.ValidationFailed,
                     description: SanitizeEditErrorMessage(ex.Message, InvalidFeatureDataMessage));
             }
             catch (Exception ex)
@@ -329,7 +336,7 @@ internal sealed class FeatureServerEditsHandler(
                 FeatureServerLog.FeatureAddFailed(logger, i, ex.Message, ex);
                 context.HasValidationErrors = true;
                 context.AddResults![i] = CreateFailureResult(
-                    code: 1000,
+                    code: GeoServicesEditErrorCodes.GenericFailure,
                     description: "Failed to add feature");
             }
         }
@@ -358,7 +365,7 @@ internal sealed class FeatureServerEditsHandler(
             {
                 context.HasValidationErrors = true;
                 context.UpdateResults![i] = CreateFailureResult(
-                    code: 1001,
+                    code: GeoServicesEditErrorCodes.InvalidObjectId,
                     description: "ObjectId is required for update operations");
                 continue;
             }
@@ -386,7 +393,7 @@ internal sealed class FeatureServerEditsHandler(
                 {
                     context.HasValidationErrors = true;
                     context.UpdateResults![i] = CreateFailureResult(
-                        code: 1002,
+                        code: GeoServicesEditErrorCodes.InvalidObjectId,
                         description: description,
                         objectId: failedObjectId);
                 }
@@ -416,7 +423,7 @@ internal sealed class FeatureServerEditsHandler(
                 {
                     context.HasValidationErrors = true;
                     context.UpdateResults![i] = CreateFailureResult(
-                        code: 1002,
+                        code: GeoServicesEditErrorCodes.NotFound,
                         description: "Feature not found",
                         objectId: objectId);
                     continue;
@@ -441,11 +448,19 @@ internal sealed class FeatureServerEditsHandler(
                 context.UpdateObjectIds.Add(objectId);
                 context.UpdateGeometryChanged.Add(requestHasGeometry);
             }
+            catch (EditNotPermittedException ex)
+            {
+                context.HasValidationErrors = true;
+                context.UpdateResults![i] = CreateFailureResult(
+                    code: GeoServicesEditErrorCodes.NotPermitted,
+                    description: SanitizeEditErrorMessage(ex.Message, "Edit not permitted."),
+                    objectId: objectId);
+            }
             catch (ArgumentException ex)
             {
                 context.HasValidationErrors = true;
                 context.UpdateResults![i] = CreateFailureResult(
-                    code: 1002,
+                    code: GeoServicesEditErrorCodes.ValidationFailed,
                     description: SanitizeEditErrorMessage(ex.Message, InvalidFeatureDataMessage),
                     objectId: objectId);
             }
@@ -454,7 +469,7 @@ internal sealed class FeatureServerEditsHandler(
                 FeatureServerLog.FeatureUpdateFailed(logger, i, ex.Message, ex);
                 context.HasValidationErrors = true;
                 context.UpdateResults![i] = CreateFailureResult(
-                    code: 1002,
+                    code: GeoServicesEditErrorCodes.GenericFailure,
                     description: "Failed to update feature",
                     objectId: objectId);
             }
@@ -484,7 +499,7 @@ internal sealed class FeatureServerEditsHandler(
             {
                 context.HasValidationErrors = true;
                 context.DeleteResults![i] = CreateFailureResult(
-                    code: 1003,
+                    code: GeoServicesEditErrorCodes.InvalidObjectId,
                     description: "Invalid ObjectId for delete operation");
                 continue;
             }
@@ -515,7 +530,7 @@ internal sealed class FeatureServerEditsHandler(
             {
                 context.HasValidationErrors = true;
                 context.DeleteResults![i] = CreateFailureResult(
-                    code: 1003,
+                    code: GeoServicesEditErrorCodes.DeleteNotFound,
                     description: "Feature not found",
                     objectId: objectId);
                 continue;
@@ -533,7 +548,7 @@ internal sealed class FeatureServerEditsHandler(
             {
                 context.HasValidationErrors = true;
                 context.DeleteResults![i] = CreateFailureResult(
-                    code: 1003,
+                    code: GeoServicesEditErrorCodes.NotPermitted,
                     description: SanitizeEditErrorMessage(ownerDecision.Reason!, "Edit not permitted."),
                     objectId: objectId);
                 continue;
@@ -619,11 +634,11 @@ internal sealed class FeatureServerEditsHandler(
         using var outboxScope = Honua.Core.Features.Infrastructure.Events.Outbox.FeatureMutationOutboxScope.BeginIfNotNull(outboxScopeData);
         var editResult = await _featureWriter.ApplyEditsAsync(layerId, editBatch, cancellationToken).ConfigureAwait(false);
 
-        ApplyResults(context.AddResults, context.CreateIndexes, editResult.CreateResults);
+        ApplyResults(context.AddResults, context.CreateIndexes, editResult.CreateResults, FeatureEditOperationKind.Create);
         ApplyCreateResponseObjectIds(context);
         CaptureCreateEventObjectIds(context, editResult.CreateResults);
-        ApplyResults(context.UpdateResults, context.UpdateIndexes, editResult.UpdateResults, context.UpdateObjectIds);
-        ApplyResults(context.DeleteResults, context.DeleteIndexes, editResult.DeleteResults, context.DeleteResponseObjectIds);
+        ApplyResults(context.UpdateResults, context.UpdateIndexes, editResult.UpdateResults, FeatureEditOperationKind.Update, context.UpdateObjectIds);
+        ApplyResults(context.DeleteResults, context.DeleteIndexes, editResult.DeleteResults, FeatureEditOperationKind.Delete, context.DeleteResponseObjectIds);
 
         return editResult;
     }
@@ -668,7 +683,7 @@ internal sealed class FeatureServerEditsHandler(
     {
         var rollbackError = new EditError
         {
-            Code = 1000,
+            Code = GeoServicesEditErrorCodes.OperationRolledBack,
             Description = "Operation rolled back due to validation failure"
         };
 
@@ -1280,7 +1295,10 @@ internal sealed class FeatureServerEditsHandler(
                 ownerPolicy, editEvent, existingOwner, principal);
             if (!ownerDecision.IsAllowed)
             {
-                throw new ArgumentException(SanitizeEditErrorMessage(ownerDecision.Reason!, "Edit not permitted."));
+                // Owner-policy denial is an authorization failure, not invalid data: throw a
+                // typed exception so the per-feature catch maps it to the stable
+                // GeoServicesEditErrorCodes.NotPermitted code rather than ValidationFailed.
+                throw new EditNotPermittedException(SanitizeEditErrorMessage(ownerDecision.Reason!, "Edit not permitted."));
             }
 
             if (editEvent == AttributeRuleEditEvent.Insert &&
@@ -1491,7 +1509,10 @@ internal sealed class FeatureServerEditsHandler(
         };
     }
 
-    private static EditResult ConvertEditOperationResult(EditOperationResult result, long? responseObjectId = null)
+    private static EditResult ConvertEditOperationResult(
+        EditOperationResult result,
+        FeatureEditOperationKind kind,
+        long? responseObjectId = null)
     {
         if (result.IsSuccess)
         {
@@ -1503,8 +1524,11 @@ internal sealed class FeatureServerEditsHandler(
             };
         }
 
+        // Map the writer's typed outcome onto the stable per-feature conflict code (#2251)
+        // so clients can classify deterministically (e.g. update-update vs delete-delete)
+        // without parsing the free-form description.
         return CreateFailureResult(
-            result.ErrorCode,
+            GeoServicesEditErrorCodes.ClassifyWriterFailure(result, kind),
             SanitizeEditErrorMessage(result.ErrorMessage, "Operation failed"),
             responseObjectId ?? result.ObjectId,
             result.GlobalId);
@@ -1533,6 +1557,7 @@ internal sealed class FeatureServerEditsHandler(
         EditResult?[]? results,
         List<int> indexes,
         ImmutableArray<EditOperationResult> operationResults,
+        FeatureEditOperationKind kind,
         List<long>? responseObjectIds = null)
     {
         if (results == null)
@@ -1546,12 +1571,12 @@ internal sealed class FeatureServerEditsHandler(
             var responseObjectId = responseObjectIds != null && i < responseObjectIds.Count
                 ? responseObjectIds[i]
                 : (long?)null;
-            results[indexes[i]] = ConvertEditOperationResult(operationResults[i], responseObjectId);
+            results[indexes[i]] = ConvertEditOperationResult(operationResults[i], kind, responseObjectId);
         }
 
         for (var i = count; i < indexes.Count; i++)
         {
-            results[indexes[i]] ??= CreateFailureResult(1000, "Operation failed");
+            results[indexes[i]] ??= CreateFailureResult(GeoServicesEditErrorCodes.GenericFailure, "Operation failed");
         }
     }
 
@@ -1601,7 +1626,7 @@ internal sealed class FeatureServerEditsHandler(
         var finalized = new EditResult[results.Length];
         for (var i = 0; i < results.Length; i++)
         {
-            finalized[i] = results[i] ?? CreateFailureResult(1000, "Operation failed");
+            finalized[i] = results[i] ?? CreateFailureResult(GeoServicesEditErrorCodes.GenericFailure, "Operation failed");
         }
 
         return finalized;
@@ -1648,5 +1673,14 @@ internal sealed class FeatureServerEditsHandler(
                message.Contains("password", StringComparison.OrdinalIgnoreCase);
     }
 
-
+    /// <summary>
+    /// Raised inside the per-feature build path when an owner-based edit policy denies the
+    /// edit. Distinct from <see cref="ArgumentException"/> (used for invalid-data validation
+    /// failures) so the surrounding per-feature catch can classify the failure as
+    /// <see cref="GeoServicesEditErrorCodes.NotPermitted"/> rather than
+    /// <see cref="GeoServicesEditErrorCodes.ValidationFailed"/>.
+    /// </summary>
+    private sealed class EditNotPermittedException(string message) : Exception(message)
+    {
+    }
 }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/GeoServicesEditErrorCodes.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/GeoServicesEditErrorCodes.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Protocols.GeoServices.FeatureServer.Models;
+
+/// <summary>
+/// Stable, machine-readable per-feature edit error codes surfaced in the
+/// <see cref="EditError.Code"/> field of an <c>applyEdits</c> HTTP-200 result envelope
+/// (<see cref="ApplyEditsResponse"/>). The Esri wire shape only carries a numeric
+/// <c>code</c> and free-form <c>description</c>, so clients that need to branch on the
+/// <em>kind</em> of failure (e.g. retry on a conflict, surface a "deleted elsewhere"
+/// message, prompt re-authentication) must key on a deterministic code rather than parsing
+/// the description. These codes are the stable contract for that classification (#2251):
+/// once published they do not change meaning, and every per-feature failure the
+/// FeatureServer edit path emits maps to exactly one of them.
+/// </summary>
+/// <remarks>
+/// The codes occupy the Esri-conventional <c>1000+</c> per-edit error range and remain
+/// compatible with ArcGIS clients, which treat any non-zero <c>code</c> with a
+/// <c>success:false</c> result as an edit failure. The values are intentionally distinct so
+/// the conflict classes the ticket calls out — update-update, delete-delete, not-found, and
+/// lock/locked — are individually addressable, with <see cref="GenericFailure"/> as the
+/// catch-all fallback.
+/// </remarks>
+public static class GeoServicesEditErrorCodes
+{
+    /// <summary>
+    /// Unclassified / fallback failure. Emitted when no more specific classification applies
+    /// (e.g. an unexpected provider error during the write).
+    /// </summary>
+    public const int GenericFailure = 1000;
+
+    /// <summary>
+    /// The update/delete operation did not carry a usable object id: the OBJECTID was missing,
+    /// non-numeric, or the configured object-id field could not be resolved. A request-shape
+    /// error, not a conflict — resubmitting the same payload will fail identically.
+    /// </summary>
+    public const int InvalidObjectId = 1001;
+
+    /// <summary>
+    /// The targeted feature for an <c>update</c> does not exist (or is not visible to the
+    /// caller under row-level security). The "not-found" class: the object id has no matching
+    /// row to update.
+    /// </summary>
+    public const int NotFound = 1002;
+
+    /// <summary>
+    /// The targeted feature for a <c>delete</c> no longer exists — it was already removed,
+    /// typically by another writer. The "delete-delete" class: a concurrent or repeated delete
+    /// of the same object id.
+    /// </summary>
+    public const int DeleteNotFound = 1003;
+
+    /// <summary>
+    /// The <c>update</c> (or delete) was rejected because the stored row changed since the
+    /// caller observed it — an optimistic-concurrency / version mismatch. The "update-update"
+    /// class: two writers raced to modify the same feature. Surfaced when a writer reports an
+    /// <see cref="EditOperationResult.IsPreconditionFailure"/> (HTTP 412 semantics). Clients
+    /// may re-read and retry.
+    /// </summary>
+    public const int UpdateConflict = 1004;
+
+    /// <summary>
+    /// The feature is locked by another editor/session and cannot be modified right now. The
+    /// "lock/locked" class. Reserved for lock-aware writers: surfaced when a writer reports a
+    /// lock failure (HTTP 423 semantics). No writer in the default <c>applyEdits</c> path
+    /// produces feature locks today, but the code is part of the stable contract so lock-aware
+    /// providers map onto it without a client change.
+    /// </summary>
+    public const int FeatureLocked = 1005;
+
+    /// <summary>
+    /// The feature payload failed validation before the write: invalid attributes, invalid or
+    /// mismatched geometry, an attribute-rule violation, or an invalid contingent-value
+    /// combination. A request-shape error, not a conflict.
+    /// </summary>
+    public const int ValidationFailed = 1006;
+
+    /// <summary>
+    /// The edit was denied by an owner-based edit policy: a non-owning, non-admin principal
+    /// (or an anonymous caller, while the policy is active) attempted to modify or delete a row
+    /// owned by another principal. An authorization failure, not a conflict.
+    /// </summary>
+    public const int NotPermitted = 1007;
+
+    /// <summary>
+    /// The operation itself was otherwise applicable but the whole transaction was rolled back
+    /// because a sibling operation in the same request failed and <c>rollbackOnFailure=true</c>.
+    /// </summary>
+    public const int OperationRolledBack = 1008;
+
+    /// <summary>
+    /// Maps a failed canonical <see cref="EditOperationResult"/> returned by a feature writer
+    /// onto the stable per-feature code that should appear in the <c>applyEdits</c> envelope.
+    /// The classification is deterministic and never inspects the free-form error message:
+    /// it keys only on the result's typed flags and numeric code.
+    /// </summary>
+    /// <param name="result">The writer's per-operation result (assumed to be a failure).</param>
+    /// <param name="kind">Which operation the result belongs to, so a not-found is reported as
+    /// <see cref="NotFound"/> for updates and <see cref="DeleteNotFound"/> for deletes.</param>
+    /// <returns>The stable per-feature error code.</returns>
+    public static int ClassifyWriterFailure(EditOperationResult result, FeatureEditOperationKind kind)
+    {
+        // Optimistic-concurrency conflict (update-update). The writer flags this explicitly via
+        // EditOperationResult.PreconditionFailed (ErrorCode == 412); honour both the typed flag
+        // and the numeric code so it classifies regardless of how the result was constructed.
+        if (result.IsPreconditionFailure || result.ErrorCode == EditOperationResult.PreconditionFailedErrorCode)
+        {
+            return UpdateConflict;
+        }
+
+        return result.ErrorCode switch
+        {
+            // HTTP 404 — the row was gone by the time the write executed (a race that slipped
+            // past the handler's pre-read). Reported per operation kind.
+            404 => kind == FeatureEditOperationKind.Delete ? DeleteNotFound : NotFound,
+            // HTTP 423 — a lock-aware writer reported the feature as locked.
+            423 => FeatureLocked,
+            _ => GenericFailure,
+        };
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerApplyEditsConflictCodeTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerApplyEditsConflictCodeTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
+using Honua.TestKit.Helpers;
+using Honua.TestKit.Infrastructure;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
+
+/// <summary>
+/// Conformance tests for the stable per-feature conflict classification codes returned in the
+/// <c>applyEdits</c> HTTP-200 result envelope (#2251). Two layers of coverage:
+/// <list type="bullet">
+/// <item>Pure tests of <see cref="GeoServicesEditErrorCodes.ClassifyWriterFailure"/>, which maps a
+/// writer's typed <see cref="EditOperationResult"/> onto a stable code (update-update, locked,
+/// not-found/delete-delete, generic) without inspecting the free-form message.</item>
+/// <item>HTTP tests asserting the handler-determined classes (not-found, delete-delete, invalid
+/// object id) surface the documented code on the real <c>applyEdits</c> endpoint.</item>
+/// </list>
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.FeatureServer)]
+public sealed class FeatureServerApplyEditsConflictCodeTests
+{
+    // --- Pure classifier coverage (one assertion per conflict class) -----------------------------
+
+    [Fact]
+    public void ClassifyWriterFailure_PreconditionFailure_IsUpdateConflict()
+    {
+        var result = EditOperationResult.PreconditionFailed(objectId: 7);
+
+        GeoServicesEditErrorCodes.ClassifyWriterFailure(result, FeatureEditOperationKind.Update)
+            .Should().Be(GeoServicesEditErrorCodes.UpdateConflict);
+    }
+
+    [Fact]
+    public void ClassifyWriterFailure_PreconditionErrorCodeWithoutFlag_IsUpdateConflict()
+    {
+        // A writer that reports the well-known precondition code numerically (without the typed
+        // flag) is still classified as an update-update conflict.
+        var result = EditOperationResult.Failure(
+            "conflict",
+            errorCode: EditOperationResult.PreconditionFailedErrorCode,
+            objectId: 7);
+
+        GeoServicesEditErrorCodes.ClassifyWriterFailure(result, FeatureEditOperationKind.Update)
+            .Should().Be(GeoServicesEditErrorCodes.UpdateConflict);
+    }
+
+    [Fact]
+    public void ClassifyWriterFailure_LockCode_IsFeatureLocked()
+    {
+        var result = EditOperationResult.Failure("locked", errorCode: 423, objectId: 7);
+
+        GeoServicesEditErrorCodes.ClassifyWriterFailure(result, FeatureEditOperationKind.Update)
+            .Should().Be(GeoServicesEditErrorCodes.FeatureLocked);
+    }
+
+    [Fact]
+    public void ClassifyWriterFailure_NotFoundCode_MapsByOperationKind()
+    {
+        var result = EditOperationResult.Failure("gone", errorCode: 404, objectId: 7);
+
+        GeoServicesEditErrorCodes.ClassifyWriterFailure(result, FeatureEditOperationKind.Update)
+            .Should().Be(GeoServicesEditErrorCodes.NotFound);
+        GeoServicesEditErrorCodes.ClassifyWriterFailure(result, FeatureEditOperationKind.Delete)
+            .Should().Be(GeoServicesEditErrorCodes.DeleteNotFound);
+    }
+
+    [Fact]
+    public void ClassifyWriterFailure_UnknownCode_IsGenericFallback()
+    {
+        var result = EditOperationResult.Failure("boom", objectId: 7);
+
+        GeoServicesEditErrorCodes.ClassifyWriterFailure(result, FeatureEditOperationKind.Create)
+            .Should().Be(GeoServicesEditErrorCodes.GenericFailure);
+    }
+
+    [Fact]
+    public void StableCodes_AreDistinct()
+    {
+        int[] codes =
+        [
+            GeoServicesEditErrorCodes.GenericFailure,
+            GeoServicesEditErrorCodes.InvalidObjectId,
+            GeoServicesEditErrorCodes.NotFound,
+            GeoServicesEditErrorCodes.DeleteNotFound,
+            GeoServicesEditErrorCodes.UpdateConflict,
+            GeoServicesEditErrorCodes.FeatureLocked,
+            GeoServicesEditErrorCodes.ValidationFailed,
+            GeoServicesEditErrorCodes.NotPermitted,
+            GeoServicesEditErrorCodes.OperationRolledBack,
+        ];
+
+        codes.Should().OnlyHaveUniqueItems();
+    }
+
+    // --- HTTP envelope coverage for handler-determined classes -----------------------------------
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_UpdateMissingFeature_ReturnsNotFoundCode()
+    {
+        await using var harness = await EditHarness.CreateAsync();
+
+        var response = await harness.PostApplyEditsAsync(new ApplyEditsRequest
+        {
+            Updates =
+            [
+                new GeoServicesFeature
+                {
+                    Attributes = new Dictionary<string, object?> { ["objectid"] = 999_999, ["name"] = "ghost" }
+                }
+            ]
+        });
+
+        response.Be200Ok();
+        var result = await harness.ReadAsync(response);
+        result.Success.Should().BeFalse();
+        result.UpdateResults.Should().ContainSingle();
+        result.UpdateResults![0].Success.Should().BeFalse();
+        result.UpdateResults[0].Error!.Code.Should().Be(GeoServicesEditErrorCodes.NotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_DeleteMissingFeature_ReturnsDeleteConflictCode()
+    {
+        await using var harness = await EditHarness.CreateAsync();
+
+        var response = await harness.PostApplyEditsAsync(new ApplyEditsRequest
+        {
+            Deletes = [999_999]
+        });
+
+        response.Be200Ok();
+        var result = await harness.ReadAsync(response);
+        result.Success.Should().BeFalse();
+        result.DeleteResults.Should().ContainSingle();
+        result.DeleteResults![0].Success.Should().BeFalse();
+        result.DeleteResults[0].Error!.Code.Should().Be(GeoServicesEditErrorCodes.DeleteNotFound);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_DeleteNonNumericObjectId_ReturnsInvalidObjectIdCode()
+    {
+        await using var harness = await EditHarness.CreateAsync();
+
+        var response = await harness.PostApplyEditsAsync(new ApplyEditsRequest
+        {
+            Deletes = ["not-a-number"]
+        });
+
+        response.Be200Ok();
+        var result = await harness.ReadAsync(response);
+        result.Success.Should().BeFalse();
+        result.DeleteResults.Should().ContainSingle();
+        result.DeleteResults![0].Success.Should().BeFalse();
+        result.DeleteResults[0].Error!.Code.Should().Be(GeoServicesEditErrorCodes.InvalidObjectId);
+    }
+
+    /// <summary>
+    /// Spins up the FeatureServer edit endpoint backed by an in-memory <see cref="TestFeatureStore"/>
+    /// under a Pro license (the FeatureServer editing gate, #1591). Mirrors the harness used by the
+    /// plugin-validation conformance tests.
+    /// </summary>
+    private sealed class EditHarness : IAsyncDisposable
+    {
+        private const string ServiceId = "test";
+        private const int LayerId = 0;
+
+        private readonly WebAppFixture _fixture;
+
+        private EditHarness(WebAppFixture fixture) => _fixture = fixture;
+
+        public static async Task<EditHarness> CreateAsync()
+        {
+            var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+            var store = new TestFeatureStore();
+            fixture.ReplaceService<IFeatureReader>(store);
+            fixture.ReplaceService<IFeatureWriter>(store);
+            fixture.ReplaceService<ITileProvider>(store);
+            fixture.ReplaceService<IRelationshipStore>(store);
+            fixture.ReplaceService<IStreamingFeatureStore>(store);
+            await fixture.InitializeAsync();
+            return new EditHarness(fixture);
+        }
+
+        public Task<HttpResponseMessage> PostApplyEditsAsync(ApplyEditsRequest request)
+        {
+            var json = JsonSerializer.Serialize(request, FeatureServerJsonContext.Default.ApplyEditsRequest);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            return _fixture.Client.PostAsync(
+                $"/rest/services/{ServiceId}/FeatureServer/{LayerId}/applyEdits", content);
+        }
+
+        public async Task<ApplyEditsResponse> ReadAsync(HttpResponseMessage response)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            var parsed = JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.ApplyEditsResponse);
+            parsed.Should().NotBeNull();
+            return parsed!;
+        }
+
+        public async ValueTask DisposeAsync() => await _fixture.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2251

`applyEdits` returns HTTP 200 with a per-feature `error.{code,description}` for each failed edit, but the `code` was an ad-hoc magic number, so clients (honua-mobile `ConflictType`, honua-collect sync) had to guess the failure kind from the free-form description. This PR defines a **stable, documented per-feature error-code taxonomy** and maps every per-feature failure onto it so clients can classify deterministically.

The taxonomy covers the classes the ticket calls out — update-update, delete-delete, not-found, lock/locked — plus the other distinct outcomes the edit path already produces, with a generic fallback:

| code | class | trigger |
|---:|---|---|
| 1000 | Generic | unclassified / fallback |
| 1001 | Invalid object id | missing/non-numeric/unresolvable object id |
| 1002 | Not found | update target absent (or RLS-hidden) |
| 1003 | Delete conflict (delete-delete) | delete target already removed |
| 1004 | Update conflict (update-update) | optimistic-concurrency / version mismatch (writer precondition failure) |
| 1005 | Locked | feature locked by another editor/session (HTTP 423; reserved for lock-aware providers) |
| 1006 | Validation failed | invalid attributes/geometry, attribute-rule or contingent-value violation |
| 1007 | Not permitted | owner-based edit-policy denial |
| 1008 | Rolled back | sibling op failed under `rollbackOnFailure=true` |

Classification is deterministic — derived from the edit pipeline's typed outcome (precondition flag, HTTP 404/423), never by parsing the message — and stays inside the Esri wire shape (`error.code` / `error.description`).

## Changes Made

- Add `GeoServicesEditErrorCodes` (public, XML-documented) with the stable codes and a deterministic `ClassifyWriterFailure(result, kind)` that maps a writer's typed `EditOperationResult` onto a stable code (precondition → 1004, 423 → 1005, 404 → not-found per op kind).
- Replace every magic per-feature code in `FeatureServerEditsHandler` (add/update/delete validation, not-found, invalid object id, rollback, fallback) with the named stable codes, and route writer results through `ClassifyWriterFailure`.
- Surface owner-based edit-policy denials as `NotPermitted` via a typed `EditNotPermittedException` so they are no longer lumped with invalid-data validation failures.
- Document the codes in the GeoServices parity contract (`docs/reference/compatibility/geoservices-parity.md`) and the editing-parity conformance receipt (`docs/internal/evidence/editing-parity-conformance.md`).
- Add `FeatureServerApplyEditsConflictCodeTests`: pure classifier coverage per conflict class plus HTTP envelope assertions for the handler-determined classes (not-found, delete-delete, invalid object id).

## Breaking Changes

None. The change only assigns stable, distinct values to the existing `error.code` field within the Esri `applyEdits` result envelope; the wire shape is unchanged and ArcGIS clients still treat any non-zero code with `success:false` as an edit failure. No existing test pinned the previous ad-hoc code values.

## Gate Impact

- [x] No gate-tier change (FeatureServer editing remains a Pro entitlement)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

What was built/run locally:
- `dotnet build src/Honua.Protocols.GeoServices` (Release, `TreatWarningsAsErrors=true`) — succeeded, 0 warnings.
- `dotnet test tests/dotnet/Honua.Protocols.GeoServices.Tests` filtered to the Docker-free classifier tests (`ClassifyWriterFailure*`, `StableCodes_AreDistinct`) — **6/6 passed**.
- `dotnet format --verify-no-changes` on the changed source and test files — clean.

CI-only: the 3 HTTP envelope integration tests in `FeatureServerApplyEditsConflictCodeTests` (not-found / delete-delete / invalid object id) require a Docker daemon (Testcontainers + PostGIS), which is unavailable in this environment; they compile and run under CI. They mirror the established `FeatureServerPluginValidationTests` harness.
