### PR TITLE
feat(telemetry): emit metrics for GeoServices error envelopes (#2243)

### DIFF
--- a/src/Honua.Core/Honua.Core.csproj
+++ b/src/Honua.Core/Honua.Core.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Honua.Core.Tests" />
+    <InternalsVisibleTo Include="Honua.ServiceDefaults" />
     <InternalsVisibleTo Include="Honua.Geometry" />
     <InternalsVisibleTo Include="Honua.Io" />
     <InternalsVisibleTo Include="Honua.Import" />

--- a/src/Honua.Hosting/Features/Models/StandardErrorResponseFormatter.cs
+++ b/src/Honua.Hosting/Features/Models/StandardErrorResponseFormatter.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Security;
 using Honua.Infrastructure.Middleware;
+using Honua.ServiceDefaults;
 
 namespace Honua.Infrastructure.Models;
 
@@ -58,6 +59,7 @@ internal static class StandardErrorResponseFormatter
         options ??= new ErrorResponseFormatterOptions();
 
         TryRecordRecentError(context, errorResponse);
+        RecordErrorTelemetry(context, errorResponse.StatusCode);
 
         var path = context.Request.Path;
 
@@ -337,4 +339,121 @@ internal static class StandardErrorResponseFormatter
     private static void TryRecordRecentError(HttpContext context, StandardErrorResponse errorResponse)
         => RecentErrorBufferRecordOverride?.Invoke(context, errorResponse);
 
+    /// <summary>
+    /// Emits the keystone error-rate telemetry (#2243) for a produced error
+    /// envelope. Every error-envelope construction path funnels here — both the
+    /// central <see cref="FormatError"/> dispatch and the GeoServices builders in
+    /// <c>ValidationErrorHelpers</c> that bypass this formatter — so the platform
+    /// can aggregate and alert on its own compat error rate. Classifies the
+    /// surface from the request path and delegates to
+    /// <see cref="HonuaTelemetry.RecordErrorEnvelope"/>.
+    /// </summary>
+    /// <param name="context">The HTTP context for protocol/operation classification.</param>
+    /// <param name="statusCode">The HTTP status carried by the error envelope.</param>
+    internal static void RecordErrorTelemetry(HttpContext context, int statusCode)
+    {
+        var path = context.Request.Path;
+        var (serviceType, isGeoServices) = ClassifyServiceType(path);
+        HonuaTelemetry.RecordErrorEnvelope(serviceType, ResolveOperation(path), statusCode, isGeoServices);
+    }
+
+    private static readonly string[] GeoServicesServiceTypes =
+    [
+        "FeatureServer",
+        "MapServer",
+        "ImageServer",
+        "VectorTileServer",
+        "GPServer",
+        "GeocodeServer",
+        "GeometryServer",
+        "NAServer",
+        "SceneServer"
+    ];
+
+    private static (string ServiceType, bool IsGeoServices) ClassifyServiceType(PathString path)
+    {
+        if (ProtocolRequestClassifier.IsOData(path))
+        {
+            return ("OData", false);
+        }
+
+        if (ProtocolRequestClassifier.IsOgcServiceAlias(path))
+        {
+            return ("OGC-Service", false);
+        }
+
+        if (ProtocolRequestClassifier.IsOgc(path))
+        {
+            return ("OGC", false);
+        }
+
+        if (ProtocolRequestClassifier.IsWfs(path))
+        {
+            return ("WFS", false);
+        }
+
+        if (ProtocolRequestClassifier.IsAdmin(path))
+        {
+            return ("Admin", false);
+        }
+
+        if (ProtocolRequestClassifier.IsGeoServices(path))
+        {
+            return (ExtractGeoServicesServiceType(path), true);
+        }
+
+        return ("Generic", false);
+    }
+
+    private static string ExtractGeoServicesServiceType(PathString path)
+    {
+        var value = path.Value;
+        if (string.IsNullOrEmpty(value))
+        {
+            return "GeoServices";
+        }
+
+        foreach (var segment in value.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var type in GeoServicesServiceTypes)
+            {
+                if (string.Equals(segment, type, StringComparison.OrdinalIgnoreCase))
+                {
+                    return type;
+                }
+            }
+        }
+
+        return "GeoServices";
+    }
+
+    private static string ResolveOperation(PathString path)
+    {
+        var value = path.Value;
+        if (string.IsNullOrEmpty(value))
+        {
+            return "unknown";
+        }
+
+        var segments = value.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+        {
+            return "unknown";
+        }
+
+        // Use the last segment as the operation only when it is purely alphabetic
+        // (Esri operations like query/addFeatures/applyEdits/exportImage). Numeric
+        // or mixed segments are identifiers (layer/feature ids) and would explode
+        // metric cardinality, so they collapse to "unknown".
+        var last = segments[^1];
+        foreach (var ch in last)
+        {
+            if (!char.IsLetter(ch))
+            {
+                return "unknown";
+            }
+        }
+
+        return last.ToLowerInvariant();
+    }
 }

--- a/src/Honua.Hosting/Features/Validation/ValidationErrorHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/ValidationErrorHelpers.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Honua.Core.Features.Validation;
 using Honua.Infrastructure.Middleware;
 using Honua.Infrastructure.Models;
+using Honua.ServiceDefaults;
 
 namespace Honua.Infrastructure.Validation;
 
@@ -32,6 +33,15 @@ public static class ValidationErrorHelpers
                 Details = details
             }
         };
+
+        // #2243: this builder bypasses the central formatter, so emit the error
+        // telemetry here too. No HttpContext is available, so the surface is
+        // recorded as the generic GeoServices service type.
+        HonuaTelemetry.RecordErrorEnvelope(
+            "GeoServices",
+            "validation",
+            GeoServicesErrorCodes.BadRequest,
+            isGeoServices: true);
 
         return Results.BadRequest(errorResponse);
     }
@@ -238,6 +248,11 @@ public static class ValidationErrorHelpers
                 Details = details
             }
         };
+
+        // #2243: this writer bypasses the central formatter, so emit the error
+        // telemetry through the same funnel using the request path for surface
+        // classification.
+        StandardErrorResponseFormatter.RecordErrorTelemetry(context, statusCode);
 
         context.Response.StatusCode = statusCode;
         context.Response.ContentType = "application/json; charset=utf-8";

--- a/src/Honua.ServiceDefaults/HonuaTelemetry.cs
+++ b/src/Honua.ServiceDefaults/HonuaTelemetry.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Text.RegularExpressions;
+using Honua.Core.Features.Infrastructure.Monitoring;
 
 namespace Honua.ServiceDefaults;
 
@@ -34,6 +35,31 @@ public static class HonuaTelemetry
     /// Used to record counters, histograms, and gauges for Honua-specific operations.
     /// </summary>
     public static readonly Meter Meter = new(ServiceName, ServiceVersion);
+
+    /// <summary>
+    /// Counter for GeoServices/ArcGIS REST error envelopes produced by the server.
+    /// GeoServices returns most errors as an <c>{"error":{code,message,details}}</c>
+    /// body (often with an HTTP 2xx status), so without this counter the headline
+    /// compat surface's error rate is invisible to aggregatable metrics. Tags:
+    /// <c>service_type</c>, <c>operation</c>, <c>error_code</c>.
+    /// </summary>
+    public static readonly Counter<long> GeoServicesErrors = Meter.CreateCounter<long>(
+        "honua_geoservices_error_total",
+        "errors",
+        "Total GeoServices/ArcGIS REST error envelopes produced, tagged by service_type, operation, and error_code.");
+
+    /// <summary>
+    /// Generic counter for protocol error envelopes produced across every surface
+    /// (GeoServices, OGC, WFS, OData, Admin, generic Problem Details). The
+    /// <c>in_band</c> tag is <c>true</c> when the error is delivered with a
+    /// non-error HTTP status (a 2xx/3xx body envelope) that is invisible to
+    /// load-balancer 5xx metrics and SLO gates. Tags: <c>service_type</c>,
+    /// <c>operation</c>, <c>error_code</c>, <c>in_band</c>.
+    /// </summary>
+    public static readonly Counter<long> RequestErrors = Meter.CreateCounter<long>(
+        "honua_request_error_total",
+        "errors",
+        "Total protocol error envelopes produced across all surfaces, tagged by service_type, operation, error_code, and in_band.");
 
     private const int DefaultMaxExceptionDetailLength = 256;
 
@@ -80,6 +106,59 @@ public static class HonuaTelemetry
         _exportExceptionDetails = exportDetails;
         _includeExceptionStackTraces = includeStackTraces;
         _maxExceptionDetailLength = maxDetailLength > 0 ? maxDetailLength : DefaultMaxExceptionDetailLength;
+    }
+
+    /// <summary>
+    /// Records telemetry for a single produced error envelope. This is the one
+    /// funnel every error-envelope construction path must call so the platform can
+    /// aggregate and alert on its own compat error rate (#2243). It increments
+    /// <see cref="RequestErrors"/> for every protocol, <see cref="GeoServicesErrors"/>
+    /// additionally for GeoServices surfaces, and the Core
+    /// <c>PerformanceMetrics.ApplicationErrors</c> counter so protocol error paths
+    /// are no longer silent. AOT-safe: no reflection, statically-shaped tag lists.
+    /// </summary>
+    /// <param name="serviceType">The protocol/service surface (e.g. FeatureServer, OGC, OData).</param>
+    /// <param name="operation">The logical operation (e.g. query, addfeatures) or "unknown".</param>
+    /// <param name="errorCode">The error code carried in the envelope (HTTP status or GeoServices code).</param>
+    /// <param name="isGeoServices">When true, also increments the GeoServices-specific counter.</param>
+    public static void RecordErrorEnvelope(string serviceType, string operation, int errorCode, bool isGeoServices)
+    {
+        serviceType = string.IsNullOrWhiteSpace(serviceType) ? "unknown" : serviceType;
+        operation = string.IsNullOrWhiteSpace(operation) ? "unknown" : operation;
+
+        // An error delivered with a non-error HTTP status (2xx/3xx) is "in band":
+        // the body carries an {error} envelope but the transport status reads
+        // success, so load-balancer/SLO 5xx metrics never see it. This is the
+        // keystone signal the audit is blind to today.
+        var inBand = errorCode < 400;
+
+        var requestTags = new TagList
+        {
+            { "service_type", serviceType },
+            { "operation", operation },
+            { "error_code", errorCode },
+            { "in_band", inBand },
+        };
+        RequestErrors.Add(1, requestTags);
+
+        if (isGeoServices)
+        {
+            var geoTags = new TagList
+            {
+                { "service_type", serviceType },
+                { "operation", operation },
+                { "error_code", errorCode },
+            };
+            GeoServicesErrors.Add(1, geoTags);
+        }
+
+        var appErrorTags = new TagList
+        {
+            { "error_type", "protocol_error" },
+            { "operation", operation },
+            { "service_type", serviceType },
+        };
+        PerformanceMetrics.ApplicationErrors.Add(1, appErrorTags);
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/GeoServicesErrorTelemetryTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/GeoServicesErrorTelemetryTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Validation;
+using Microsoft.AspNetCore.Http;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Verifies the keystone error-rate telemetry (#2243): every GeoServices error
+/// envelope — including the LB-invisible HTTP-200 in-band <c>{error}</c> body and
+/// sub-500 errors — must increment the OTel meter counters
+/// (<c>honua_geoservices_error_total</c>, <c>honua_request_error_total</c>) and the
+/// Core <c>honua_application_errors_total</c> counter.
+/// </summary>
+[Collection("Unit")]
+public sealed class GeoServicesErrorTelemetryTests
+{
+    [Fact]
+    public void FormatError_GeoServicesInBand200Envelope_IncrementsCountersWithInBandTrue()
+    {
+        // Arrange: GeoServices returns HTTP 200 with an {error} body for Esri compat.
+        var context = CreateContext("/rest/services/0/FeatureServer/0/query");
+        var errorResponse = new StandardErrorResponse(
+            StatusCode: StatusCodes.Status200OK,
+            Title: "Unable to complete operation.",
+            Detail: "Invalid where clause.");
+
+        using var collector = new ErrorMetricsCollector(
+            "honua_geoservices_error_total",
+            "honua_request_error_total",
+            "honua_application_errors_total");
+
+        // Act
+        _ = StandardErrorResponseFormatter.FormatError(context, errorResponse);
+
+        // Assert: filter on this test's distinctive tags so concurrent tests in
+        // other collections that share these counters cannot perturb the result.
+        var geo = collector.Match(
+            "honua_geoservices_error_total",
+            ("service_type", "FeatureServer"),
+            ("operation", "query"),
+            ("error_code", StatusCodes.Status200OK));
+        geo.Should().ContainSingle("the in-band 200 {error} envelope must record a GeoServices error");
+        geo[0].Value.Should().Be(1);
+
+        collector.Match(
+                "honua_request_error_total",
+                ("service_type", "FeatureServer"),
+                ("error_code", StatusCodes.Status200OK),
+                ("in_band", true))
+            .Should().ContainSingle("a 2xx error body is invisible to LB 5xx metrics (in_band=true)");
+
+        collector.Match(
+                "honua_application_errors_total",
+                ("service_type", "FeatureServer"),
+                ("operation", "query"))
+            .Should().NotBeEmpty("the protocol error path must finally increment ApplicationErrors");
+    }
+
+    [Fact]
+    public void FormatError_GeoServicesSub500Error_IncrementsCountersWithInBandFalse()
+    {
+        // Arrange: a sub-500 error returned with its real HTTP status (400).
+        var context = CreateContext("/rest/services/0/FeatureServer/0/query");
+        var errorResponse = StandardErrorResponse.BadRequest("Invalid where clause");
+
+        using var collector = new ErrorMetricsCollector(
+            "honua_geoservices_error_total",
+            "honua_request_error_total");
+
+        // Act
+        _ = StandardErrorResponseFormatter.FormatError(context, errorResponse);
+
+        // Assert
+        collector.Match(
+                "honua_geoservices_error_total",
+                ("service_type", "FeatureServer"),
+                ("error_code", StatusCodes.Status400BadRequest))
+            .Should().ContainSingle();
+
+        collector.Match(
+                "honua_request_error_total",
+                ("service_type", "FeatureServer"),
+                ("error_code", StatusCodes.Status400BadRequest),
+                ("in_band", false))
+            .Should().ContainSingle("a 4xx status is reflected by the HTTP transport (in_band=false)");
+    }
+
+    [Fact]
+    public void CreateGeoServicesValidationError_BypassBuilder_IncrementsCounters()
+    {
+        // Arrange / Act: this builder bypasses the central formatter entirely.
+        using var collector = new ErrorMetricsCollector(
+            "honua_geoservices_error_total",
+            "honua_request_error_total");
+
+        _ = ValidationErrorHelpers.CreateGeoServicesValidationError("Missing required parameter 'f'.");
+
+        // Assert
+        collector.Match(
+                "honua_geoservices_error_total",
+                ("service_type", "GeoServices"),
+                ("operation", "validation"))
+            .Should().ContainSingle("the bypassing GeoServices validation builder must still emit telemetry");
+        collector.Match(
+                "honua_request_error_total",
+                ("service_type", "GeoServices"),
+                ("operation", "validation"))
+            .Should().ContainSingle();
+    }
+
+    private static DefaultHttpContext CreateContext(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.example.com");
+        return context;
+    }
+
+    private sealed record Sample(long Value, KeyValuePair<string, object?>[] Tags)
+    {
+        public bool HasTag(string name, object? expected)
+        {
+            foreach (var tag in Tags)
+            {
+                if (tag.Key == name)
+                {
+                    return Equals(tag.Value, expected);
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Test-only MeterListener capturing long measurements for a set of named
+    /// instruments on the "Honua" meter.
+    /// </summary>
+    private sealed class ErrorMetricsCollector : IDisposable
+    {
+        private readonly MeterListener _listener;
+        private readonly HashSet<string> _instrumentNames;
+        private readonly List<(string Name, Sample Sample)> _samples = new();
+        private readonly object _gate = new();
+
+        public ErrorMetricsCollector(params string[] instrumentNames)
+        {
+            _instrumentNames = new HashSet<string>(instrumentNames, StringComparer.Ordinal);
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == "Honua" && _instrumentNames.Contains(instrument.Name))
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                lock (_gate)
+                {
+                    _samples.Add((instrument.Name, new Sample(measurement, tags.ToArray())));
+                }
+            });
+            _listener.Start();
+        }
+
+        public Sample[] Match(string instrumentName, params (string Key, object? Value)[] expectedTags)
+        {
+            lock (_gate)
+            {
+                return _samples
+                    .Where(s => s.Name == instrumentName)
+                    .Select(s => s.Sample)
+                    .Where(sample => expectedTags.All(t => sample.HasTag(t.Key, t.Value)))
+                    .ToArray();
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2243

## Summary
GeoServices/ArcGIS REST returns most errors as an in-band `{"error":{code,message,details}}` body (often with an HTTP 200 status), and no code path emitted a metric when that envelope was produced. The platform was therefore blind to its own compat error rate — a burst of 200+`{error}` on the headline surface was recorded as success and invisible to LB 5xx metrics, SLOs, dashboards, and the SLO release gate.

This adds aggregatable OTel meter counters and routes every error-envelope construction path (the central formatter plus the two GeoServices builders that bypassed it) through one telemetry funnel, and finally increments the existing-but-dormant `ApplicationErrors` counter on protocol error paths.

## Changes Made
- Added two counters to `HonuaTelemetry` (`src/Honua.ServiceDefaults/HonuaTelemetry.cs`), exported via the existing OTel `Honua` meter, AOT-safe (`TagList`, no reflection):
  - `honua_geoservices_error_total` with tags `{service_type, operation, error_code}`
  - `honua_request_error_total` with tags `{service_type, operation, error_code, in_band}` (`in_band=true` when an error rides a non-error 2xx/3xx HTTP status — the LB-invisible case)
- Added `HonuaTelemetry.RecordErrorEnvelope(...)` — the single funnel that increments both new counters and the Core `honua_application_errors_total` (`ApplicationErrors`) counter with `error_type=protocol_error`.
- Routed the central `StandardErrorResponseFormatter.FormatError` (`src/Honua.Hosting/Features/Models/StandardErrorResponseFormatter.cs`) through the funnel, classifying `service_type`/`operation` from the request path (GeoServices service-type extraction, bounded `operation` tag to avoid cardinality blowup).
- Routed the two GeoServices builders in `ValidationErrorHelpers` (`src/Honua.Hosting/Features/Validation/ValidationErrorHelpers.cs`) — `CreateGeoServicesValidationError` and the `WriteValidationErrorAsync` writer — that previously bypassed the central formatter, so they now emit the same telemetry.
- Granted `InternalsVisibleTo` for `Honua.ServiceDefaults` in `Honua.Core.csproj` so the telemetry funnel can increment the internal `PerformanceMetrics.ApplicationErrors`.
- Added unit tests (`tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/GeoServicesErrorTelemetryTests.cs`) asserting the counters increment for an in-band HTTP-200 `{error}` envelope (`in_band=true`), a sub-500 (400) error (`in_band=false`), and the bypassing validation builder, using a `MeterListener`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
