### PR TITLE
fix(docker): repair Lambda AOT nightly image build (restore + ILC OOM hardening)

### DIFF
--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -56,6 +56,7 @@ COPY src/Honua.Protocols.Ogc.Shared/*.csproj src/Honua.Protocols.Ogc.Shared/
 COPY src/Honua.Protocols.OgcApi/*.csproj src/Honua.Protocols.OgcApi/
 COPY src/Honua.Protocols.OgcClassic/*.csproj src/Honua.Protocols.OgcClassic/
 COPY src/Honua.Protocols.Stac/*.csproj src/Honua.Protocols.Stac/
+COPY src/Honua.Protocols.SensorThings/*.csproj src/Honua.Protocols.SensorThings/
 COPY src/Honua.Protocols.GeoServices/*.csproj src/Honua.Protocols.GeoServices/
 COPY src/Honua.Scene/*.csproj src/Honua.Scene/
 COPY src/Honua.Core.Abstractions/*.csproj src/Honua.Core.Abstractions/

--- a/docker/Dockerfile.lambda.aot
+++ b/docker/Dockerfile.lambda.aot
@@ -96,28 +96,52 @@ COPY . .
 ARG CONFIGURATION=Release
 # Re-declared so the build stage sees the build-arg for the conditional STAC ops publish.
 ARG HONUA_INCLUDE_STAC_OPS_DEMO=false
+# ILC (the native compiler) is single-threaded on BOTH arches and the publish is
+# retried with backoff — mirroring the hardening already in docker/Dockerfile.aot
+# (#1360). The Native AOT link peaks well above the hosted runner's memory ceiling,
+# so parallel ILC (IlcSingleThreaded=false, previously used on amd64) gets OOM-killed
+# mid-link: ilc exits with code -1 and surfaces only as Microsoft.NETCore.Native.targets
+# error MSB3073 "...ilc... exited with code -1". Single-threaded linking trades
+# wall-clock for a much lower memory peak; the retry loop additionally rides out an
+# intermittent OOM kill (the regular AOT image relies on the same retry to stay green).
+# The plain Dockerfile.aot wraps restore+publish; here restore is a cached prior stage,
+# so the loop wraps the --no-restore publish that actually OOMs.
+ARG AOT_PUBLISH_MAX_ATTEMPTS=3
 RUN --mount=type=cache,target=/root/.nuget/packages \
     case "${TARGETARCH:-amd64}" in \
-      amd64) RUNTIME_ID="linux-x64" ; ILC_SINGLE_THREADED="false" ;; \
-      arm64) RUNTIME_ID="linux-arm64" ; ILC_SINGLE_THREADED="true" ;; \
+      amd64) RUNTIME_ID="linux-x64" ;; \
+      arm64) RUNTIME_ID="linux-arm64" ;; \
       *) echo "Unsupported TARGETARCH=${TARGETARCH}" && exit 1 ;; \
     esac && \
-    dotnet publish src/Honua.Server/Honua.Server.csproj \
-      --configuration "$CONFIGURATION" \
-      --runtime "$RUNTIME_ID" \
-      --no-restore \
-      --self-contained true \
-      --output /app \
-      -p:RuntimeIdentifier="$RUNTIME_ID" \
-      -p:PublishAot=true \
-      -p:DebugType=None \
-      -p:DebugSymbols=false \
-      -p:StripSymbols=true \
-      -p:OptimizationPreference=Speed \
-      -p:IlcOptimizationPreference=Speed \
-      -p:IlcSingleThreaded="$ILC_SINGLE_THREADED" \
-      -p:HonuaSkipOracleForAotVerification=true \
-      -p:HonuaSkipSnowflakeForAotVerification=true && \
+    attempt=1 && \
+    max_attempts="${AOT_PUBLISH_MAX_ATTEMPTS:-3}" && \
+    until \
+        dotnet publish src/Honua.Server/Honua.Server.csproj \
+          --configuration "$CONFIGURATION" \
+          --runtime "$RUNTIME_ID" \
+          --no-restore \
+          --self-contained true \
+          --output /app \
+          -p:RuntimeIdentifier="$RUNTIME_ID" \
+          -p:PublishAot=true \
+          -p:DebugType=None \
+          -p:DebugSymbols=false \
+          -p:StripSymbols=true \
+          -p:OptimizationPreference=Speed \
+          -p:IlcOptimizationPreference=Speed \
+          -p:IlcSingleThreaded=true \
+          -p:HonuaSkipOracleForAotVerification=true \
+          -p:HonuaSkipSnowflakeForAotVerification=true ; \
+    do \
+        status=$? ; \
+        if [ "$attempt" -ge "$max_attempts" ]; then \
+            echo "AOT publish failed after ${attempt} attempts (last exit ${status})" >&2 ; \
+            exit "$status" ; \
+        fi ; \
+        echo "AOT publish attempt ${attempt} failed (exit ${status}); retrying after backoff..." >&2 ; \
+        sleep $((attempt * 15)) ; \
+        attempt=$((attempt + 1)) ; \
+    done && \
     if [ "$HONUA_INCLUDE_STAC_OPS_DEMO" = "true" ]; then \
       dotnet publish samples/Honua.StacOpsDemo/Honua.StacOpsDemo.csproj \
         --configuration "$CONFIGURATION" --no-restore --output /tmp/stac-ops-demo && \


### PR DESCRIPTION
## Problem

The **Nightly Container Build**'s `Build & Push Lambda AOT` jobs (amd64 + arm64) have failed every night for ~a week. There are **two** independent breaks, uncovered one after the other:

### 1. Restore — `NETSDK1004`
`docker/Dockerfile.lambda.aot` restores Honua.Server's graph from a hand-maintained csproj copy-list, then publishes `--no-restore`. `Honua.Protocols.SensorThings` was added to the graph but never added to the list, so restore skipped it and the publish failed with:
```
error NETSDK1004: Assets file '/src/src/Honua.Protocols.SensorThings/obj/project.assets.json' not found.
```
Verified the copy-list now **exactly** matches Honua.Server's full transitive `ProjectReference` closure (SensorThings was the only gap).

### 2. ILC native compile — OOM (`MSB3073 … ilc … exited with code -1`)
With restore fixed, the build reaches the Native-AOT link and dies on **both** arches:
```
Microsoft.NETCore.Native.targets: error MSB3073: "…ilc…" exited with code -1
```
`exit -1` is the kernel OOM-killer reaping ilc mid-link. The regular AOT image (`docker/Dockerfile.aot`) already survives this (#1360) via two mechanisms the Lambda Dockerfile never adopted:
- `IlcSingleThreaded=true` on **both** arches (the Lambda file used parallel ILC on amd64 → higher RSS peak);
- a **publish retry loop** with backoff (the Lambda file did a single attempt, so one transient OOM failed the nightly). In this run the regular AOT image also OOM'd once (`MSB3073`) but its retry recovered and it published green.

## Fix
1. Add the missing `COPY src/Honua.Protocols.SensorThings/*.csproj` line.
2. Force `IlcSingleThreaded=true` on both arches and wrap the `--no-restore` publish in an `AOT_PUBLISH_MAX_ATTEMPTS` (default 3) retry loop with backoff — mirroring `Dockerfile.aot`. (Restore stays in the cached prior stage; only the OOM-prone publish retries.)

## Verification
Dispatched the Nightly Container Build on this branch; confirming both Lambda AOT arches go green.

## Related
- Companion PR #2272 fixes the **web** `nightly-aot` image's startup crash (GP managed-executor constructors trimmed under AOT — the `IL2091` trim warning visible in this same build log).