### PR TITLE
fix(geoprocessing): root managed-executor constructors for Native AOT (web image boot)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics.CodeAnalysis;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Orchestration.Abstractions;
@@ -217,9 +218,11 @@ internal static class GeoprocessingServiceCollectionExtensions
     /// surfaced into the enumerable <see cref="IProcessExecutor"/> set the
     /// <see cref="GeoprocessingDispatchJobExecutor"/> enumerates — both bound to the
     /// SAME singleton instance via a resolving factory, so there is exactly one of
-    /// each. No reflection scan is used, keeping the registration AOT-safe; adding a
-    /// new managed process is a one-line <c>Register&lt;T&gt;</c> call here plus its
-    /// catalog entry.
+    /// each. No reflection scan is used; combined with the
+    /// <c>[DynamicallyAccessedMembers(PublicConstructors)]</c> annotation on
+    /// <c>Register</c>'s type parameter (which roots each executor's constructor for
+    /// the trimmer), the registration is Native-AOT-safe. Adding a new managed process
+    /// is a one-line <c>Register&lt;T&gt;</c> call here plus its catalog entry.
     /// </summary>
     private static void AddProcessExecutors(IServiceCollection services)
     {
@@ -285,7 +288,16 @@ internal static class GeoprocessingServiceCollectionExtensions
         Register<ImportDatasetJobExecutor>(services);
     }
 
-    private static void Register<TExecutor>(IServiceCollection services)
+    // [DynamicallyAccessedMembers] is REQUIRED for Native AOT: TryAddSingleton<T>()
+    // annotates its type parameter with PublicConstructors so the trimmer roots the
+    // constructor the DI container later reflects over. Without propagating that
+    // annotation through this generic helper, ILC trims every executor's constructor
+    // (the call sites pass concrete types, but the requirement does not flow), and the
+    // AOT image then crash-loops at startup under ValidateOnBuild with ~490 "a suitable
+    // constructor for type '...Executor' could not be located" errors — even though the
+    // JIT image, which binds constructors at runtime, starts fine.
+    private static void Register<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TExecutor>(
+        IServiceCollection services)
         where TExecutor : class, IProcessExecutor
     {
         services.TryAddSingleton<TExecutor>();


### PR DESCRIPTION
## Problem

Today's `nightly-aot` server image **crash-loops at startup** under DI `ValidateOnBuild` (`ASPNETCORE_ENVIRONMENT=Development`) with ~490 inner errors:

```
A suitable constructor for type 'Honua.Geoprocessing.Execution.<X>Executor' could not be located.
```

(GeometryLength/ConvexHull/Dissolve…, Managed*, Overlay*, Proximity*, Statistics*, HonuaLayerSink, ImportDataset, …). The older `bca62e2` image booted fine, so this is a recent regression. This also keeps the **Esri SDK Certification / compat suite** red, because the harness can't boot the image.

Verified the JIT `nightly` image does **not** hit these (it fails only on the separate, already-fixed `TenantLifecycleService` lifetime issue) — confirming the executor errors are **Native-AOT-trimming only**.

## Root cause

`AddProcessExecutors` registers each managed executor through a generic helper:

```csharp
private static void Register<TExecutor>(IServiceCollection services) where TExecutor : class, IProcessExecutor
{
    services.TryAddSingleton<TExecutor>();   // <-- T is [DynamicallyAccessedMembers(PublicConstructors)]
    ...
}
```

`TryAddSingleton<T>()` annotates its type parameter with `[DynamicallyAccessedMembers(PublicConstructors)]` so the trimmer roots the constructor the DI container later reflects over. `Register<TExecutor>` **did not propagate** that annotation, so ILC trimmed every executor's constructor and the AOT container can't construct them at validation time. (The in-file comment even claimed the pattern was already "AOT-safe".)

## Fix

Annotate `Register`'s type parameter with `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]`. Each call site passes a concrete executor type, so the trimmer roots exactly those constructors.

**No runtime behavior change.** This is the opposite of gating GP out of the web image: the in-process job worker (Redis profile) and the `honua gp` local runner (which executes managed tools with **no** Redis) keep the same executor set, and the heavy GDAL executors remain worker-only (`Honua.Worker.Gdal`). The lightweight managed executors were always intended to be available in the serving image.

## Verification

Building the AOT image from this branch and booting it under the compat harness (Development env) — the ~490 errors are gone and the server reaches `Now listening`. The full Esri compat suite is then run against the image.

## Related
- `TenantLifecycleService` (the other startup-validation failure on the *published* image) was already fixed on trunk in #2259 (Singleton → Scoped).
- Companion PR #2271 fixes the nightly **Lambda** AOT image build (separate concern).