### PR TITLE
feat(geoprocessing): add Hot Spot Analysis (Getis-Ord Gi*) tool (#2142)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -344,6 +344,20 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
             ],
             OutputArtifactKinds = [ArtifactKind.FeatureLayer]
         },
+        new ProcessDefinition
+        {
+            ProcessId = "analytics.hotspot-managed",
+            Title = "Hot Spot Analysis (Getis-Ord Gi*, Managed)",
+            Description = "Job-executable, managed (NetTopologySuite) Hot Spot Analysis over an inline FeatureCollection, computing the Getis-Ord Gi* statistic per feature using a fixed-distance-band conceptualization of spatial relationships. Every input feature is preserved one-to-one with GI_ZSCORE (Gi* z-score), GI_PVALUE (two-tailed p-value) and GI_BIN (Esri-style confidence bin in [-3, 3]: sign = hot/cold, magnitude = 99/95/90% significance) attributes appended. Distances are evaluated in the CRS units of the supplied feature geometries — geodesic conversion is not performed. Rejects degenerate inputs (fewer than two located features, or zero variance in the analysis field).",
+            Category = "analytics",
+            Parameters =
+            [
+                Param("input", "Input Features", "Input FeatureCollection as a data:application/geo+json;base64 data URI. Non-point geometries are analysed on their centroid; features with null/empty geometry are dropped before analysis.", ProcessParameterValueType.Text, required: true),
+                Param("field", "Analysis Field", "Attribute name whose numeric values are analysed for clustering. Every located feature must carry a numeric value for this field.", ProcessParameterValueType.Text, required: true),
+                Param("distanceBand", "Distance Band", "Fixed distance band in CRS units. Features within this Euclidean distance of one another are neighbours (each feature is always its own neighbour for Gi*). Must be a finite positive number.", ProcessParameterValueType.FloatingPoint, required: true),
+            ],
+            OutputArtifactKinds = [ArtifactKind.FeatureLayer]
+        },
 
         // -----------------------------------------------------------------------
         // Layer-aware overlay operations (#2206, #2139)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ManagedHotSpotExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ManagedHotSpotExecutor.cs
@@ -1,0 +1,384 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Index.Strtree;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// <c>analytics.hotspot-managed</c> executor. A job-dispatchable, managed
+/// (NetTopologySuite) Hot Spot Analysis that computes the Getis-Ord Gi*
+/// statistic for every input feature over an inline FeatureCollection. Like the
+/// other managed analytics executors (<see cref="ManagedClusterExecutor"/>,
+/// <see cref="ManagedDensityExecutor"/>) it is the workflow/codemod-reachable
+/// counterpart that runs against an INLINE FeatureCollection so the lean
+/// dispatcher can construct it unconditionally without a Postgres dependency.
+///
+/// <para>
+/// Conceptualization of spatial relationships: a <b>fixed distance band</b>. Two
+/// features are neighbours when the Euclidean distance between their point
+/// representatives (centroid for non-point inputs) is &lt;= <c>distanceBand</c>
+/// CRS units. As this is the Gi* (with-star) statistic, each feature is always
+/// its own neighbour. Distances are evaluated in the CRS units of the supplied
+/// feature geometries — geodesic conversion is not performed (the same
+/// convention used by the managed <c>geometry.buffer</c> and clustering
+/// executors).
+/// </para>
+///
+/// <para>
+/// For feature <c>i</c> with analysis value <c>x</c>, global mean
+/// <c>X̄</c>, global population standard deviation <c>S</c>, total feature
+/// count <c>n</c>, and binary fixed-distance weights <c>w_ij ∈ {0,1}</c> (so
+/// <c>Σ w_ij = Σ w_ij² = W_i</c>, the neighbour count including self):
+/// <code>
+/// Gi* = (Σ_j w_ij x_j - X̄·W_i) / (S · sqrt((n·W_i - W_i²) / (n - 1)))
+/// </code>
+/// The Gi* statistic is a z-score; the two-tailed p-value is
+/// <c>2·(1 - Φ(|z|))</c> where <c>Φ</c> is the standard-normal CDF. Each output
+/// feature preserves its input geometry and attributes and carries:
+/// <list type="bullet">
+///   <item><c>GI_ZSCORE</c>: the Gi* z-score.</item>
+///   <item><c>GI_PVALUE</c>: the two-tailed p-value.</item>
+///   <item><c>GI_BIN</c>: the Esri-style confidence bin in [-3, 3] — sign from
+///   the z-score (hot = positive, cold = negative) and magnitude from the
+///   significance level (3 = 99%, 2 = 95%, 1 = 90%, 0 = not significant).</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Degenerate inputs are rejected with a clear error: fewer than two located
+/// features (Gi* is undefined for a single point) and a zero-variance analysis
+/// field (all-identical values). Features with null/empty geometry are dropped
+/// before analysis and are not emitted. A feature whose neighbourhood spans the
+/// entire dataset (<c>W_i == n</c>) has an undefined local variance term and is
+/// emitted with a neutral z-score of 0, p-value 1, and bin 0.
+/// </para>
+/// </summary>
+internal sealed class ManagedHotSpotExecutor(
+    IOptionsMonitor<GeoprocessingExecutorOptions> options)
+    : FeatureCollectionTransformExecutor(options)
+{
+    internal const string HandledProcessId = "analytics.hotspot-managed";
+    internal const string ZScoreAttribute = "GI_ZSCORE";
+    internal const string PValueAttribute = "GI_PVALUE";
+    internal const string BinAttribute = "GI_BIN";
+
+    protected override string ProcessId => HandledProcessId;
+
+    protected override List<IFeature> Apply(
+        FeatureCollection source,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+    {
+        var field = inputs.Require("field").Trim();
+        if (field.Length == 0)
+        {
+            throw new TransformInputException("'field' must be a non-empty attribute name");
+        }
+
+        var distanceBand = ReadDistanceBand(inputs);
+        var points = MaterializePoints(source, field);
+
+        if (points.Count < 2)
+        {
+            throw new TransformInputException(
+                "Hot Spot Analysis requires at least two features with a located geometry and a numeric analysis value");
+        }
+
+        var n = points.Count;
+
+        double sum = 0;
+        double sumSquares = 0;
+        foreach (var point in points)
+        {
+            sum += point.Value;
+            sumSquares += point.Value * point.Value;
+        }
+
+        var mean = sum / n;
+        // Population standard deviation (matches the Getis-Ord Gi* definition).
+        var variance = (sumSquares / n) - (mean * mean);
+        if (variance <= 0)
+        {
+            throw new TransformInputException(
+                $"Hot Spot Analysis requires variation in '{field}'; all analysis values are identical (zero variance)");
+        }
+
+        var standardDeviation = Math.Sqrt(variance);
+
+        var index = BuildIndex(points, distanceBand, cancellationToken);
+
+        var output = new List<IFeature>(n);
+        for (var i = 0; i < n; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var (neighbourValueSum, neighbourCount) = SumNeighbours(index, points, i, distanceBand);
+            var (zScore, pValue, bin) = ComputeStatistic(
+                neighbourValueSum, neighbourCount, n, mean, standardDeviation);
+
+            output.Add(WithStatistics(points[i].SourceFeature, zScore, pValue, bin));
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Computes the Getis-Ord Gi* z-score, two-tailed p-value, and confidence
+    /// bin for a single feature given the sum of analysis values over its
+    /// fixed-distance neighbourhood (including itself) and the neighbour count.
+    /// </summary>
+    private static (double ZScore, double PValue, int Bin) ComputeStatistic(
+        double neighbourValueSum,
+        int neighbourCount,
+        int n,
+        double mean,
+        double standardDeviation)
+    {
+        // Binary weights: Σ w_ij = Σ w_ij² = W_i (the neighbour count incl. self).
+        double weightSum = neighbourCount;
+
+        // (n·W - W²)/(n-1) is the local variance term. It is zero when the
+        // neighbourhood is the whole dataset (W == n): no local contrast exists,
+        // so the statistic is neutral rather than a divide-by-zero NaN.
+        var localVariance = ((n * weightSum) - (weightSum * weightSum)) / (n - 1);
+        if (localVariance <= 0)
+        {
+            return (0d, 1d, 0);
+        }
+
+        var numerator = neighbourValueSum - (mean * weightSum);
+        var denominator = standardDeviation * Math.Sqrt(localVariance);
+        var zScore = numerator / denominator;
+
+        var pValue = TwoTailedPValue(zScore);
+        var bin = ConfidenceBin(zScore, pValue);
+        return (zScore, pValue, bin);
+    }
+
+    /// <summary>
+    /// Two-tailed standard-normal p-value <c>2·(1 - Φ(|z|)) = erfc(|z|/√2)</c>,
+    /// clamped to [0, 1].
+    /// </summary>
+    private static double TwoTailedPValue(double zScore)
+    {
+        var p = Erfc(Math.Abs(zScore) / Math.Sqrt(2.0));
+        return Math.Clamp(p, 0d, 1d);
+    }
+
+    /// <summary>
+    /// Esri-style Gi_Bin: sign from the z-score (positive = hot, negative =
+    /// cold), magnitude from the two-tailed significance level — 3 at 99%
+    /// (p &lt;= 0.01), 2 at 95% (p &lt;= 0.05), 1 at 90% (p &lt;= 0.10), 0 when
+    /// not statistically significant.
+    /// </summary>
+    private static int ConfidenceBin(double zScore, double pValue)
+    {
+        var magnitude = pValue switch
+        {
+            <= 0.01 => 3,
+            <= 0.05 => 2,
+            <= 0.10 => 1,
+            _ => 0,
+        };
+
+        if (magnitude == 0)
+        {
+            return 0;
+        }
+
+        return zScore >= 0 ? magnitude : -magnitude;
+    }
+
+    /// <summary>
+    /// Complementary error function via the Numerical Recipes rational
+    /// approximation (fractional error &lt; 1.2e-7 across the whole range),
+    /// avoiding a dependency on a non-AOT math package for the normal CDF.
+    /// </summary>
+    private static double Erfc(double x)
+    {
+        var z = Math.Abs(x);
+        var t = 1.0 / (1.0 + (0.5 * z));
+
+        // Horner evaluation of the NR polynomial, innermost coefficient first.
+        var poly = 0.17087277;
+        poly = -0.82215223 + (t * poly);
+        poly = 1.48851587 + (t * poly);
+        poly = -1.13520398 + (t * poly);
+        poly = 0.27886807 + (t * poly);
+        poly = -0.18628806 + (t * poly);
+        poly = 0.09678418 + (t * poly);
+        poly = 0.37409196 + (t * poly);
+        poly = 1.00002368 + (t * poly);
+
+        var ans = t * Math.Exp((-z * z) - 1.26551223 + (t * poly));
+        return x >= 0.0 ? ans : 2.0 - ans;
+    }
+
+    private static (double ValueSum, int Count) SumNeighbours(
+        STRtree<int> index,
+        List<MaterializedPoint> points,
+        int origin,
+        double distanceBand)
+    {
+        var originPoint = points[origin];
+        var envelope = new Envelope(
+            originPoint.X - distanceBand,
+            originPoint.X + distanceBand,
+            originPoint.Y - distanceBand,
+            originPoint.Y + distanceBand);
+
+        var bandSquared = distanceBand * distanceBand;
+        double valueSum = 0;
+        var count = 0;
+        foreach (var candidate in index.Query(envelope))
+        {
+            var dx = points[candidate].X - originPoint.X;
+            var dy = points[candidate].Y - originPoint.Y;
+            if ((dx * dx) + (dy * dy) <= bandSquared)
+            {
+                valueSum += points[candidate].Value;
+                count++;
+            }
+        }
+
+        return (valueSum, count);
+    }
+
+    private static STRtree<int> BuildIndex(
+        List<MaterializedPoint> points,
+        double distanceBand,
+        CancellationToken cancellationToken)
+    {
+        var index = new STRtree<int>();
+        for (var i = 0; i < points.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var point = points[i];
+            index.Insert(
+                new Envelope(
+                    point.X - distanceBand,
+                    point.X + distanceBand,
+                    point.Y - distanceBand,
+                    point.Y + distanceBand),
+                i);
+        }
+
+        index.Build();
+        return index;
+    }
+
+    private static List<MaterializedPoint> MaterializePoints(FeatureCollection source, string field)
+    {
+        var materialized = new List<MaterializedPoint>(source.Count);
+        foreach (var feature in source)
+        {
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                continue;
+            }
+
+            var coord = geometry is Point p ? p.Coordinate : geometry.Centroid.Coordinate;
+            if (coord is null || double.IsNaN(coord.X) || double.IsNaN(coord.Y))
+            {
+                continue;
+            }
+
+            if (!TryReadNumeric(feature, field, out var value))
+            {
+                throw new TransformInputException(
+                    $"feature is missing a numeric value for analysis field '{field}'");
+            }
+
+            materialized.Add(new MaterializedPoint(feature, coord.X, coord.Y, value));
+        }
+
+        return materialized;
+    }
+
+    private static Feature WithStatistics(IFeature source, double zScore, double pValue, int bin)
+    {
+        var merged = new AttributesTable();
+        if (source.Attributes is not null)
+        {
+            foreach (var name in source.Attributes.GetNames())
+            {
+                if (string.Equals(name, ZScoreAttribute, StringComparison.Ordinal)
+                    || string.Equals(name, PValueAttribute, StringComparison.Ordinal)
+                    || string.Equals(name, BinAttribute, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                merged.Add(name, source.Attributes.GetOptionalValue(name));
+            }
+        }
+
+        merged.Add(ZScoreAttribute, zScore);
+        merged.Add(PValueAttribute, pValue);
+        merged.Add(BinAttribute, bin);
+        return new Feature(source.Geometry, merged);
+    }
+
+    private static double ReadDistanceBand(StepInputReader inputs)
+    {
+        if (!inputs.TryGet("distanceBand", out var raw) || string.IsNullOrWhiteSpace(raw)
+            || !double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+            || !double.IsFinite(value)
+            || value <= 0)
+        {
+            throw new TransformInputException(
+                "'distanceBand' must be a finite positive number (CRS units)");
+        }
+
+        return value;
+    }
+
+    private static bool TryReadNumeric(IFeature feature, string field, out double value)
+    {
+        value = 0;
+        var attributes = feature.Attributes;
+        if (attributes is null || !attributes.Exists(field))
+        {
+            return false;
+        }
+
+        var raw = attributes.GetOptionalValue(field);
+        switch (raw)
+        {
+            case null:
+                return false;
+            case double d:
+                value = d;
+                return true;
+            case float f:
+                value = f;
+                return true;
+            case int i:
+                value = i;
+                return true;
+            case long l:
+                value = l;
+                return true;
+            case short s:
+                value = s;
+                return true;
+            case decimal m:
+                value = (double)m;
+                return true;
+            default:
+                return double.TryParse(
+                    Convert.ToString(raw, CultureInfo.InvariantCulture),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out value);
+        }
+    }
+
+    private readonly record struct MaterializedPoint(IFeature SourceFeature, double X, double Y, double Value);
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -244,6 +244,8 @@ internal static class GeoprocessingServiceCollectionExtensions
         Register<ManagedClusterExecutor>(services);
         Register<ManagedBufferAggregateExecutor>(services);
         Register<ManagedDensityExecutor>(services);
+        // Spatial-statistics tool pack (#2142): Hot Spot Analysis (Getis-Ord Gi*).
+        Register<ManagedHotSpotExecutor>(services);
         // Layer-aware overlay tool pack (#2206, #2139).
         Register<OverlayClipExecutor>(services);
         Register<OverlayIntersectExecutor>(services);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -414,6 +414,9 @@ internal static partial class ProcessPlanValidator
             case "analytics.density-managed":
                 ValidateManagedDensitySemantics(step, violations);
                 break;
+            case "analytics.hotspot-managed":
+                ValidateManagedHotSpotSemantics(step, violations);
+                break;
             case "analytics.density":
                 ValidateDensitySemantics(step, analyticsLimits, violations);
                 ApplySharedAnalyticsFilterSemantics(step, violations);
@@ -704,6 +707,19 @@ internal static partial class ProcessPlanValidator
 
         // cellSize must be a finite positive number (CRS units, not meters).
         RequirePositiveFiniteDouble(step, "cellSize", violations);
+    }
+
+    private static void ValidateManagedHotSpotSemantics(
+        AnalysisPlanStep step,
+        List<GeoprocessingValidationFailure> violations)
+    {
+        // The analysis field is mandatory: Gi* needs a numeric attribute to test.
+        RequireConditionalParameter(step, "field", "running Hot Spot Analysis", violations);
+
+        // distanceBand is the fixed-distance conceptualization of spatial
+        // relationships; it must be a finite positive number in CRS units.
+        RequireConditionalParameter(step, "distanceBand", "running Hot Spot Analysis", violations);
+        RequirePositiveFiniteDouble(step, "distanceBand", violations);
     }
 
     private static void ValidateSpatialFilterSemantics(

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -73,6 +73,8 @@ public sealed class CatalogExecutableConformanceTests
         "analytics.cluster-managed",
         "analytics.buffer-aggregate-managed",
         "analytics.density-managed",
+        // Spatial-statistics tool pack (#2142): Hot Spot Analysis (Getis-Ord Gi*).
+        "analytics.hotspot-managed",
         // Layer-aware overlay tool pack (#2206, #2139): managed NTS, two
         // FeatureCollections in, one FeatureCollection/table out.
         "overlay.clip",
@@ -383,6 +385,7 @@ public sealed class CatalogExecutableConformanceTests
             new ManagedClusterExecutor(monitor),
             new ManagedBufferAggregateExecutor(monitor),
             new ManagedDensityExecutor(monitor),
+            new ManagedHotSpotExecutor(monitor),
             new OverlayClipExecutor(monitor),
             new OverlayIntersectExecutor(monitor),
             new OverlayUnionExecutor(monitor),

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ManagedHotSpotExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ManagedHotSpotExecutorTests.cs
@@ -1,0 +1,355 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Honua.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// In-memory unit coverage for the managed (NetTopologySuite) Hot Spot Analysis
+/// executor — the job-dispatchable Getis-Ord Gi* tool over an inline
+/// FeatureCollection. The Gi* expectations below are hand-derived closed-form
+/// reference values, so the assertions exercise the statistic's correctness
+/// rather than echoing the implementation.
+/// </summary>
+public sealed class ManagedHotSpotExecutorTests
+{
+    private const string DataUriPrefix = "data:application/geo+json;base64,";
+
+    [UnitTest]
+    public async Task GiStar_MatchesHandDerivedReference_ForAOneDimensionalFixture()
+    {
+        // Fixture: five collinear points at x = 0..4 (y = 0), values [1, 2, 9, 2, 1],
+        // fixed distance band = 1.5 so each point neighbours itself and its immediate
+        // neighbour(s). Reference derivation:
+        //   n = 5, Σx = 15, X̄ = 3, Σx² = 91, S = sqrt(91/5 - 9) = sqrt(9.2).
+        //   Centre (x=2, value 9): W = 3, Σ_N x = 2+9+2 = 13,
+        //     z = (13 - 3·3) / (sqrt(9.2)·sqrt((5·3 - 9)/4)) = 4 / (sqrt(9.2)·sqrt(1.5))
+        //       = 1.0767648...
+        //   Mid (x=1, value 2): W = 3, Σ_N x = 1+2+9 = 12,
+        //     z = (12 - 3·3) / (sqrt(9.2)·sqrt(1.5)) = 3 / (sqrt(9.2)·sqrt(1.5)) = 0.8075736...
+        //   Endpoint (x=0, value 1): W = 2, Σ_N x = 1+2 = 3,
+        //     z = (3 - 3·2) / (sqrt(9.2)·sqrt((5·2 - 4)/4)) = -3 / (sqrt(9.2)·sqrt(1.5))
+        //       = -0.8075736...
+        var executor = new ManagedHotSpotExecutor(Options());
+
+        var input = BuildUri(
+            Feature(Point(0, 0), ("val", 1)),
+            Feature(Point(1, 0), ("val", 2)),
+            Feature(Point(2, 0), ("val", 9)),
+            Feature(Point(3, 0), ("val", 2)),
+            Feature(Point(4, 0), ("val", 1)));
+
+        var (status, uri) = await RunAsync(
+            executor,
+            ManagedHotSpotExecutor.HandledProcessId,
+            ("input", input),
+            ("field", "val"),
+            ("distanceBand", "1.5"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().HaveCount(5, "every located feature is preserved one-to-one");
+
+        var byX = features.ToDictionary(
+            f => (int)Math.Round(f.Geometry.Coordinate.X),
+            f => f);
+
+        ZScore(byX[2]).Should().BeApproximately(1.0767648, 1e-5);
+        ZScore(byX[1]).Should().BeApproximately(0.8075736, 1e-5);
+        ZScore(byX[3]).Should().BeApproximately(0.8075736, 1e-5);
+        ZScore(byX[0]).Should().BeApproximately(-0.8075736, 1e-5);
+        ZScore(byX[4]).Should().BeApproximately(-0.8075736, 1e-5);
+
+        // Two-tailed p-value relationship p = erfc(|z|/√2) must hold for every feature.
+        foreach (var feature in features)
+        {
+            var expectedP = Erfc(Math.Abs(ZScore(feature)) / Math.Sqrt(2.0));
+            PValue(feature).Should().BeApproximately(expectedP, 1e-6);
+        }
+    }
+
+    [UnitTest]
+    public async Task GiStar_FlagsAStrongHotSpot_WithA99PercentConfidenceBin()
+    {
+        // Four high-value (100) points clustered within the distance band, plus 16
+        // far-flung isolated low-value (1) points. Reference derivation:
+        //   n = 20, Σx = 416, X̄ = 20.8, Σx² = 40016, S = sqrt(40016/20 - 20.8²) = 39.6.
+        //   Cluster point: W = 4, Σ_N x = 400,
+        //     z = (400 - 20.8·4) / (39.6·sqrt(4·(20-4)/(20-1))) = 316.8 / (39.6·sqrt(64/19))
+        //       = 4.358806...  → p ≈ 1.3e-5 → Gi_Bin = +3 (99% hot).
+        //   Isolated point: W = 1, Σ_N x = 1,
+        //     z = (1 - 20.8) / (39.6·sqrt(1·19/19)) = -19.8 / 39.6 = -0.5 → Gi_Bin = 0.
+        var executor = new ManagedHotSpotExecutor(Options());
+
+        var features = new List<IFeature>
+        {
+            Feature(Point(0, 0), ("val", 100), ("kind", "hot")),
+            Feature(Point(0, 1), ("val", 100), ("kind", "hot")),
+            Feature(Point(1, 0), ("val", 100), ("kind", "hot")),
+            Feature(Point(1, 1), ("val", 100), ("kind", "hot")),
+        };
+        for (var i = 0; i < 16; i++)
+        {
+            features.Add(Feature(Point(100 + (i * 10), 0), ("val", 1), ("kind", "cold")));
+        }
+
+        var (status, uri) = await RunAsync(
+            executor,
+            ManagedHotSpotExecutor.HandledProcessId,
+            ("input", BuildUri(features.ToArray())),
+            ("field", "val"),
+            ("distanceBand", "1.5"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var results = ReadFeatures(uri!);
+        results.Should().HaveCount(20);
+
+        var hot = results.First(f =>
+            string.Equals(Convert.ToString(f.Attributes.GetOptionalValue("kind"), CultureInfo.InvariantCulture), "hot", StringComparison.Ordinal));
+        ZScore(hot).Should().BeApproximately(4.358806, 1e-3);
+        PValue(hot).Should().BeLessThan(0.01);
+        Bin(hot).Should().Be(3, "a 99%-confidence hot spot is binned +3");
+
+        var cold = results.First(f =>
+            string.Equals(Convert.ToString(f.Attributes.GetOptionalValue("kind"), CultureInfo.InvariantCulture), "cold", StringComparison.Ordinal));
+        ZScore(cold).Should().BeApproximately(-0.5, 1e-9);
+        Bin(cold).Should().Be(0, "an isolated below-mean feature is not statistically significant");
+    }
+
+    [UnitTest]
+    public async Task NonPointGeometry_IsAnalysedOnItsCentroid_AndAttributesArePreserved()
+    {
+        var executor = new ManagedHotSpotExecutor(Options());
+
+        var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(4326);
+        Polygon Square(double cx, double cy) => factory.CreatePolygon(new[]
+        {
+            new Coordinate(cx - 0.1, cy - 0.1),
+            new Coordinate(cx + 0.1, cy - 0.1),
+            new Coordinate(cx + 0.1, cy + 0.1),
+            new Coordinate(cx - 0.1, cy + 0.1),
+            new Coordinate(cx - 0.1, cy - 0.1),
+        });
+
+        var input = BuildUri(
+            Feature(Square(0, 0), ("val", 5), ("name", "a")),
+            Feature(Square(1, 0), ("val", 6), ("name", "b")),
+            Feature(Square(2, 0), ("val", 7), ("name", "c")));
+
+        var (status, uri) = await RunAsync(
+            executor,
+            ManagedHotSpotExecutor.HandledProcessId,
+            ("input", input),
+            ("field", "val"),
+            ("distanceBand", "1.5"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().HaveCount(3);
+        features.Should().AllSatisfy(f =>
+        {
+            f.Attributes.GetOptionalValue("name").Should().NotBeNull();
+            f.Attributes.Exists(ManagedHotSpotExecutor.ZScoreAttribute).Should().BeTrue();
+            f.Attributes.Exists(ManagedHotSpotExecutor.PValueAttribute).Should().BeTrue();
+            f.Attributes.Exists(ManagedHotSpotExecutor.BinAttribute).Should().BeTrue();
+            f.Geometry.SRID.Should().Be(4326);
+        });
+    }
+
+    [UnitTest]
+    public async Task SinglePoint_FailsCleanly()
+    {
+        var executor = new ManagedHotSpotExecutor(Options());
+        var (status, _) = await RunAsync(
+            executor,
+            ManagedHotSpotExecutor.HandledProcessId,
+            ("input", BuildUri(Feature(Point(0, 0), ("val", 1)))),
+            ("field", "val"),
+            ("distanceBand", "1.5"));
+
+        status.Should().Be(ExecutionJobStatus.Failed, "Gi* is undefined for fewer than two features");
+    }
+
+    [UnitTest]
+    public async Task AllIdenticalValues_FailCleanly()
+    {
+        var executor = new ManagedHotSpotExecutor(Options());
+        var (status, _) = await RunAsync(
+            executor,
+            ManagedHotSpotExecutor.HandledProcessId,
+            ("input", BuildUri(
+                Feature(Point(0, 0), ("val", 7)),
+                Feature(Point(1, 0), ("val", 7)),
+                Feature(Point(2, 0), ("val", 7)))),
+            ("field", "val"),
+            ("distanceBand", "1.5"));
+
+        status.Should().Be(ExecutionJobStatus.Failed, "a zero-variance analysis field has no hot/cold structure");
+    }
+
+    [UnitTest]
+    public async Task MissingDistanceBand_FailsCleanly()
+    {
+        var executor = new ManagedHotSpotExecutor(Options());
+        var (status, _) = await RunAsync(
+            executor,
+            ManagedHotSpotExecutor.HandledProcessId,
+            ("input", BuildUri(
+                Feature(Point(0, 0), ("val", 1)),
+                Feature(Point(1, 0), ("val", 2)))),
+            ("field", "val"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+    }
+
+    [UnitTest]
+    public async Task NonNumericAnalysisValue_FailsCleanly()
+    {
+        var executor = new ManagedHotSpotExecutor(Options());
+        var (status, _) = await RunAsync(
+            executor,
+            ManagedHotSpotExecutor.HandledProcessId,
+            ("input", BuildUri(
+                Feature(Point(0, 0), ("val", 1)),
+                Feature(Point(1, 0), ("val", "n/a")))),
+            ("field", "val"),
+            ("distanceBand", "1.5"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static double ZScore(IFeature feature)
+        => Convert.ToDouble(feature.Attributes.GetOptionalValue(ManagedHotSpotExecutor.ZScoreAttribute), CultureInfo.InvariantCulture);
+
+    private static double PValue(IFeature feature)
+        => Convert.ToDouble(feature.Attributes.GetOptionalValue(ManagedHotSpotExecutor.PValueAttribute), CultureInfo.InvariantCulture);
+
+    private static int Bin(IFeature feature)
+        => Convert.ToInt32(feature.Attributes.GetOptionalValue(ManagedHotSpotExecutor.BinAttribute), CultureInfo.InvariantCulture);
+
+    private static double Erfc(double x)
+    {
+        var z = Math.Abs(x);
+        var t = 1.0 / (1.0 + (0.5 * z));
+
+        var poly = 0.17087277;
+        poly = -0.82215223 + (t * poly);
+        poly = 1.48851587 + (t * poly);
+        poly = -1.13520398 + (t * poly);
+        poly = 0.27886807 + (t * poly);
+        poly = -0.18628806 + (t * poly);
+        poly = 0.09678418 + (t * poly);
+        poly = 0.37409196 + (t * poly);
+        poly = 1.00002368 + (t * poly);
+
+        var ans = t * Math.Exp((-z * z) - 1.26551223 + (t * poly));
+        return x >= 0.0 ? ans : 2.0 - ans;
+    }
+
+    private static IOptionsMonitor<GeoprocessingExecutorOptions> Options()
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return monitor;
+    }
+
+    private static Point Point(double x, double y)
+        => NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(4326).CreatePoint(new Coordinate(x, y));
+
+    private static Feature Feature(Geometry geometry, params (string Name, object Value)[] attributes)
+    {
+        var table = new AttributesTable();
+        foreach (var (name, value) in attributes)
+        {
+            table.Add(name, value);
+        }
+
+        return new Feature(geometry, table);
+    }
+
+    private static string BuildUri(params IFeature[] features)
+    {
+        var collection = new FeatureCollection();
+        foreach (var feature in features)
+        {
+            collection.Add(feature);
+        }
+
+        var json = new GeoJsonWriter().Write(collection);
+        return DataUriPrefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+    }
+
+    private static List<IFeature> ReadFeatures(string dataUri)
+    {
+        var bytes = Convert.FromBase64String(dataUri[DataUriPrefix.Length..]);
+        var json = Encoding.UTF8.GetString(bytes);
+        return new GeoJsonReader().Read<FeatureCollection>(json).ToList();
+    }
+
+    private static async Task<(ExecutionJobStatus Status, string? Uri)> RunAsync(
+        ManagedHotSpotExecutor executor,
+        string processId,
+        params (string Name, string Value)[] inputs)
+    {
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        foreach (var (name, value) in inputs)
+        {
+            parameters[prefix + name] = value;
+        }
+
+        var record = new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+        return (result.Status, publishedUri);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -73,7 +73,9 @@ public sealed class ProcessCatalogTests
         // proximity.euclidean-distance, proximity.euclidean-allocation,
         // surface.contour, surface.viewshed, conversion.polygonize,
         // conversion.rasterize (#2240).
-        all.Should().HaveCount(95);
+        // + 1 spatial-statistics tool-pack op (analytics.hotspot-managed, Hot Spot
+        // Analysis / Getis-Ord Gi*) added by #2142.
+        all.Should().HaveCount(96);
         all.Select(p => p.ProcessId).Should().OnlyHaveUniqueItems();
     }
 
@@ -91,15 +93,16 @@ public sealed class ProcessCatalogTests
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
-    public void Catalog_AnalyticsCategory_Returns8Processes()
+    public void Catalog_AnalyticsCategory_Returns9Processes()
     {
         var analytics = _catalog.GetProcessesByCategory("analytics");
 
         // 4 trunk analytics + analytics.spatial-join-managed +
         // 3 managed counterparts from #1260 (analytics.cluster-managed,
         // analytics.buffer-aggregate-managed, analytics.density-managed) — the
-        // job-dispatchable managed counterparts to the PostGIS-protocol entries.
-        analytics.Should().HaveCount(8);
+        // job-dispatchable managed counterparts to the PostGIS-protocol entries —
+        // + analytics.hotspot-managed (Getis-Ord Gi* Hot Spot Analysis, #2142).
+        analytics.Should().HaveCount(9);
         analytics.Should().AllSatisfy(p => p.Category.Should().Be("analytics"));
     }
 
@@ -257,6 +260,7 @@ public sealed class ProcessCatalogTests
             "analytics.cluster-managed",
             "analytics.buffer-aggregate-managed",
             "analytics.density-managed",
+            "analytics.hotspot-managed",
             "analytics.buffer-aggregate", "analytics.density",
             "surface.slope", "surface.aspect", "surface.hillshade",
             "surface.rugosity-tri", "surface.rugosity-tpi", "surface.roughness",


### PR DESCRIPTION
Closes #2142

Relands the managed Getis-Ord Gi* Hot Spot Analysis tool (`analytics.hotspot-managed`) that was reverted from the #2259 bundle to avoid duplication with the separate GP effort #2253. #2253 landed without the hotspot tool, so it was genuinely missing from trunk.

## What
- `ManagedHotSpotExecutor`: job-dispatchable, managed (NetTopologySuite) Hot Spot Analysis over an inline FeatureCollection, computing the Getis-Ord Gi* statistic per feature (fixed-distance-band conceptualization, STRtree neighbour search).
- Emits `GI_ZSCORE` (Gi* z-score), `GI_PVALUE` (two-tailed p-value via an erfc normal-CDF approximation) and `GI_BIN` (Esri-style confidence bin in [-3, 3]).
- Rejects degenerate inputs (fewer than two located features, zero variance) with clear errors; neutralises whole-dataset neighbourhoods.
- Registers the executor (`Register<ManagedHotSpotExecutor>`), adds the `analytics.hotspot-managed` catalog descriptor, and the plan-validator semantics — consistent with the other managed analytics tools (spatial-join/cluster/buffer-aggregate/density).
- Unit tests assert Gi* against hand-derived closed-form reference fixtures plus degenerate/bad-input handling.

## GP catalog count reconciliation
Reconciled with current trunk (which had caught up to 95 processes after the original bundle's count of 82):
- Total processes **95 -> 96**.
- Analytics category **8 -> 9**.

## Build / test
- `Honua.Geoprocessing` and `Honua.Server.Tests` build with 0 warnings / 0 errors.
- `ProcessCatalogTests`, `ManagedHotSpotExecutorTests`, `CatalogExecutableConformanceTests`: 125 passed, 0 failed.