### PR TITLE
feat(control-plane): Azure Monitor deploy telemetry evaluator for health-gated rollback parity (#1849)

### DIFF
--- a/src/Honua.Azure/Features/ControlPlane/AzureMonitorDeployTelemetryProviderEvaluator.cs
+++ b/src/Honua.Azure/Features/ControlPlane/AzureMonitorDeployTelemetryProviderEvaluator.cs
@@ -1,0 +1,293 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+using Azure.Core;
+using Azure.Identity;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Thin seam over the Azure Monitor Logs (Log Analytics / Application Insights) query API so the
+/// deploy telemetry gate can be unit-tested without a live Azure subscription. The production
+/// implementation is <see cref="AzureMonitorLogsQueryClient"/>; tests substitute a fake. The seam
+/// mirrors <c>ICloudWatchMetricClient</c> on the AWS side: a single scalar reading per configured
+/// signal evaluated over a fixed window.
+/// </summary>
+internal interface IAzureMonitorMetricClient
+{
+    /// <summary>
+    /// Evaluates a single Kusto (KQL) query against the supplied Log Analytics workspace over the
+    /// supplied window and returns the first scalar cell of the first result row, or <c>null</c>
+    /// when the workspace returned no rows.
+    /// </summary>
+    Task<double?> GetScalarValueAsync(
+        string workspaceId,
+        string query,
+        TimeSpan window,
+        string? endpointOverride = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Azure Monitor Logs query client using direct HTTPS calls to the Log Analytics query API
+/// (<c>https://api.loganalytics.io</c> by default), authenticated with
+/// <see cref="DefaultAzureCredential"/>. Direct-REST is the same approach the sibling Azure deploy
+/// adapters (<c>AzureManagementContainerAppsRevisionClient</c>,
+/// <c>AzureManagementFunctionsSlotClient</c>) take against <c>management.azure.com</c>, so the
+/// Azure surface does not pull the heavier Azure.Monitor.Query SDK transitively.
+/// </summary>
+internal sealed class AzureMonitorLogsQueryClient(IHttpClientFactory httpClientFactory)
+    : IAzureMonitorMetricClient
+{
+    // Public-cloud Log Analytics query endpoint. Sovereign clouds (for example
+    // https://api.loganalytics.azure.cn or https://api.loganalytics.us) supply an endpoint override
+    // on the telemetry connection's BaseUrl.
+    internal const string DefaultEndpoint = "https://api.loganalytics.io";
+
+    private readonly TokenCredential _credential = new DefaultAzureCredential();
+
+    public async Task<double?> GetScalarValueAsync(
+        string workspaceId,
+        string query,
+        TimeSpan window,
+        string? endpointOverride = null,
+        CancellationToken cancellationToken = default)
+    {
+        var endpoint = ResolveEndpoint(endpointOverride);
+        var requestUri = new Uri(endpoint, $"v1/workspaces/{Uri.EscapeDataString(workspaceId)}/query");
+
+        var payload = BuildQueryPayload(query, window);
+        using var request = await CreateRequestAsync(endpoint, requestUri, payload, cancellationToken).ConfigureAwait(false);
+
+        using var client = httpClientFactory.CreateClient("control-plane-azure");
+        using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, cancellationToken).ConfigureAwait(false);
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return ParseScalar(document.RootElement);
+    }
+
+    private async Task<HttpRequestMessage> CreateRequestAsync(
+        Uri endpoint,
+        Uri requestUri,
+        byte[] payload,
+        CancellationToken cancellationToken)
+    {
+        // The token resource follows the resolved endpoint authority so sovereign-cloud endpoints
+        // sign with the matching audience (https://{host}/.default).
+        var scope = $"https://{endpoint.Host}/.default";
+
+        AccessToken accessToken;
+        try
+        {
+            accessToken = await _credential.GetTokenAsync(
+                    new TokenRequestContext([scope]),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (AuthenticationFailedException ex)
+        {
+            // Normalize credential failures to a null-status HttpRequestException so they flow
+            // through the same recoverable path as transport failures (mirrors the Container Apps /
+            // Functions ARM clients): the backend preserves durable rollout state on an ambiguous
+            // outcome instead of terminalizing on a transient managed-identity IMDS hiccup.
+            throw new HttpRequestException(
+                "Azure Monitor Logs query credential acquisition failed.",
+                ex);
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+        request.Content = new ByteArrayContent(payload);
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json")
+        {
+            CharSet = Encoding.UTF8.WebName
+        };
+
+        return request;
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        throw new HttpRequestException(
+            $"Azure Monitor Logs query failed with status {(int)response.StatusCode}: {body}",
+            null,
+            response.StatusCode);
+    }
+
+    private static byte[] BuildQueryPayload(string query, TimeSpan window)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+        writer.WriteStartObject();
+        writer.WriteString("query", query);
+        // ISO 8601 duration (for example "PT5M") restricts the query to the rollout's bake window,
+        // matching the CloudWatch evaluator's fixed-window metric-math evaluation.
+        writer.WriteString("timespan", XmlConvert.ToString(window));
+        writer.WriteEndObject();
+        writer.Flush();
+
+        return stream.ToArray();
+    }
+
+    // The Log Analytics query response shape is { "tables": [ { "columns": [...],
+    // "rows": [ [ <cell>, ... ], ... ] } ] }. A health/error/latency gate query is expected to
+    // project a single scalar; read tables[0].rows[0][0] and coerce it to a double.
+    private static double? ParseScalar(JsonElement root)
+    {
+        if (!root.TryGetProperty("tables", out var tables) ||
+            tables.ValueKind != JsonValueKind.Array ||
+            tables.GetArrayLength() == 0)
+        {
+            return null;
+        }
+
+        var table = tables[0];
+        if (!table.TryGetProperty("rows", out var rows) ||
+            rows.ValueKind != JsonValueKind.Array ||
+            rows.GetArrayLength() == 0)
+        {
+            return null;
+        }
+
+        var firstRow = rows[0];
+        if (firstRow.ValueKind != JsonValueKind.Array || firstRow.GetArrayLength() == 0)
+        {
+            return null;
+        }
+
+        var cell = firstRow[0];
+        return cell.ValueKind switch
+        {
+            JsonValueKind.Number => cell.GetDouble(),
+            JsonValueKind.String when double.TryParse(
+                cell.GetString(),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var parsed) => parsed,
+            _ => null
+        };
+    }
+
+    private static Uri ResolveEndpoint(string? endpointOverride)
+    {
+        if (!string.IsNullOrWhiteSpace(endpointOverride) &&
+            Uri.TryCreate(endpointOverride.Trim(), UriKind.Absolute, out var overrideUri))
+        {
+            return overrideUri;
+        }
+
+        return new Uri(DefaultEndpoint);
+    }
+}
+
+/// <summary>
+/// Azure Monitor-backed deploy telemetry provider. Selected when a telemetry connection's
+/// <c>Provider</c> is <c>azuremonitor</c>. The policy's error-rate / latency / sample-count query
+/// strings are interpreted as Log Analytics / Application Insights KQL queries that each project a
+/// single scalar. Thresholds and the promote/rollback/wait decision are shared with every other
+/// provider via <c>DeployTelemetrySignalEvaluator</c>, so only the query dialect differs from the
+/// Prometheus and CloudWatch evaluators — giving Azure deploy backends the same health-gated safe
+/// rollout + auto-rollback parity as the AWS backends.
+/// </summary>
+internal sealed class AzureMonitorDeployTelemetryProviderEvaluator(
+    IAzureMonitorMetricClient metricClient) : IDeployTelemetryProviderEvaluator
+{
+    // Mirror the Prometheus presets' 5m rate window and the CloudWatch evaluator's 300s sample
+    // horizon so thresholds keep the same meaning across providers.
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(300);
+
+    public string Provider => "azuremonitor";
+
+    public async Task<DeployTelemetryReadings> ReadAsync(
+        DeployTelemetryPolicyDescriptor policy,
+        DeployTelemetryConnectionDescriptor connection,
+        CancellationToken cancellationToken)
+    {
+        // Azure Monitor has no preset query dialect; the Honua HTTP presets emit PromQL. Require the
+        // operator to supply explicit KQL queries so we never silently ship PromQL to Log Analytics
+        // and stall the gate.
+        if (!policy.HasExplicitQueryOverride)
+        {
+            throw new InvalidOperationException(
+                $"Telemetry connection '{connection.ConnectionId}' uses the azuremonitor provider, which requires explicit " +
+                "telemetry.error_rate.query / telemetry.latency_p95.query / telemetry.sample_count.query KQL queries.");
+        }
+
+        // The Log Analytics workspace id is carried on the connection's Region field, mirroring how
+        // the CloudWatch evaluator repurposes Region for the AWS region. BaseUrl, when non-default,
+        // overrides the query endpoint for sovereign clouds.
+        var workspaceId = ResolveWorkspaceId(connection);
+        if (string.IsNullOrWhiteSpace(workspaceId))
+        {
+            throw new InvalidOperationException(
+                $"Telemetry connection '{connection.ConnectionId}' uses the azuremonitor provider, which requires the " +
+                "Log Analytics workspace id to be supplied via the connection's Region setting.");
+        }
+
+        var endpointOverride = ResolveEndpointOverride(connection);
+
+        var sampleCount = string.IsNullOrWhiteSpace(policy.MinimumSampleQuery)
+            ? (double?)null
+            : await metricClient.GetScalarValueAsync(workspaceId, policy.MinimumSampleQuery, Window, endpointOverride, cancellationToken).ConfigureAwait(false);
+
+        // Short-circuit when the sample-count gate already fails; mirrors the Prometheus/CloudWatch
+        // evaluators that do not read error-rate/latency until the minimum sample gate clears.
+        if (policy.MinimumSampleCount.HasValue && (!sampleCount.HasValue || sampleCount.Value < policy.MinimumSampleCount.Value))
+        {
+            return new DeployTelemetryReadings { SampleCount = sampleCount };
+        }
+
+        double? errorRate = null;
+        if (!string.IsNullOrWhiteSpace(policy.ErrorRateQuery) && policy.ErrorRateThreshold.HasValue)
+        {
+            errorRate = await metricClient.GetScalarValueAsync(workspaceId, policy.ErrorRateQuery, Window, endpointOverride, cancellationToken).ConfigureAwait(false);
+        }
+
+        double? latencyP95 = null;
+        if (!string.IsNullOrWhiteSpace(policy.LatencyP95Query) && policy.LatencyP95ThresholdMs.HasValue)
+        {
+            latencyP95 = await metricClient.GetScalarValueAsync(workspaceId, policy.LatencyP95Query, Window, endpointOverride, cancellationToken).ConfigureAwait(false);
+        }
+
+        return new DeployTelemetryReadings
+        {
+            SampleCount = sampleCount,
+            ErrorRate = errorRate,
+            LatencyP95 = latencyP95
+        };
+    }
+
+    private static string? ResolveWorkspaceId(DeployTelemetryConnectionDescriptor connection)
+        => string.IsNullOrWhiteSpace(connection.Region) ? null : connection.Region.Trim();
+
+    // A non-default BaseUrl selects a sovereign-cloud Log Analytics endpoint; the standard public
+    // endpoint (or an unset BaseUrl) leaves the client on its built-in default.
+    private static string? ResolveEndpointOverride(DeployTelemetryConnectionDescriptor connection)
+    {
+        if (string.IsNullOrWhiteSpace(connection.BaseUrl) ||
+            !Uri.TryCreate(connection.BaseUrl, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        var isStandardPublicEndpoint = string.Equals(
+            uri.Host,
+            new Uri(AzureMonitorLogsQueryClient.DefaultEndpoint).Host,
+            StringComparison.OrdinalIgnoreCase);
+
+        return isStandardPublicEndpoint ? null : connection.BaseUrl.Trim();
+    }
+}

--- a/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
+++ b/src/Honua.Server/Startup/BatchAndDeployBackendsRegistration.cs
@@ -37,11 +37,16 @@ internal static class BatchAndDeployBackendsRegistration
 
         // Multi-provider deploy telemetry gate. The dispatcher selects a provider evaluator by the
         // telemetry connection's Provider; Prometheus is always available, CloudWatch is added with
-        // the rest of the AWS surface.
+        // the rest of the AWS surface, and Azure Monitor with the Azure surface so Azure deploy
+        // backends get the same health-gated rollback parity as AWS.
         services.AddSingleton<IDeployTelemetryProviderEvaluator, PrometheusDeployTelemetryProviderEvaluator>();
 #if !HONUA_EXCLUDE_AWS
         services.AddSingleton<ICloudWatchMetricClient, AwsSdkCloudWatchMetricClient>();
         services.AddSingleton<IDeployTelemetryProviderEvaluator, CloudWatchDeployTelemetryProviderEvaluator>();
+#endif
+#if !HONUA_EXCLUDE_AZURE
+        services.AddSingleton<IAzureMonitorMetricClient, AzureMonitorLogsQueryClient>();
+        services.AddSingleton<IDeployTelemetryProviderEvaluator, AzureMonitorDeployTelemetryProviderEvaluator>();
 #endif
         // Provider-independent synthetic /healthz/ready gate inherited by every deploy backend.
         services.AddSingleton<IDeployHealthProbe, HttpDeployHealthProbe>();

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AzureMonitorDeployTelemetryProviderEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/AzureMonitorDeployTelemetryProviderEvaluatorTests.cs
@@ -1,0 +1,273 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.ControlPlane;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Verifies the Azure Monitor deploy telemetry provider end-to-end through the multi-provider
+/// dispatcher with a faked Log Analytics query client (no live Azure subscription required). Mirrors
+/// <see cref="CloudWatchDeployTelemetryProviderEvaluatorTests"/> so the Azure evaluator is held to
+/// the same promote/rollback/wait contract as the AWS one.
+/// </summary>
+public sealed class AzureMonitorDeployTelemetryProviderEvaluatorTests
+{
+    private const string ErrorRateQuery = "requests | summarize errors=todouble(countif(success==false))/count()";
+    private const string LatencyQuery = "requests | summarize percentile(duration, 95)";
+    private const string SampleQuery = "requests | summarize count()";
+    private const string WorkspaceId = "11111111-2222-3333-4444-555555555555";
+
+    [Fact]
+    public async Task EvaluateAsync_HealthyAzureMonitorMetrics_ReturnsPromoteSignal()
+    {
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleQuery] = 50,
+            [ErrorRateQuery] = 0.01,
+            [LatencyQuery] = 120
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeFalse();
+        decision.RollbackRecommended.Should().BeFalse();
+        client.RequestedQueries.Should().Contain([SampleQuery, ErrorRateQuery, LatencyQuery]);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_BreachingErrorRate_ReturnsRollbackSignal()
+    {
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleQuery] = 50,
+            [ErrorRateQuery] = 0.4,
+            [LatencyQuery] = 120
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.RollbackRecommended.Should().BeTrue();
+        decision.WaitForMoreTelemetry.Should().BeFalse();
+        decision.Message.Should().Contain("error rate");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_BreachingLatency_ReturnsRollbackSignal()
+    {
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleQuery] = 50,
+            [ErrorRateQuery] = 0.01,
+            [LatencyQuery] = 9000
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.RollbackRecommended.Should().BeTrue();
+        decision.Message.Should().Contain("latency");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_BelowMinimumSampleCount_WaitsForMoreTelemetry()
+    {
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleQuery] = 3,
+            [ErrorRateQuery] = 0.4,
+            [LatencyQuery] = 9000
+        });
+
+        var decision = await Evaluate(client);
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeTrue();
+        decision.RollbackRecommended.Should().BeFalse();
+        // Error-rate / latency must not be read until the minimum sample gate clears.
+        client.RequestedQueries.Should().ContainSingle().Which.Should().Be(SampleQuery);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithoutExplicitQueries_FailsClosedToWait()
+    {
+        // Azure Monitor has no preset query dialect (presets emit PromQL); a connection that relies
+        // on a preset must fall back to a wait rather than shipping PromQL to Log Analytics.
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal));
+
+        var evaluator = CreateDispatcher(client);
+        var decision = await evaluator.EvaluateAsync(CreateOperation(new Dictionary<string, string>
+        {
+            ["telemetry.connection"] = "prod-azmon",
+            ["telemetry.policy"] = "azure-aca-canary",
+            ["telemetry.prometheus.canary_job"] = "honua-canary"
+        }));
+
+        decision.Should().NotBeNull();
+        decision!.WaitForMoreTelemetry.Should().BeTrue();
+        client.RequestedQueries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PassesWorkspaceId_FromConnectionRegion()
+    {
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleQuery] = 50,
+            [ErrorRateQuery] = 0.01,
+            [LatencyQuery] = 120
+        });
+
+        await Evaluate(client);
+
+        client.LastWorkspaceId.Should().Be(WorkspaceId);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_StandardPublicEndpoint_DoesNotForwardEndpointOverride()
+    {
+        // The public Log Analytics endpoint is the client default and must NOT be forwarded as an
+        // override, so production connections keep the built-in endpoint + audience.
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleQuery] = 50,
+            [ErrorRateQuery] = 0.01,
+            [LatencyQuery] = 120
+        });
+
+        await Evaluate(client, baseUrl: "https://api.loganalytics.io");
+
+        client.LastEndpointOverride.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_SovereignEndpoint_ForwardsEndpointOverride()
+    {
+        // A non-default Log Analytics endpoint (sovereign cloud) must be forwarded so the gate signs
+        // and queries against the matching authority.
+        var client = new FakeAzureMonitorMetricClient(new Dictionary<string, double?>(StringComparer.Ordinal)
+        {
+            [SampleQuery] = 50,
+            [ErrorRateQuery] = 0.01,
+            [LatencyQuery] = 120
+        });
+
+        await Evaluate(client, baseUrl: "https://api.loganalytics.us");
+
+        client.LastEndpointOverride.Should().Be("https://api.loganalytics.us");
+    }
+
+    private static async Task<DeployTelemetryDecision?> Evaluate(
+        FakeAzureMonitorMetricClient client,
+        string baseUrl = "https://api.loganalytics.io")
+    {
+        var evaluator = CreateDispatcher(client, baseUrl);
+        return await evaluator.EvaluateAsync(CreateOperation(new Dictionary<string, string>
+        {
+            ["telemetry.connection"] = "prod-azmon",
+            ["telemetry.error_rate.query"] = ErrorRateQuery,
+            ["telemetry.error_rate.threshold"] = "0.05",
+            ["telemetry.latency_p95.query"] = LatencyQuery,
+            ["telemetry.latency_p95.threshold_ms"] = "2000",
+            ["telemetry.sample_count.query"] = SampleQuery,
+            ["telemetry.sample_count.minimum"] = "10"
+        }));
+    }
+
+    private static DeployTelemetrySignalEvaluator CreateDispatcher(
+        FakeAzureMonitorMetricClient client,
+        string baseUrl = "https://api.loganalytics.io")
+    {
+        var azureMonitorProvider = new AzureMonitorDeployTelemetryProviderEvaluator(client);
+        var options = new ControlPlaneOptions
+        {
+            TelemetryConnections =
+            [
+                new DeployTelemetryConnectionOptions
+                {
+                    ConnectionId = "prod-azmon",
+                    Provider = "azuremonitor",
+                    BaseUrl = baseUrl,
+                    Region = WorkspaceId,
+                    TimeoutSeconds = 2
+                }
+            ]
+        };
+
+        return new DeployTelemetrySignalEvaluator(
+            new TestControlPlaneOptionsMonitor(options),
+            [azureMonitorProvider],
+            NullLogger<DeployTelemetrySignalEvaluator>.Instance);
+    }
+
+    private static WorkflowOperationRecord CreateOperation(IReadOnlyDictionary<string, string> parameters)
+    {
+        var now = DateTimeOffset.UtcNow.AddMinutes(-5);
+        return new WorkflowOperationRecord
+        {
+            OperationId = $"deploy-{Guid.NewGuid():N}",
+            Kind = WorkflowOperationKind.Deploy,
+            Status = WorkflowOperationStatus.Reconciling,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CurrentPhase = "Reconciling rollout",
+            Audit = new OperationAuditInfo(),
+            Concurrency = new OperationConcurrencyPolicy
+            {
+                PartitionKey = "production:prod-api",
+                RequiresExclusiveLease = true
+            },
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = "prod-api",
+                TargetKind = DeployTargetKind.AzureContainerApps,
+                Backend = "honua-azure-container-apps-revision",
+                Environment = "production",
+                TargetName = "honua-server",
+                ArtifactReference = "ghcr.io/honua/server",
+                RuntimeProfile = "dotnet-api",
+                CurrentRevision = "honua-server--old",
+                DesiredRevision = "honua-server--new",
+                Parameters = new Dictionary<string, string>(parameters, StringComparer.Ordinal)
+            }
+        };
+    }
+
+    private sealed class TestControlPlaneOptionsMonitor(ControlPlaneOptions currentValue) : IOptionsMonitor<ControlPlaneOptions>
+    {
+        public ControlPlaneOptions CurrentValue => currentValue;
+
+        public ControlPlaneOptions Get(string? name) => currentValue;
+
+        public IDisposable? OnChange(Action<ControlPlaneOptions, string?> listener) => null;
+    }
+
+    private sealed class FakeAzureMonitorMetricClient(IReadOnlyDictionary<string, double?> values) : IAzureMonitorMetricClient
+    {
+        public ConcurrentQueue<string> RequestedQueries { get; } = new();
+
+        public string? LastWorkspaceId { get; private set; }
+
+        public string? LastEndpointOverride { get; private set; }
+
+        public Task<double?> GetScalarValueAsync(
+            string workspaceId,
+            string query,
+            TimeSpan window,
+            string? endpointOverride = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastWorkspaceId = workspaceId;
+            LastEndpointOverride = endpointOverride;
+            RequestedQueries.Enqueue(query);
+            return Task.FromResult(values.TryGetValue(query, out var value) ? value : null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1849.

Implements the remaining gap in #1849: **Azure parity for the deploy telemetry gate**. Adds an `AzureMonitorDeployTelemetryProviderEvaluator` (provider key `azuremonitor`) so Azure deploy backends get the same health-gated safe-rollout + auto-rollback metrics evaluation that AWS (CloudWatch) and Prometheus already have. The synthetic `/healthz/ready` gate + auto-rollback already landed on trunk; this fills in the missing metrics evaluator for Azure.

## What changed

- **`AzureMonitorDeployTelemetryProviderEvaluator`** (in `Honua.Azure`) — interprets the policy's error-rate / p95-latency / sample-count query strings as Log Analytics / Application Insights **KQL** queries and returns raw readings. Thresholds and the promote/rollback/wait decision are unchanged and shared via `DeployTelemetrySignalEvaluator`, so only the query dialect differs from the Prometheus / CloudWatch evaluators.
- **`AzureMonitorLogsQueryClient`** — a thin, testable seam (`IAzureMonitorMetricClient`) over the Azure Monitor Logs query API (`https://api.loganalytics.io/v1/workspaces/{workspaceId}/query`). It uses **direct HTTPS + `DefaultAzureCredential`**, exactly the raw-REST convention the sibling Azure deploy adapters (`AzureManagementContainerAppsRevisionClient`, `AzureManagementFunctionsSlotClient`) already use against `management.azure.com` — so the Azure surface does **not** pull the heavier `Azure.Monitor.Query` SDK. Credential failures are normalized to a null-status `HttpRequestException` so an IMDS hiccup is treated as a recoverable/ambiguous outcome, matching the ARM clients. Sovereign-cloud endpoints are supported via a `BaseUrl` override (token audience derived from the resolved host).
- **DI registration** in `BatchAndDeployBackendsRegistration.cs` — registers the client + evaluator under the `!HONUA_EXCLUDE_AZURE` Azure surface, alongside the existing CloudWatch (AWS) and Prometheus (always-on) evaluators.

## How it mirrors the AWS / Prometheus evaluators

- Same `IDeployTelemetryProviderEvaluator` contract and `Provider`-keyed dispatch.
- Same **explicit-query requirement** (the built-in presets emit PromQL; a non-Prometheus provider fails closed to a wait rather than shipping PromQL to the wrong backend).
- Same **sample-count short-circuit** (error-rate / latency are not read until the minimum-sample gate clears) and the same fixed **300s** evaluation window.
- The Log Analytics **workspace id** is carried on the connection's `Region` field, mirroring how the CloudWatch evaluator repurposes `Region` for the AWS region.

## Tests

`AzureMonitorDeployTelemetryProviderEvaluatorTests` mirrors `CloudWatchDeployTelemetryProviderEvaluatorTests` (faked metric client, no live Azure): healthy→promote, error-rate breach→rollback, latency breach→rollback, below-min-sample→wait, no-explicit-queries→fail-closed wait, workspace-id passthrough, and standard-vs-sovereign endpoint override.

## Build / test

- `dotnet build` of `Honua.Azure` and `Honua.Server.Tests`: **0 warnings, 0 errors**.
- New evaluator tests: **8/8 green**; full `Features.Infrastructure.ControlPlane` suite: **680 passed, 2 skipped**.
- Two pre-existing `Honua.Architecture.Tests` failures (a SceneServer attribute route missing a feature-catalog entry) are unrelated to this change — they touch no files in this diff.

## Scope note

This PR covers the **Azure telemetry-evaluator** half of #1849's Azure-parity criterion. The Azure `IDeployBackend` canary (Container Apps revision split / Functions slot swap) is a separate, larger piece; this evaluator is what those backends gate on and is the missing metrics-parity primitive.
