### PR TITLE
fix: register usage-ranking endpoint in EndpointRegistry (#2274 follow-up)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -1590,6 +1590,22 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-admin-geoprocessing-tools-usage-ranking",
+      "route": "/api/v1/admin/geoprocessing/tools/usage-ranking",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.GeoprocessingUsageEndpointsTests.GetUsageRanking_AfterRecordingInvocations_RanksMostInvokedFirst",
+        "Honua.Server.Tests.Features.Admin.GeoprocessingUsageEndpointsTests.GetUsageRanking_WithLimit_TruncatesToRequestedCount",
+        "Honua.Server.Tests.Features.Admin.GeoprocessingUsageEndpointsTests.GetUsageRanking_WithNonPositiveLimit_Returns400",
+        "Honua.Server.Tests.Features.Admin.GeoprocessingUsageEndpointsTests.GetUsageRanking_WithoutAdminAuth_IsUnauthorized"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-admin-identity-providers",
       "route": "/api/v1/admin/identity/providers",
       "method": "GET",

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -201,6 +201,7 @@ public static class EndpointRegistry
         new("GET", "/api/v1/admin/cache/status"),
         new("POST", "/api/v1/admin/cache/invalidate"),
         new("GET", "/api/v1/admin/geocoding/providers"),
+        new("GET", "/api/v1/admin/geoprocessing/tools/usage-ranking"),
         new("GET", "/api/v1/admin/features"),
 
         // v1 admin rate limit policy endpoints (#355)


### PR DESCRIPTION
#2274 merged the `GET /api/v1/admin/geoprocessing/tools/usage-ranking` endpoint but missed adding the route to `EndpointRegistry.All`, so the architecture guard `EveryDiscoveredEndpoint_IsRegisteredInEndpointRegistry` and the feature-catalog drift guard are red on trunk. Register the route and regenerate `docs/gis/data/feature-catalog.json` (picks up the existing `[Endpoint]`-attributed `GeoprocessingUsageEndpointsTests`). Guards: 10/10 pass. +17 lines.