### PR TITLE
feat: GP MVP follow-ups — sink approval, central authz, raster sourcing, NoData, docs (#2262, #2263, #2264, #2265, #2267)

### DIFF
--- a/docs/reference/geoprocessing-operations.md
+++ b/docs/reference/geoprocessing-operations.md
@@ -5,7 +5,8 @@ Catalog of the built-in geoprocessing processes (process catalog `honua.process_
 Execution notes that apply across families:
 
 - **Runtime profile.** Processes marked *native* below execute out-of-process in the heavyweight GDAL worker image; the lean GDAL-free serving image validates their plans but never executes them. A deployment without the GDAL worker cannot run them.
-- **Raster sourcing.** Native raster/surface processes currently read the raster as base64-encoded GeoTIFF bytes on the `source` parameter; layer-resolved sourcing (`layerId`/`rasterId`) is declared but not yet wired.
+- **Raster sourcing.** Native raster/surface processes accept the raster either as base64-encoded GeoTIFF bytes on the `source` parameter, or by reference to a registered catalog raster via `layerId`/`rasterId` (#2264). Layer/raster references are resolved on the submit side and materialized onto `source` before dispatch, so a plan must supply exactly one of `source`, `layerId`, or `rasterId`. Layer-resolved sourcing requires a configured raster catalog; deployments without one must supply an inline `source`.
+- **NoData (raster calc).** `raster.map-algebra`, `raster.spectral-index`, and `raster.reclassify` propagate NoData: each input is masked by its own NoData, and the output band is tagged with an explicit `noData` value when supplied, otherwise with the first source raster's detected band NoData (#2267).
 - **Inline FeatureCollections.** `*-managed`, `transform.*`, `source.*`, and `sink.*` processes exchange features as `data:application/geo+json;base64` data URIs so they compose as workflow nodes.
 - **Approval gate.** `data-management.delete-features` and `data-management.calculate-field` are destructive and require operator approval.
 - **Admission.** Submissions pass through admission control (`ExecutionAdmission__*` — see [environment variables](configuration/environment-variables.md#admission-and-pooling)).

--- a/docs/reference/geoprocessing-operations.md
+++ b/docs/reference/geoprocessing-operations.md
@@ -2,17 +2,20 @@
 
 Catalog of the built-in geoprocessing processes (process catalog `honua.process_catalog.builtin.v1`). The same catalog is exposed through three surfaces: OGC API Processes (`/ogc/processes/processes`), the ArcGIS-compatible GPServer adapter (`/rest/services/{serviceId}/GPServer`), and gRPC `geospatial.v1.ProcessService`. For a submit/poll/fetch walkthrough see [run geoprocessing](../guides/query-analyze/run-geoprocessing.md); to write your own process, see [author a geoprocessing process](../guides/query-analyze/gp-devkit-authoring.md).
 
+The catalog currently registers **95 processes** across 14 families. This page is regenerated from `src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs`; a catalog-vs-doc parity test (`tests/dotnet/Honua.Architecture.Tests/GeoprocessingCatalogDocParityTests.cs`) fails the build if a registered process id is missing here.
+
 Execution notes that apply across families:
 
-- **Runtime profile.** Processes marked *native* below execute out-of-process in the heavyweight GDAL worker image; the lean GDAL-free serving image validates their plans but never executes them. A deployment without the GDAL worker cannot run them.
-- **Raster sourcing.** Native raster/surface processes currently read the raster as base64-encoded GeoTIFF bytes on the `source` parameter; layer-resolved sourcing (`layerId`/`rasterId`) is declared but not yet wired.
-- **Inline FeatureCollections.** `*-managed`, `transform.*`, `source.*`, and `sink.*` processes exchange features as `data:application/geo+json;base64` data URIs so they compose as workflow nodes.
+- **Runtime profile.** Processes marked *native* below declare `RuntimeProfile = native` and execute out-of-process in the heavyweight GDAL/PDAL worker image; the lean GDAL-free serving image validates their plans (parameter shape + per-process semantic rules) but never executes them. **A deployment without the GDAL worker cannot run any native process** — all `surface.*`, all `raster.*`, the native `conversion.*` (raster/OGR/point-cloud) idioms, `proximity.euclidean-*`, `source.ogr`, `gdal.*`, and `pcloud.translate`. 30 of the 95 processes are native.
+- **Flagged / unsupported.** Two native processes are advertised so callers can *discover* the capability gap but **fail with a clear message when submitted** rather than silently substituting a different algorithm: `raster.interpolate-kriging` (no kriging backend in the worker image — use `raster.interpolate-idw`) and `proximity.euclidean-allocation` (stock GDAL `gdal_proximity` computes distance only — use `proximity.euclidean-distance`).
+- **Raster sourcing.** Native raster/surface processes read the raster as base64-encoded GeoTIFF bytes on the `source` parameter; `layerId`/`rasterId` selectors are declared but layer-resolved sourcing is a follow-on and `source` remains required today.
+- **Inline FeatureCollections.** Managed `*-managed`, `overlay.*`, `proximity.near*`, `statistics.*`, `transform.*`, `source.*`, and `sink.*` processes exchange features as `data:application/geo+json;base64` data URIs so they compose as workflow nodes.
 - **Approval gate.** `data-management.delete-features` and `data-management.calculate-field` are destructive and require operator approval.
 - **Admission.** Submissions pass through admission control (`ExecutionAdmission__*` — see [environment variables](configuration/environment-variables.md#admission-and-pooling)).
 
 ## Geometry (14)
 
-Single-geometry operations; inputs are base64-encoded WKB plus an SRID.
+Single-geometry operations; inputs are base64-encoded WKB plus an SRID. Managed (NetTopologySuite/PostGIS-equivalent).
 
 | Process ID | Description | Key parameters |
 | --- | --- | --- |
@@ -33,54 +36,52 @@ Single-geometry operations; inputs are base64-encoded WKB plus an SRID.
 
 ## Analytics (8)
 
-The layer-scoped processes (`analytics.cluster`, `analytics.spatial-join`, `analytics.buffer-aggregate`, `analytics.density`) run synchronously against PostGIS-backed layers and are **not job-dispatchable**; each has a job-executable `*-managed` counterpart that runs in managed code (NetTopologySuite) over inline FeatureCollections. All layer-scoped processes accept the shared GeoServices filter parameters (`where`, `objectIds`, `geometry`, `geometryType`, `inSR`, `spatialRel`, `time`, `timeRelation`).
+The layer-scoped processes (`analytics.cluster`, `analytics.spatial-join`, `analytics.buffer-aggregate`, `analytics.density`) run synchronously against PostGIS-backed layers and are **not job-dispatchable**; each has a job-executable `*-managed` counterpart that runs in managed code (NetTopologySuite) over inline FeatureCollections. The layer-scoped processes accept the shared GeoServices filter parameters (`where`, `objectIds`, `geometry`, `geometryType`, `inSR`, `spatialRel`, `time`, `timeRelation`). Managed-counterpart distances are evaluated in CRS units (no geodesic conversion).
 
 | Process ID | Description | Key parameters |
 | --- | --- | --- |
-| `analytics.cluster` | DBSCAN or K-Means clustering on a layer. | `layerId`, `algorithm`, `eps`, `minPoints`, `k`, `returnHullPerCluster`, `outStatistics` |
-| `analytics.spatial-join` | Enrich target features from a join layer by spatial predicate. | `layerId`, `joinLayerId`, `predicate` (intersects/contains/within/dwithin), `distance`, `carryFields`, `outStatistics` |
-| `analytics.buffer-aggregate` | Buffer and optionally dissolve per group with statistics. | `layerId`, `distance`, `unit`, `dissolve`, `groupByFields`, `outStatistics` |
-| `analytics.density` | Hex or square grid binning with counts or weighted sums. | `layerId`, `mode`, `cellSize` (m), `weightField` |
-| `analytics.cluster-managed` | Job-executable DBSCAN/K-Means over inline features; appends `CLUSTER_ID`. Distances in CRS units. | `input`, `algorithm`, `eps`, `minPoints`, `k` |
+| `analytics.cluster` | DBSCAN or K-Means clustering on a layer (synchronous, PostGIS). | `layerId`, `algorithm`, `eps`, `minPoints`, `k`, `returnHullPerCluster`, `outStatistics` |
+| `analytics.spatial-join` | Enrich target features from a join layer by spatial predicate (synchronous, PostGIS). | `layerId`, `joinLayerId`, `predicate`, `distance`, `carryFields`, `outStatistics` |
+| `analytics.buffer-aggregate` | Buffer and optionally dissolve per group with statistics (synchronous, PostGIS). | `layerId`, `distance`, `unit`, `dissolve`, `groupByFields`, `outStatistics` |
+| `analytics.density` | Hex or square grid binning with counts or weighted sums (synchronous, PostGIS). | `layerId`, `mode`, `cellSize` (m), `weightField` |
+| `analytics.cluster-managed` | Job-executable DBSCAN/K-Means over inline features; appends `CLUSTER_ID`. | `input`, `algorithm`, `eps`, `minPoints`, `k` |
 | `analytics.spatial-join-managed` | Job-executable join over two inline FeatureCollections; `JOIN_COUNT` plus sum/mean/min/max aggregates. | `input`, `join`, `predicate`, `statistics` |
 | `analytics.buffer-aggregate-managed` | Job-executable buffer-and-dissolve over inline features. | `input`, `distance`, `unit`, `dissolve`, `groupByFields` |
-| `analytics.density-managed` | Job-executable hex/square binning over inline features; cell size in CRS units. | `input`, `mode`, `cellSize`, `weightField` |
+| `analytics.density-managed` | Job-executable hex/square binning over inline features. | `input`, `mode`, `cellSize`, `weightField` |
 
-## Surface analysis (6) — native
+## Overlay (6)
 
-DEM-derived raster products executed by the GDAL worker via `gdaldem`. All take `source` (base64 GeoTIFF DEM) and publish a GeoTIFF artifact.
-
-| Process ID | Description | Key parameters |
-| --- | --- | --- |
-| `surface.slope` | Slope raster. | `units` (degrees/percent), `zFactor` |
-| `surface.aspect` | Compass-bearing aspect raster. | `source` |
-| `surface.hillshade` | Hillshade raster. | `azimuth` (315), `altitude` (45), `zFactor` |
-| `surface.rugosity-tri` | Terrain ruggedness index (3×3 window only). | `windowRadius` (must be 1) |
-| `surface.rugosity-tpi` | Topographic position index (3×3 window only). | `windowRadius` (must be 1) |
-| `surface.roughness` | Roughness raster (3×3 window only). | `windowRadius` (must be 1) |
-
-## Raster (6) — native
-
-Executed by the GDAL worker via `gdalwarp`/`gdalinfo`. All take `source` (base64 GeoTIFF).
+Managed (NetTopologySuite) overlay ops over **two inline FeatureCollections** addressed by data URI — the layer-aware counterparts of the single-WKB `geometry.*` primitives, covering the Esri Clip/Intersect/Union/Erase/Merge/Split toolset. No Postgres or GDAL dependency.
 
 | Process ID | Description | Key parameters |
 | --- | --- | --- |
-| `raster.clip` | Clip to a boundary geometry (`gdalwarp -cutline`). | `boundary` (WKB), `boundarySrid` |
-| `raster.reproject` | Reproject with a resampling algorithm (`gdalwarp -t_srs`). | `targetSrid`, `resampling` (nearestneighbor/bilinear/cubic/lanczos) |
-| `raster.statistics` | Per-band min/max/mean/stddev (`gdalinfo -stats`). | `bands` |
-| `raster.histogram` | Per-band 256-bin histograms (`gdalinfo -hist`). | `bands` |
-| `raster.zonal-statistics` | Zonal aggregates over inline polygon zones. | `zones` (inline GeoJSON, required), `band`, `statistics` (count/sum/mean/min/max/stddev/variance) |
-| `gdal.gdalwarp` | Full PROJ-backed raster reprojection, including datum shifts the managed path rejects. | `source`, `targetSrs`, `sourceSrs` |
+| `overlay.clip` | Truncate input geometries to the clip layer's union (Esri Clip; also layer-level Extract). | `input`, `clip` |
+| `overlay.intersect` | Pairwise intersection of input × overlay, merging attributes (Esri Intersect). | `input`, `overlay` |
+| `overlay.union` | Planar union: input-only, overlay-only, and intersection pieces (Esri Union). | `input`, `overlay` |
+| `overlay.erase` | Subtract the erase layer's union from each input geometry (Esri Erase). | `input`, `erase` |
+| `overlay.merge` | Concatenate two FeatureCollections into a union-schema output (Esri Merge). | `input`, `merge` |
+| `overlay.split` | Partition the input, tagging each output with `SPLIT_TARGET` (Esri Split). | `input`, `split`, `splitField` |
 
-## Conversion (5)
+## Proximity (4)
+
+Nearest-feature and Euclidean-distance tools.
+
+| Process ID | Description | Key parameters | Profile |
+| --- | --- | --- | --- |
+| `proximity.near` | Append `NEAR_FID`/`NEAR_DIST` for the closest near-layer feature (Esri Near). Planar CRS units. | `input`, `near`, `nearIdField`, `searchRadius` | managed |
+| `proximity.near-table` | Emit a table of `IN_FID`/`NEAR_FID`/`NEAR_DIST` rows (Esri GenerateNearTable). | `input`, `near`, `inputIdField`, `nearIdField`, `searchRadius` | managed |
+| `proximity.euclidean-distance` | Raster of distance from each cell to the nearest source cell (`gdal_proximity.py`). | `source` (base64 GeoTIFF), `maxDistance`, `distUnits`, `values` | **native** |
+| `proximity.euclidean-allocation` | **FLAGGED / UNSUPPORTED** — allocation needs a mode stock GDAL `gdal_proximity` lacks; submitted jobs fail with a clear message. Use `proximity.euclidean-distance`. | `source` | **native (flagged)** |
+
+## Statistics (3)
+
+Managed table-producing aggregates over a single inline FeatureCollection. Table outputs are null-geometry FeatureCollections (one feature per row).
 
 | Process ID | Description | Key parameters |
 | --- | --- | --- |
-| `conversion.geometry-format` | Convert a geometry to WKT, GeoJSON, WKB, or EWKT. | `geometry`, `target` |
-| `conversion.feature-project` | Reproject every feature in a layer. | `layerId`, `targetSrid` |
-| `conversion.raster-format` | Raster format conversion (GTiff/PNG/JPEG/COG). **Validation-only today — no executor is wired.** | `layerId`, `rasterId`, `targetFormat`, `compression` |
-| `conversion.raster-reproject` | Raster CRS conversion. **Validation-only today — no executor is wired.** | `layerId`, `rasterId`, `targetSrid`, `resampling` |
-| `gdal.ogr2ogr` | Vector format conversion via the GDAL worker (*native*). Target drivers: GeoJSON, GPKG, CSV, FlatGeobuf, ESRI Shapefile. | `source`, `targetFormat`, `sourceFormat` |
+| `statistics.summarize` | Per-group summary stats over `caseFields` (Esri Summary Statistics); `FREQUENCY` plus SUM/MEAN/MIN/MAX/STDDEV. | `input`, `caseFields`, `statistics` |
+| `statistics.frequency` | Count of each distinct `frequencyFields` combination (Esri Frequency); optional `SUM_<field>`. | `input`, `frequencyFields`, `summaryFields` |
+| `statistics.calculate` | Descriptive stats (COUNT/MIN/MAX/MEAN/SUM/STDDEV) per requested field across the dataset. | `input`, `fields` |
 
 ## Generalization (2)
 
@@ -91,47 +92,119 @@ Layer-level counterparts of the geometry-scoped operations; accept the shared Ge
 | `generalization.simplify-layer` | Topology-aware simplification across a layer; tolerance in the layer's SR units. | `layerId`, `tolerance`, `preserveTopology` |
 | `generalization.dissolve` | Union features by attribute group with optional aggregates (no buffer). | `layerId`, `groupByFields`, `dissolve`, `outStatistics` |
 
-## Data management (3)
+## Surface analysis (8) — native
+
+DEM-derived raster products executed by the GDAL worker via `gdaldem` / `gdal_contour` / `gdal_viewshed`. All take `source` (base64 GeoTIFF DEM). **Require the GDAL worker.**
+
+| Process ID | Description | Key parameters |
+| --- | --- | --- |
+| `surface.slope` | Slope raster. | `units` (degrees/percent), `zFactor` |
+| `surface.aspect` | Compass-bearing aspect raster. | `source` |
+| `surface.hillshade` | Hillshade raster. | `azimuth` (315), `altitude` (45), `zFactor` |
+| `surface.rugosity-tri` | Terrain ruggedness index (3×3 window only). | `windowRadius` (must be 1) |
+| `surface.rugosity-tpi` | Topographic position index (3×3 window only). | `windowRadius` (must be 1) |
+| `surface.roughness` | Roughness raster (3×3 window only). | `windowRadius` (must be 1) |
+| `surface.contour` | Contour lines from a DEM; GeoJSON with an `ELEV` attribute. | `interval` (required), `base` |
+| `surface.viewshed` | Binary visibility raster from a DEM and observer location. | `observerX`, `observerY`, `observerHeight`, `targetHeight`, `maxDistance` |
+
+## Raster (13) — native
+
+Raster analysis and mutation executed by the GDAL worker via `gdalwarp` / `gdalinfo` / `gdal_grid` / `gdal_calc.py`. All take `source` (base64 GeoTIFF) unless noted. **Require the GDAL worker.**
+
+| Process ID | Description | Key parameters |
+| --- | --- | --- |
+| `raster.clip` | Clip to a boundary geometry (`gdalwarp -cutline`). | `boundary` (WKB), `boundarySrid` |
+| `raster.reproject` | Reproject with a resampling algorithm (`gdalwarp -t_srs`). | `targetSrid`, `resampling` |
+| `raster.statistics` | Per-band min/max/mean/stddev (`gdalinfo -stats`). | `bands` |
+| `raster.histogram` | Per-band 256-bin histograms (`gdalinfo -hist`). | `bands` |
+| `raster.zonal-statistics` | Zonal aggregates over inline polygon zones (per-zone clip + `gdalinfo`). | `zones` (inline GeoJSON, required), `zonesLayerId` (reserved), `band`, `statistics` |
+| `raster.resample` | Change cell size with a resampling algorithm (`gdalwarp -tr`). | `cellSize`, `cellSizeY`, `resampling` |
+| `raster.interpolate-idw` | Inverse-distance-weighted surface from scattered points (`gdal_grid -a invdist`). | `points`, `zField`, `power`, `smoothing`, `radius`, `width`, `height` |
+| `raster.interpolate-kriging` | **FLAGGED / UNSUPPORTED** — no kriging backend in the worker image; submitted jobs fail with a clear message. Use `raster.interpolate-idw`. | `points`, `zField` |
+| `raster.mosaic` | Combine multiple rasters (`gdalwarp`); `first`/`last` overlap only. | `sources` (`|`-separated), `operator`, `resampling` |
+| `raster.map-algebra` | Allow-listed arithmetic/logical expression over band variables (`gdal_calc.py`). | `sources` (`|`-separated), `expression`, `dataType` |
+| `raster.spectral-index` | Named spectral index (NDVI/NDWI/NDBI/SAVI/EVI) compiled to map-algebra. | `index`, `red`, `nir`, `green`, `swir`, `blue`, `L` |
+| `raster.reclassify` | Remap pixel values per a remap table (`gdal_calc.py`). | `remap`, `defaultValue`, `dataType` |
+| `gdal.gdalwarp` | Full PROJ-backed raster reprojection, including datum shifts the managed path rejects. | `source`, `targetSrs`, `sourceSrs` |
+
+## Conversion (8)
+
+Explicit format/CRS conversion idioms. Two are managed; the rest run in the GDAL/PDAL worker (*native*).
+
+| Process ID | Description | Key parameters | Profile |
+| --- | --- | --- | --- |
+| `conversion.geometry-format` | Convert a geometry to WKT, GeoJSON, WKB, or EWKT. | `geometry`, `target` | managed |
+| `conversion.feature-project` | Reproject every feature in a layer. | `layerId`, `targetSrid` | managed |
+| `conversion.raster-format` | Raster format conversion (GTiff/PNG/JPEG/COG) via real GDAL `gdal_translate` (#2138). | `source`, `targetFormat`, `compression` | **native** |
+| `conversion.raster-reproject` | Raster CRS conversion via real GDAL `gdalwarp` (#2138). | `source`, `targetSrid`, `resampling` | **native** |
+| `conversion.polygonize` | Vectorize a raster into polygons per connected region (`gdal_polygonize.py`). | `source`, `band`, `connectedness`, `fieldName` | **native** |
+| `conversion.rasterize` | Burn vector features into a new raster grid (`gdal_rasterize`). | `source`, `burnValue`/`attribute`, `cellSize`/`width`+`height`, `nodata` | **native** |
+| `gdal.ogr2ogr` | Vector format conversion via the GDAL worker. Target drivers: GeoJSON, GPKG, CSV, FlatGeobuf, ESRI Shapefile. | `source`, `targetFormat`, `sourceFormat` | **native** |
+| `pcloud.translate` | Decompress LAZ/COPC to uncompressed LAS, optionally reprojecting to EPSG:4979 (`pdal translate`). | `source`, `sourceSrs` | **native** |
+
+## Data management (4)
+
+Bulk, layer-level mutation workflows. `delete-features` and `calculate-field` are destructive and route through the approval gate.
 
 | Process ID | Description | Key parameters |
 | --- | --- | --- |
 | `data-management.copy-features` | Copy (optionally filtered) features into a new layer; non-destructive. | `sourceLayerId`, `targetLayerName`, `where`, `objectIds` |
+| `data-management.append` | Append a source FeatureCollection into the target's schema (Esri Append), with optional `fieldMap`. | `input` (target), `append` (source), `fieldMap` |
 | `data-management.delete-features` | Delete matching features. **Destructive — requires approval**; `where` or `objectIds` is mandatory. | `layerId`, `where`, `objectIds` |
 | `data-management.calculate-field` | Set a field via constant or allow-listed SQL expression. **Destructive — requires approval.** | `layerId`, `fieldName`, `expression`, `where`, `objectIds` |
 
-## Transform (8)
+## Import (1)
 
-GeoETL transform nodes: read a FeatureCollection data URI on `input`, emit a FeatureCollection data URI. Managed NetTopologySuite only.
+| Process ID | Description | Key parameters |
+| --- | --- | --- |
+| `import.dataset` | End-to-end durable import: stage → import/chunk → flatten to a typed layer → optional raster tiling → extent/MVT refresh → provenance. The canonical execution layer the geospatial-mcp `publish_data` family submits into. Managed. | `connection`, `sourcePath`, `fileName`, `tableName`, `layerName`, `serviceName`, `targetSrid`, `rasterLayerId`, … |
+
+## Transform (12)
+
+GeoETL transform nodes: read a FeatureCollection data URI on `input`, emit a FeatureCollection data URI. Managed NetTopologySuite only — no GDAL.
 
 | Process ID | Description | Key parameters |
 | --- | --- | --- |
 | `transform.attribute-rename` | Rename an attribute key on every feature. | `from`, `to` |
 | `transform.attribute-cast` | Coerce an attribute to int/long/double/bool/string. | `field`, `to`, `onError` (drop/null/keep) |
-| `transform.computed-field` | Derive a new attribute (concat, add, subtract, multiply, divide, const). | `target`, `op`, `fields`, `left`, `right`, `value` |
+| `transform.computed-field` | Derive a new attribute via a fixed op set (concat/add/…) or a sandboxed, AOT-safe expression engine. | `target`, `op`, `expression`, `fields`, `left`, `right`, `value` |
 | `transform.attribute-filter` | Keep features matching a comparison (eq/neq/gt/gte/lt/lte/contains/exists). | `field`, `op`, `value` |
+| `transform.attribute-join` | Hash-join to a right FeatureCollection on key columns, carrying selected fields (inner/left). | `input`, `right`, `leftKeys`, `rightKeys`, `fields`, `type`, `prefix` |
+| `transform.aggregate` | Group-by aggregate (count/sum/min/max/mean/stddev/first/collect) with optional geometry reduction. | `input`, `groupBy`, `aggregates`, `geometry` |
+| `transform.pivot` | Reshape long → wide: `pivotField` values become columns sourced from `valueField`. | `groupBy`, `pivotField`, `valueField`, `prefix` |
+| `transform.unpivot` | Melt wide → long: one output feature per `fields` column. | `fields`, `keep`, `nameField`, `valueField`, `dropNulls` |
 | `transform.spatial-filter` | Keep features intersecting/within a bbox or WKT region. | `bbox` or `wkt`, `predicate` |
 | `transform.clip` | Clip feature geometries to a region, dropping features outside it. | `bbox` or `wkt` |
 | `transform.dedup` | Keep the first feature per distinct attribute and/or geometry key. | `keys`, `geometry` |
 | `transform.reproject` | Managed reprojection (4326 ↔ Web Mercator and aliases); datum-shift pairs are rejected — use `gdal.gdalwarp`. | `fromSrid`, `toSrid` |
 
-## Source (2)
+## Source (8)
 
-| Process ID | Description | Key parameters |
-| --- | --- | --- |
-| `source.geojson` | Parse inline GeoJSON (or a data URI) into the standard FeatureCollection artifact. | `inline` or `input` |
-| `source.csv` | Parse inline CSV; geometry from a WKT column or lon/lat pair. | `inline`, `delimiter` |
+GeoETL DAG sources that produce a FeatureCollection artifact. Seven are managed parsers/connectors; `source.ogr` runs in the GDAL worker (*native*).
 
-Native-format sources (shapefile, GeoPackage) are not catalog sources today; convert with `gdal.ogr2ogr` first.
+| Process ID | Description | Key parameters | Profile |
+| --- | --- | --- | --- |
+| `source.geojson` | Parse inline GeoJSON (or a data URI) into the standard FeatureCollection. | `inline` or `input` | managed |
+| `source.csv` | Parse inline CSV; geometry from a WKT column or lon/lat pair. | `inline`, `delimiter` | managed |
+| `source.honua-layer` | Stream a Honua catalog layer through the canonical query pipeline. | `layerId`, `where`, `bbox`, `outFields`, `outSrid`, `since`, `watermarkField` | managed |
+| `source.esri-featureserver` | Stream an ArcGIS FeatureServer/MapServer layer (paged), Esri-JSON → GeoJSON. | `serviceUrl`, `esriLayerId`, `where`, `outFields`, `outSrid`, `pageSize`, token/credential params, `since` | managed |
+| `source.ogc-features` | Stream an OGC API Features collection via `rel=next` link paging; `where` is CQL2-text. | `serviceUrl`, `collectionId`, `where`, `bbox`, `pageSize`, credential params, `since` | managed |
+| `source.wfs` | Stream a WFS GetFeature endpoint with startIndex/count paging, GeoJSON output. | `serviceUrl`, `typeName`, `bbox`, `pageSize`, credential params | managed |
+| `source.postgis` | Stream a customer-owned PostGIS table/view via a registered secure connection. | `connectionName`/`connectionId`, `table`, `schema`, `geometryColumn`, `where`, `bbox`, `outSrid`, `since`, `watermarkField` | managed |
+| `source.ogr` | GDAL/OGR import reader for the full driver universe (FileGDB, GML, KML, MapInfo, Shapefile, GPKG, FlatGeobuf, …); multi-file datasets supplied as a base64 ZIP. | `source`, `sourceFormat` | **native** |
 
-## Sink (3)
+## Sink (4)
+
+Terminate a workflow by writing the input FeatureCollection and emitting a result descriptor (target location + row counts). Managed writers / Npgsql only — no GDAL.
 
 | Process ID | Description | Key parameters |
 | --- | --- | --- |
 | `sink.geojson-file` | Write the input FeatureCollection to a GeoJSON file under the configured output root. | `input`, `path` |
 | `sink.quarantine` | Dead-letter sink: write rejected rows with batch id and reason. | `input`, `path`, `reasonField`, `batchId` |
 | `sink.external-postgis` | Load features into a customer-owned PostGIS database via a registered secure connection (never a raw connection string). | `input`, `connectionName`/`connectionId`, `table`, `targetSrid`, `schema`, `geometryColumn`, `batchSize` |
+| `sink.honua-layer` | Load features into a named layer in the Honua catalog database (append/replace/upsert). Executed by `HonuaLayerSinkExecutor` through the optional `IHonuaLayerSink` capability (#2210); **fails closed with a clear "unavailable in this deployment" message in lean, database-free deployments**. | `input`, `layer`, `targetSrid`, `loadMode`, `keyFields`, `schema`, `geometryColumn`, `batchId` |
 
-A sink that writes back into the Honua catalog itself is deferred.
+Native-format sinks (shapefile, GeoPackage) are deferred to the GDAL worker stream; for those, convert with `gdal.ogr2ogr`.
 
 ## Related pages
 

--- a/src/Honua.Core/Features/Geoprocessing/Abstractions/IGeoprocessingRasterSourceResolver.cs
+++ b/src/Honua.Core/Features/Geoprocessing/Abstractions/IGeoprocessingRasterSourceResolver.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Geoprocessing.Abstractions;
+
+/// <summary>
+/// Resolves a geoprocessing raster-source reference (<c>layerId</c> / <c>rasterId</c>)
+/// to readable raster bytes so native raster/surface processes can run against
+/// registered catalog rasters without a manual inline upload (#2264).
+///
+/// <para>
+/// The resolver runs on the SUBMIT side (the serving image, where the raster
+/// catalog and cloud range readers are available), NOT inside the lean GDAL worker.
+/// The submit path materializes the resolved bytes onto the canonical base64
+/// <c>source</c> step input, so the worker contract is unchanged. Deployments
+/// without a raster catalog leave this unregistered; the submit path then rejects
+/// layer-referenced plans with a clear "not available in this deployment" message
+/// rather than failing later in the worker.
+/// </para>
+/// </summary>
+public interface IGeoprocessingRasterSourceResolver
+{
+    /// <summary>
+    /// Resolves <paramref name="reference"/> to raster bytes, rejecting any resolved
+    /// object larger than <paramref name="maxBytes"/>. Returns a failure result
+    /// (never throws) when the reference cannot be resolved so the caller maps it
+    /// onto the submit-time validation channel.
+    /// </summary>
+    Task<RasterSourceResolution> ResolveAsync(
+        RasterSourceReference reference,
+        long maxBytes,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A reference to a registered catalog raster. Exactly one of <see cref="RasterId"/>
+/// or <see cref="LayerId"/> drives resolution; when both are supplied the
+/// <see cref="RasterId"/> is authoritative and the <see cref="LayerId"/> is treated
+/// as a consistency hint.
+/// </summary>
+/// <param name="LayerId">Catalog layer identifier whose registered raster to resolve.</param>
+/// <param name="RasterId">Registered raster identifier to resolve directly.</param>
+public sealed record RasterSourceReference(int? LayerId, long? RasterId);
+
+/// <summary>
+/// Outcome of a <see cref="IGeoprocessingRasterSourceResolver.ResolveAsync"/> call.
+/// </summary>
+public sealed record RasterSourceResolution
+{
+    /// <summary>Whether the reference resolved to readable raster bytes.</summary>
+    public bool Found { get; init; }
+
+    /// <summary>The resolved raster bytes when <see cref="Found"/> is <c>true</c>.</summary>
+    public byte[]? Bytes { get; init; }
+
+    /// <summary>
+    /// A caller-safe explanation when <see cref="Found"/> is <c>false</c>. Must not
+    /// leak provider internals, paths, or connection details.
+    /// </summary>
+    public string? FailureReason { get; init; }
+
+    /// <summary>Builds a successful resolution carrying <paramref name="bytes"/>.</summary>
+    public static RasterSourceResolution Success(byte[] bytes) =>
+        new() { Found = true, Bytes = bytes };
+
+    /// <summary>Builds a failed resolution carrying a caller-safe <paramref name="reason"/>.</summary>
+    public static RasterSourceResolution Failure(string reason) =>
+        new() { Found = false, FailureReason = reason };
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -879,6 +879,7 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 Param("sources", "Sources", "One or more source rasters as base64-encoded GeoTIFFs separated by '|', bound to band variables A, B, C, … in order. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
                 Param("expression", "Expression", "Allow-listed map-algebra expression over the band variables (e.g. '(A-B)/(A+B)'). Required.", ProcessParameterValueType.Text, required: true),
                 Param("dataType", "Output Type", "Optional GDAL output data type. Allowed values: Byte, Int16, UInt16, Int32, UInt32, Float32, Float64.", ProcessParameterValueType.Text),
+                Param("noData", "NoData Value", "Optional output NoData value tagged on the result band and used to fill masked cells. When omitted, the first source raster's band NoData is detected and propagated. Each input is masked by its own NoData by default.", ProcessParameterValueType.FloatingPoint),
             ],
             OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native
@@ -899,6 +900,7 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 Param("swir", "SWIR Band", "Short-wave-infrared-band raster as a base64-encoded GeoTIFF. Required by NDBI.", ProcessParameterValueType.Text),
                 Param("blue", "Blue Band", "Blue-band raster as a base64-encoded GeoTIFF. Required by EVI.", ProcessParameterValueType.Text),
                 Param("L", "Soil Factor (SAVI)", "SAVI soil-adjustment factor in the closed range [0, 1]. Defaults to 0.5. Ignored by other indices.", ProcessParameterValueType.FloatingPoint, defaultValue: "0.5"),
+                Param("noData", "NoData Value", "Optional output NoData value tagged on the index band and used to fill masked cells. When omitted, the first band-role raster's band NoData is detected and propagated.", ProcessParameterValueType.FloatingPoint),
             ],
             OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native
@@ -915,6 +917,7 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
                 Param("remap", "Remap Table", "Reclassification table: ';'-separated 'value:newValue' or 'lo..hi:newValue' entries (e.g. '0..10:1;10..20:2'). Required.", ProcessParameterValueType.Text, required: true),
                 Param("defaultValue", "Default Value", "Optional output value for pixels matching no remap entry. When omitted, unmatched pixels keep their original value.", ProcessParameterValueType.FloatingPoint),
                 Param("dataType", "Output Type", "Optional GDAL output data type. Allowed values: Byte, Int16, UInt16, Int32, UInt32, Float32, Float64.", ProcessParameterValueType.Text),
+                Param("noData", "NoData Value", "Optional output NoData value tagged on the result band and used to fill masked cells. When omitted, the source raster's band NoData is detected and propagated.", ProcessParameterValueType.FloatingPoint),
             ],
             OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native
@@ -1691,17 +1694,18 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
     ];
 
     // Native worker raster source selector for surface.* and raster.* entries.
-    // The native GDAL worker reads a base64 GeoTIFF directly from 'source';
-    // layer-resolved sourcing (`layerId`/`rasterId`) is a follow-on, so both are
-    // declared OPTIONAL here even though future submit-side resolution will
-    // populate `source` from them. Marking `source` as REQUIRED keeps the
-    // catalog honest about what the worker accepts today: plans that omit
-    // `source` would route to the native worker and fail at runtime.
+    // The native GDAL worker reads a base64 GeoTIFF directly from 'source'. As of
+    // #2264 the submit path also resolves a registered catalog raster from
+    // `layerId`/`rasterId` and materializes it onto `source` before dispatch, so a
+    // plan must supply EXACTLY ONE of: an inline `source`, a `layerId`, or a
+    // `rasterId`. `source` is therefore declared OPTIONAL and the "supply one of"
+    // rule is enforced by ValidateSharedRasterSourceSemantics so a plan that omits
+    // all three is rejected at submit time rather than failing in the worker.
     private static readonly ProcessParameterSpec[] NativeRasterSourceParameters =
     [
-        Param("source", "Source Raster", "Source raster as base64-encoded GeoTIFF bytes. Required by the native worker execution path; layer-resolved sourcing (layerId/rasterId) is a follow-on.", ProcessParameterValueType.Text, required: true),
-        Param("layerId", "Layer", "Target raster layer identifier. Optional today; reserved for submit-time layer-to-source resolution (a follow-on).", ProcessParameterValueType.LayerId),
-        Param("rasterId", "Raster", "Optional raster identifier. Reserved for submit-time layer-to-source resolution (a follow-on). When supplied, it must be a positive 64-bit integer.", ProcessParameterValueType.Text),
+        Param("source", "Source Raster", "Source raster as base64-encoded GeoTIFF bytes. Supply this OR a layerId/rasterId that resolves to a registered catalog raster.", ProcessParameterValueType.Text),
+        Param("layerId", "Layer", "Catalog raster layer identifier. Resolved at submit time to the layer's registered raster (newest registration when several exist). Supply this OR an inline source / rasterId.", ProcessParameterValueType.LayerId),
+        Param("rasterId", "Raster", "Registered raster identifier. Resolved at submit time to the registered raster bytes. Supply this OR an inline source / layerId. When supplied, it must be a positive 64-bit integer.", ProcessParameterValueType.Text),
     ];
 
     private static ProcessParameterSpec Param(

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -47,6 +47,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
     private readonly IScopedJobTokenIssuer? _scopedJobTokenIssuer;
     private readonly IOptionsMonitor<CustomCodeOptions>? _customCodeOptions;
     private readonly CustomCodeSubmitCoordinator? _customCodeCoordinator;
+    private readonly IGeoprocessingRasterSourceResolver? _rasterSourceResolver;
 
     public GeoprocessingJobService(
         IUniversalProgressStore progressStore,
@@ -65,7 +66,8 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         IGeoprocessingResultPackageStore? resultPackageStore = null,
         IScopedJobTokenIssuer? scopedJobTokenIssuer = null,
         IOptionsMonitor<CustomCodeOptions>? customCodeOptions = null,
-        ICustomCodeCommitSignatureVerifier? customCodeSignatureVerifier = null)
+        ICustomCodeCommitSignatureVerifier? customCodeSignatureVerifier = null,
+        IGeoprocessingRasterSourceResolver? rasterSourceResolver = null)
     {
         _progressStore = progressStore;
         _cancellationNotifiers = cancellationNotifiers.ToArray();
@@ -86,6 +88,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         _customCodeCoordinator = scopedJobTokenIssuer is null
             ? null
             : new CustomCodeSubmitCoordinator(scopedJobTokenIssuer, customCodeSignatureVerifier);
+        _rasterSourceResolver = rasterSourceResolver;
     }
 
     private TimeSpan ProgressRetention => _executorOptions.CurrentValue.ResultRetention;
@@ -211,6 +214,18 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         var resolvedKey = string.IsNullOrWhiteSpace(idempotencyKey) ? null : idempotencyKey;
         var jobId = CreateJobId(resolvedKey);
         var requestFingerprint = CreateRequestFingerprint(plan);
+
+        // Resolve any native raster/surface step that references a registered catalog
+        // raster by layerId/rasterId, materializing the bytes onto the canonical base64
+        // 'source' input the worker reads (#2264). The fingerprint above is computed on
+        // the caller's original (reference-carrying) plan so idempotency keys map to the
+        // request, not the resolved payload; the spec below carries the resolved bytes.
+        plan = await GeoprocessingRasterSourceResolution.ResolveAsync(
+            plan,
+            _processCatalog,
+            _rasterSourceResolver,
+            _executorOptions.CurrentValue.MaxArtifactBytes,
+            cancellationToken).ConfigureAwait(false);
 
         var specParams = protocolMetadata != null
             ? new Dictionary<string, string>(protocolMetadata)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -138,10 +138,10 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             }
         }
 
-        var destructiveProcessId = ProcessDestructiveClassifier.FindFirstDestructiveProcessId(plan);
-        if (destructiveProcessId != null)
+        var approvalGatedProcessId = ProcessDestructiveClassifier.FindFirstApprovalGatedProcessId(plan);
+        if (approvalGatedProcessId != null)
         {
-            GeoprocessingServiceLog.DestructivePlanDetected(_logger, plan.PlanId ?? "", destructiveProcessId);
+            GeoprocessingServiceLog.DestructivePlanDetected(_logger, plan.PlanId ?? "", approvalGatedProcessId);
         }
 
         var approvalReq = _approvalEvaluator.Evaluate(
@@ -150,7 +150,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             {
                 ResourceType = OperatorResourceType.Process,
                 Operation = OperatorOperation.Execute,
-                IsDestructive = destructiveProcessId != null
+                IsDestructive = approvalGatedProcessId != null
             });
 
         var result = new PlanValidationResult
@@ -1046,10 +1046,10 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
 
     private void EnsureApproved(ClaimsPrincipal principal, AnalysisPlan plan)
     {
-        var destructiveProcessId = ProcessDestructiveClassifier.FindFirstDestructiveProcessId(plan);
-        if (destructiveProcessId != null)
+        var approvalGatedProcessId = ProcessDestructiveClassifier.FindFirstApprovalGatedProcessId(plan);
+        if (approvalGatedProcessId != null)
         {
-            GeoprocessingServiceLog.DestructivePlanDetected(_logger, plan.PlanId ?? "", destructiveProcessId);
+            GeoprocessingServiceLog.DestructivePlanDetected(_logger, plan.PlanId ?? "", approvalGatedProcessId);
         }
 
         var approval = _approvalEvaluator.Evaluate(
@@ -1058,7 +1058,7 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
             {
                 ResourceType = OperatorResourceType.Process,
                 Operation = OperatorOperation.Execute,
-                IsDestructive = destructiveProcessId != null
+                IsDestructive = approvalGatedProcessId != null
             });
 
         if (!approval.IsRequired)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -190,6 +190,18 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         IReadOnlyDictionary<string, string>? protocolMetadata = null,
         CancellationToken cancellationToken = default)
     {
+        // Centralize submit-path authorization here so every adapter (GPServer,
+        // OGC Processes, MCP, and the AnalysisContent run/rerun paths) is gated
+        // through the shared pipeline rather than relying on caller discipline
+        // (#2263). Adapters that already call EnsureCallerAuthorizedAsync before
+        // submit stay correct — this evaluation is idempotent and never
+        // double-fails an authorized caller.
+        await EnsureAuthorizedAsync(
+            principal,
+            OperatorResourceType.Process,
+            OperatorOperation.Execute,
+            cancellationToken).ConfigureAwait(false);
+
         ValidatePlanStructure(plan);
         EnsurePlanExecutable(plan);
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingRasterSourceResolution.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingRasterSourceResolution.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// Submit-side resolution of native raster/surface process inputs from a registered
+/// catalog raster (#2264). Native raster processes read a base64 <c>source</c> the
+/// worker decodes; this helper lets a plan instead reference a catalog raster by
+/// <c>layerId</c>/<c>rasterId</c> and materializes the resolved bytes onto the
+/// <c>source</c> step input BEFORE the spec is projected, so the worker contract is
+/// unchanged.
+///
+/// <para>
+/// A step is eligible only when its catalog process declares the native raster-source
+/// shape (both a <c>source</c> and a <c>rasterId</c> parameter, the
+/// <c>NativeRasterSourceParameters</c> group). Steps that already carry an inline
+/// <c>source</c> are left untouched (inline wins). When resolution is required but no
+/// resolver is configured, or the reference does not resolve, a
+/// <see cref="GeoprocessingValidationException"/> is thrown so the adapter maps it onto
+/// the same submit-time validation channel as other plan failures.
+/// </para>
+/// </summary>
+internal static class GeoprocessingRasterSourceResolution
+{
+    private const string SourceInput = "source";
+    private const string LayerIdInput = "layerId";
+    private const string RasterIdInput = "rasterId";
+
+    /// <summary>
+    /// Returns a plan whose eligible native-raster steps have their <c>source</c>
+    /// populated from the resolved catalog raster. Returns the original plan unchanged
+    /// when no step requires resolution.
+    /// </summary>
+    public static async Task<AnalysisPlan> ResolveAsync(
+        AnalysisPlan plan,
+        IProcessCatalog catalog,
+        IGeoprocessingRasterSourceResolver? resolver,
+        long maxBytes,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(catalog);
+
+        List<AnalysisPlanStep>? rewritten = null;
+
+        for (var i = 0; i < plan.Steps.Count; i++)
+        {
+            var step = plan.Steps[i];
+            if (!TryGetReference(step, catalog, out var reference))
+            {
+                continue;
+            }
+
+            if (resolver is null)
+            {
+                throw new GeoprocessingValidationException(
+                    $"Step '{step.StepId}' references a catalog raster by layerId/rasterId, but layer-resolved "
+                    + "raster sourcing is not available in this deployment (no raster catalog is configured). "
+                    + "Supply an inline base64 'source' raster instead.");
+            }
+
+            var resolution = await resolver
+                .ResolveAsync(reference, maxBytes, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!resolution.Found || resolution.Bytes is null)
+            {
+                throw new GeoprocessingValidationException(
+                    $"Step '{step.StepId}' could not resolve its raster source: "
+                    + (resolution.FailureReason ?? "the referenced catalog raster was not found."));
+            }
+
+            rewritten ??= [.. plan.Steps];
+            rewritten[i] = WithResolvedSource(step, resolution.Bytes);
+        }
+
+        if (rewritten is null)
+        {
+            return plan;
+        }
+
+        return plan with { Steps = rewritten };
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="step"/> must be resolved from a catalog
+    /// raster: its process declares the native raster-source shape, it has no inline
+    /// <c>source</c>, and it carries a parseable <c>layerId</c> or <c>rasterId</c>.
+    /// </summary>
+    internal static bool TryGetReference(
+        AnalysisPlanStep step,
+        IProcessCatalog catalog,
+        out RasterSourceReference reference)
+    {
+        reference = new RasterSourceReference(null, null);
+
+        if (step.Kind != AnalysisPlanStepKind.Geoprocess || string.IsNullOrWhiteSpace(step.ProcessId))
+        {
+            return false;
+        }
+
+        var definition = catalog.GetProcess(step.ProcessId);
+        if (definition is null || !DeclaresNativeRasterSource(definition))
+        {
+            return false;
+        }
+
+        // Inline source wins; nothing to resolve.
+        if (step.Inputs.TryGetValue(SourceInput, out var source) && !string.IsNullOrWhiteSpace(source))
+        {
+            return false;
+        }
+
+        long? rasterId = null;
+        if (step.Inputs.TryGetValue(RasterIdInput, out var rasterRaw)
+            && !string.IsNullOrWhiteSpace(rasterRaw)
+            && long.TryParse(rasterRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedRaster)
+            && parsedRaster > 0)
+        {
+            rasterId = parsedRaster;
+        }
+
+        int? layerId = null;
+        if (step.Inputs.TryGetValue(LayerIdInput, out var layerRaw)
+            && !string.IsNullOrWhiteSpace(layerRaw)
+            && int.TryParse(layerRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedLayer)
+            && parsedLayer >= 0)
+        {
+            layerId = parsedLayer;
+        }
+
+        if (rasterId is null && layerId is null)
+        {
+            return false;
+        }
+
+        reference = new RasterSourceReference(layerId, rasterId);
+        return true;
+    }
+
+    private static bool DeclaresNativeRasterSource(ProcessDefinition definition)
+    {
+        var hasSource = false;
+        var hasRasterId = false;
+        foreach (var parameter in definition.Parameters)
+        {
+            if (string.Equals(parameter.Name, SourceInput, StringComparison.Ordinal))
+            {
+                hasSource = true;
+            }
+            else if (string.Equals(parameter.Name, RasterIdInput, StringComparison.Ordinal))
+            {
+                hasRasterId = true;
+            }
+        }
+
+        return hasSource && hasRasterId;
+    }
+
+    private static AnalysisPlanStep WithResolvedSource(AnalysisPlanStep step, byte[] bytes)
+    {
+        var inputs = new Dictionary<string, string>(step.Inputs, StringComparer.Ordinal)
+        {
+            [SourceInput] = Convert.ToBase64String(bytes),
+        };
+
+        return step with { Inputs = inputs };
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessDestructiveClassifier.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessDestructiveClassifier.cs
@@ -7,8 +7,10 @@ using Honua.Core.Features.Geoprocessing.Domain;
 namespace Honua.Geoprocessing;
 
 /// <summary>
-/// Classifies canonical process ids by whether they mutate or erase caller-owned
-/// data. Destructive plans route through the existing approval gate (with
+/// Classifies canonical process ids by whether they require the approval gate —
+/// either because they mutate/erase caller-owned data (destructive) or because
+/// they write data out to an external/owned destination (sink/write). Such plans
+/// route through the existing approval gate (with
 /// <c>OperatorAuthorizationRequest.IsDestructive = true</c>) before any job or
 /// progress record is created: when
 /// <c>Operator:Approval:DestructiveActionsRequireApproval</c> is on, submission
@@ -34,12 +36,42 @@ internal static class ProcessDestructiveClassifier
             "data-management.calculate-field",
         }.ToFrozenSet(StringComparer.Ordinal);
 
+    // Canonical ids that terminate a plan by WRITING the input FeatureCollection
+    // out to an external or caller-owned destination. These produce durable
+    // side-effects (rows in an external/catalog database, files on disk) and so
+    // must pass the same approval gate as destructive mutations (#2262).
+    // sink.quarantine is deliberately excluded: it is the internal dead-letter
+    // half of the row-level-error contract (it only persists rows the pipeline
+    // already rejected), not a caller-chosen data destination.
+    private static readonly FrozenSet<string> SinkProcessIds =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "sink.external-postgis",
+            "sink.honua-layer",
+            "sink.geojson-file",
+        }.ToFrozenSet(StringComparer.Ordinal);
+
     /// <summary>
     /// Returns true when the given process id represents a destructive
     /// layer-level mutation that must pass the approval gate.
     /// </summary>
     public static bool IsDestructive(string? processId)
         => !string.IsNullOrWhiteSpace(processId) && DestructiveProcessIds.Contains(processId);
+
+    /// <summary>
+    /// Returns true when the given process id writes the input out to an external
+    /// or caller-owned destination (a sink/write process) and therefore must pass
+    /// the approval gate.
+    /// </summary>
+    public static bool IsSink(string? processId)
+        => !string.IsNullOrWhiteSpace(processId) && SinkProcessIds.Contains(processId);
+
+    /// <summary>
+    /// Returns true when the given process id must pass the approval gate, i.e.
+    /// it is either destructive or a sink/write process.
+    /// </summary>
+    public static bool RequiresApproval(string? processId)
+        => IsDestructive(processId) || IsSink(processId);
 
     /// <summary>
     /// Returns true when any <see cref="AnalysisPlanStepKind.Geoprocess"/> step
@@ -49,12 +81,34 @@ internal static class ProcessDestructiveClassifier
         => FindFirstDestructiveProcessId(plan) != null;
 
     /// <summary>
+    /// Returns true when any <see cref="AnalysisPlanStepKind.Geoprocess"/> step
+    /// in the plan references a process id that must pass the approval gate
+    /// (destructive or sink/write).
+    /// </summary>
+    public static bool HasApprovalGatedStep(AnalysisPlan plan)
+        => FindFirstApprovalGatedProcessId(plan) != null;
+
+    /// <summary>
     /// Returns the first destructive canonical process id referenced by any
     /// <see cref="AnalysisPlanStepKind.Geoprocess"/> step, or <c>null</c> when
     /// the plan is non-destructive. Used for approval-gate telemetry so the
     /// emitted log carries the triggering process id.
     /// </summary>
     public static string? FindFirstDestructiveProcessId(AnalysisPlan plan)
+        => FindFirst(plan, IsDestructive);
+
+    /// <summary>
+    /// Returns the first canonical process id referenced by any
+    /// <see cref="AnalysisPlanStepKind.Geoprocess"/> step that must pass the
+    /// approval gate (destructive or sink/write), or <c>null</c> when the plan
+    /// needs no approval. Used to drive both the approval gate and its telemetry
+    /// so a plan that writes to an external sink is gated identically to a
+    /// destructive mutation (#2262).
+    /// </summary>
+    public static string? FindFirstApprovalGatedProcessId(AnalysisPlan plan)
+        => FindFirst(plan, RequiresApproval);
+
+    private static string? FindFirst(AnalysisPlan plan, Func<string?, bool> predicate)
     {
         foreach (var step in plan.Steps)
         {
@@ -63,7 +117,7 @@ internal static class ProcessDestructiveClassifier
                 continue;
             }
 
-            if (IsDestructive(step.ProcessId))
+            if (predicate(step.ProcessId))
             {
                 return step.ProcessId;
             }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -1016,6 +1016,7 @@ internal static partial class ProcessPlanValidator
         }
 
         ValidateCalcDataType(step, violations);
+        RequireFiniteDouble(step, "noData", violations);
     }
 
     private static void ValidateRasterSpectralIndexSemantics(
@@ -1054,6 +1055,7 @@ internal static partial class ProcessPlanValidator
         }
 
         RequireDoubleInClosedRange(step, "L", 0d, 1d, "(soil factor)", violations);
+        RequireFiniteDouble(step, "noData", violations);
     }
 
     private static void ValidateRasterReclassifySemantics(
@@ -1071,6 +1073,7 @@ internal static partial class ProcessPlanValidator
 
         RequireFiniteDouble(step, "defaultValue", violations);
         ValidateCalcDataType(step, violations);
+        RequireFiniteDouble(step, "noData", violations);
     }
 
     private static void ValidateProximityEuclideanDistanceSemantics(
@@ -1377,6 +1380,25 @@ internal static partial class ProcessPlanValidator
         List<GeoprocessingValidationFailure> violations)
     {
         ValidatePositiveLong(step, "rasterId", violations);
+
+        // The native worker reads a base64 'source'; the submit path can also
+        // materialize 'source' from a registered catalog raster referenced by
+        // 'layerId' or 'rasterId' (#2264). A plan that supplies NONE of the three
+        // would route to the worker with no readable input and fail there, so the
+        // catalog rejects it at submit-time validation instead. (The base required
+        // loop no longer enforces 'source' because it is now optional.)
+        var hasSource = step.Inputs.TryGetValue("source", out var source) && !string.IsNullOrWhiteSpace(source);
+        var hasLayerId = step.Inputs.TryGetValue("layerId", out var layerId) && !string.IsNullOrWhiteSpace(layerId);
+        var hasRasterId = step.Inputs.TryGetValue("rasterId", out var rasterId) && !string.IsNullOrWhiteSpace(rasterId);
+        if (!hasSource && !hasLayerId && !hasRasterId)
+        {
+            violations.Add(new GeoprocessingValidationFailure
+            {
+                Code = "MISSING_REQUIRED_PARAMETER",
+                Message = $"Step '{step.StepId}' requires an inline 'source' raster or a 'layerId'/'rasterId' that resolves to a registered catalog raster for process '{step.ProcessId}'.",
+                FieldPath = $"steps[{step.StepId}].inputs.source"
+            });
+        }
     }
 
     // pcloud.translate decompresses LAZ/COPC and, when a projected source CRS is

--- a/src/Honua.Server/Features/Protocols/Cog/CatalogRasterSourceResolver.cs
+++ b/src/Honua.Server/Features/Protocols/Cog/CatalogRasterSourceResolver.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Features.Protocols.Cog;
+
+/// <summary>
+/// Resolves geoprocessing raster-source references (<c>layerId</c>/<c>rasterId</c>) to
+/// raster bytes from the registered COG catalog (#2264), reusing the same
+/// <see cref="ICogStore"/> registry and per-provider <see cref="ICloudRangeReader"/>
+/// readers the COG tile path uses. Registered as a singleton (the GP submit service is
+/// a singleton); the scoped <see cref="ICogStore"/> is resolved through a per-call
+/// service scope so there is no captive-dependency violation. When no COG store is
+/// configured the resolver returns a clear failure rather than throwing.
+/// </summary>
+internal sealed class CatalogRasterSourceResolver(IServiceScopeFactory scopeFactory)
+    : IGeoprocessingRasterSourceResolver
+{
+    /// <inheritdoc />
+    public async Task<RasterSourceResolution> ResolveAsync(
+        RasterSourceReference reference,
+        long maxBytes,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var cogStore = scope.ServiceProvider.GetService<ICogStore>();
+        if (cogStore is null)
+        {
+            return RasterSourceResolution.Failure(
+                "no raster catalog is configured in this deployment.");
+        }
+
+        var registration = await ResolveRegistrationAsync(cogStore, reference, cancellationToken)
+            .ConfigureAwait(false);
+        if (registration is null)
+        {
+            return RasterSourceResolution.Failure(DescribeMissing(reference));
+        }
+
+        var reader = scope.ServiceProvider
+            .GetServices<ICloudRangeReader>()
+            .FirstOrDefault(r => r.Provider == registration.Provider);
+        if (reader is null)
+        {
+            return RasterSourceResolution.Failure(
+                $"no reader is configured for the resolved raster's storage provider "
+                + $"({registration.Provider.ToString()}).");
+        }
+
+        long size;
+        try
+        {
+            size = await reader.GetObjectSizeAsync(registration.Bucket, registration.ObjectKey, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception) when (cancellationToken.IsCancellationRequested is false)
+        {
+            return RasterSourceResolution.Failure("the resolved raster object could not be read.");
+        }
+
+        if (size <= 0)
+        {
+            return RasterSourceResolution.Failure("the resolved raster object is empty.");
+        }
+
+        if (size > maxBytes || size > int.MaxValue)
+        {
+            return RasterSourceResolution.Failure(
+                $"the resolved raster size {size.ToString(CultureInfo.InvariantCulture)} bytes exceeds the "
+                + $"maximum {maxBytes.ToString(CultureInfo.InvariantCulture)} bytes accepted for inline sourcing.");
+        }
+
+        byte[] bytes;
+        try
+        {
+            bytes = await reader.ReadRangeAsync(registration.Bucket, registration.ObjectKey, 0, (int)size, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception) when (cancellationToken.IsCancellationRequested is false)
+        {
+            return RasterSourceResolution.Failure("the resolved raster object could not be read.");
+        }
+
+        return bytes.Length == 0
+            ? RasterSourceResolution.Failure("the resolved raster object is empty.")
+            : RasterSourceResolution.Success(bytes);
+    }
+
+    private static async Task<CogRegistration?> ResolveRegistrationAsync(
+        ICogStore cogStore,
+        RasterSourceReference reference,
+        CancellationToken cancellationToken)
+    {
+        if (reference.RasterId is { } rasterId)
+        {
+            var registration = await cogStore.GetAsync(rasterId, cancellationToken).ConfigureAwait(false);
+            if (registration is null)
+            {
+                return null;
+            }
+
+            // When a layerId is also supplied it is a consistency hint: reject a
+            // rasterId that belongs to a different layer rather than silently sourcing
+            // an unrelated raster.
+            if (reference.LayerId is { } layerHint && registration.LayerId != layerHint)
+            {
+                return null;
+            }
+
+            return registration;
+        }
+
+        if (reference.LayerId is { } layerId)
+        {
+            var registrations = await cogStore.ListByLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
+            // ListByLayerAsync orders newest-first; take the most recent registration.
+            return registrations.Length > 0 ? registrations[0] : null;
+        }
+
+        return null;
+    }
+
+    private static string DescribeMissing(RasterSourceReference reference)
+    {
+        if (reference.RasterId is { } rasterId)
+        {
+            return reference.LayerId is { } layerId
+                ? $"no registered raster with rasterId={rasterId.ToString(CultureInfo.InvariantCulture)} on layerId={layerId.ToString(CultureInfo.InvariantCulture)}."
+                : $"no registered raster with rasterId={rasterId.ToString(CultureInfo.InvariantCulture)}.";
+        }
+
+        return reference.LayerId is { } onlyLayer
+            ? $"no registered raster for layerId={onlyLayer.ToString(CultureInfo.InvariantCulture)}."
+            : "either a layerId or a rasterId is required to resolve a raster source.";
+    }
+}

--- a/src/Honua.Server/Features/Protocols/Cog/CogServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Protocols/Cog/CogServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.CogParser;
 using Honua.FileStorage;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Server.Features.Protocols.Cog;
 
@@ -25,6 +27,13 @@ internal static class CogServiceCollectionExtensions
 
         // Register the tile resolver
         services.AddScoped<ICogTileResolver, CogTileResolver>();
+
+        // Register the geoprocessing raster-source resolver (#2264) so native
+        // raster/surface processes can source a registered catalog raster by
+        // layerId/rasterId. Singleton (the GP submit service is a singleton); it
+        // opens a per-call scope to reach the scoped COG store and fails cleanly
+        // when no store is configured.
+        services.TryAddSingleton<IGeoprocessingRasterSourceResolver, CatalogRasterSourceResolver>();
 
         // Register range readers based on available provider configurations.
 #if !HONUA_EXCLUDE_AWS

--- a/src/Honua.Worker.Gdal/Execution/GdalNoData.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalNoData.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Shared NoData handling for the <c>gdal_calc.py</c>-backed executors
+/// (<c>raster.map-algebra</c>, <c>raster.spectral-index</c>,
+/// <c>raster.reclassify</c>; #2267).
+///
+/// <para>
+/// gdal_calc.py masks each input by its own NoData value BY DEFAULT (the
+/// <c>--hideNoData</c> flag DISABLES that masking, so it is never used here).
+/// What the default path does NOT do is tag the OUTPUT band with a NoData value,
+/// so masked cells are written as an untagged fill and downstream consumers lose
+/// the NoData contract. The fix is to resolve a concrete output NoData value —
+/// an explicit caller-supplied <c>noData</c> input, otherwise the primary source
+/// raster's band NoData read back via <c>gdalinfo -json</c> — and pass it as a
+/// real <c>--NoDataValue</c> so gdal_calc both fills masked cells with it AND
+/// records it on the output band.
+/// </para>
+/// </summary>
+internal static class GdalNoData
+{
+    /// <summary>Canonical step-input name for an explicit output NoData override.</summary>
+    public const string InputName = "noData";
+
+    /// <summary>
+    /// Reads the optional explicit <c>noData</c> step input. A present value must be
+    /// a finite number; absent/blank reports <c>false</c> presence with no failure so
+    /// the caller falls back to source-NoData detection.
+    /// </summary>
+    public static bool TryReadExplicitNoData(
+        IReadOnlyDictionary<string, string> parameters,
+        out double? value,
+        out string failure)
+    {
+        value = null;
+        failure = "";
+
+        if (!GdalJobInputReader.TryGetInput(parameters, InputName, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || double.IsNaN(parsed) || double.IsInfinity(parsed))
+        {
+            failure = $"'noData' must be a finite number; got '{raw}'";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    /// <summary>
+    /// Best-effort read of the band-1 NoData value of <paramref name="inputPath"/> via
+    /// <c>gdalinfo -json</c>. Detection is advisory: any failure (tool error, timeout,
+    /// missing/non-numeric NoData) returns <c>null</c> so the calc job still runs — it
+    /// simply runs without an output NoData tag, exactly as before this change.
+    /// </summary>
+    public static async Task<double?> TryReadSourceNoDataAsync(
+        IGdalCommandRunner runner,
+        string inputPath,
+        string workspace,
+        TimeSpan toolTimeout,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = new CancellationTokenSource(toolTimeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        GdalCommandResult result;
+        try
+        {
+            result = await runner.RunAsync("gdalinfo", ["-json", inputPath], workspace, linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+
+        return result.Succeeded ? ParseBandNoData(result.StandardOutput) : null;
+    }
+
+    /// <summary>
+    /// Extracts the first finite numeric <c>noDataValue</c> from a <c>gdalinfo -json</c>
+    /// document's <c>bands</c> array. Returns <c>null</c> when the document is empty,
+    /// unparseable, has no bands, or carries a non-numeric NoData (e.g. the string
+    /// <c>"nan"</c>).
+    /// </summary>
+    internal static double? ParseBandNoData(string gdalinfoJson)
+    {
+        if (string.IsNullOrWhiteSpace(gdalinfoJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(gdalinfoJson);
+            if (!document.RootElement.TryGetProperty("bands", out var bands)
+                || bands.ValueKind != JsonValueKind.Array)
+            {
+                return null;
+            }
+
+            foreach (var band in bands.EnumerateArray())
+            {
+                if (band.TryGetProperty("noDataValue", out var noData)
+                    && noData.ValueKind == JsonValueKind.Number
+                    && noData.TryGetDouble(out var value)
+                    && !double.IsNaN(value)
+                    && !double.IsInfinity(value))
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Appends a <c>--NoDataValue=&lt;v&gt;</c> token when <paramref name="noData"/> has a
+    /// value, formatting the number invariantly. No-ops on <c>null</c> so the calc runs
+    /// with gdal_calc's default (no output NoData tag). Never emits <c>--hideNoData</c>.
+    /// </summary>
+    public static void AppendNoDataArg(List<string> args, double? noData)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        if (noData is null)
+        {
+            return;
+        }
+
+        args.Add($"--NoDataValue={noData.Value.ToString("R", CultureInfo.InvariantCulture)}");
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterMapAlgebraJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterMapAlgebraJobExecutor.cs
@@ -105,16 +105,26 @@ internal sealed partial class GdalRasterMapAlgebraJobExecutor(
             }
         }
 
+        if (!GdalNoData.TryReadExplicitNoData(parameters, out var explicitNoData, out var noDataError))
+        {
+            return JobExecutionResult.Failed($"Invalid map-algebra inputs: {noDataError}");
+        }
+
         var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
         try
         {
             var outputPath = Path.Combine(workspace, "output.tif");
+            var firstInputPath = "";
             var args = new List<string>(sources.Count * 2 + 8);
             for (var i = 0; i < sources.Count; i++)
             {
                 var letter = (char)('A' + i);
                 var inputPath = Path.Combine(workspace, $"input{i.ToString(CultureInfo.InvariantCulture)}.tif");
                 await File.WriteAllBytesAsync(inputPath, sources[i], cancellationToken).ConfigureAwait(false);
+                if (i == 0)
+                {
+                    firstInputPath = inputPath;
+                }
                 args.Add($"-{letter}");
                 args.Add(inputPath);
             }
@@ -128,6 +138,15 @@ internal sealed partial class GdalRasterMapAlgebraJobExecutor(
                 args.Add("--type");
                 args.Add(dataType);
             }
+
+            // Propagate NoData: explicit override, else the first source's band NoData
+            // (best-effort). Passing a real --NoDataValue tags the output band and fills
+            // gdal_calc's default-masked cells with it; --hideNoData is never used.
+            var effectiveNoData = explicitNoData
+                ?? await GdalNoData.TryReadSourceNoDataAsync(
+                    runner, firstInputPath, workspace, opts.ToolTimeout, cancellationToken).ConfigureAwait(false);
+            GdalNoData.AppendNoDataArg(args, effectiveNoData);
+
             args.Add("--overwrite");
             args.Add("--quiet");
             args.Add("--outfile");

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterReclassifyJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterReclassifyJobExecutor.cs
@@ -101,6 +101,11 @@ internal sealed partial class GdalRasterReclassifyJobExecutor(
             }
         }
 
+        if (!GdalNoData.TryReadExplicitNoData(parameters, out var explicitNoData, out var noDataError))
+        {
+            return JobExecutionResult.Failed($"Invalid reclassify inputs: {noDataError}");
+        }
+
         if (!GdalJobInputReader.TryGetBase64Input(parameters, "source", opts.MaxArtifactBytes, out var sourceBytes, out var sourceError))
         {
             Log.InvalidInputs(logger, job.OperationId, sourceError);
@@ -124,6 +129,14 @@ internal sealed partial class GdalRasterReclassifyJobExecutor(
                 args.Add("--type");
                 args.Add(dataType);
             }
+
+            // Propagate NoData: explicit override, else the source's band NoData
+            // (best-effort). --hideNoData is never used (it would DISABLE masking).
+            var effectiveNoData = explicitNoData
+                ?? await GdalNoData.TryReadSourceNoDataAsync(
+                    runner, inputPath, workspace, opts.ToolTimeout, cancellationToken).ConfigureAwait(false);
+            GdalNoData.AppendNoDataArg(args, effectiveNoData);
+
             args.Add("--overwrite");
             args.Add("--quiet");
             args.Add("--outfile");

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterSpectralIndexJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterSpectralIndexJobExecutor.cs
@@ -98,10 +98,16 @@ internal sealed partial class GdalRasterSpectralIndexJobExecutor(
             return JobExecutionResult.Failed($"Invalid spectral-index inputs: {buildError}");
         }
 
+        if (!GdalNoData.TryReadExplicitNoData(parameters, out var explicitNoData, out var noDataError))
+        {
+            return JobExecutionResult.Failed($"Invalid spectral-index inputs: {noDataError}");
+        }
+
         var workspace = GdalScratch.CreateWorkspace(opts.ScratchRoot, job.OperationId);
         try
         {
             var outputPath = Path.Combine(workspace, "output.tif");
+            var firstInputPath = "";
             var args = new List<string>(roles.Count * 2 + 8);
             for (var i = 0; i < roles.Count; i++)
             {
@@ -114,6 +120,10 @@ internal sealed partial class GdalRasterSpectralIndexJobExecutor(
 
                 var inputPath = Path.Combine(workspace, $"{roles[i]}.tif");
                 await File.WriteAllBytesAsync(inputPath, bytes, cancellationToken).ConfigureAwait(false);
+                if (i == 0)
+                {
+                    firstInputPath = inputPath;
+                }
                 args.Add($"-{letter}");
                 args.Add(inputPath);
             }
@@ -122,6 +132,15 @@ internal sealed partial class GdalRasterSpectralIndexJobExecutor(
             args.Add(calc);
             args.Add("--type");
             args.Add("Float32");
+
+            // Propagate NoData: explicit override, else the first band-role raster's
+            // band NoData (best-effort). --hideNoData is never used (it would DISABLE
+            // gdal_calc's per-input masking).
+            var effectiveNoData = explicitNoData
+                ?? await GdalNoData.TryReadSourceNoDataAsync(
+                    runner, firstInputPath, workspace, opts.ToolTimeout, cancellationToken).ConfigureAwait(false);
+            GdalNoData.AppendNoDataArg(args, effectiveNoData);
+
             args.Add("--overwrite");
             args.Add("--quiet");
             args.Add("--outfile");

--- a/tests/dotnet/Honua.Architecture.Tests/GeoprocessingCatalogDocParityTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/GeoprocessingCatalogDocParityTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Geoprocessing;
+using Xunit;
+
+namespace Honua.Architecture.Tests;
+
+/// <summary>
+/// Guards against silent drift between the built-in geoprocessing process catalog
+/// (<c>BuiltInProcessCatalog</c>) and its public reference documentation
+/// (<c>docs/reference/geoprocessing-operations.md</c>). Every registered process id
+/// must be documented so adapters and operators can trust the page.
+/// </summary>
+[Trait("Category", "Architecture")]
+public sealed class GeoprocessingCatalogDocParityTests
+{
+    private const string DocRelativePath = "docs/reference/geoprocessing-operations.md";
+
+    [Fact]
+    public void EveryCatalogProcessId_IsDocumentedInReference()
+    {
+        var docPath = Path.Combine(
+            ArchitectureTestHelpers.ResolveRepositoryRoot(),
+            DocRelativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        File.Exists(docPath).Should().BeTrue($"the geoprocessing reference doc should exist at {DocRelativePath}");
+
+        var docText = File.ReadAllText(docPath);
+
+        var catalog = new BuiltInProcessCatalog();
+        var processIds = catalog.ListProcesses().Select(p => p.ProcessId).ToList();
+
+        processIds.Should().NotBeEmpty();
+
+        // Each id is rendered in a Markdown table cell as `process.id`; require the
+        // back-ticked token so a stray prose mention does not satisfy the check.
+        var missing = processIds
+            .Where(id => !docText.Contains($"`{id}`", StringComparison.Ordinal))
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every registered geoprocessing process id must be documented in "
+            + $"{DocRelativePath}; regenerate it from BuiltInProcessCatalog. Missing: {string.Join(", ", missing)}");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/AnalysisContent/AnalysisContentServiceTests.cs
@@ -5,9 +5,13 @@ using System.Security.Claims;
 using Honua.Core.Exceptions;
 using Honua.Core.Features.AnalysisContent.Abstractions;
 using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Query;
 using Honua.Ai.AnalysisContent;
@@ -17,6 +21,7 @@ using Honua.TestKit.Constants;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using StackExchange.Redis;
@@ -269,6 +274,93 @@ public sealed class AnalysisContentServiceTests
             Assert.Equal(itemId, resolved!.ItemId);
         }
     }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    public async Task SubmitAnalysisPackageAsync_WhenCallerNotAuthorized_RejectedByCentralSubmitGate()
+    {
+        // The AnalysisContent run path delegates straight to the shared
+        // GeoprocessingJobService.SubmitJobAsync without authorizing first, so the
+        // centralized submit-path authorization (#2263) is what protects it. Wire a
+        // real job service whose evaluator forbids Process/Execute and assert the
+        // package submission is rejected centrally.
+        var authEvaluator = Substitute.For<IOperatorAuthorizationEvaluator>();
+        authEvaluator
+            .EvaluateAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<OperatorAuthorizationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(AccessDecision.Forbidden()));
+        var approvalEvaluator = Substitute.For<IOperatorApprovalEvaluator>();
+        approvalEvaluator
+            .Evaluate(Arg.Any<ClaimsPrincipal>(), Arg.Any<OperatorAuthorizationRequest>())
+            .Returns(ApprovalRequirement.NotRequired());
+        var executorOptions = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        executorOptions.CurrentValue.Returns(new GeoprocessingExecutorOptions());
+
+        var jobService = new GeoprocessingJobService(
+            Substitute.For<IUniversalProgressStore>(),
+            Array.Empty<IJobCancellationNotifier>(),
+            authEvaluator,
+            approvalEvaluator,
+            new BuiltInProcessCatalog(),
+            NullLogger<GeoprocessingJobService>.Instance,
+            executorOptions);
+
+        const string itemId = "analysis-package-auth";
+        var store = Substitute.For<IAnalysisContentStore>();
+        store.GetVersionAsync(itemId, Arg.Any<int?>(), Arg.Any<CancellationToken>())
+            .Returns(CreatePackageVersion(itemId));
+
+        var sut = new AnalysisContentService(
+            store,
+            Substitute.For<IMetadataV2GraphProvider>(),
+            Substitute.For<IQueryProcessor>(),
+            Substitute.For<IFeatureReader>(),
+            jobService,
+            Array.Empty<IExecutionLogStore>(),
+            TimeProvider.System,
+            NullLogger<AnalysisContentService>.Instance);
+
+        await Assert.ThrowsAsync<GeoprocessingAuthorizationException>(
+            () => sut.SubmitAnalysisPackageAsync(
+                itemId,
+                1,
+                new RunAnalysisContentVersionCommand(IdempotencyKey: null, Parameters: null),
+                Principal(),
+                CancellationToken.None));
+    }
+
+    private static AnalysisContentVersion CreatePackageVersion(string itemId)
+        => new()
+        {
+            VersionId = $"{itemId}:v1",
+            ItemId = itemId,
+            Version = 1,
+            Kind = AnalysisContentKind.AnalysisPackage,
+            AnalysisPackage = new AnalysisPackageContent
+            {
+                Plan = new AnalysisPlan
+                {
+                    PlanId = "plan-1",
+                    IntentId = "intent-1",
+                    Steps =
+                    [
+                        new AnalysisPlanStep
+                        {
+                            StepId = "step-1",
+                            Kind = AnalysisPlanStepKind.Geoprocess,
+                            ProcessId = "geometry.buffer",
+                            Inputs = new Dictionary<string, string>
+                            {
+                                ["wkb"] = "AAAA",
+                                ["srid"] = "4326",
+                                ["distance"] = "100"
+                            }
+                        }
+                    ]
+                }
+            },
+            ContentHash = "hash-1",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
 
     private static AnalysisContentService CreateService(
         IGeoprocessingJobService? jobService = null,

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -389,6 +389,26 @@ public sealed class GeoprocessingJobServiceTests
     [UnitTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_SinkProcessRequiresApproval_ThrowsApprovalException()
+    {
+        // A sink/write process must pass the same approval gate as a destructive
+        // mutation (#2262). The evaluator requires approval only when the request
+        // is flagged destructive, so this asserts the submit path raises that flag
+        // for a sink plan that materializes data into a caller-owned destination.
+        _approvalEvaluator
+            .Evaluate(Arg.Any<ClaimsPrincipal>(), Arg.Is<OperatorAuthorizationRequest>(r => r.IsDestructive))
+            .Returns(ApprovalRequirement.Required("operator.destructive.process", "destructive-action-requires-approval"));
+
+        var act = async () => await _sut.SubmitJobAsync(CreateSinkPlan(), null, CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingApprovalRequiredException>();
+        await _jobStore.DidNotReceive().TryCreateAsync(
+            Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJob_WithConfiguredWorkload_SubmitsToMatchingBackendAndPersistsState()
     {
         var workloadRegistry = Substitute.For<IExecutionJobDefinitionRegistry>();
@@ -2651,6 +2671,30 @@ public sealed class GeoprocessingJobServiceTests
                     ["wkb"] = "AAAA",
                     ["srid"] = "4326",
                     ["distance"] = "100"
+                }
+            }
+        ]
+    };
+
+    private static AnalysisPlan CreateSinkPlan() => new()
+    {
+        PlanId = "plan-sink",
+        IntentId = "intent-sink",
+        Steps =
+        [
+            new AnalysisPlanStep
+            {
+                StepId = "step-sink",
+                Kind = AnalysisPlanStepKind.Geoprocess,
+                ProcessId = "sink.honua-layer",
+                Inputs = new Dictionary<string, string>
+                {
+                    // Minimal canonical geo+json data URI ({"type":"FeatureCollection","features":[]}).
+                    ["input"] =
+                        "data:application/geo+json;base64," +
+                        "eyJ0eXBlIjoiRmVhdHVyZUNvbGxlY3Rpb24iLCJmZWF0dXJlcyI6W119",
+                    ["layer"] = "sink_layer",
+                    ["targetSrid"] = "4326"
                 }
             }
         ]

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -409,6 +409,25 @@ public sealed class GeoprocessingJobServiceTests
     [UnitTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CallerNotAuthorized_ThrowsAuthorizationException()
+    {
+        // The submit path centralizes Process/Execute authorization (#2263) so a
+        // forbidden caller is rejected before any job record is created, regardless
+        // of which adapter (or none) authorized first.
+        _authEvaluator
+            .EvaluateAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<OperatorAuthorizationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(AccessDecision.Forbidden()));
+
+        var act = async () => await _sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal());
+
+        await act.Should().ThrowAsync<GeoprocessingAuthorizationException>();
+        await _jobStore.DidNotReceive().TryCreateAsync(
+            Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJob_WithConfiguredWorkload_SubmitsToMatchingBackendAndPersistsState()
     {
         var workloadRegistry = Substitute.For<IExecutionJobDefinitionRegistry>();

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogTests.cs
@@ -3138,6 +3138,62 @@ public sealed class ProcessCatalogTests
         ProcessDestructiveClassifier.HasDestructiveStep(plan).Should().BeFalse();
     }
 
+    [Theory]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    [InlineData("sink.external-postgis")]
+    [InlineData("sink.honua-layer")]
+    [InlineData("sink.geojson-file")]
+    public void DestructiveClassifier_SinkProcess_RequiresApproval(string processId)
+    {
+        // A sink/write process is not a destructive source mutation, but it must
+        // still pass the approval gate (#2262).
+        ProcessDestructiveClassifier.IsSink(processId).Should().BeTrue();
+        ProcessDestructiveClassifier.IsDestructive(processId).Should().BeFalse();
+        ProcessDestructiveClassifier.RequiresApproval(processId).Should().BeTrue();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void DestructiveClassifier_QuarantineSink_IsNotApprovalGated()
+    {
+        // The dead-letter quarantine sink is the internal half of the row-level
+        // error contract, not a caller-chosen destination, so it is not gated.
+        ProcessDestructiveClassifier.IsSink("sink.quarantine").Should().BeFalse();
+        ProcessDestructiveClassifier.RequiresApproval("sink.quarantine").Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void DestructiveClassifier_PlanWithSinkStep_IsApprovalGated()
+    {
+        var plan = new AnalysisPlan
+        {
+            PlanId = "p1",
+            IntentId = "i1",
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "s1",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = "sink.honua-layer"
+                }
+            ]
+        };
+
+        // The sink step is not classified as a destructive source mutation...
+        ProcessDestructiveClassifier.FindFirstDestructiveProcessId(plan).Should().BeNull();
+        ProcessDestructiveClassifier.HasDestructiveStep(plan).Should().BeFalse();
+
+        // ...but it is approval-gated, which is what drives EnsureApproved.
+        ProcessDestructiveClassifier.FindFirstApprovalGatedProcessId(plan)
+            .Should().Be("sink.honua-layer");
+        ProcessDestructiveClassifier.HasApprovalGatedStep(plan).Should().BeTrue();
+    }
+
     // -----------------------------------------------------------------------
     // Integration: ValidatePlan RPC with catalog validation
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Issue Link
Closes #2262
Closes #2263
Closes #2264
Closes #2265
Closes #2267

## Summary
Single consolidated PR for the remaining GP MVP follow-ups from the GP audit. Groups four honua-server workstreams onto one branch (per request to keep it to one PR). **Draft:** the two heaviest workstreams (#2263 partial, #2264/#2267) were cut off mid-implementation by a weekly usage limit and need a build/test verification pass before this leaves draft.

## Changes Made
- **#2265 (complete, verified):** regenerated `docs/reference/geoprocessing-operations.md` from `BuiltInProcessCatalog` (95 processes, all 14 families, flagged tools marked, false statements fixed) + new catalog↔doc parity test in `Honua.Architecture.Tests` (passing).
- **#2262 (complete):** GP sink/write processes (`sink.external-postgis`/`honua-layer`/`geojson-file`) now require approval (`ProcessDestructiveClassifier`) + tests.
- **#2263 (WIP):** centralize `Process/Execute` authorization in `GeoprocessingJobService.SubmitJobAsync` (+ AnalysisContent submit path) + tests — implementation in progress, needs verification.
- **#2264 (WIP):** layer-resolved raster sourcing — new `IGeoprocessingRasterSourceResolver` / `CatalogRasterSourceResolver` / `GeoprocessingRasterSourceResolution`, wiring `layerId`/`rasterId` for native raster GP — in progress, needs verification.
- **#2267 (WIP):** correct NoData propagation for gdal_calc tools (new `GdalNoData` helper; reads source NoData, sets `--NoDataValue`, NOT `--hideNoData`) — in progress, needs verification.

## Breaking Changes
None.

## Status / remaining before ready-for-review
- [ ] Build (Release, warnings-as-errors) green for the combined branch
- [ ] Affected unit/integration tests pass
- [ ] `dotnet format --verify-no-changes`
- [ ] `scripts/ci/pre-pr-check.sh`
Work preserved on branches `feat/gp-rbac`, `feat/gp-raster-sourcing`, `feat/gp-docs`. Cut off by weekly usage limit (resets 1am Pacific/Honolulu).

## Gate Impact
- [x] PR gates (build, test, governance)

## Testing
- [x] Unit tests added/updated

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed  (pending — draft/WIP)
- [x] Commit messages follow conventional format
- [x] Issue numbers linked above
