### PR TITLE
feat: add MCP list/read pagination cursors (#1953)

### DIFF
--- a/docs/guides/connect/ai-agents-mcp.md
+++ b/docs/guides/connect/ai-agents-mcp.md
@@ -68,6 +68,12 @@ curl -s -X POST "$BASE/mcp" -H "Content-Type: application/json" \
 
 The response lists the nine `honua_*` tools above with JSON Schema input definitions. From your agent, "list the Honua tools and validate an empty plan" should return a structured violation list (for example `EMPTY_PLAN_ID`), not an error.
 
+Each tool descriptor also carries MCP behavior `annotations` (`title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`) and a `structuredContentSchema` describing the tool's structured result, so schema-driven clients can reason about safety and validate responses.
+
+## Pagination
+
+The list methods (`tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`) are paginated per MCP 2025-03-26: when more entries remain the result carries an opaque `nextCursor`; pass it back as `params.cursor` to fetch the next page. A single-page result omits `nextCursor`. Treat cursors as opaque and echo them verbatim; an invalid or expired cursor returns JSON-RPC `-32602` invalid-params. Large `resources/read` documents (job results, catalogs) are chunked the same way — each page's `text` concatenates per `uri` to rebuild the full document, with `nextCursor` pointing at the next chunk.
+
 ## Troubleshoot
 
 - **`unauthenticated` on `tools/call` or `resources/read`** — handshake methods work anonymously but tool calls do not; attach the `X-API-Key` header (or token) to the client config. See [troubleshooting](../deploy/troubleshooting.md).

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
@@ -38,15 +38,18 @@ internal sealed class McpOperatorSurface
 
     private readonly IReadOnlyDictionary<string, IMcpTool> _tools;
     private readonly IReadOnlyList<IMcpResource> _resources;
+    private readonly McpSurfaceLimits _limits;
     private readonly ILogger<McpOperatorSurface> _logger;
 
     public McpOperatorSurface(
         IEnumerable<IMcpTool> tools,
         IEnumerable<IMcpResource> resources,
-        ILogger<McpOperatorSurface> logger)
+        ILogger<McpOperatorSurface> logger,
+        McpSurfaceLimits? limits = null)
     {
         _tools = tools.ToDictionary(t => t.Name, StringComparer.Ordinal);
         _resources = resources.ToList();
+        _limits = limits ?? McpSurfaceLimits.Default;
         _logger = logger;
 
         McpLog.SurfaceInitialized(
@@ -141,12 +144,12 @@ internal sealed class McpOperatorSurface
             return request.Method switch
             {
                 "initialize" => HandleInitialize(request),
-                "tools/list" => SuccessResponse(request.Id, ListTools(), McpJsonContext.Default.McpToolsListResult),
+                "tools/list" => ListTools(request),
                 "tools/call" => await CallToolAsync(httpContext, request, cancellationToken).ConfigureAwait(false),
-                "resources/list" => SuccessResponse(request.Id, ListResources(), McpJsonContext.Default.McpResourcesListResult),
-                "resources/templates/list" => SuccessResponse(request.Id, ListResourceTemplates(), McpJsonContext.Default.McpResourceTemplatesListResult),
+                "resources/list" => ListResources(request),
+                "resources/templates/list" => ListResourceTemplates(request),
                 "resources/read" => await ReadResourceAsync(httpContext, request, cancellationToken).ConfigureAwait(false),
-                "prompts/list" => SuccessResponse(request.Id, McpPromptCatalog.List(), McpJsonContext.Default.McpPromptsListResult),
+                "prompts/list" => ListPrompts(request),
                 "prompts/get" => GetPrompt(request),
                 _ => ErrorResponse(request.Id, McpErrorMapper.MethodNotFound($"Unknown MCP method '{request.Method}'."))
             };
@@ -209,13 +212,55 @@ internal sealed class McpOperatorSurface
         return LatestProtocolVersion;
     }
 
-    private McpToolsListResult ListTools() => new()
+    private McpJsonRpcResponse ListTools(McpJsonRpcRequest request)
     {
-        Tools = _tools.Values
+        if (!TryReadCursor(request, out var cursor, out var error))
+        {
+            return error;
+        }
+
+        var ordered = _tools.Values
             .Select(t => t.Describe())
             .OrderBy(d => d.Name, StringComparer.Ordinal)
-            .ToList()
-    };
+            .ToList();
+
+        try
+        {
+            var page = McpPagination.Page(ordered, cursor, _limits.ListPageSize, out var nextCursor);
+            return SuccessResponse(
+                request.Id,
+                new McpToolsListResult { Tools = page, NextCursor = nextCursor },
+                McpJsonContext.Default.McpToolsListResult);
+        }
+        catch (GeoprocessingValidationException ex)
+        {
+            return ErrorResponse(request.Id, McpErrorMapper.InvalidArgument(ex.Message));
+        }
+    }
+
+    private McpJsonRpcResponse ListPrompts(McpJsonRpcRequest request)
+    {
+        if (!TryReadCursor(request, out var cursor, out var error))
+        {
+            return error;
+        }
+
+        // McpPromptCatalog.List() already returns the catalog in stable name order.
+        var ordered = McpPromptCatalog.List().Prompts;
+
+        try
+        {
+            var page = McpPagination.Page(ordered, cursor, _limits.ListPageSize, out var nextCursor);
+            return SuccessResponse(
+                request.Id,
+                new McpPromptsListResult { Prompts = page, NextCursor = nextCursor },
+                McpJsonContext.Default.McpPromptsListResult);
+        }
+        catch (GeoprocessingValidationException ex)
+        {
+            return ErrorResponse(request.Id, McpErrorMapper.InvalidArgument(ex.Message));
+        }
+    }
 
     private static McpJsonRpcResponse GetPrompt(McpJsonRpcRequest request)
     {
@@ -350,21 +395,82 @@ internal sealed class McpOperatorSurface
         return SuccessResponse(request.Id, result, McpJsonContext.Default.McpToolsCallResult);
     }
 
-    private McpResourcesListResult ListResources() => new()
+    private McpJsonRpcResponse ListResources(McpJsonRpcRequest request)
     {
-        Resources = _resources
+        if (!TryReadCursor(request, out var cursor, out var error))
+        {
+            return error;
+        }
+
+        var ordered = _resources
             .SelectMany(r => r.Describe())
             .OrderBy(d => d.Uri, StringComparer.Ordinal)
-            .ToList()
-    };
+            .ToList();
 
-    private McpResourceTemplatesListResult ListResourceTemplates() => new()
+        try
+        {
+            var page = McpPagination.Page(ordered, cursor, _limits.ListPageSize, out var nextCursor);
+            return SuccessResponse(
+                request.Id,
+                new McpResourcesListResult { Resources = page, NextCursor = nextCursor },
+                McpJsonContext.Default.McpResourcesListResult);
+        }
+        catch (GeoprocessingValidationException ex)
+        {
+            return ErrorResponse(request.Id, McpErrorMapper.InvalidArgument(ex.Message));
+        }
+    }
+
+    private McpJsonRpcResponse ListResourceTemplates(McpJsonRpcRequest request)
     {
-        ResourceTemplates = _resources
+        if (!TryReadCursor(request, out var cursor, out var error))
+        {
+            return error;
+        }
+
+        var ordered = _resources
             .SelectMany(r => r.DescribeTemplates())
             .OrderBy(d => d.UriTemplate, StringComparer.Ordinal)
-            .ToList()
-    };
+            .ToList();
+
+        try
+        {
+            var page = McpPagination.Page(ordered, cursor, _limits.ListPageSize, out var nextCursor);
+            return SuccessResponse(
+                request.Id,
+                new McpResourceTemplatesListResult { ResourceTemplates = page, NextCursor = nextCursor },
+                McpJsonContext.Default.McpResourceTemplatesListResult);
+        }
+        catch (GeoprocessingValidationException ex)
+        {
+            return ErrorResponse(request.Id, McpErrorMapper.InvalidArgument(ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Parses the optional opaque <c>cursor</c> from a paginated list request's
+    /// <c>params</c>. Returns <c>false</c> with a populated
+    /// <paramref name="errorResponse"/> when the params shape is malformed; a
+    /// missing or null cursor is valid and yields <c>null</c>.
+    /// </summary>
+    private static bool TryReadCursor(
+        McpJsonRpcRequest request,
+        out string? cursor,
+        out McpJsonRpcResponse errorResponse)
+    {
+        cursor = null;
+        errorResponse = null!;
+        try
+        {
+            cursor = ParseParams(request.Params, McpJsonContext.Default.McpListParams)?.Cursor;
+            return true;
+        }
+        catch (GeoprocessingValidationException ex)
+        {
+            errorResponse = ErrorResponse(request.Id, McpErrorMapper.InvalidArgument(ex.Message));
+            return false;
+        }
+    }
 
     private async Task<McpJsonRpcResponse> ReadResourceAsync(
         HttpContext httpContext,
@@ -421,6 +527,29 @@ internal sealed class McpOperatorSurface
             var result = await handler
                 .ReadAsync(httpContext, parameters.Uri, cancellationToken)
                 .ConfigureAwait(false);
+
+            // Chunk large documents (job results, catalogs) into windowed pages so
+            // a single resources/read response stays bounded; small documents are
+            // returned verbatim with no nextCursor. An invalid cursor surfaces as
+            // the same invalid_argument the list methods use.
+            try
+            {
+                var page = McpPagination.Chunk(
+                    result.Contents,
+                    parameters.Cursor,
+                    _limits.MaxResourceReadChars,
+                    out var nextCursor);
+                result = new McpResourcesReadResult { Contents = page, NextCursor = nextCursor };
+            }
+            catch (GeoprocessingValidationException ex)
+            {
+                McpTelemetry.ResourceReadCount.Add(
+                    1,
+                    new KeyValuePair<string, object?>("resource_family", resourceFamily),
+                    new KeyValuePair<string, object?>("status", McpTelemetry.Status.Error));
+                return ErrorResponse(request.Id, McpErrorMapper.InvalidArgument(ex.Message));
+            }
+
             // Contract-first stub resources return `not_implemented` envelopes.
             // Tag the counter accordingly so dashboards can separate stub reads
             // from functional reads.

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpPagination.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpPagination.cs
@@ -1,0 +1,274 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp.Models;
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Opaque-cursor pagination helpers for the MCP operator surface (#1953). MCP
+/// 2025-03-26 paginates list operations (<c>tools/list</c>, <c>resources/list</c>,
+/// <c>resources/templates/list</c>, <c>prompts/list</c>) with an opaque
+/// <c>cursor</c> request field and a <c>nextCursor</c> response field; this helper
+/// produces and validates those cursors over a deterministically ordered list.
+/// It also implements a Honua extension that chunks a large
+/// <c>resources/read</c> payload into windowed pages so job-results and catalog
+/// documents do not have to be returned in a single response.
+/// </summary>
+/// <remarks>
+/// Cursors are opaque base64url tokens that callers MUST treat as black boxes and
+/// echo verbatim — their internal shape (a stable offset into the ordered list,
+/// or a content-index/character-offset pair for reads) is an implementation
+/// detail and may change. An unparseable or out-of-range cursor surfaces as a
+/// <see cref="GeoprocessingValidationException"/> so the dispatcher maps it to the
+/// JSON-RPC <c>-32602</c> invalid-params error MCP requires for an invalid cursor.
+/// </remarks>
+internal static class McpPagination
+{
+    /// <summary>
+    /// Default maximum number of list entries returned per page when the host
+    /// does not override <see cref="McpSurfaceLimits.ListPageSize"/>.
+    /// </summary>
+    public const int DefaultListPageSize = 50;
+
+    /// <summary>
+    /// Default maximum number of characters returned per <c>resources/read</c>
+    /// page. Sized large enough that ordinary resource documents are returned in
+    /// a single response (no <c>nextCursor</c>) and only genuinely large
+    /// job-results/catalog payloads are chunked.
+    /// </summary>
+    public const int DefaultMaxResourceReadChars = 1_000_000;
+
+    private const string ListCursorPrefix = "l1:";
+    private const string ReadCursorPrefix = "r1:";
+
+    /// <summary>
+    /// Returns the page of <paramref name="ordered"/> identified by
+    /// <paramref name="cursor"/>, emitting <paramref name="nextCursor"/> when more
+    /// entries remain. <paramref name="ordered"/> must already be in a stable
+    /// order so the offset a cursor encodes is meaningful across calls.
+    /// </summary>
+    /// <exception cref="GeoprocessingValidationException">
+    /// The cursor is malformed or points past the end of the list.
+    /// </exception>
+    public static IReadOnlyList<T> Page<T>(
+        IReadOnlyList<T> ordered,
+        string? cursor,
+        int pageSize,
+        out string? nextCursor)
+    {
+        ArgumentNullException.ThrowIfNull(ordered);
+
+        if (pageSize <= 0)
+        {
+            nextCursor = null;
+            return ordered;
+        }
+
+        var offset = 0;
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            offset = DecodeListCursor(cursor);
+            if (offset < 0 || offset > ordered.Count)
+            {
+                throw new GeoprocessingValidationException("The pagination cursor is invalid or has expired.");
+            }
+        }
+
+        var end = Math.Min(offset + pageSize, ordered.Count);
+        var page = new List<T>(end - offset);
+        for (var i = offset; i < end; i++)
+        {
+            page.Add(ordered[i]);
+        }
+
+        nextCursor = end < ordered.Count ? EncodeListCursor(end) : null;
+        return page;
+    }
+
+    /// <summary>
+    /// Chunks the <paramref name="contents"/> of a <c>resources/read</c> result so
+    /// no single page exceeds <paramref name="maxChars"/> characters, preserving
+    /// each content block's <c>uri</c> and <c>mimeType</c>. When the whole
+    /// document fits in one page and no cursor was supplied the original
+    /// <paramref name="contents"/> are returned unchanged (no chunking, no
+    /// <paramref name="nextCursor"/>) so small resources are byte-for-byte
+    /// identical to the un-paginated behavior. Each emitted page's <c>text</c> is a
+    /// fragment that a client concatenates per <c>uri</c> to reconstruct the full
+    /// document.
+    /// </summary>
+    /// <exception cref="GeoprocessingValidationException">
+    /// The cursor is malformed or points past the end of the contents.
+    /// </exception>
+    public static IReadOnlyList<McpResourceContent> Chunk(
+        IReadOnlyList<McpResourceContent> contents,
+        string? cursor,
+        int maxChars,
+        out string? nextCursor)
+    {
+        ArgumentNullException.ThrowIfNull(contents);
+
+        var totalChars = 0L;
+        foreach (var content in contents)
+        {
+            totalChars += content.Text.Length;
+        }
+
+        // Fast path: an unpaginated read of a document that fits in one page is
+        // returned verbatim so existing resources keep identical wire output.
+        if (string.IsNullOrEmpty(cursor) && (maxChars <= 0 || totalChars <= maxChars))
+        {
+            nextCursor = null;
+            return contents;
+        }
+
+        if (maxChars <= 0)
+        {
+            nextCursor = null;
+            return contents;
+        }
+
+        var contentIndex = 0;
+        var charOffset = 0;
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            (contentIndex, charOffset) = DecodeReadCursor(cursor);
+            if (contentIndex < 0
+                || contentIndex > contents.Count
+                || (contentIndex < contents.Count && (charOffset < 0 || charOffset > contents[contentIndex].Text.Length)))
+            {
+                throw new GeoprocessingValidationException("The pagination cursor is invalid or has expired.");
+            }
+        }
+
+        var page = new List<McpResourceContent>();
+        var budget = maxChars;
+        var i = contentIndex;
+        var offset = charOffset;
+        while (i < contents.Count && budget > 0)
+        {
+            var content = contents[i];
+            if (offset >= content.Text.Length)
+            {
+                i++;
+                offset = 0;
+                continue;
+            }
+
+            var take = Math.Min(budget, content.Text.Length - offset);
+            page.Add(new McpResourceContent
+            {
+                Uri = content.Uri,
+                MimeType = content.MimeType,
+                Text = content.Text.Substring(offset, take),
+            });
+            offset += take;
+            budget -= take;
+            if (offset >= content.Text.Length)
+            {
+                i++;
+                offset = 0;
+            }
+        }
+
+        // Normalize the resume position past any fully consumed/empty blocks so a
+        // trailing empty content does not produce a dangling nextCursor.
+        while (i < contents.Count && offset >= contents[i].Text.Length)
+        {
+            i++;
+            offset = 0;
+        }
+
+        nextCursor = i < contents.Count ? EncodeReadCursor(i, offset) : null;
+        return page;
+    }
+
+    private static string EncodeListCursor(int offset) =>
+        Encode(ListCursorPrefix + offset.ToString(CultureInfo.InvariantCulture));
+
+    private static int DecodeListCursor(string cursor)
+    {
+        var token = Decode(cursor);
+        if (token is null || !token.StartsWith(ListCursorPrefix, StringComparison.Ordinal))
+        {
+            throw new GeoprocessingValidationException("The pagination cursor is invalid or has expired.");
+        }
+
+        if (!int.TryParse(
+                token.AsSpan(ListCursorPrefix.Length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var offset))
+        {
+            throw new GeoprocessingValidationException("The pagination cursor is invalid or has expired.");
+        }
+
+        return offset;
+    }
+
+    private static string EncodeReadCursor(int contentIndex, int charOffset) =>
+        Encode(ReadCursorPrefix
+            + contentIndex.ToString(CultureInfo.InvariantCulture)
+            + ':'
+            + charOffset.ToString(CultureInfo.InvariantCulture));
+
+    private static (int ContentIndex, int CharOffset) DecodeReadCursor(string cursor)
+    {
+        var token = Decode(cursor);
+        if (token is null || !token.StartsWith(ReadCursorPrefix, StringComparison.Ordinal))
+        {
+            throw new GeoprocessingValidationException("The pagination cursor is invalid or has expired.");
+        }
+
+        var body = token.AsSpan(ReadCursorPrefix.Length);
+        var separator = body.IndexOf(':');
+        if (separator <= 0
+            || !int.TryParse(body[..separator], NumberStyles.None, CultureInfo.InvariantCulture, out var contentIndex)
+            || !int.TryParse(body[(separator + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out var charOffset))
+        {
+            throw new GeoprocessingValidationException("The pagination cursor is invalid or has expired.");
+        }
+
+        return (contentIndex, charOffset);
+    }
+
+    private static string Encode(string token)
+    {
+        var bytes = Encoding.UTF8.GetBytes(token);
+        return Base64Url.EncodeToString(bytes);
+    }
+
+    private static string? Decode(string cursor)
+    {
+        try
+        {
+            var bytes = Base64Url.DecodeFromChars(cursor);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// Host-tunable limits for the MCP operator surface: the list-pagination page
+/// size and the per-page character budget for chunked <c>resources/read</c>
+/// responses. Injected into <see cref="McpOperatorSurface"/>; defaults to
+/// <see cref="Default"/> when the host does not register an override.
+/// </summary>
+internal sealed record McpSurfaceLimits(int ListPageSize, int MaxResourceReadChars)
+{
+    /// <summary>
+    /// The default limits: <see cref="McpPagination.DefaultListPageSize"/> list
+    /// entries per page and <see cref="McpPagination.DefaultMaxResourceReadChars"/>
+    /// characters per <c>resources/read</c> page.
+    /// </summary>
+    public static McpSurfaceLimits Default { get; } =
+        new(McpPagination.DefaultListPageSize, McpPagination.DefaultMaxResourceReadChars);
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
@@ -25,6 +25,7 @@ namespace Honua.Ai.Protocols.Mcp.Models;
 [JsonSerializable(typeof(McpInitializeResult))]
 [JsonSerializable(typeof(McpServerCapabilities))]
 [JsonSerializable(typeof(McpServerInfo))]
+[JsonSerializable(typeof(McpListParams))]
 [JsonSerializable(typeof(McpToolsListResult))]
 [JsonSerializable(typeof(McpToolDescriptor))]
 [JsonSerializable(typeof(McpToolAnnotations))]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
@@ -187,12 +187,32 @@ internal sealed class McpServerInfo
 }
 
 /// <summary>
+/// Request payload shared by the paginated MCP list methods (<c>tools/list</c>,
+/// <c>resources/list</c>, <c>resources/templates/list</c>, <c>prompts/list</c>).
+/// The optional opaque <c>cursor</c> resumes a previous page; clients MUST echo
+/// the <c>nextCursor</c> from the prior result verbatim and treat it as opaque.
+/// See https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/pagination.
+/// </summary>
+internal sealed class McpListParams
+{
+    [JsonPropertyName("cursor")]
+    public string? Cursor { get; set; }
+}
+
+/// <summary>
 /// Response payload for <c>tools/list</c>.
 /// </summary>
 internal sealed class McpToolsListResult
 {
     [JsonPropertyName("tools")]
     public IReadOnlyList<McpToolDescriptor> Tools { get; set; } = [];
+
+    /// <summary>
+    /// Opaque cursor for the next page, present only when more tools remain.
+    /// Omitted (null) on the final page per MCP 2025-03-26 pagination.
+    /// </summary>
+    [JsonPropertyName("nextCursor")]
+    public string? NextCursor { get; set; }
 }
 
 internal sealed class McpToolDescriptor
@@ -350,6 +370,13 @@ internal sealed class McpResourcesListResult
 {
     [JsonPropertyName("resources")]
     public IReadOnlyList<McpResourceDescriptor> Resources { get; set; } = [];
+
+    /// <summary>
+    /// Opaque cursor for the next page, present only when more resources remain.
+    /// Omitted (null) on the final page per MCP 2025-03-26 pagination.
+    /// </summary>
+    [JsonPropertyName("nextCursor")]
+    public string? NextCursor { get; set; }
 }
 
 internal sealed class McpResourceDescriptor
@@ -377,6 +404,13 @@ internal sealed class McpResourceTemplatesListResult
 {
     [JsonPropertyName("resourceTemplates")]
     public IReadOnlyList<McpResourceTemplateDescriptor> ResourceTemplates { get; set; } = [];
+
+    /// <summary>
+    /// Opaque cursor for the next page, present only when more templates remain.
+    /// Omitted (null) on the final page per MCP 2025-03-26 pagination.
+    /// </summary>
+    [JsonPropertyName("nextCursor")]
+    public string? NextCursor { get; set; }
 }
 
 internal sealed class McpResourceTemplateDescriptor
@@ -401,6 +435,15 @@ internal sealed class McpResourcesReadParams
 {
     [JsonPropertyName("uri")]
     public string? Uri { get; set; }
+
+    /// <summary>
+    /// Optional opaque cursor that resumes a chunked read of a large resource
+    /// document (job results, catalogs). Honua extension over MCP 2025-03-26,
+    /// which does not paginate <c>resources/read</c>; clients echo the prior
+    /// <c>nextCursor</c> verbatim. Omit to read from the start of the document.
+    /// </summary>
+    [JsonPropertyName("cursor")]
+    public string? Cursor { get; set; }
 }
 
 /// <summary>
@@ -410,6 +453,15 @@ internal sealed class McpResourcesReadResult
 {
     [JsonPropertyName("contents")]
     public IReadOnlyList<McpResourceContent> Contents { get; set; } = [];
+
+    /// <summary>
+    /// Opaque cursor for the next chunk of a large resource document, present
+    /// only when more content remains. Honua extension over MCP 2025-03-26; each
+    /// page's <c>text</c> concatenates per <c>uri</c> to rebuild the full
+    /// document. Omitted (null) when the whole document was returned.
+    /// </summary>
+    [JsonPropertyName("nextCursor")]
+    public string? NextCursor { get; set; }
 }
 
 internal sealed class McpResourceContent
@@ -439,6 +491,13 @@ internal sealed class McpPromptsListResult
 {
     [JsonPropertyName("prompts")]
     public IReadOnlyList<McpPromptDescriptor> Prompts { get; set; } = [];
+
+    /// <summary>
+    /// Opaque cursor for the next page, present only when more prompts remain.
+    /// Omitted (null) on the final page per MCP 2025-03-26 pagination.
+    /// </summary>
+    [JsonPropertyName("nextCursor")]
+    public string? NextCursor { get; set; }
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpEndpointIntegrationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpEndpointIntegrationTests.cs
@@ -637,6 +637,50 @@ public sealed class McpEndpointIntegrationTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.GetMetadata)]
     [Endpoint("POST /mcp")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/list")]
+    public async Task ToolsList_WithInvalidCursor_ReturnsInvalidParamsJsonRpcError()
+    {
+        // MCP 2025-03-26 pagination: an unparseable/expired cursor must surface as
+        // the JSON-RPC -32602 invalid-params error so the client restarts paging.
+        var response = await PostRpcAsync("""
+            {"jsonrpc":"2.0","id":"page-bad","method":"tools/list","params":{"cursor":"not-a-cursor"}}
+            """);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = await ReadJsonAsync(response);
+        var root = document.RootElement;
+
+        root.GetProperty("id").GetString().Should().Be("page-bad");
+        var error = root.GetProperty("error");
+        error.GetProperty("code").GetInt32().Should().Be(-32602);
+        error.GetProperty("data").GetProperty("code").GetString().Should().Be("invalid_argument");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/list")]
+    public async Task ToolsList_WhenSinglePage_OmitsNextCursor()
+    {
+        // The default page size comfortably holds the composed tool catalog, so a
+        // single-page result must omit nextCursor entirely (WhenWritingNull) —
+        // proving the pagination plumbing is additive and backward compatible.
+        var response = await PostRpcAsync("""
+            {"jsonrpc":"2.0","id":"page-1","method":"tools/list"}
+            """);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = await ReadJsonAsync(response);
+        var result = document.RootElement.GetProperty("result");
+
+        result.GetProperty("tools").ValueKind.Should().Be(JsonValueKind.Array);
+        result.TryGetProperty("nextCursor", out _).Should().BeFalse(
+            "a single-page list must not advertise a nextCursor");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp")]
     [InterfaceOperation(TestProtocols.Mcp, "resources/list")]
     public async Task ResourcesList_ExcludesParameterizedUris()
     {

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpPaginationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpPaginationTests.cs
@@ -1,0 +1,295 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Resources;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Pins the MCP opaque-cursor pagination contract (#1953): list paging over
+/// <c>tools/list</c> / <c>resources/list</c> / <c>resources/templates/list</c> /
+/// <c>prompts/list</c>, the windowed chunking of large <c>resources/read</c>
+/// documents, and the dispatcher plumbing that surfaces <c>nextCursor</c> and
+/// rejects an invalid cursor with JSON-RPC <c>-32602</c> invalid-params.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class McpPaginationTests
+{
+    [UnitTest]
+    public void Page_WhenMoreRemain_ReturnsFirstPageAndOpaqueNextCursor()
+    {
+        var items = Enumerable.Range(0, 10).ToList();
+
+        var page = McpPagination.Page(items, cursor: null, pageSize: 4, out var nextCursor);
+
+        page.Should().Equal(0, 1, 2, 3);
+        nextCursor.Should().NotBeNullOrWhiteSpace();
+        // Cursors are opaque tokens, not the raw offset.
+        nextCursor.Should().NotBe("4");
+    }
+
+    [UnitTest]
+    public void Page_SecondCall_ResumesFromCursor()
+    {
+        var items = Enumerable.Range(0, 10).ToList();
+
+        var first = McpPagination.Page(items, cursor: null, pageSize: 4, out var firstCursor);
+        var second = McpPagination.Page(items, firstCursor, pageSize: 4, out var secondCursor);
+        var third = McpPagination.Page(items, secondCursor, pageSize: 4, out var thirdCursor);
+
+        first.Should().Equal(0, 1, 2, 3);
+        second.Should().Equal(4, 5, 6, 7);
+        third.Should().Equal(8, 9);
+        // The final page omits the cursor.
+        thirdCursor.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void Page_WhenAllFitInOnePage_OmitsNextCursor()
+    {
+        var items = Enumerable.Range(0, 3).ToList();
+
+        var page = McpPagination.Page(items, cursor: null, pageSize: 50, out var nextCursor);
+
+        page.Should().Equal(0, 1, 2);
+        nextCursor.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void Page_WithMalformedCursor_ThrowsValidation()
+    {
+        var items = Enumerable.Range(0, 10).ToList();
+
+        var act = () => McpPagination.Page(items, cursor: "not-a-real-cursor", pageSize: 4, out _);
+
+        act.Should().Throw<GeoprocessingValidationException>();
+    }
+
+    [UnitTest]
+    public void Chunk_WhenDocumentFitsBudget_ReturnsVerbatimWithoutCursor()
+    {
+        IReadOnlyList<McpResourceContent> contents =
+        [
+            new McpResourceContent { Uri = "honua://catalog/x", MimeType = "application/json", Text = "{\"a\":1}" }
+        ];
+
+        var page = McpPagination.Chunk(contents, cursor: null, maxChars: 1000, out var nextCursor);
+
+        page.Should().BeSameAs(contents);
+        nextCursor.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void Chunk_WhenDocumentExceedsBudget_SplitsAndReassembles()
+    {
+        var text = new string('x', 25) + new string('y', 25);
+        IReadOnlyList<McpResourceContent> contents =
+        [
+            new McpResourceContent { Uri = "honua://jobs/j/results", MimeType = "application/json", Text = text }
+        ];
+
+        var reassembled = string.Empty;
+        string? cursor = null;
+        var pages = 0;
+        do
+        {
+            var page = McpPagination.Chunk(contents, cursor, maxChars: 20, out cursor);
+            page.Should().HaveCount(1);
+            page[0].Uri.Should().Be("honua://jobs/j/results");
+            page[0].Text.Length.Should().BeLessThanOrEqualTo(20);
+            reassembled += page[0].Text;
+            pages++;
+        }
+        while (cursor is not null && pages < 10);
+
+        pages.Should().Be(3);
+        reassembled.Should().Be(text);
+    }
+
+    [UnitTest]
+    public void Chunk_WithMalformedCursor_ThrowsValidation()
+    {
+        IReadOnlyList<McpResourceContent> contents =
+        [
+            new McpResourceContent { Uri = "honua://catalog/x", MimeType = "application/json", Text = "abc" }
+        ];
+
+        var act = () => McpPagination.Chunk(contents, cursor: "%%bogus%%", maxChars: 1, out _);
+
+        act.Should().Throw<GeoprocessingValidationException>();
+    }
+
+    [UnitTest]
+    public async Task ToolsList_OverDispatcher_PagesWithNextCursor()
+    {
+        var surface = new McpOperatorSurface(
+            tools: Enumerable.Range(0, 5).Select(i => (IMcpTool)new StubTool($"honua_tool_{i}")),
+            resources: [],
+            logger: NullLogger<McpOperatorSurface>.Instance,
+            limits: new McpSurfaceLimits(ListPageSize: 2, MaxResourceReadChars: 1000));
+
+        var firstNames = await ListToolPageAsync(surface, cursor: null);
+        firstNames.Names.Should().Equal("honua_tool_0", "honua_tool_1");
+        firstNames.NextCursor.Should().NotBeNullOrWhiteSpace();
+
+        var secondNames = await ListToolPageAsync(surface, firstNames.NextCursor);
+        secondNames.Names.Should().Equal("honua_tool_2", "honua_tool_3");
+
+        var thirdNames = await ListToolPageAsync(surface, secondNames.NextCursor);
+        thirdNames.Names.Should().Equal("honua_tool_4");
+        thirdNames.NextCursor.Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task ToolsList_WithInvalidCursor_ReturnsInvalidParams()
+    {
+        var surface = new McpOperatorSurface(
+            tools: [new StubTool("honua_tool_0")],
+            resources: [],
+            logger: NullLogger<McpOperatorSurface>.Instance,
+            limits: new McpSurfaceLimits(ListPageSize: 2, MaxResourceReadChars: 1000));
+
+        var response = await DispatchAsync(
+            surface,
+            """{"jsonrpc":"2.0","id":"x","method":"tools/list","params":{"cursor":"garbage"}}""");
+
+        response!.Error.Should().NotBeNull();
+        response.Error!.Code.Should().Be(McpErrorMapper.JsonRpcInvalidParams);
+        response.Error.Data!.Code.Should().Be(McpErrorMapper.Codes.InvalidArgument);
+    }
+
+    [UnitTest]
+    public async Task ResourcesRead_OverDispatcher_ChunksLargeDocument()
+    {
+        var text = new string('z', 50);
+        var surface = new McpOperatorSurface(
+            tools: [],
+            resources: [new StubResource("honua://big/doc", text)],
+            logger: NullLogger<McpOperatorSurface>.Instance,
+            limits: new McpSurfaceLimits(ListPageSize: 50, MaxResourceReadChars: 20));
+
+        var context = McpTestFactory.AuthenticatedHttpContext();
+
+        var first = await DispatchAsync(
+            surface,
+            """{"jsonrpc":"2.0","id":"r1","method":"resources/read","params":{"uri":"honua://big/doc"}}""",
+            context);
+
+        var firstResult = first!.Result!.Value;
+        var firstChunk = firstResult.GetProperty("contents")[0].GetProperty("text").GetString();
+        firstChunk!.Length.Should().Be(20);
+        var nextCursor = firstResult.GetProperty("nextCursor").GetString();
+        nextCursor.Should().NotBeNullOrWhiteSpace();
+
+        var second = await DispatchAsync(
+            surface,
+            "{\"jsonrpc\":\"2.0\",\"id\":\"r2\",\"method\":\"resources/read\",\"params\":{\"uri\":\"honua://big/doc\",\"cursor\":\""
+                + nextCursor + "\"}}",
+            context);
+        var secondResult = second!.Result!.Value;
+        secondResult.GetProperty("contents")[0].GetProperty("text").GetString()!.Length.Should().Be(20);
+    }
+
+    private static async Task<(string[] Names, string? NextCursor)> ListToolPageAsync(
+        McpOperatorSurface surface,
+        string? cursor)
+    {
+        var paramsJson = cursor is null
+            ? string.Empty
+            : ",\"params\":{\"cursor\":\"" + cursor + "\"}";
+        var response = await DispatchAsync(
+            surface,
+            "{\"jsonrpc\":\"2.0\",\"id\":\"t\",\"method\":\"tools/list\"" + paramsJson + "}");
+
+        var result = response!.Result!.Value;
+        var names = result.GetProperty("tools")
+            .EnumerateArray()
+            .Select(t => t.GetProperty("name").GetString()!)
+            .ToArray();
+        var nextCursor = result.TryGetProperty("nextCursor", out var nc) ? nc.GetString() : null;
+        return (names, nextCursor);
+    }
+
+    private static async Task<McpJsonRpcResponse?> DispatchAsync(
+        McpOperatorSurface surface,
+        string body,
+        HttpContext? context = null)
+    {
+        var request = JsonSerializer.Deserialize(body, McpJsonContext.Default.McpJsonRpcRequest)!;
+        return await surface.DispatchAsync(
+            context ?? McpTestFactory.AuthenticatedHttpContext(),
+            request,
+            CancellationToken.None);
+    }
+
+    private sealed class StubTool : IMcpTool
+    {
+        private readonly string _name;
+
+        public StubTool(string name) => _name = name;
+
+        public string Name => _name;
+
+        public string WorkflowFamily => McpTelemetry.WorkflowFamily.Unknown;
+
+        public McpToolDescriptor Describe() => new()
+        {
+            Name = _name,
+            Description = "stub",
+            InputSchema = McpTestFactory.ParseJson("{\"type\":\"object\"}")
+        };
+
+        public Task<McpToolsCallResult> InvokeAsync(
+            HttpContext httpContext,
+            JsonElement? arguments,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new McpToolsCallResult());
+    }
+
+    private sealed class StubResource : IMcpResource
+    {
+        private readonly string _uri;
+        private readonly string _text;
+
+        public StubResource(string uri, string text)
+        {
+            _uri = uri;
+            _text = text;
+        }
+
+        public string Family => McpTelemetry.ResourceFamily.Unknown;
+
+        public IReadOnlyList<McpResourceDescriptor> Describe() =>
+            [new McpResourceDescriptor { Uri = _uri, Name = "stub", Description = "stub" }];
+
+        public IReadOnlyList<McpResourceTemplateDescriptor> DescribeTemplates() => [];
+
+        public bool CanHandle(string uri) => string.Equals(uri, _uri, System.StringComparison.Ordinal);
+
+        public Task<McpResourcesReadResult> ReadAsync(
+            HttpContext httpContext,
+            string uri,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new McpResourcesReadResult
+            {
+                Contents =
+                [
+                    new McpResourceContent { Uri = _uri, MimeType = "application/json", Text = _text }
+                ]
+            });
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #1953

## Summary
Completes the remaining acceptance criterion of #1953 (MCP tool ergonomics & safety metadata): **opaque-cursor pagination**. The other three criteria already landed on trunk — tool annotations + output schemas (PR #1960) and the curated MCP prompts catalog (PR #2088) — so this PR adds only the pagination pillar, additively and aligned with ADR-0056 (it does not rearchitect the transport/surface; that is the #1948 epic's job).

Pagination is implemented per MCP 2025-03-26: list methods take an opaque `cursor` and return `nextCursor` only when more entries remain; large `resources/read` documents (job results, catalogs) are chunked the same way as a documented Honua extension (MCP has no native `resources/read` pagination).

## Changes Made
- Add `McpPagination` helper: opaque base64url cursors — offset-based paging for list methods and content-index/char-offset windowed chunking for `resources/read`. Invalid/expired cursors raise a validation error mapped to JSON-RPC `-32602` invalid-params.
- Paginate `tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list` (page-size bounded; `nextCursor` omitted on the final/single page).
- Chunk large `resources/read` payloads into windowed pages; documents within the budget are returned **byte-for-byte unchanged** with no `nextCursor`, so existing resource output and tests are unaffected.
- Add host-tunable `McpSurfaceLimits` (list page size, max read chars) injected into `McpOperatorSurface` with sane defaults.
- Add `McpListParams` + `nextCursor` wire fields and register them in the AOT `McpJsonContext`.
- Tests: `McpPaginationTests` (helper + dispatcher paging/chunking, 10 cases) plus HTTP-level integration assertions (invalid-cursor → -32602, single page omits `nextCursor`). Document pagination in `docs/guides/connect/ai-agents-mcp.md`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. All additions are opt-in: clients that send no `cursor` and read documents within the size budget see identical responses (the new `nextCursor` fields are omitted when null).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
