### PR TITLE
feat: NATS JetStream event-bus sink with idempotent producer + DLQ (#357)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,6 +82,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
+    <PackageVersion Include="NATS.Net" Version="2.8.2" />
     <PackageVersion Include="NBomber" Version="6.3.0" />
     <PackageVersion Include="NBomber.Http" Version="6.2.0" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />

--- a/src/Honua.Hosting/Features/Events/Sinks/Nats/INatsEventProducer.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Nats/INatsEventProducer.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Minimal transport abstraction over a NATS JetStream producer (#357).
+/// </summary>
+/// <remarks>
+/// The concrete <see cref="NatsJetStreamEventProducer"/> wraps the NATS.Net
+/// client and owns all JetStream connection and deduplication configuration.
+/// Keeping the sink dependent on this thin abstraction rather than the concrete
+/// client means the dead-letter routing and serialization logic in
+/// <see cref="NatsFeatureChangeEventSink"/> can be unit-tested without a live
+/// JetStream server.
+/// </remarks>
+internal interface INatsEventProducer : IAsyncDisposable
+{
+    /// <summary>
+    /// Publishes a single message to <paramref name="subject"/> through JetStream
+    /// and awaits the server acknowledgement. Throws when the publish is not
+    /// acknowledged (the sink turns a throw into dead-letter routing or a metered
+    /// failure).
+    /// </summary>
+    /// <param name="subject">Destination JetStream subject.</param>
+    /// <param name="messageId">
+    /// Deduplication identifier published as the <c>Nats-Msg-Id</c> header. When
+    /// non-empty, JetStream rejects a duplicate within the stream's dedup window,
+    /// giving publish-side exactly-once delivery. Empty disables deduplication for
+    /// the message.
+    /// </param>
+    /// <param name="value">Serialized event payload.</param>
+    /// <param name="headers">Message headers (event id, operation, content-type, ...).</param>
+    /// <param name="cancellationToken">Token signalling host shutdown.</param>
+    Task PublishAsync(
+        string subject,
+        string messageId,
+        byte[] value,
+        IReadOnlyList<KeyValuePair<string, string>> headers,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Hosting/Features/Events/Sinks/Nats/NatsFeatureChangeEventSink.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Nats/NatsFeatureChangeEventSink.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Concrete <see cref="IFeatureChangeEventSink"/> that publishes committed
+/// feature-change events to NATS JetStream (#357).
+/// </summary>
+/// <remarks>
+/// Events are serialized as JSON and published to a single JetStream subject so
+/// per-subject ordering preserves commit order. When deduplication is enabled the
+/// message carries a <c>Nats-Msg-Id</c> equal to the event id, so JetStream
+/// rejects a duplicate within the stream's dedup window (publish-side
+/// exactly-once: no duplicate stored on retry). When a delivery still fails, the
+/// event is routed to the configured dead-letter subject with diagnostic headers;
+/// if dead-lettering is disabled or itself fails, the failure surfaces to the
+/// broadcaster, which isolates and meters it without affecting durable storage or
+/// sibling sinks.
+/// </remarks>
+internal sealed partial class NatsFeatureChangeEventSink : IFeatureChangeEventSink
+{
+    private const string ContentType = "application/json";
+
+    private readonly INatsEventProducer _producer;
+    private readonly NatsFeatureChangeEventSinkOptions _options;
+    private readonly ILogger<NatsFeatureChangeEventSink> _logger;
+
+    public NatsFeatureChangeEventSink(
+        INatsEventProducer producer,
+        IOptions<NatsFeatureChangeEventSinkOptions> options,
+        ILogger<NatsFeatureChangeEventSink> logger)
+    {
+        _producer = producer ?? throw new ArgumentNullException(nameof(producer));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public string Name => "nats";
+
+    /// <inheritdoc />
+    public async Task PublishAsync(FeatureChangeEvent featureEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        var messageId = _options.EnableDeduplication ? featureEvent.EventId : string.Empty;
+        var value = JsonSerializer.SerializeToUtf8Bytes(
+            featureEvent,
+            FeatureChangeEventsJsonContext.Default.FeatureChangeEvent);
+        var headers = BuildHeaders(featureEvent);
+
+        try
+        {
+            await _producer
+                .PublishAsync(_options.Subject, messageId, value, headers, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            await DeadLetterAsync(featureEvent, value, headers, ex, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DeadLetterAsync(
+        FeatureChangeEvent featureEvent,
+        byte[] value,
+        IReadOnlyList<KeyValuePair<string, string>> headers,
+        Exception failure,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.DeadLetterSubject))
+        {
+            // Dead-lettering disabled: surface to the broadcaster, which isolates
+            // and meters the failure without affecting durable storage or siblings.
+            throw failure;
+        }
+
+        var dlqHeaders = new List<KeyValuePair<string, string>>(headers.Count + 3);
+        dlqHeaders.AddRange(headers);
+        dlqHeaders.Add(new("x-dlq-source-subject", _options.Subject));
+        dlqHeaders.Add(new("x-dlq-error", Truncate(failure.Message, 1024)));
+        dlqHeaders.Add(new("x-dlq-failed-at", DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture)));
+
+        // A distinct dedup id avoids the dead-letter copy colliding with the
+        // primary event in the dead-letter stream's dedup window.
+        var dlqMessageId = _options.EnableDeduplication
+            ? string.Concat(featureEvent.EventId, ":dlq")
+            : string.Empty;
+
+        try
+        {
+            await _producer
+                .PublishAsync(_options.DeadLetterSubject!, dlqMessageId, value, dlqHeaders, cancellationToken)
+                .ConfigureAwait(false);
+            FeatureChangeEventSinkMetrics.DeadLettered.Add(
+                1,
+                new KeyValuePair<string, object?>("sink", Name));
+            LogDeadLettered(_logger, featureEvent.EventId, _options.DeadLetterSubject!, failure);
+        }
+        catch (Exception dlqEx)
+        {
+            // Both primary and dead-letter delivery failed: surface the original
+            // failure so the broadcaster meters it. Record the DLQ failure too.
+            LogDeadLetterFailed(_logger, featureEvent.EventId, _options.DeadLetterSubject!, dlqEx);
+            throw failure;
+        }
+    }
+
+    private static IReadOnlyList<KeyValuePair<string, string>> BuildHeaders(FeatureChangeEvent featureEvent)
+        =>
+        [
+            new("content-type", ContentType),
+            new("x-event-id", featureEvent.EventId),
+            new("x-event-cursor", featureEvent.Cursor.ToString(CultureInfo.InvariantCulture)),
+            new("x-service-id", featureEvent.ServiceId),
+            new("x-layer-id", featureEvent.LayerId.ToString(CultureInfo.InvariantCulture)),
+            new("x-feature-id", featureEvent.ObjectId.ToString(CultureInfo.InvariantCulture)),
+            new("x-operation", featureEvent.Operation),
+            new("x-protocol", featureEvent.Protocol),
+        ];
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length <= maxLength ? value : value[..maxLength];
+
+    [LoggerMessage(
+        EventId = 9412,
+        Level = LogLevel.Warning,
+        Message = "NATS sink dead-lettered feature-change event {EventId} to subject '{DeadLetterSubject}' after a delivery failure.")]
+    private static partial void LogDeadLettered(ILogger logger, string eventId, string deadLetterSubject, Exception failure);
+
+    [LoggerMessage(
+        EventId = 9413,
+        Level = LogLevel.Error,
+        Message = "NATS sink failed to dead-letter feature-change event {EventId} to subject '{DeadLetterSubject}'; the original delivery failure will be surfaced.")]
+    private static partial void LogDeadLetterFailed(ILogger logger, string eventId, string deadLetterSubject, Exception failure);
+}

--- a/src/Honua.Hosting/Features/Events/Sinks/Nats/NatsFeatureChangeEventSinkOptions.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Nats/NatsFeatureChangeEventSinkOptions.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// Configuration for the NATS JetStream feature-change event sink (#357).
+/// </summary>
+/// <remarks>
+/// The NATS sink is one concrete <see cref="IFeatureChangeEventSink"/> adapter
+/// behind the broker-agnostic broadcaster. It is off by default and only wired
+/// when both the umbrella sink fan-out (<see cref="FeatureChangeEventSinkOptions.Enabled"/>)
+/// and this adapter are enabled. Committed feature-change events are published to a
+/// JetStream <see cref="Subject"/>; when <see cref="EnableDeduplication"/> is set
+/// each message carries a <c>Nats-Msg-Id</c> equal to the event id so JetStream
+/// rejects duplicates within the stream's dedup window (publish-side exactly-once).
+/// Deliveries that fail are routed to <see cref="DeadLetterSubject"/> with
+/// diagnostic headers so operators can inspect and replay them. JetStream
+/// preserves per-subject ordering, so all mutations published to the same subject
+/// retain their commit order.
+/// </remarks>
+public sealed class NatsFeatureChangeEventSinkOptions
+{
+    /// <summary>
+    /// Configuration section name bound from application configuration.
+    /// </summary>
+    public const string SectionName = "FeatureChangeEvents:Sinks:Nats";
+
+    /// <summary>
+    /// Enables the NATS sink adapter. Defaults to <see langword="false"/> so the
+    /// dependency is inert unless explicitly configured.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Comma-separated NATS server URL list (for example <c>nats://localhost:4222</c>).
+    /// </summary>
+    public string? Url { get; set; }
+
+    /// <summary>
+    /// JetStream subject that committed feature-change events are published to.
+    /// </summary>
+    public string Subject { get; set; } = "honua.feature-changes";
+
+    /// <summary>
+    /// Subject that deliveries which fail are routed to. When null or empty,
+    /// dead-lettering is disabled and a terminal publish failure surfaces to the
+    /// broadcaster (metered, isolated, never fatal).
+    /// </summary>
+    public string? DeadLetterSubject { get; set; } = "honua.feature-changes.dlq";
+
+    /// <summary>
+    /// Enables JetStream message deduplication for publish-side exactly-once
+    /// semantics. When true each message is published with a <c>Nats-Msg-Id</c>
+    /// equal to the event id, so a redelivery within the stream's dedup window is
+    /// rejected as a duplicate. Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool EnableDeduplication { get; set; } = true;
+
+    /// <summary>
+    /// Per-message publish timeout in milliseconds. A publish attempt that does not
+    /// complete within this window is treated as a delivery failure and, when
+    /// configured, routed to the dead-letter subject.
+    /// </summary>
+    public int PublishTimeoutMs { get; set; } = 30_000;
+
+    /// <summary>
+    /// Optional path to a NATS credentials (<c>.creds</c>) file for JWT/NKey auth.
+    /// </summary>
+    public string? CredsFile { get; set; }
+
+    /// <summary>
+    /// Optional bearer token used for token authentication.
+    /// </summary>
+    public string? Token { get; set; }
+
+    /// <summary>
+    /// Optional username for user/password authentication.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Optional password for user/password authentication.
+    /// </summary>
+    public string? Password { get; set; }
+}
+
+/// <summary>
+/// Validates <see cref="NatsFeatureChangeEventSinkOptions"/> on startup so a
+/// misconfigured NATS sink fails fast rather than silently dropping events.
+/// </summary>
+internal sealed class NatsFeatureChangeEventSinkOptionsValidator
+    : IValidateOptions<NatsFeatureChangeEventSinkOptions>
+{
+    public ValidateOptionsResult Validate(string? name, NatsFeatureChangeEventSinkOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!options.Enabled)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.Url))
+        {
+            failures.Add("NATS sink Url must be configured when the NATS sink is enabled.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Subject))
+        {
+            failures.Add("NATS sink Subject must be configured when the NATS sink is enabled.");
+        }
+
+        if (options.PublishTimeoutMs < 1)
+        {
+            failures.Add("NATS sink PublishTimeoutMs must be at least 1 millisecond.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.DeadLetterSubject) &&
+            string.Equals(options.DeadLetterSubject, options.Subject, StringComparison.Ordinal))
+        {
+            failures.Add("NATS sink DeadLetterSubject must differ from Subject to avoid redelivery loops.");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Honua.Hosting/Features/Events/Sinks/Nats/NatsJetStreamEventProducer.cs
+++ b/src/Honua.Hosting/Features/Events/Sinks/Nats/NatsJetStreamEventProducer.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Options;
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+
+namespace Honua.Infrastructure.Events;
+
+/// <summary>
+/// NATS.Net-backed <see cref="INatsEventProducer"/> that owns all JetStream
+/// connection and deduplication configuration (#357).
+/// </summary>
+/// <remarks>
+/// This is the only type that references the NATS client. It is constructed once
+/// as a singleton; the underlying <see cref="NatsConnection"/> is thread-safe and
+/// shared across all publishes. Messages are published through JetStream so the
+/// server persists and acknowledges them; supplying a <c>Nats-Msg-Id</c> header
+/// lets JetStream reject duplicates within the stream's dedup window, giving
+/// publish-side exactly-once delivery (no duplicate stored on retry).
+/// </remarks>
+internal sealed class NatsJetStreamEventProducer : INatsEventProducer
+{
+    private const string MessageIdHeader = "Nats-Msg-Id";
+
+    private readonly NatsConnection _connection;
+    private readonly NatsJSContext _jetStream;
+    private readonly TimeSpan _publishTimeout;
+
+    public NatsJetStreamEventProducer(IOptions<NatsFeatureChangeEventSinkOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var value = options.Value ?? throw new ArgumentNullException(nameof(options));
+
+        var natsOpts = new NatsOpts
+        {
+            Url = value.Url ?? "nats://localhost:4222",
+            Name = "honua-feature-event-sink",
+            // The default registry routes byte[] payloads through the raw
+            // serializer, so the already-JSON-serialized event envelope is written
+            // to the wire verbatim without an extra serialization layer.
+            SerializerRegistry = NatsDefaultSerializerRegistry.Default,
+            AuthOpts = BuildAuthOpts(value),
+        };
+
+        _connection = new NatsConnection(natsOpts);
+        _jetStream = new NatsJSContext(_connection);
+        _publishTimeout = TimeSpan.FromMilliseconds(value.PublishTimeoutMs);
+    }
+
+    private static NatsAuthOpts BuildAuthOpts(NatsFeatureChangeEventSinkOptions value)
+    {
+        var auth = NatsAuthOpts.Default;
+
+        if (!string.IsNullOrWhiteSpace(value.CredsFile))
+        {
+            auth = auth with { CredsFile = value.CredsFile };
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.Token))
+        {
+            auth = auth with { Token = value.Token };
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.Username))
+        {
+            auth = auth with { Username = value.Username };
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.Password))
+        {
+            auth = auth with { Password = value.Password };
+        }
+
+        return auth;
+    }
+
+    /// <inheritdoc />
+    public async Task PublishAsync(
+        string subject,
+        string messageId,
+        byte[] value,
+        IReadOnlyList<KeyValuePair<string, string>> headers,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        var natsHeaders = new NatsHeaders();
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var header = headers[i];
+            natsHeaders.Add(header.Key, header.Value ?? string.Empty);
+        }
+
+        if (!string.IsNullOrEmpty(messageId))
+        {
+            natsHeaders[MessageIdHeader] = messageId;
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_publishTimeout);
+
+        var ack = await _jetStream
+            .PublishAsync(subject, value, headers: natsHeaders, cancellationToken: timeoutCts.Token)
+            .ConfigureAwait(false);
+
+        if (ack.Error is not null)
+        {
+            throw new InvalidOperationException(
+                $"JetStream rejected publish to subject '{subject}': {ack.Error.Description} (code {ack.Error.Code}).");
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Honua.Hosting/Honua.Hosting.csproj
+++ b/src/Honua.Hosting/Honua.Hosting.csproj
@@ -73,6 +73,15 @@
          on the IKafkaEventProducer abstraction so it stays unit-testable
          without a live broker. -->
     <PackageReference Include="Confluent.Kafka" />
+    <!-- NATS.Net backs the enterprise event-bus NATS sink (#357): the
+         broker-agnostic IFeatureChangeEventSink NATS adapter publishes committed
+         feature-change events to a configurable JetStream subject with optional
+         message deduplication (publish-side exactly-once) and routes failed
+         deliveries to a dead-letter subject. The dependency is isolated behind
+         the NatsJetStreamEventProducer wrapper; the sink itself depends only on
+         the INatsEventProducer abstraction so it stays unit-testable without a
+         live JetStream server. -->
+    <PackageReference Include="NATS.Net" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
+++ b/src/Honua.Server/Startup/FeatureEventsAndStreamingRegistration.cs
@@ -83,8 +83,8 @@ internal static partial class FeatureEventsAndStreamingRegistration
         // Broker-agnostic event-bus sinks (#357). The publish path fans committed
         // feature-change events out to every registered sink through the broadcaster.
         // Sinks are off by default; the no-op sink keeps the fan-out path exercised
-        // and observable. Concrete Kafka/NATS adapters register additional sinks in a
-        // follow-up increment (they require a live broker).
+        // and observable. The concrete Kafka and NATS JetStream adapters below
+        // register additional sinks when enabled (they require a live broker).
         services.AddOptions<FeatureChangeEventSinkOptions>()
             .Bind(configuration.GetSection(FeatureChangeEventSinkOptions.SectionName));
         services.AddSingleton<IFeatureChangeEventSink, NoOpFeatureChangeEventSink>();
@@ -104,6 +104,23 @@ internal static partial class FeatureEventsAndStreamingRegistration
         {
             services.AddSingleton<IKafkaEventProducer, ConfluentKafkaEventProducer>();
             services.AddSingleton<IFeatureChangeEventSink, KafkaFeatureChangeEventSink>();
+        }
+
+        // NATS JetStream sink adapter (#357). Bound and validated always, but the
+        // producer and sink are only registered when the adapter is enabled so
+        // deployments without NATS never open a JetStream connection. The sink
+        // publishes with optional message deduplication (publish-side
+        // exactly-once) and routes failed deliveries to a dead-letter subject.
+        services.AddOptions<NatsFeatureChangeEventSinkOptions>()
+            .Bind(configuration.GetSection(NatsFeatureChangeEventSinkOptions.SectionName))
+            .ValidateOnStart();
+        services.AddSingleton<
+            IValidateOptions<NatsFeatureChangeEventSinkOptions>,
+            NatsFeatureChangeEventSinkOptionsValidator>();
+        if (configuration.GetValue<bool>($"{NatsFeatureChangeEventSinkOptions.SectionName}:Enabled"))
+        {
+            services.AddSingleton<INatsEventProducer, NatsJetStreamEventProducer>();
+            services.AddSingleton<IFeatureChangeEventSink, NatsFeatureChangeEventSink>();
         }
 
         services.AddSingleton<FeatureChangeEventSinkBroadcaster>();

--- a/tests/dotnet/Honua.Server.Tests/Features/Streaming/NatsFeatureChangeEventSinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Streaming/NatsFeatureChangeEventSinkTests.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Infrastructure.Events;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Streaming;
+
+/// <summary>
+/// Unit tests for the NATS JetStream feature-change event sink (#357), verifying
+/// the serialized payload/dedup id/headers, the dead-letter routing on delivery
+/// failure, and the surfaced-failure behaviour when dead-lettering is unavailable.
+/// The sink is exercised against a fake <see cref="INatsEventProducer"/> so no
+/// live JetStream server is required.
+/// </summary>
+public sealed class NatsFeatureChangeEventSinkTests
+{
+    private static FeatureChangeEvent SampleEvent(string eventId = "evt-1") => new()
+    {
+        EventId = eventId,
+        Cursor = 42,
+        Timestamp = DateTimeOffset.UnixEpoch,
+        ServiceId = "parcels",
+        LayerId = 3,
+        ObjectId = 99,
+        Operation = "update",
+        Protocol = "rest",
+        RequestId = "req-1"
+    };
+
+    private static NatsFeatureChangeEventSink Create(
+        INatsEventProducer producer,
+        NatsFeatureChangeEventSinkOptions options)
+        => new(
+            producer,
+            Options.Create(options),
+            NullLogger<NatsFeatureChangeEventSink>.Instance);
+
+    [UnitTest]
+    public async Task PublishAsync_OnSuccess_PublishesToSubjectWithDedupIdAndHeaders()
+    {
+        var producer = new RecordingProducer();
+        var sink = Create(producer, new NatsFeatureChangeEventSinkOptions
+        {
+            Subject = "feature-changes",
+            DeadLetterSubject = "feature-changes.dlq",
+        });
+
+        await sink.PublishAsync(SampleEvent());
+
+        var published = Assert.Single(producer.Published);
+        Assert.Equal("feature-changes", published.Subject);
+
+        // Dedup id is the event id so JetStream rejects duplicate publishes.
+        Assert.Equal("evt-1", published.MessageId);
+
+        // Payload round-trips to the original event.
+        var roundTripped = JsonSerializer.Deserialize(
+            published.Value,
+            FeatureChangeEventsJsonContext.Default.FeatureChangeEvent);
+        Assert.NotNull(roundTripped);
+        Assert.Equal("evt-1", roundTripped!.EventId);
+
+        Assert.Equal("evt-1", published.HeaderValue("x-event-id"));
+        Assert.Equal("update", published.HeaderValue("x-operation"));
+        Assert.Equal("99", published.HeaderValue("x-feature-id"));
+        Assert.Equal("application/json", published.HeaderValue("content-type"));
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WhenDeduplicationDisabled_OmitsMessageId()
+    {
+        var producer = new RecordingProducer();
+        var sink = Create(producer, new NatsFeatureChangeEventSinkOptions
+        {
+            Subject = "feature-changes",
+            EnableDeduplication = false,
+        });
+
+        await sink.PublishAsync(SampleEvent());
+
+        var published = Assert.Single(producer.Published);
+        Assert.Equal(string.Empty, published.MessageId);
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WhenPrimaryFails_RoutesToDeadLetterSubject()
+    {
+        var producer = new RecordingProducer { FailSubject = "feature-changes" };
+        var sink = Create(producer, new NatsFeatureChangeEventSinkOptions
+        {
+            Subject = "feature-changes",
+            DeadLetterSubject = "feature-changes.dlq",
+        });
+
+        // Must not throw: a routed-to-DLQ event is handled, not a sink failure.
+        await sink.PublishAsync(SampleEvent());
+
+        var dlq = Assert.Single(producer.Published);
+        Assert.Equal("feature-changes.dlq", dlq.Subject);
+        Assert.Equal("evt-1:dlq", dlq.MessageId);
+        Assert.Equal("feature-changes", dlq.HeaderValue("x-dlq-source-subject"));
+        Assert.False(string.IsNullOrEmpty(dlq.HeaderValue("x-dlq-error")));
+        Assert.False(string.IsNullOrEmpty(dlq.HeaderValue("x-dlq-failed-at")));
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WhenPrimaryFails_AndDlqDisabled_SurfacesFailure()
+    {
+        var producer = new RecordingProducer { FailSubject = "feature-changes" };
+        var sink = Create(producer, new NatsFeatureChangeEventSinkOptions
+        {
+            Subject = "feature-changes",
+            DeadLetterSubject = null,
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sink.PublishAsync(SampleEvent()));
+    }
+
+    [UnitTest]
+    public async Task PublishAsync_WhenPrimaryAndDlqFail_SurfacesOriginalFailure()
+    {
+        var producer = new RecordingProducer { FailAllSubjects = true };
+        var sink = Create(producer, new NatsFeatureChangeEventSinkOptions
+        {
+            Subject = "feature-changes",
+            DeadLetterSubject = "feature-changes.dlq",
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sink.PublishAsync(SampleEvent()));
+    }
+
+    [UnitTest]
+    public void Validate_WhenEnabledWithoutUrl_Fails()
+    {
+        var validator = new NatsFeatureChangeEventSinkOptionsValidator();
+
+        var result = validator.Validate(null, new NatsFeatureChangeEventSinkOptions
+        {
+            Enabled = true,
+            Url = null,
+            Subject = "feature-changes",
+        });
+
+        Assert.True(result.Failed);
+    }
+
+    [UnitTest]
+    public void Validate_WhenDeadLetterSubjectEqualsSubject_Fails()
+    {
+        var validator = new NatsFeatureChangeEventSinkOptionsValidator();
+
+        var result = validator.Validate(null, new NatsFeatureChangeEventSinkOptions
+        {
+            Enabled = true,
+            Url = "nats://localhost:4222",
+            Subject = "feature-changes",
+            DeadLetterSubject = "feature-changes",
+        });
+
+        Assert.True(result.Failed);
+    }
+
+    [UnitTest]
+    public void Validate_WhenDisabled_Succeeds()
+    {
+        var validator = new NatsFeatureChangeEventSinkOptionsValidator();
+
+        var result = validator.Validate(null, new NatsFeatureChangeEventSinkOptions { Enabled = false });
+
+        Assert.True(result.Succeeded);
+    }
+
+    private sealed record PublishedMessage(
+        string Subject,
+        string MessageId,
+        byte[] Value,
+        IReadOnlyList<KeyValuePair<string, string>> Headers)
+    {
+        public string? HeaderValue(string key)
+        {
+            foreach (var header in Headers)
+            {
+                if (string.Equals(header.Key, key, StringComparison.Ordinal))
+                {
+                    return header.Value;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private sealed class RecordingProducer : INatsEventProducer
+    {
+        public List<PublishedMessage> Published { get; } = [];
+
+        public string? FailSubject { get; set; }
+
+        public bool FailAllSubjects { get; set; }
+
+        public Task PublishAsync(
+            string subject,
+            string messageId,
+            byte[] value,
+            IReadOnlyList<KeyValuePair<string, string>> headers,
+            CancellationToken cancellationToken = default)
+        {
+            if (FailAllSubjects || string.Equals(subject, FailSubject, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"simulated JetStream failure for subject '{subject}'");
+            }
+
+            Published.Add(new PublishedMessage(subject, messageId, value, headers));
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #357

## Summary
Advanced event-bus sink: NATS JetStream producer with idempotent publish + DLQ, config-gated, over the canonical feature-change event pipeline.

## Changes Made
- Add NATS JetStream event sink + producer + options + registration + unit tests

## Breaking Changes
None.

## Gate Impact
- [x] PR gates (build, test, governance)
## Docs or Contract Impact
- [x] None — no docs or contract impact
## Release/Deploy Impact
- [x] None — standard merge-and-release flow
## Testing
- [x] Unit tests added/updated
## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format
- [x] Issue numbers linked above