### PR TITLE
feat: HA/DR recovery-objective domain + failover decision evaluator (#356)

### DIFF
--- a/docs/guides/deploy/backup-and-restore.md
+++ b/docs/guides/deploy/backup-and-restore.md
@@ -104,11 +104,27 @@ Readiness reporting projects recorded backups onto the objectives and reports on
 The shared posture rules live in `Honua.Core` (`Features/DisasterRecovery`), so the admin
 reporting surface and provider implementations agree on a single definition of recoverable.
 
-> Scope note (#356): this slice ships the licensing catalog entries, the recovery-objective /
-> backup-record / readiness domain, and this runbook. The PostgreSQL backup service that
-> executes the schedule, the Redis backup path, the failover state machine, the admin
-> endpoint, and the multi-region Terraform modules are tracked as follow-up work on the same
-> issue.
+### Failover decision (active-passive)
+
+The failover playbook reacts to automated health checks against the primary serving surface.
+The shared decision rules also live in `Honua.Core` (`Features/DisasterRecovery`) so the
+failover automation, the admin reporting surface, and tests agree on when to fail over:
+
+| Decision | When | Action |
+|---|---|---|
+| `hold` | The primary is healthy, or it has fewer consecutive failed health checks than the configured threshold. | Stay on the primary. |
+| `promote` | The primary has reached the consecutive-failure threshold and the standby is recoverable inside its objectives (`ready`). | Promote the standby. |
+| `block` | The primary has reached the threshold but the standby is not recoverable inside its objectives. | Block automated failover and page an operator — promoting now would breach the RPO. |
+
+The default enterprise policy triggers after **three consecutive failed health checks** and
+requires the standby to be recoverable before an automated promotion proceeds; a policy may
+opt out of the standby-readiness gate for environments that accept best-effort failover.
+
+> Scope note (#356): the landed slices ship the licensing catalog entries, the
+> recovery-objective / backup-record / readiness domain, the active-passive failover decision
+> domain, and this runbook. The PostgreSQL backup service that executes the schedule, the
+> Redis backup path, the failover orchestration runtime, the admin endpoint, and the
+> multi-region Terraform modules are tracked as follow-up work on the same issue.
 
 ## Next steps
 

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverAssessment.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverAssessment.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// A point-in-time assessment of an active-passive failover playbook, derived from the recent
+/// health-check history of the primary and the standby's recovery readiness. This is the
+/// projection a failover orchestrator or the admin observability surface acts on (#356).
+/// </summary>
+/// <param name="Decision">The recommended failover action.</param>
+/// <param name="ConsecutiveFailures">The number of trailing consecutive failed health checks against the primary.</param>
+/// <param name="FailureThreshold">The configured failover threshold the failures were measured against.</param>
+/// <param name="StandbyRecoveryReady">Whether the standby was recoverable inside its objectives at assessment time.</param>
+/// <param name="AssessedAt">When the assessment was computed.</param>
+/// <param name="Reason">Operator-facing explanation of why the <paramref name="Decision"/> was reached.</param>
+public sealed record FailoverAssessment(
+    FailoverDecision Decision,
+    int ConsecutiveFailures,
+    int FailureThreshold,
+    bool StandbyRecoveryReady,
+    DateTimeOffset AssessedAt,
+    string Reason);

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverDecisionEvaluator.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverDecisionEvaluator.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// Pure, deterministic evaluator that decides whether an active-passive failover should be
+/// triggered. It counts the trailing run of consecutive failed health checks against the
+/// primary and, once that run crosses the configured threshold, gates the failover on the
+/// standby being recoverable inside its objectives. Keeping the failover decision in Core
+/// (independent of any orchestration or health-probe backend) lets the failover automation,
+/// the admin reporting surface, and tests share one definition of "should we fail over?"
+/// (#356, ADR-0024).
+/// </summary>
+public static class FailoverDecisionEvaluator
+{
+    /// <summary>
+    /// Evaluates the failover decision as of <paramref name="asOf"/>.
+    /// </summary>
+    /// <param name="policy">The failover policy to apply.</param>
+    /// <param name="primaryHealthChecks">
+    /// Health checks against the primary in chronological order (oldest first). The trailing
+    /// run of unhealthy checks is what counts toward the failover threshold; an empty series
+    /// is treated as zero failures.
+    /// </param>
+    /// <param name="standbyReadiness">The standby's current recovery readiness.</param>
+    /// <param name="asOf">The reference time the assessment is stamped with.</param>
+    /// <returns>A failover assessment.</returns>
+    /// <remarks>
+    /// Decision rules:
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     Fewer trailing consecutive failures than the threshold →
+    ///     <see cref="FailoverDecision.Hold"/>; stay on the primary.
+    ///   </description></item>
+    ///   <item><description>
+    ///     Threshold reached and the standby is recoverable (or the policy does not require it)
+    ///     → <see cref="FailoverDecision.Promote"/>.
+    ///   </description></item>
+    ///   <item><description>
+    ///     Threshold reached but the policy requires a recoverable standby and the standby is
+    ///     not <see cref="RecoveryReadinessLevel.Ready"/> → <see cref="FailoverDecision.Block"/>;
+    ///     promoting would risk breaching the recovery point objective.
+    ///   </description></item>
+    /// </list>
+    /// </remarks>
+    public static FailoverAssessment Evaluate(
+        FailoverPolicy policy,
+        IReadOnlyList<HealthSample> primaryHealthChecks,
+        RecoveryReadiness standbyReadiness,
+        DateTimeOffset asOf)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(primaryHealthChecks);
+        ArgumentNullException.ThrowIfNull(standbyReadiness);
+
+        var consecutiveFailures = 0;
+        for (var i = primaryHealthChecks.Count - 1; i >= 0; i--)
+        {
+            if (primaryHealthChecks[i].Healthy)
+            {
+                break;
+            }
+
+            consecutiveFailures++;
+        }
+
+        var standbyReady = standbyReadiness.Level == RecoveryReadinessLevel.Ready;
+        var thresholdReached = consecutiveFailures >= policy.FailureThreshold;
+
+        FailoverDecision decision;
+        string reason;
+        if (!thresholdReached)
+        {
+            decision = FailoverDecision.Hold;
+            reason = consecutiveFailures == 0
+                ? "Primary is healthy; holding."
+                : $"Primary has {consecutiveFailures} consecutive failed health check(s), below the threshold of {policy.FailureThreshold}; holding.";
+        }
+        else if (!policy.RequireStandbyRecoveryReady || standbyReady)
+        {
+            decision = FailoverDecision.Promote;
+            reason = $"Primary failed {consecutiveFailures} consecutive health check(s), reaching the threshold of {policy.FailureThreshold}; standby is recoverable, promoting.";
+        }
+        else
+        {
+            decision = FailoverDecision.Block;
+            reason = $"Primary failed {consecutiveFailures} consecutive health check(s), reaching the threshold of {policy.FailureThreshold}, but the standby is not recoverable inside its objectives ({standbyReadiness.Level}); blocking automated failover pending operator action.";
+        }
+
+        return new FailoverAssessment(
+            Decision: decision,
+            ConsecutiveFailures: consecutiveFailures,
+            FailureThreshold: policy.FailureThreshold,
+            StandbyRecoveryReady: standbyReady,
+            AssessedAt: asOf,
+            Reason: reason);
+    }
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverEnums.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverEnums.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// The action an active-passive failover playbook should take, derived from automated health
+/// checks against the primary serving surface and the standby's recovery readiness. The
+/// decision is the contract a failover orchestrator (state machine, runbook automation, or an
+/// operator) acts on (#356, ADR-0024).
+/// </summary>
+public enum FailoverDecision
+{
+    /// <summary>
+    /// Stay on the primary. The primary is healthy, or it has not yet failed enough
+    /// consecutive health checks to cross the failover threshold.
+    /// </summary>
+    [JsonStringEnumMemberName("hold")]
+    Hold = 0,
+
+    /// <summary>
+    /// Promote the standby. The primary has crossed the failover threshold and the standby is
+    /// recoverable inside its objectives, so an active-passive failover can proceed safely.
+    /// </summary>
+    [JsonStringEnumMemberName("promote")]
+    Promote = 1,
+
+    /// <summary>
+    /// Block automated failover. The primary has crossed the failover threshold but the
+    /// standby is not recoverable inside its objectives, so promoting it would risk data loss
+    /// beyond the recovery point objective. This requires operator intervention.
+    /// </summary>
+    [JsonStringEnumMemberName("block")]
+    Block = 2
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverPolicy.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/FailoverPolicy.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// Configuration that governs an active-passive failover playbook: how many consecutive failed
+/// health checks against the primary trigger a failover, and whether the standby must be
+/// recoverable inside its objectives before automated failover is allowed to proceed
+/// (#356, ADR-0024).
+/// </summary>
+public sealed record FailoverPolicy
+{
+    /// <summary>
+    /// Initializes a new <see cref="FailoverPolicy"/>.
+    /// </summary>
+    /// <param name="failureThreshold">
+    /// Number of consecutive failed health checks against the primary required before failover
+    /// is triggered. Must be greater than zero.
+    /// </param>
+    /// <param name="requireStandbyRecoveryReady">
+    /// When true (the default), automated failover is blocked unless the standby is recoverable
+    /// inside its recovery objectives, preventing a failover that would breach the recovery
+    /// point objective.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="failureThreshold"/> is not strictly positive.</exception>
+    public FailoverPolicy(int failureThreshold, bool requireStandbyRecoveryReady = true)
+    {
+        if (failureThreshold <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(failureThreshold),
+                failureThreshold,
+                "Failure threshold must be greater than zero.");
+        }
+
+        FailureThreshold = failureThreshold;
+        RequireStandbyRecoveryReady = requireStandbyRecoveryReady;
+    }
+
+    /// <summary>
+    /// Number of consecutive failed health checks against the primary required before failover
+    /// is triggered.
+    /// </summary>
+    public int FailureThreshold { get; }
+
+    /// <summary>
+    /// Whether automated failover is blocked unless the standby is recoverable inside its
+    /// recovery objectives.
+    /// </summary>
+    public bool RequireStandbyRecoveryReady { get; }
+
+    /// <summary>
+    /// Default enterprise failover policy: three consecutive failed health checks trigger
+    /// failover, and the standby must be recoverable inside its objectives first.
+    /// </summary>
+    public static FailoverPolicy Default { get; } = new(failureThreshold: 3);
+}

--- a/src/Honua.Core/Features/DisasterRecovery/Domain/HealthSample.cs
+++ b/src/Honua.Core/Features/DisasterRecovery/Domain/HealthSample.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.DisasterRecovery.Domain;
+
+/// <summary>
+/// A single automated health-check observation of the primary serving surface. Failover
+/// playbooks consume an ordered series of these to decide whether the primary has failed
+/// enough consecutive checks to warrant failover (#356, ADR-0024).
+/// </summary>
+/// <param name="ObservedAt">When the health check was taken.</param>
+/// <param name="Healthy">Whether the primary responded healthily to this check.</param>
+/// <param name="Reason">Operator-facing detail for an unhealthy check; null when healthy or unknown.</param>
+public sealed record HealthSample(
+    DateTimeOffset ObservedAt,
+    bool Healthy,
+    string? Reason = null);

--- a/tests/dotnet/Honua.Core.Tests/Features/DisasterRecovery/FailoverDecisionEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/DisasterRecovery/FailoverDecisionEvaluatorTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.DisasterRecovery.Domain;
+
+namespace Honua.Core.Tests.Features.DisasterRecovery;
+
+/// <summary>
+/// Unit tests for the active-passive failover decision evaluator (#356). These assert the
+/// shared failover-trigger rules the failover automation and admin reporting surface depend on.
+/// </summary>
+public sealed class FailoverDecisionEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 26, 12, 0, 0, TimeSpan.Zero);
+
+    private static RecoveryReadiness Readiness(RecoveryReadinessLevel level) => new(
+        Level: level,
+        Objectives: RecoveryObjectives.Default,
+        LastSuccessfulBaseBackup: Now.AddMinutes(-10),
+        RestorablePoint: Now.AddMinutes(-1),
+        DataLossWindow: TimeSpan.FromMinutes(1),
+        RecoveryPointObjectiveMet: level == RecoveryReadinessLevel.Ready,
+        AssessedAt: Now);
+
+    private static HealthSample Healthy(int minutesAgo) =>
+        new(Now.AddMinutes(-minutesAgo), Healthy: true);
+
+    private static HealthSample Unhealthy(int minutesAgo) =>
+        new(Now.AddMinutes(-minutesAgo), Healthy: false, Reason: "timeout");
+
+    [Fact]
+    public void Evaluate_HealthyPrimary_Holds()
+    {
+        var checks = new[] { Healthy(3), Healthy(2), Healthy(1) };
+
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            FailoverPolicy.Default, checks, Readiness(RecoveryReadinessLevel.Ready), Now);
+
+        assessment.Decision.Should().Be(FailoverDecision.Hold);
+        assessment.ConsecutiveFailures.Should().Be(0);
+    }
+
+    [Fact]
+    public void Evaluate_NoChecks_Holds()
+    {
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            FailoverPolicy.Default, [], Readiness(RecoveryReadinessLevel.Ready), Now);
+
+        assessment.Decision.Should().Be(FailoverDecision.Hold);
+        assessment.ConsecutiveFailures.Should().Be(0);
+        assessment.AssessedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void Evaluate_FailuresBelowThreshold_Holds()
+    {
+        // Two trailing failures with a threshold of three stays on the primary.
+        var checks = new[] { Healthy(3), Unhealthy(2), Unhealthy(1) };
+
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            FailoverPolicy.Default, checks, Readiness(RecoveryReadinessLevel.Ready), Now);
+
+        assessment.Decision.Should().Be(FailoverDecision.Hold);
+        assessment.ConsecutiveFailures.Should().Be(2);
+        assessment.FailureThreshold.Should().Be(3);
+    }
+
+    [Fact]
+    public void Evaluate_ThresholdReachedAndStandbyReady_Promotes()
+    {
+        var checks = new[] { Unhealthy(3), Unhealthy(2), Unhealthy(1) };
+
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            FailoverPolicy.Default, checks, Readiness(RecoveryReadinessLevel.Ready), Now);
+
+        assessment.Decision.Should().Be(FailoverDecision.Promote);
+        assessment.ConsecutiveFailures.Should().Be(3);
+        assessment.StandbyRecoveryReady.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_ThresholdReachedButStandbyNotReady_Blocks()
+    {
+        var checks = new[] { Unhealthy(3), Unhealthy(2), Unhealthy(1) };
+
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            FailoverPolicy.Default, checks, Readiness(RecoveryReadinessLevel.AtRisk), Now);
+
+        assessment.Decision.Should().Be(FailoverDecision.Block);
+        assessment.StandbyRecoveryReady.Should().BeFalse();
+        assessment.Reason.Should().Contain("not recoverable");
+    }
+
+    [Fact]
+    public void Evaluate_ThresholdReachedNotReadyButPolicyAllows_Promotes()
+    {
+        // When the policy does not require a recoverable standby, failover proceeds regardless.
+        var policy = new FailoverPolicy(failureThreshold: 3, requireStandbyRecoveryReady: false);
+        var checks = new[] { Unhealthy(3), Unhealthy(2), Unhealthy(1) };
+
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            policy, checks, Readiness(RecoveryReadinessLevel.NotReady), Now);
+
+        assessment.Decision.Should().Be(FailoverDecision.Promote);
+    }
+
+    [Fact]
+    public void Evaluate_RecoveredAfterFailures_ResetsConsecutiveCount()
+    {
+        // A trailing healthy check breaks the failure run even after earlier failures.
+        var checks = new[] { Unhealthy(4), Unhealthy(3), Unhealthy(2), Healthy(1) };
+
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            FailoverPolicy.Default, checks, Readiness(RecoveryReadinessLevel.Ready), Now);
+
+        assessment.Decision.Should().Be(FailoverDecision.Hold);
+        assessment.ConsecutiveFailures.Should().Be(0);
+    }
+
+    [Fact]
+    public void Evaluate_CountsOnlyTrailingFailures()
+    {
+        // Earlier failures separated by a healthy check do not count toward the trailing run.
+        var checks = new[] { Unhealthy(5), Healthy(4), Unhealthy(3), Unhealthy(2), Unhealthy(1) };
+
+        var assessment = FailoverDecisionEvaluator.Evaluate(
+            FailoverPolicy.Default, checks, Readiness(RecoveryReadinessLevel.Ready), Now);
+
+        assessment.ConsecutiveFailures.Should().Be(3);
+        assessment.Decision.Should().Be(FailoverDecision.Promote);
+    }
+
+    [Fact]
+    public void Evaluate_NullArguments_Throw()
+    {
+        var ready = Readiness(RecoveryReadinessLevel.Ready);
+
+        var actPolicy = () => FailoverDecisionEvaluator.Evaluate(null!, [], ready, Now);
+        var actChecks = () => FailoverDecisionEvaluator.Evaluate(FailoverPolicy.Default, null!, ready, Now);
+        var actReadiness = () => FailoverDecisionEvaluator.Evaluate(FailoverPolicy.Default, [], null!, Now);
+
+        actPolicy.Should().Throw<ArgumentNullException>();
+        actChecks.Should().Throw<ArgumentNullException>();
+        actReadiness.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FailoverPolicy_NonPositiveThreshold_Throws(int threshold)
+    {
+        var act = () => new FailoverPolicy(threshold);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("failureThreshold");
+    }
+
+    [Fact]
+    public void FailoverPolicy_Default_RequiresRecoverableStandby()
+    {
+        FailoverPolicy.Default.FailureThreshold.Should().Be(3);
+        FailoverPolicy.Default.RequireStandbyRecoveryReady.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #356

## Summary
HA/DR domain: recovery-objective model, failover decision evaluator over health samples, plus backup/restore guide.

## Changes Made
- Add DisasterRecovery domain (FailoverPolicy/Assessment/DecisionEvaluator/HealthSample) + tests + backup-restore doc

## Breaking Changes
None.

## Gate Impact
- [x] PR gates (build, test, governance)
## Docs or Contract Impact
- [x] None — no docs or contract impact
## Release/Deploy Impact
- [x] None — standard merge-and-release flow
## Testing
- [x] Unit tests added/updated
## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format
- [x] Issue numbers linked above