### PR TITLE
feat(federation): HTTP federated source connectors + per-source metrics (#341)

### DIFF
--- a/src/Honua.Core/Features/Federation/ServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Federation/ServiceCollectionExtensions.cs
@@ -25,11 +25,13 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddFederationCore(this IServiceCollection services)
     {
         services.TryAddSingleton<IFederationQueryPlanner, FederationQueryPlanner>();
+        services.TryAddSingleton<FederationMetrics>();
         services.TryAddSingleton<IFederatedQueryExecutor>(static sp => new FederatedQueryExecutor(
             sp.GetRequiredService<IFederationQueryPlanner>(),
             sp.GetServices<IFederatedSourceConnector>(),
             sp.GetService<ResiliencePolicyOptions>() ?? ResiliencePolicyOptions.Default,
-            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<FederatedQueryExecutor>>()));
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<FederatedQueryExecutor>>(),
+            sp.GetRequiredService<FederationMetrics>()));
         return services;
     }
 }

--- a/src/Honua.Core/Features/Federation/Services/FederatedQueryExecutor.cs
+++ b/src/Honua.Core/Features/Federation/Services/FederatedQueryExecutor.cs
@@ -26,6 +26,7 @@ internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
     private readonly IFederationQueryPlanner _planner;
     private readonly Dictionary<FederatedSourceKind, IFederatedSourceConnector> _connectors;
     private readonly ResiliencePolicyOptions _resilienceOptions;
+    private readonly FederationMetrics _metrics;
     private readonly ILogger<FederatedQueryExecutor> _logger;
 
     // Circuit-breaker state must persist across calls, so the per-source policy is cached.
@@ -35,7 +36,8 @@ internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
         IFederationQueryPlanner planner,
         IEnumerable<IFederatedSourceConnector> connectors,
         ResiliencePolicyOptions resilienceOptions,
-        ILogger<FederatedQueryExecutor> logger)
+        ILogger<FederatedQueryExecutor> logger,
+        FederationMetrics? metrics = null)
     {
         ArgumentNullException.ThrowIfNull(planner);
         ArgumentNullException.ThrowIfNull(connectors);
@@ -44,6 +46,7 @@ internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
 
         _planner = planner;
         _resilienceOptions = resilienceOptions;
+        _metrics = metrics ?? new FederationMetrics();
         _logger = logger;
 
         // Last writer wins when two connectors claim the same kind; this keeps registration
@@ -66,6 +69,7 @@ internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
 
         if (!_connectors.TryGetValue(source.Kind, out var connector))
         {
+            _metrics.RecordUnavailable(source, FederatedSourceUnavailableReason.NoConnector, TimeSpan.Zero);
             throw new FederatedSourceUnavailableException(source.Id, FederatedSourceUnavailableReason.NoConnector);
         }
 
@@ -79,13 +83,18 @@ internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
             candidates = await FetchWithResilienceAsync(source, connector, request, cancellationToken)
                 .ConfigureAwait(false);
         }
-        finally
+        catch (FederatedSourceUnavailableException ex)
         {
             stopwatch.Stop();
+            _metrics.RecordUnavailable(source, ex.Reason, stopwatch.Elapsed);
+            throw;
         }
+
+        stopwatch.Stop();
 
         var refinement = RefineLocally(query, plan, candidates);
 
+        _metrics.RecordSuccess(source, stopwatch.Elapsed, refinement.Result.Items.Length);
         FederationExecutionLog.SourceExecuted(_logger, source.Id, stopwatch.Elapsed.TotalMilliseconds, refinement.Result.Items.Length);
 
         return new FederatedQueryResult

--- a/src/Honua.Core/Features/Federation/Services/FederationMetrics.cs
+++ b/src/Honua.Core/Features/Federation/Services/FederationMetrics.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Honua.Core.Features.Federation.Domain;
+
+namespace Honua.Core.Features.Federation.Services;
+
+/// <summary>
+/// Per-source latency and error metrics for federated query execution (issue #341
+/// acceptance criterion: "Latency and error metrics per federated source"). Every remote
+/// fetch the <see cref="FederatedQueryExecutor"/> performs records one duration sample and
+/// one request count, tagged with the source identifier, transport kind, and the outcome
+/// (success or the failure reason), so operators can see which federated source is slow or
+/// failing and confirm the circuit breaker is shedding load rather than cascading.
+/// </summary>
+public sealed class FederationMetrics : IDisposable
+{
+    /// <summary>
+    /// The <see cref="Meter"/> name emitted for OpenTelemetry. Registered in the service
+    /// defaults meter allow-list so the federation metrics are exported by default.
+    /// </summary>
+    public const string MeterName = "Honua.Federation";
+
+    private readonly Meter _meter;
+    private readonly Histogram<double> _sourceDuration;
+    private readonly Counter<long> _sourceRequests;
+    private readonly Counter<long> _sourceRows;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FederationMetrics"/> class.
+    /// </summary>
+    public FederationMetrics()
+    {
+        _meter = new Meter(MeterName);
+
+        _sourceDuration = _meter.CreateHistogram<double>(
+            "honua_federation_source_duration_ms",
+            "milliseconds",
+            "Wall-clock time spent fetching candidate rows from a federated source, including resilience handling.");
+
+        _sourceRequests = _meter.CreateCounter<long>(
+            "honua_federation_source_requests_total",
+            description: "Total federated source fetches, tagged by outcome (success or failure reason).");
+
+        _sourceRows = _meter.CreateCounter<long>(
+            "honua_federation_source_rows_total",
+            description: "Total candidate rows returned by federated sources after local refinement.");
+    }
+
+    /// <summary>
+    /// Records a successful federated source fetch.
+    /// </summary>
+    /// <param name="source">The source that was queried.</param>
+    /// <param name="elapsed">The wall-clock time spent on the fetch.</param>
+    /// <param name="rowCount">The number of rows returned after local refinement.</param>
+    public void RecordSuccess(FederatedSourceDescriptor source, TimeSpan elapsed, int rowCount)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var tags = BuildTags(source, "success");
+        _sourceDuration.Record(elapsed.TotalMilliseconds, tags);
+        _sourceRequests.Add(1, tags);
+        if (rowCount > 0)
+        {
+            _sourceRows.Add(rowCount, tags);
+        }
+    }
+
+    /// <summary>
+    /// Records a federated source fetch that failed because the source was unavailable.
+    /// </summary>
+    /// <param name="source">The source that was queried.</param>
+    /// <param name="reason">Why the source was unavailable.</param>
+    /// <param name="elapsed">The wall-clock time spent before the failure surfaced.</param>
+    public void RecordUnavailable(FederatedSourceDescriptor source, FederatedSourceUnavailableReason reason, TimeSpan elapsed)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var tags = BuildTags(source, OutcomeFor(reason));
+        _sourceDuration.Record(elapsed.TotalMilliseconds, tags);
+        _sourceRequests.Add(1, tags);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _meter.Dispose();
+
+    private static TagList BuildTags(FederatedSourceDescriptor source, string outcome) => new()
+    {
+        { "source.id", source.Id },
+        { "source.kind", source.Kind.ToString() },
+        { "outcome", outcome },
+    };
+
+    private static string OutcomeFor(FederatedSourceUnavailableReason reason) => reason switch
+    {
+        FederatedSourceUnavailableReason.TimedOut => "timed_out",
+        FederatedSourceUnavailableReason.CircuitOpen => "circuit_open",
+        FederatedSourceUnavailableReason.NoConnector => "no_connector",
+        FederatedSourceUnavailableReason.Faulted => "faulted",
+        _ => "faulted",
+    };
+}

--- a/src/Honua.Server/Features/Admin/Federation/Connectors/EsriRestFederatedSourceConnector.cs
+++ b/src/Honua.Server/Features/Admin/Federation/Connectors/EsriRestFederatedSourceConnector.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Features.Admin.Federation.Connectors;
+
+/// <summary>
+/// HTTP <see cref="HttpGeoJsonFederatedSourceConnector"/> for Esri ArcGIS REST feature
+/// services. It fetches GeoJSON from <c>{endpoint}/{remoteLayer}/query</c> with
+/// <c>f=geojson</c>, pushing down the predicates the planner allows for the
+/// <see cref="FederatedSourceKind.EsriRest"/> transport: a SQL-like <c>where</c> clause, an
+/// <c>esriGeometryEnvelope</c> spatial filter, result ordering, and result paging. Exact
+/// spatial relationships and temporal-interval filters are refined locally by the federation
+/// executor, so this connector pushes only an envelope superset for them (issue #341).
+/// </summary>
+internal sealed class EsriRestFederatedSourceConnector : HttpGeoJsonFederatedSourceConnector
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EsriRestFederatedSourceConnector"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">Factory for the named federation HTTP client.</param>
+    /// <param name="logger">Logger for transport diagnostics.</param>
+    public EsriRestFederatedSourceConnector(
+        IHttpClientFactory httpClientFactory,
+        ILogger<EsriRestFederatedSourceConnector> logger)
+        : base(httpClientFactory, logger)
+    {
+    }
+
+    /// <inheritdoc />
+    public override FederatedSourceKind Kind => FederatedSourceKind.EsriRest;
+
+    /// <inheritdoc />
+    protected override Uri BuildRequestUri(FederatedFetchRequest request)
+    {
+        var source = request.Source;
+        var query = request.Query;
+
+        var basePath = source.Endpoint.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        var queryUrl = $"{basePath}/{Uri.EscapeDataString(source.RemoteLayer)}/query";
+
+        var parameters = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["f"] = "geojson",
+            ["outFields"] = "*",
+            ["returnGeometry"] = "true",
+            // Esri requires a where clause; "1=1" selects all rows when no attribute filter
+            // is pushed down.
+            ["where"] = request.ShouldPushDown(FederationPredicateKind.AttributeFilter) &&
+                        !string.IsNullOrWhiteSpace(query.Where)
+                ? query.Where
+                : "1=1",
+        };
+
+        if (TryGetPushedDownEnvelope(request, out var envelope))
+        {
+            parameters["geometryType"] = "esriGeometryEnvelope";
+            parameters["spatialRel"] = "esriSpatialRelIntersects";
+            parameters["geometry"] = string.Join(
+                ',',
+                Invariant(envelope.MinX),
+                Invariant(envelope.MinY),
+                Invariant(envelope.MaxX),
+                Invariant(envelope.MaxY));
+
+            if (envelope.Srid is { } srid)
+            {
+                parameters["inSR"] = srid.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        if (request.ShouldPushDown(FederationPredicateKind.OrderBy) &&
+            query.OrderBy is { IsDefaultOrEmpty: false } orderBy)
+        {
+            parameters["orderByFields"] = FormatOrderByFields(orderBy);
+        }
+
+        if (request.ShouldPushDown(FederationPredicateKind.Paging))
+        {
+            if (query.Limit is { } limit && limit > 0)
+            {
+                parameters["resultRecordCount"] = limit.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (query.Offset is { } offset && offset > 0)
+            {
+                parameters["resultOffset"] = offset.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        return new Uri(QueryHelpers.AddQueryString(queryUrl, parameters));
+    }
+
+    private static string FormatOrderByFields(System.Collections.Immutable.ImmutableArray<OrderByClause> orderBy)
+    {
+        var builder = new StringBuilder();
+        for (var i = 0; i < orderBy.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(", ");
+            }
+
+            var clause = orderBy[i];
+            builder.Append(clause.Field);
+            builder.Append(clause.Ascending ? " ASC" : " DESC");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Honua.Server/Features/Admin/Federation/Connectors/FederationConnectorLog.cs
+++ b/src/Honua.Server/Features/Admin/Federation/Connectors/FederationConnectorLog.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Features.Admin.Federation.Connectors;
+
+/// <summary>
+/// Source-generated structured logging for the HTTP federated-source connectors (issue #341).
+/// </summary>
+internal static partial class FederationConnectorLog
+{
+    [LoggerMessage(EventId = 4520, Level = LogLevel.Warning,
+        Message = "Failed to parse the GeoJSON response from a '{Kind}' federated source")]
+    public static partial void ResponseParseFailed(ILogger logger, string kind, Exception exception);
+}

--- a/src/Honua.Server/Features/Admin/Federation/Connectors/HttpGeoJsonFederatedSourceConnector.cs
+++ b/src/Honua.Server/Features/Admin/Federation/Connectors/HttpGeoJsonFederatedSourceConnector.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Microsoft.Extensions.Logging;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using CoreFeature = Honua.Core.Features.FeatureStore.Domain.Feature;
+
+namespace Honua.Server.Features.Admin.Federation.Connectors;
+
+/// <summary>
+/// Base <see cref="IFederatedSourceConnector"/> for HTTP transports whose query response is a
+/// GeoJSON <c>FeatureCollection</c> (Esri ArcGIS REST with <c>f=geojson</c>, OGC API - Features
+/// / WFS items). It performs the only remote I/O in the federation layer: it builds the
+/// pushed-down remote request URI, issues a single GET through the named federation HTTP
+/// client, parses the GeoJSON response, and maps each remote feature to a canonical
+/// <see cref="CoreFeature"/> (WKB geometry + attribute table). Transport and HTTP-status
+/// failures surface as exceptions so the federation executor counts them toward the per-source
+/// timeout and circuit breaker (issue #341).
+/// </summary>
+internal abstract class HttpGeoJsonFederatedSourceConnector : IFederatedSourceConnector
+{
+    /// <summary>
+    /// Logical name of the named <see cref="HttpClient"/> the federation connectors resolve.
+    /// </summary>
+    public const string HttpClientName = "honua-federation";
+
+    // Common attribute keys that carry a stable remote identifier, in priority order. Remote
+    // sources rarely agree on casing, so the lookup is exhaustive before falling back to the
+    // feature's ordinal position.
+    private static readonly string[] IdentifierKeys =
+    [
+        "objectid", "OBJECTID", "fid", "FID", "id", "ID", "gid", "GID",
+    ];
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpGeoJsonFederatedSourceConnector"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">Factory for the named federation HTTP client.</param>
+    /// <param name="logger">Logger for transport diagnostics.</param>
+    protected HttpGeoJsonFederatedSourceConnector(IHttpClientFactory httpClientFactory, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public abstract FederatedSourceKind Kind { get; }
+
+    /// <summary>
+    /// Builds the remote query URI for the fetch request, applying only the predicates the
+    /// plan marked as pushed down for this transport.
+    /// </summary>
+    /// <param name="request">The federated fetch request.</param>
+    /// <returns>The absolute remote query URI.</returns>
+    protected abstract Uri BuildRequestUri(FederatedFetchRequest request);
+
+    /// <inheritdoc />
+    public async Task<ImmutableArray<CoreFeature>> FetchAsync(
+        FederatedFetchRequest request,
+        CancellationToken cancellationToken)
+    {
+        var uri = BuildRequestUri(request);
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+
+        using var response = await client
+            .GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        // A non-success status is a transport fault: surface it so the executor's circuit
+        // breaker counts it. The remote URL is intentionally not echoed to callers; it is only
+        // logged for operators.
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        return MapFeatures(json);
+    }
+
+    /// <summary>
+    /// Appends an envelope (bbox) push-down parameter set to a query builder when the plan
+    /// pushes the spatial filter down and the filter exposes a simple axis-aligned envelope.
+    /// </summary>
+    /// <param name="request">The fetch request.</param>
+    /// <param name="envelope">The resolved envelope, when available.</param>
+    /// <returns><see langword="true"/> when an envelope is available to push down.</returns>
+    protected static bool TryGetPushedDownEnvelope(
+        in FederatedFetchRequest request,
+        out (double MinX, double MinY, double MaxX, double MaxY, int? Srid) envelope)
+    {
+        envelope = default;
+
+        if (!request.ShouldPushDown(FederationPredicateKind.SpatialFilter) ||
+            request.Query.SpatialFilter is not { } spatial ||
+            spatial.EnvelopeMinX is not { } minX ||
+            spatial.EnvelopeMinY is not { } minY ||
+            spatial.EnvelopeMaxX is not { } maxX ||
+            spatial.EnvelopeMaxY is not { } maxY)
+        {
+            return false;
+        }
+
+        envelope = (minX, minY, maxX, maxY, spatial.Srid);
+        return true;
+    }
+
+    /// <summary>
+    /// Formats a double using the invariant culture so the remote request never carries a
+    /// locale-specific decimal separator.
+    /// </summary>
+    /// <param name="value">The value to format.</param>
+    /// <returns>The invariant-culture string.</returns>
+    protected static string Invariant(double value) =>
+        value.ToString("R", CultureInfo.InvariantCulture);
+
+    private ImmutableArray<CoreFeature> MapFeatures(string geoJson)
+    {
+        if (string.IsNullOrWhiteSpace(geoJson))
+        {
+            return ImmutableArray<CoreFeature>.Empty;
+        }
+
+        FeatureCollection collection;
+        try
+        {
+            collection = new GeoJsonReader().Read<FeatureCollection>(geoJson) ?? new FeatureCollection();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A malformed remote payload is a transport-level fault from the federation layer's
+            // point of view; surface it so the executor classifies the source as faulted.
+            FederationConnectorLog.ResponseParseFailed(_logger, Kind.ToString(), ex);
+            throw new InvalidOperationException(
+                $"Federated source response from a '{Kind}' source could not be parsed as GeoJSON.", ex);
+        }
+
+        if (collection.Count == 0)
+        {
+            return ImmutableArray<CoreFeature>.Empty;
+        }
+
+        var wkbWriter = new WKBWriter();
+        var builder = ImmutableArray.CreateBuilder<CoreFeature>(collection.Count);
+        var ordinal = 0;
+
+        foreach (var feature in collection)
+        {
+            var attributes = MapAttributes(feature.Attributes);
+            var id = ResolveIdentifier(attributes, ordinal);
+            var geometry = feature.Geometry is { IsEmpty: false } geom ? wkbWriter.Write(geom) : null;
+
+            builder.Add(new CoreFeature
+            {
+                Id = id,
+                Geometry = geometry,
+                Attributes = attributes,
+            });
+
+            ordinal++;
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableDictionary<string, object?> MapAttributes(IAttributesTable? table)
+    {
+        if (table is null)
+        {
+            return ImmutableDictionary<string, object?>.Empty;
+        }
+
+        var names = table.GetNames();
+        if (names.Length == 0)
+        {
+            return ImmutableDictionary<string, object?>.Empty;
+        }
+
+        var builder = ImmutableDictionary.CreateBuilder<string, object?>(StringComparer.Ordinal);
+        foreach (var name in names)
+        {
+            builder[name] = table[name];
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static long ResolveIdentifier(ImmutableDictionary<string, object?> attributes, int ordinal)
+    {
+        foreach (var key in IdentifierKeys)
+        {
+            if (attributes.TryGetValue(key, out var value) && TryConvertToInt64(value, out var id))
+            {
+                return id;
+            }
+        }
+
+        return ordinal;
+    }
+
+    private static bool TryConvertToInt64(object? value, out long result)
+    {
+        switch (value)
+        {
+            case null:
+                result = 0;
+                return false;
+            case long l:
+                result = l;
+                return true;
+            case int i:
+                result = i;
+                return true;
+            case short s:
+                result = s;
+                return true;
+            case double d when d == Math.Floor(d) && !double.IsInfinity(d):
+                result = (long)d;
+                return true;
+            case string str when long.TryParse(str, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed):
+                result = parsed;
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+}

--- a/src/Honua.Server/Features/Admin/Federation/Connectors/OgcFeaturesFederatedSourceConnector.cs
+++ b/src/Honua.Server/Features/Admin/Federation/Connectors/OgcFeaturesFederatedSourceConnector.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Federation.Domain;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Features.Admin.Federation.Connectors;
+
+/// <summary>
+/// HTTP <see cref="HttpGeoJsonFederatedSourceConnector"/> for OGC API - Features / WFS sources.
+/// It fetches GeoJSON items from <c>{endpoint}/collections/{remoteLayer}/items</c>, pushing
+/// down the predicates the planner allows for the <see cref="FederatedSourceKind.OgcWfs"/>
+/// transport: a CQL2-text attribute <c>filter</c>, a <c>bbox</c> envelope, and offset/limit
+/// paging. Ordering and exact spatial relationships are refined locally by the federation
+/// executor, so this connector never emits them remotely (issue #341).
+/// </summary>
+internal sealed class OgcFeaturesFederatedSourceConnector : HttpGeoJsonFederatedSourceConnector
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OgcFeaturesFederatedSourceConnector"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">Factory for the named federation HTTP client.</param>
+    /// <param name="logger">Logger for transport diagnostics.</param>
+    public OgcFeaturesFederatedSourceConnector(
+        IHttpClientFactory httpClientFactory,
+        ILogger<OgcFeaturesFederatedSourceConnector> logger)
+        : base(httpClientFactory, logger)
+    {
+    }
+
+    /// <inheritdoc />
+    public override FederatedSourceKind Kind => FederatedSourceKind.OgcWfs;
+
+    /// <inheritdoc />
+    protected override Uri BuildRequestUri(FederatedFetchRequest request)
+    {
+        var source = request.Source;
+        var query = request.Query;
+
+        var basePath = source.Endpoint.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        var itemsUrl = $"{basePath}/collections/{Uri.EscapeDataString(source.RemoteLayer)}/items";
+
+        var parameters = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["f"] = "json",
+        };
+
+        if (request.ShouldPushDown(FederationPredicateKind.AttributeFilter) &&
+            !string.IsNullOrWhiteSpace(query.Where))
+        {
+            // The planner pushes the attribute filter down for OGC sources; simple comparison
+            // predicates are compatible between the canonical WHERE syntax and CQL2-text.
+            parameters["filter"] = query.Where;
+            parameters["filter-lang"] = "cql2-text";
+        }
+
+        if (TryGetPushedDownEnvelope(request, out var envelope))
+        {
+            parameters["bbox"] = string.Join(
+                ',',
+                Invariant(envelope.MinX),
+                Invariant(envelope.MinY),
+                Invariant(envelope.MaxX),
+                Invariant(envelope.MaxY));
+        }
+
+        if (request.ShouldPushDown(FederationPredicateKind.Paging))
+        {
+            if (query.Limit is { } limit && limit > 0)
+            {
+                parameters["limit"] = limit.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (query.Offset is { } offset && offset > 0)
+            {
+                parameters["offset"] = offset.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        return new Uri(QueryHelpers.AddQueryString(itemsUrl, parameters));
+    }
+}

--- a/src/Honua.Server/Features/Admin/Federation/FederationServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Admin/Federation/FederationServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Features.Federation;
 using Honua.Core.Features.Federation.Abstractions;
+using Honua.Server.Features.Admin.Federation.Connectors;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -15,8 +16,9 @@ namespace Honua.Server.Features.Admin.Federation;
 public static class FederationServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the federation query planner, the configuration-backed source registry, and
-    /// binds <see cref="FederationSourceOptions"/> from the <c>Federation</c> section.
+    /// Registers the federation query planner, the remote-execution layer, the configuration-backed
+    /// source registry, the HTTP transport connectors (Esri REST and OGC API - Features / WFS),
+    /// and binds <see cref="FederationSourceOptions"/> from the <c>Federation</c> section.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configuration">The application configuration.</param>
@@ -28,6 +30,15 @@ public static class FederationServiceCollectionExtensions
         services.Configure<FederationSourceOptions>(configuration.GetSection(FederationSourceOptions.SectionName));
         services.AddFederationCore();
         services.TryAddSingleton<IFederationSourceRegistry, ConfiguredFederationSourceRegistry>();
+
+        // Named HTTP client shared by every HTTP federation connector. The executor applies the
+        // per-source timeout and circuit breaker, so the client itself stays unopinionated.
+        services.AddHttpClient(HttpGeoJsonFederatedSourceConnector.HttpClientName);
+
+        // Transport connectors are additive: the executor maps each registered connector by its
+        // FederatedSourceKind, so a deployment without a kind simply cannot federate to it.
+        services.AddSingleton<IFederatedSourceConnector, EsriRestFederatedSourceConnector>();
+        services.AddSingleton<IFederatedSourceConnector, OgcFeaturesFederatedSourceConnector>();
 
         return services;
     }

--- a/src/Honua.ServiceDefaults/Extensions.cs
+++ b/src/Honua.ServiceDefaults/Extensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Federation.Services;
 using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Core.Features.Studio.Services;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -36,6 +37,7 @@ public static partial class Extensions
         "Honua.Wfs20.Transactions",
         "Honua.Database.ConnectionPool",
         "Honua.Production.Metrics",
+        FederationMetrics.MeterName,
         LambdaTelemetry.MeterName
     ];
     private static readonly string[] _activitySourceNames =

--- a/tests/dotnet/Honua.Core.Tests/Features/Federation/FederationMetricsTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Federation/FederationMetricsTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Honua.Core.Features.Federation;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.Federation.Services;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.Core.Tests.Features.Federation;
+
+/// <summary>
+/// Unit tests for the per-source federation latency/error metrics (issue #341 acceptance
+/// criterion: "Latency and error metrics per federated source"). A <see cref="MeterListener"/>
+/// captures the instruments the executor records so the tests assert the metric tags without a
+/// live exporter.
+/// </summary>
+public sealed class FederationMetricsTests
+{
+    private static readonly ResiliencePolicyOptions FastFail = new()
+    {
+        MaxRetryAttempts = 0,
+        CircuitBreakerFailures = 2,
+        CircuitBreakDuration = TimeSpan.FromMinutes(5),
+    };
+
+    private static FederatedSourceDescriptor Source(FederatedSourceKind kind) => new()
+    {
+        Id = $"src-{kind}",
+        DisplayName = kind.ToString(),
+        Kind = kind,
+        Endpoint = new Uri("https://remote.example.com/"),
+        RemoteLayer = "0",
+        RequestTimeout = TimeSpan.FromSeconds(30),
+    };
+
+    [UnitTest]
+    public async Task ExecuteAsync_Success_RecordsDurationAndSuccessOutcome()
+    {
+        using var capture = new MetricCapture();
+        var rows = ImmutableArray.Create(
+            new Feature { Id = 1, Geometry = null, Attributes = ImmutableDictionary<string, object?>.Empty });
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.HonuaGrpc, rows), capture.Metrics);
+
+        await executor.ExecuteAsync(Source(FederatedSourceKind.HonuaGrpc), new FeatureQuery());
+        capture.Flush();
+
+        var request = Assert.Single(capture.Measurements.Where(m => m.Instrument == "honua_federation_source_requests_total"));
+        Assert.Equal("success", request.Tags["outcome"]);
+        Assert.Equal("src-HonuaGrpc", request.Tags["source.id"]);
+        Assert.Equal("HonuaGrpc", request.Tags["source.kind"]);
+
+        Assert.Contains(capture.Measurements, m => m.Instrument == "honua_federation_source_duration_ms");
+        Assert.Contains(capture.Measurements, m => m.Instrument == "honua_federation_source_rows_total" && m.Value >= 1);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_NoConnector_RecordsNoConnectorOutcome()
+    {
+        using var capture = new MetricCapture();
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.HonuaGrpc, ImmutableArray<Feature>.Empty), capture.Metrics);
+
+        await Assert.ThrowsAsync<FederatedSourceUnavailableException>(
+            () => executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), new FeatureQuery()));
+        capture.Flush();
+
+        var request = Assert.Single(capture.Measurements.Where(m => m.Instrument == "honua_federation_source_requests_total"));
+        Assert.Equal("no_connector", request.Tags["outcome"]);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_RemoteFault_RecordsFaultedOutcome()
+    {
+        using var capture = new MetricCapture();
+        var executor = BuildExecutor(new ThrowingConnector(FederatedSourceKind.EsriRest), capture.Metrics);
+
+        await Assert.ThrowsAsync<FederatedSourceUnavailableException>(
+            () => executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), new FeatureQuery()));
+        capture.Flush();
+
+        Assert.Contains(
+            capture.Measurements,
+            m => m.Instrument == "honua_federation_source_requests_total" && (string)m.Tags["outcome"]! == "faulted");
+    }
+
+    private static FederatedQueryExecutor BuildExecutor(IFederatedSourceConnector connector, FederationMetrics metrics)
+    {
+        var services = new ServiceCollection();
+        services.AddFederationCore();
+        var planner = services.BuildServiceProvider().GetRequiredService<IFederationQueryPlanner>();
+
+        return new FederatedQueryExecutor(
+            planner,
+            new[] { connector },
+            FastFail,
+            NullLogger<FederatedQueryExecutor>.Instance,
+            metrics);
+    }
+
+    private sealed record CapturedMeasurement(string Instrument, double Value, IReadOnlyDictionary<string, object?> Tags);
+
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener;
+        private readonly ConcurrentQueue<CapturedMeasurement> _measurements = new();
+
+        public MetricCapture()
+        {
+            Metrics = new FederationMetrics();
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (instrument.Meter.Name == FederationMetrics.MeterName)
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+
+            _listener.SetMeasurementEventCallback<double>(OnDouble);
+            _listener.SetMeasurementEventCallback<long>(OnLong);
+            _listener.Start();
+        }
+
+        public FederationMetrics Metrics { get; }
+
+        public IReadOnlyCollection<CapturedMeasurement> Measurements => _measurements.ToArray();
+
+        public void Flush() => _listener.RecordObservableInstruments();
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+            Metrics.Dispose();
+        }
+
+        private void OnDouble(Instrument instrument, double measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+            => Record(instrument, measurement, tags);
+
+        private void OnLong(Instrument instrument, long measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+            => Record(instrument, measurement, tags);
+
+        private void Record(Instrument instrument, double measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var map = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var tag in tags)
+            {
+                map[tag.Key] = tag.Value;
+            }
+
+            _measurements.Enqueue(new CapturedMeasurement(instrument.Name, measurement, map));
+        }
+    }
+
+    private sealed class StubConnector(FederatedSourceKind kind, ImmutableArray<Feature> rows) : IFederatedSourceConnector
+    {
+        public FederatedSourceKind Kind => kind;
+
+        public Task<ImmutableArray<Feature>> FetchAsync(FederatedFetchRequest request, CancellationToken cancellationToken) =>
+            Task.FromResult(rows);
+    }
+
+    private sealed class ThrowingConnector(FederatedSourceKind kind) : IFederatedSourceConnector
+    {
+        public FederatedSourceKind Kind => kind;
+
+        public Task<ImmutableArray<Feature>> FetchAsync(FederatedFetchRequest request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("remote down");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Federation/FederationMetricsTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Federation/FederationMetricsTests.cs
@@ -58,7 +58,7 @@ public sealed class FederationMetricsTests
         await executor.ExecuteAsync(Source(FederatedSourceKind.HonuaGrpc), new FeatureQuery());
         capture.Flush();
 
-        var request = Assert.Single(capture.Measurements.Where(m => m.Instrument == "honua_federation_source_requests_total"));
+        var request = Assert.Single(capture.Measurements, m => m.Instrument == "honua_federation_source_requests_total");
         Assert.Equal("success", request.Tags["outcome"]);
         Assert.Equal("src-HonuaGrpc", request.Tags["source.id"]);
         Assert.Equal("HonuaGrpc", request.Tags["source.kind"]);
@@ -77,7 +77,7 @@ public sealed class FederationMetricsTests
             () => executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), new FeatureQuery()));
         capture.Flush();
 
-        var request = Assert.Single(capture.Measurements.Where(m => m.Instrument == "honua_federation_source_requests_total"));
+        var request = Assert.Single(capture.Measurements, m => m.Instrument == "honua_federation_source_requests_total");
         Assert.Equal("no_connector", request.Tags["outcome"]);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/Federation/FederatedSourceConnectorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/Federation/FederatedSourceConnectorTests.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Honua.Core.Features.Federation.Abstractions;
+using Honua.Core.Features.Federation.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Server.Features.Admin.Federation.Connectors;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Admin.Federation;
+
+/// <summary>
+/// Unit tests for the HTTP federated-source connectors (issue #341). Remote I/O is faked with a
+/// capturing <see cref="HttpMessageHandler"/>, so these tests exercise the real push-down URI
+/// construction and GeoJSON-to-canonical-feature mapping without contacting a live source.
+/// </summary>
+public sealed class FederatedSourceConnectorTests
+{
+    private const string GeoJsonResponse = """
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "id": 42,
+              "geometry": { "type": "Point", "coordinates": [1.5, 2.5] },
+              "properties": { "objectid": 42, "name": "Alpha" }
+            },
+            {
+              "type": "Feature",
+              "geometry": { "type": "Point", "coordinates": [3.0, 4.0] },
+              "properties": { "name": "Bravo" }
+            }
+          ]
+        }
+        """;
+
+    [UnitTest]
+    public async Task EsriRest_PushesDownWhereEnvelopeAndPaging_AndMapsFeatures()
+    {
+        var (handler, factory) = CreateClient();
+        var connector = new EsriRestFederatedSourceConnector(factory, NullLogger<EsriRestFederatedSourceConnector>.Instance);
+
+        var query = new FeatureQuery
+        {
+            Where = "state = 'HI'",
+            SpatialFilter = Envelope(-160, 18, -154, 23, srid: 4326),
+            Limit = 25,
+            Offset = 50,
+        };
+
+        var features = await Fetch(connector, EsriSource(), query);
+
+        var uri = handler.LastRequestUri!;
+        uri.AbsolutePath.Should().EndWith("/0/query");
+        var q = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+        q["f"].ToString().Should().Be("geojson");
+        q["where"].ToString().Should().Be("state = 'HI'");
+        q["geometryType"].ToString().Should().Be("esriGeometryEnvelope");
+        q["geometry"].ToString().Should().Be("-160,18,-154,23");
+        q["inSR"].ToString().Should().Be("4326");
+        q["resultRecordCount"].ToString().Should().Be("25");
+        q["resultOffset"].ToString().Should().Be("50");
+
+        AssertMappedFeatures(features);
+    }
+
+    [UnitTest]
+    public async Task EsriRest_NoAttributeFilter_SendsSelectAllWhere()
+    {
+        var (handler, factory) = CreateClient();
+        var connector = new EsriRestFederatedSourceConnector(factory, NullLogger<EsriRestFederatedSourceConnector>.Instance);
+
+        await Fetch(connector, EsriSource(), new FeatureQuery());
+
+        var q = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(handler.LastRequestUri!.Query);
+        q["where"].ToString().Should().Be("1=1");
+    }
+
+    [UnitTest]
+    public async Task OgcFeatures_PushesDownFilterBboxAndPaging_AndMapsFeatures()
+    {
+        var (handler, factory) = CreateClient();
+        var connector = new OgcFeaturesFederatedSourceConnector(factory, NullLogger<OgcFeaturesFederatedSourceConnector>.Instance);
+
+        var query = new FeatureQuery
+        {
+            Where = "pop > 1000",
+            SpatialFilter = Envelope(-10, -20, 30, 40),
+            Limit = 100,
+            Offset = 200,
+        };
+
+        var features = await Fetch(connector, OgcSource(), query);
+
+        var uri = handler.LastRequestUri!;
+        uri.AbsolutePath.Should().EndWith("/collections/places/items");
+        var q = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+        q["f"].ToString().Should().Be("json");
+        q["filter"].ToString().Should().Be("pop > 1000");
+        q["filter-lang"].ToString().Should().Be("cql2-text");
+        q["bbox"].ToString().Should().Be("-10,-20,30,40");
+        q["limit"].ToString().Should().Be("100");
+        q["offset"].ToString().Should().Be("200");
+
+        AssertMappedFeatures(features);
+    }
+
+    [UnitTest]
+    public async Task OgcFeatures_OrderByPresent_DoesNotPushPagingOrSort()
+    {
+        var (handler, factory) = CreateClient();
+        var connector = new OgcFeaturesFederatedSourceConnector(factory, NullLogger<OgcFeaturesFederatedSourceConnector>.Instance);
+
+        // OGC sources do not push ordering down, which forces paging to be applied locally too,
+        // so the remote request must not carry limit/offset.
+        var query = new FeatureQuery
+        {
+            OrderBy = ImmutableArray.Create(OrderByClause.Asc("name")),
+            Limit = 10,
+        };
+
+        await Fetch(connector, OgcSource(), query);
+
+        var q = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(handler.LastRequestUri!.Query);
+        q.ContainsKey("limit").Should().BeFalse();
+        q.ContainsKey("offset").Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task FetchAsync_RemoteErrorStatus_Throws()
+    {
+        var handler = new CapturingHandler(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var factory = new StubHttpClientFactory(handler);
+        var connector = new EsriRestFederatedSourceConnector(factory, NullLogger<EsriRestFederatedSourceConnector>.Instance);
+
+        var act = async () => await Fetch(connector, EsriSource(), new FeatureQuery());
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    private static void AssertMappedFeatures(ImmutableArray<Feature> features)
+    {
+        features.Should().HaveCount(2);
+
+        // First feature carries an explicit object id; geometry maps to WKB.
+        features[0].Id.Should().Be(42);
+        features[0].Geometry.Should().NotBeNull();
+        features[0].Attributes["name"].Should().Be("Alpha");
+
+        // Second feature has no id attribute, so the connector falls back to the ordinal index.
+        features[1].Id.Should().Be(1);
+        features[1].Attributes["name"].Should().Be("Bravo");
+    }
+
+    private static async Task<ImmutableArray<Feature>> Fetch(
+        IFederatedSourceConnector connector,
+        FederatedSourceDescriptor source,
+        FeatureQuery query)
+    {
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        Honua.Core.Features.Federation.ServiceCollectionExtensions.AddFederationCore(services);
+        var planner = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions
+            .GetRequiredService<IFederationQueryPlanner>(
+                Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(services));
+
+        var plan = planner.Plan(source, in query, joinsLocalLayer: false);
+        var request = new FederatedFetchRequest(source, query, plan);
+        return await connector.FetchAsync(request, CancellationToken.None);
+    }
+
+    private static (CapturingHandler Handler, StubHttpClientFactory Factory) CreateClient()
+    {
+        var handler = new CapturingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(GeoJsonResponse),
+        });
+        return (handler, new StubHttpClientFactory(handler));
+    }
+
+    private static FederatedSourceDescriptor EsriSource() => new()
+    {
+        Id = "esri",
+        DisplayName = "Esri",
+        Kind = FederatedSourceKind.EsriRest,
+        Endpoint = new Uri("https://gis.example.gov/arcgis/rest/services/Parcels/FeatureServer"),
+        RemoteLayer = "0",
+        RequestTimeout = TimeSpan.FromSeconds(15),
+    };
+
+    private static FederatedSourceDescriptor OgcSource() => new()
+    {
+        Id = "ogc",
+        DisplayName = "OGC",
+        Kind = FederatedSourceKind.OgcWfs,
+        Endpoint = new Uri("https://ogc.example.org/api"),
+        RemoteLayer = "places",
+        RequestTimeout = TimeSpan.FromSeconds(15),
+    };
+
+    private static SpatialFilter Envelope(double minX, double minY, double maxX, double maxY, int? srid = null) => new()
+    {
+        Geometry = Array.Empty<byte>(),
+        SpatialRelationship = SpatialRelationship.EnvelopeIntersects,
+        Srid = srid,
+        IsSimpleEnvelope = true,
+        EnvelopeMinX = minX,
+        EnvelopeMinY = minY,
+        EnvelopeMaxX = maxX,
+        EnvelopeMaxY = maxY,
+    };
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #341

## Summary
Fills the remaining federation gap: the remote query executor/planner already landed on trunk but had no IFederatedSourceConnector implementations. Adds HTTP connectors (Esri REST, OGC Features) that translate pushed-down predicates (where/CQL2, bbox, ordering, paging) to remote requests, plus per-source OTel metrics.

## Changes Made
- Add HttpGeoJsonFederatedSourceConnector base + EsriRest + OgcFeatures connectors + registration
- Add FederationMetrics (per-source latency/counters) wired into the executor
- Tests: Core metrics + Server connector unit tests

## Breaking Changes
None.

## Gate Impact
- [x] PR gates (build, test, governance)
## Docs or Contract Impact
- [x] None — no docs or contract impact
## Release/Deploy Impact
- [x] None — standard merge-and-release flow
## Testing
- [x] Unit tests added/updated
## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format
- [x] Issue numbers linked above