### PR TITLE
docs: document saved-map collaborative edit op-log contract (#972)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -120,6 +120,7 @@
 - [Versioning & support](reference/versioning-and-support.md)
 - [Control Plane migration guide](reference/control-plane-migration-guide.md)
 - [Integration patterns](reference/integration-patterns.md)
+- [Saved-map collaboration op-log](reference/saved-map-collaboration-op-log.md)
 - Compatibility
   - [OGC conformance](reference/compatibility/ogc-conformance.md)
   - [CITE status](cite-status.md)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -22,4 +22,5 @@ Lookup material for Honua's public surfaces: protocols, the admin API, configura
 | [OpenAPI and the explorer](openapi-and-explorer.md) | Runtime OpenAPI endpoints, `/docs`, and the pinned spec bundles. |
 | [Versioning and support](versioning-and-support.md) | Admin API versioning, deprecation lifecycle, protocol and gRPC stability. |
 | [Integration patterns](integration-patterns.md) | Capability discovery, pagination, polling vs webhooks, auth, idempotent loads. |
+| [Saved-map collaboration op-log](saved-map-collaboration-op-log.md) | Durable collaborative-edit operation log: envelope, cursors, idempotency, replay, conflict/LWW semantics, resync, authorization. |
 | [Control plane migration guide](control-plane-migration-guide.md) | SDK generation and breaking-change upgrade flow for the admin API. |

--- a/docs/reference/saved-map-collaboration-op-log.md
+++ b/docs/reference/saved-map-collaboration-op-log.md
@@ -1,0 +1,131 @@
+# Saved-map collaborative edit operation log
+
+Server-owned durable ordering and conflict behavior for multi-user saved-map editing. Where presence and live cursors are ephemeral ([collaboration session transport](#related-surfaces)), saved-map edits are durable: every accepted edit is appended to a per-map operation log, assigned a monotonic server cursor, and replayable for reconnecting clients. This page is the contract for `honua-sdk-js` and Portal consumers.
+
+## Endpoints
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/saved-maps/{mapId}/collaboration/operations` | Append one edit operation. |
+| `GET` | `/api/v1/saved-maps/{mapId}/collaboration/operations?since={cursor}` | Replay operations after a known cursor. |
+
+Both routes require an authenticated principal **and** a per-map capability grant — see [Authorization](#authorization). Responses use the standard `ApiResponse<T>` envelope (`data`, `success`, `error`).
+
+## Operation envelope
+
+A client submits an append request; the server stamps it into a durable envelope.
+
+### Append request
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `operationId` | string (≤200) | yes | Client-generated, stable id. Re-submitting the same id is idempotent per map. |
+| `actorId` | string | no | Defaults to the authenticated principal's stable identifier (`sub`/name id). |
+| `baseCursor` | int64 | no | Server cursor the edit was authored against. Defaults to `0` (empty-log base). |
+| `kind` | enum | yes | Operation kind (see [families](#operation-families)). |
+| `payload` | JSON | no | Stored opaquely; the MVP log does not interpret WebMapDoc fields. |
+| `idempotencyKey` | string (≤200) | no | Optional second dedupe key alongside `operationId`. |
+
+### Accepted envelope
+
+The append response (and every replayed operation) carries:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `operationId` | string | Echoes the client id. |
+| `mapId` | string | Saved map the operation belongs to. |
+| `actorId` | string | Resolved actor. |
+| `baseCursor` | int64 | Cursor the edit was authored against. |
+| `kind` | enum | Operation kind. |
+| `serverCursor` | int64 | **Monotonic** server-assigned cursor; the reconnect/replay key. |
+| `acceptedAt` | timestamp | Server accept time (UTC). |
+| `payload` | JSON | Original payload. |
+| `idempotencyKey` | string? | Present when supplied. |
+
+Cursor `0` is the empty-log base. The first accepted operation on a map gets `serverCursor: 1`; cursors increase by one per accepted operation and never repeat.
+
+## Append semantics
+
+The append response `status` is one of:
+
+- **`accepted`** — the operation entered the log. `operation.serverCursor` is the assigned cursor and `headCursor` is the new log head. A replayed duplicate is also `accepted` with `isDuplicate: true` and the **original** cursor (a duplicate never advances the head). HTTP `200`.
+- **`conflict`** — the operation could not be merged safely from its `baseCursor`. The body carries a [conflict payload](#conflict-semantics); no operation is appended. HTTP `409`.
+- **`resyncRequired`** — `baseCursor` is ahead of the head or older than the retained replay window. The caller must [resync](#snapshot-compaction-and-resync) from a full document snapshot. HTTP `409`.
+
+### Idempotency
+
+Duplicate detection is keyed on `operationId` and, when supplied, `idempotencyKey`, scoped per map. A repeat of either returns the originally accepted envelope with `isDuplicate: true` and leaves the head cursor unchanged. Clients should generate a stable `operationId` per logical edit and safely retry on network failure.
+
+## Replay and catch-up
+
+`GET …/operations?since={cursor}` returns every operation with `serverCursor > since`, ordered by cursor, so a reconnecting client can reapply missed edits in order. The response carries:
+
+| Field | Notes |
+| --- | --- |
+| `status` | `ok` or `resyncRequired`. |
+| `sinceCursor` | The cursor the caller replayed after. |
+| `headCursor` | Current log head; the cursor to resume from. |
+| `minimumReplayCursor` | Earliest cursor the retained log can replay from. |
+| `operations` | Envelopes after `sinceCursor`. |
+
+`since=0` against an empty or unknown map returns `ok` with no operations. A `since` value above the head or below `minimumReplayCursor` returns `resyncRequired` — the client must reload the saved-map document and resume from `headCursor`.
+
+## Operation families
+
+Each `kind` maps to a conflict **family**. The MVP policy treats per-aspect families as independently reconcilable and whole-document replacement as unsafe.
+
+| `kind` | Family | Conflict class |
+| --- | --- | --- |
+| `SetMetadataField` | Metadata | safe scalar |
+| `SetViewport` | Viewport | safe scalar |
+| `SetLayerVisibility` | LayerVisibility | safe scalar |
+| `ReorderLayers` | LayerOrdering | safe scalar |
+| `PatchStyle` | Style | safe scalar |
+| `ReplaceWebMapDocument` | WebMapDocument | unsafe |
+
+## Conflict semantics
+
+The MVP conflict policy is **last-writer-wins (LWW) for safe scalar fields** and **fail-with-conflict for whole-document replacement**:
+
+- **Safe scalar families** (metadata, viewport, layer visibility, layer ordering, style) never conflict with each other. Concurrent edits to these aspects are appended in cursor order, and the last operation per aspect wins on replay. Two clients setting the title concurrently both append; the higher-cursor title is the effective value once both replay. This is safe because each family targets an independent slice of the saved-map document.
+- **`ReplaceWebMapDocument` (unsafe)** conflicts with **any** concurrent operation, and any safe operation conflicts with a concurrent `ReplaceWebMapDocument`. Whole-document replacement based on a stale cursor would silently discard peer edits, so it returns a typed `conflict` instead.
+
+A `conflict` response body carries:
+
+| Field | Notes |
+| --- | --- |
+| `code` | Stable `saved-map.operation.conflict`. |
+| `message` | Human-readable reason. |
+| `baseCursor` | The stale base cursor that produced the conflict. |
+| `headCursor` | Current head to replay toward. |
+| `conflictingOperations` | The concurrent envelopes that made the append unsafe. |
+
+On conflict, the client should replay from `baseCursor` to `headCursor`, rebase its edit, and re-append with a fresh `baseCursor`.
+
+### CRDT/OT seam
+
+The policy is intentionally pluggable (`ISavedMapOperationConflictPolicy`). When MVP operation families outgrow LWW — for example field-level WebMapDoc transforms or rich concurrent object edits — a CRDT/OT policy can replace the MVP policy without changing the envelope, cursor, or replay contract.
+
+## Snapshot compaction and resync
+
+The operation log is bounded: each map retains a finite window of recent operations and prunes older ones. Replay and append are valid only within `[minimumReplayCursor, headCursor]`.
+
+- A cursor inside the window replays/appends normally.
+- A cursor older than `minimumReplayCursor` (compacted away) or ahead of `headCursor` returns `resyncRequired`.
+
+`resyncRequired` is the explicit signal that the client must reload the current saved-map document snapshot (the compacted base state) and resume the log from `headCursor`. Compaction therefore preserves replay from supported cursors and returns a typed resync signal for cursors outside the window — it never silently drops edits.
+
+## Authorization
+
+Both endpoints reject anonymous callers at the middleware boundary (`401`), then run a **per-map** capability check through the shared `ISavedMapCollaborationAuthorizer` — the same authorizer the [collaboration session join](#related-surfaces) uses, so presence and durable edits share one identity/RBAC seam. The check is **fail-closed**: a generally authenticated principal that lacks a grant on *this* saved map gets:
+
+- `401 Unauthorized` when authentication is required, or
+- `403 Forbidden` when authenticated but not permitted on the map.
+
+Durable edits are never accepted on the strength of authentication alone.
+
+## Related surfaces
+
+- **Session transport** (presence, live cursors, follow): `POST /api/v1/saved-maps/{mapId}/collaboration/sessions/join`, `GET …/sessions/stream`. Ephemeral; see issue #971.
+- **Feature-service edit locks/conflicts**: row/geometry edit persistence is a separate seam from saved-map document edits.
+- **Capability discovery**: `GET /api/v1/capabilities/manifest` reports realtime/transport availability — see [integration patterns](integration-patterns.md#runtime-capability-discovery). Discovery only; authorization still happens at the operation endpoint.


### PR DESCRIPTION
## Issue Link
Closes #972

## Summary
Completes issue #972 (saved-map collaborative edit operation log and conflict seam) by documenting the operation envelope and conflict semantics for `honua-sdk-js` and Portal consumers — the two acceptance criteria that were still unmet.

The durable op-log itself already ships on `trunk`: the append/replay endpoints (`/api/v1/saved-maps/{mapId}/collaboration/operations`), the operation envelope with monotonic server cursors, idempotent dedupe by operation id / idempotency key, replay/catch-up from a known cursor, typed conflict and resync-required responses, the MVP last-writer-wins conflict policy, snapshot compaction, and fail-closed per-map authorization through the shared `ISavedMapCollaborationAuthorizer` (landed via #2259, with integration tests covering forbidden append/replay and the happy path). This PR fills the remaining documentation gap so the contract is consumable downstream.

## Changes Made
- Added `docs/reference/saved-map-collaboration-op-log.md`: append/replay endpoints, operation envelope and monotonic server cursors, idempotency, replay/catch-up, operation families, conflict semantics with documented last-writer-wins for MVP-safe scalar fields and fail-with-conflict for whole-document replacement, the CRDT/OT seam, snapshot compaction with typed resync-required responses, and the shared fail-closed per-map authorization seam.
- Registered the new page in `docs/reference/README.md` (cross-cutting pages table).
- Registered the new page in `docs/SUMMARY.md` (reference section).

## Testing
- [x] Architecture tests pass
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Notes: Docs-only change — no compilable surface. The op-log endpoint integration tests (`SavedMapOperationEndpointsTests`: monotonic cursors, idempotency, unauthenticated 401, forbidden-per-map append/replay 403) already exist on `trunk`. `scripts/ci/pre-pr-check.sh` (BASE_REF=origin/trunk) was run; with no `.cs` changes the build/format/unit gates have nothing to act on.

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
