### PR TITLE
test: stop asserting GML is an unsupported import format

### DIFF
--- a/tests/dotnet/Honua.Core.Tests/Features/Import/FileGdbFormatDetectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/FileGdbFormatDetectionTests.cs
@@ -28,9 +28,7 @@ public sealed class FileGdbFormatDetectionTests
     {
         var service = new FileFormatDetectionService(NullLogger<FileFormatDetectionService>.Instance);
 
-        service.DetectFormat("sample.gml").Should().BeNull();
         service.DetectFormat("sample.twkb").Should().BeNull();
-        service.GetSupportedExtensions().Should().NotContain(".gml");
         service.GetSupportedExtensions().Should().NotContain(".twkb");
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Import/ImportEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/ImportEndpointTests.cs
@@ -126,11 +126,8 @@ public class ImportEndpointTests : IAsyncLifetime
             .ToArray();
         var formatDescriptions = document.RootElement.GetProperty("formatDescriptions");
 
-        extensions.Should().NotContain(".gml");
         extensions.Should().NotContain(".twkb");
-        formatDescriptions.TryGetProperty(".gml", out _).Should().BeFalse();
         formatDescriptions.TryGetProperty(".twkb", out _).Should().BeFalse();
-        content.Should().NotContain("GML - Geography Markup Language");
         content.Should().NotContain("TinyWKB - Compact binary format");
     }
 


### PR DESCRIPTION
## Summary

GML import support (`SupportedFileFormat.Gml`, the `.gml` extension, and content sniffing for `opengis.net/gml`) landed via #2229, but two tests were never updated and still asserted that `.gml` is an **unsupported / unadvertised** format. Those stale assertions fail the **Foundation** and **FileImport** test shards, which is the root cause of CI being red on `trunk` (and therefore on every PR).

Positive GML coverage already exists in `GmlFormatDetectionTests`; this change only removes the now-incorrect negative assertions, keeping the still-unsupported TWKB checks.

## Changes Made

- `FileGdbFormatDetectionTests.DetectFormat_UnsupportedAdvertisedFormats_AreRejected`: drop the `.gml` rejection assertions; keep `.twkb`.
- `ImportEndpointTests.GetSupportedFormats_DoesNotAdvertiseUnsupportedFormats`: drop the `.gml` not-advertised assertions; keep `.twkb`.

## Breaking Changes

None. Test-only change.

## Gate Impact

- [x] Tests only — fixes existing failing tests; no product behavior change.

## Testing

- [x] Verified GML is genuinely supported on trunk (enum value, `.gml` extension map, content sniffing) and that TWKB remains unsupported; positive GML detection is covered by `GmlFormatDetectionTests`.
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
