### PR TITLE
feat(geoprocessing): GP devkit local authoring/run/test (#2130)

### DIFF
--- a/src/Honua.Geoprocessing.Cli/GpCli.cs
+++ b/src/Honua.Geoprocessing.Cli/GpCli.cs
@@ -103,10 +103,47 @@ public static class GpCli
         return services.BuildServiceProvider();
     }
 
+    /// <summary>
+    /// Resolves the registered <see cref="IProcessExecutor"/> set for the local runner,
+    /// de-duplicating any process id claimed by BOTH a managed executor and a native GDAL
+    /// executor. In the real system the managed executors (server host) and the native GDAL
+    /// executors (worker host) run in SEPARATE processes, so an id handled by both — e.g.
+    /// <c>transform.reproject</c> (managed NTS reproject vs native <c>ogr2ogr</c>) — never
+    /// collides there. The devkit composes BOTH sets into one provider for a single offline
+    /// loop, so the overlap is resolved deterministically here: the managed executor wins (the
+    /// sub-second, binary-free default), and a native executor is dropped only when EVERY id it
+    /// handles is already owned by a managed executor. Its distinct <c>gdal.*</c> ids and the
+    /// <c>--real-worker</c> fidelity path are unaffected; a partial overlap is left for
+    /// <see cref="ProcessExecutorRouteTable"/> to surface as the authoring error it is.
+    /// </summary>
+    private static List<IProcessExecutor> ResolveExecutors(ServiceProvider provider)
+    {
+        var all = provider.GetServices<IProcessExecutor>().ToList();
+        var gdalAssembly = typeof(GdalProcessExecutorMode).Assembly;
+
+        var managed = all.Where(e => e.GetType().Assembly != gdalAssembly).ToList();
+        var claimed = new HashSet<string>(
+            managed.SelectMany(e => e.ProcessIds), StringComparer.Ordinal);
+
+        var resolved = new List<IProcessExecutor>(managed);
+        foreach (var executor in all.Where(e => e.GetType().Assembly == gdalAssembly))
+        {
+            if (executor.ProcessIds.All(claimed.Contains))
+            {
+                // Pure managed/native overlap (e.g. transform.reproject): managed already owns it.
+                continue;
+            }
+
+            resolved.Add(executor);
+        }
+
+        return resolved;
+    }
+
     private static int RunList()
     {
         using var provider = BuildProvider();
-        var executors = provider.GetServices<IProcessExecutor>();
+        var executors = ResolveExecutors(provider);
         var runner = new GeoprocessingLocalRunner(executors);
         var catalog = provider.GetService<IProcessCatalog>();
 
@@ -182,7 +219,7 @@ public static class GpCli
 
         var gdalMode = await ResolveGdalModeAsync(parsed.ForceContainer).ConfigureAwait(false);
         using var provider = BuildProvider(gdalMode, capture);
-        var executors = provider.GetServices<IProcessExecutor>();
+        var executors = ResolveExecutors(provider);
         var runner = new GeoprocessingLocalRunner(executors);
 
         if (!runner.AvailableProcessIds.Contains(parsed.ProcessId, StringComparer.Ordinal))
@@ -655,7 +692,7 @@ public static class GpCli
             : GoldenUpdateMode.Assert;
 
         using var provider = BuildProvider();
-        var executors = provider.GetServices<IProcessExecutor>();
+        var executors = ResolveExecutors(provider);
         var runner = new GpProcessTestRunner(executors);
 
         Console.WriteLine($"GP golden tests : {fixtures.Count} fixture(s) under {fixtureRoot}");
@@ -731,7 +768,7 @@ public static class GpCli
         // Reuse the live P1 registration as the collision source of truth: the runner's
         // available ids are exactly the registered IProcessExecutor set.
         using var provider = BuildProvider();
-        var executors = provider.GetServices<IProcessExecutor>();
+        var executors = ResolveExecutors(provider);
         var runner = new GeoprocessingLocalRunner(executors);
         var existingIds = runner.AvailableProcessIds;
 
@@ -804,7 +841,7 @@ public static class GpCli
     private static async Task<int> RunPublish(string[] args)
     {
         using var provider = BuildProvider();
-        var executors = provider.GetServices<IProcessExecutor>();
+        var executors = ResolveExecutors(provider);
         var runner = new GeoprocessingLocalRunner(executors);
         var processIds = runner.AvailableProcessIds.ToHashSet(StringComparer.Ordinal);
         var catalog = provider.GetService<IProcessCatalog>();

--- a/tests/dotnet/Honua.Geoprocessing.Cli.Tests/GpCliEndToEndTests.cs
+++ b/tests/dotnet/Honua.Geoprocessing.Cli.Tests/GpCliEndToEndTests.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.Geoprocessing.Cli.Tests;
+
+/// <summary>
+/// End-to-end coverage for the <c>honua gp</c> command surface (<see cref="GpCli.RunAsync"/>):
+/// the GP Devkit umbrella (#2130) Wave-1 exit criterion — the minimal authoring/run/test loop
+/// "proven end-to-end with tests". Where the sibling unit tests cover each building block in
+/// isolation (the scaffolder, the describe renderer, the publish pipeline), these drive the
+/// REAL verb dispatch — argument parsing, the registered managed executor set, the Redis-free
+/// <c>GeoprocessingLocalRunner</c>, the planner, the golden test runner, exit codes, and the
+/// console output — through the public entry point a developer actually invokes.
+///
+/// Every scenario stays managed-only (the <c>geometry.buffer</c> op and the managed
+/// <c>geometry-buffer-point</c> golden fixture) so the loop is deterministic and needs no
+/// Redis, no job store, no Docker, and no GDAL binary on PATH.
+/// </summary>
+[Collection(GpCliEndToEndTests.CollectionName)]
+public sealed class GpCliEndToEndTests
+{
+    internal const string CollectionName = "GpCli console capture";
+
+    // The geometry.buffer inputs mirror samples/gp/geometry-buffer-point/fixture.json:
+    // buffer POINT(0 0) by 10 units in EPSG:4326. WKB is the base64 of a 2D point at the origin.
+    private const string PointWkbBase64 = "AQEAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    [Fact]
+    public async Task RunAsync_NoArgs_PrintsUsageAndReturnsUsageExit()
+    {
+        var (exit, stdout, _) = await InvokeAsync();
+
+        exit.Should().Be(2);
+        stdout.Should().Contain("honua gp");
+        stdout.Should().Contain("Usage:");
+    }
+
+    [Fact]
+    public async Task RunAsync_Help_PrintsUsageAndSucceeds()
+    {
+        var (exit, stdout, _) = await InvokeAsync("--help");
+
+        exit.Should().Be(0);
+        stdout.Should().Contain("Usage:");
+        stdout.Should().Contain("honua gp list");
+    }
+
+    [Fact]
+    public async Task RunAsync_UnknownVerb_ReturnsUsageExit()
+    {
+        var (exit, _, stderr) = await InvokeAsync("frobnicate");
+
+        exit.Should().Be(2);
+        stderr.Should().Contain("Unknown command 'frobnicate'.");
+    }
+
+    [Fact]
+    public async Task RunAsync_List_IncludesRegisteredManagedProcesses()
+    {
+        var (exit, stdout, _) = await InvokeAsync("list");
+
+        exit.Should().Be(0);
+        stdout.Should().Contain("Available geoprocessing processes:");
+        // geometry.buffer is part of the canonical managed executor set every host registers.
+        stdout.Should().Contain("geometry.buffer");
+    }
+
+    [Fact]
+    public async Task RunAsync_List_ResolvesManagedAndNativeProcessIdCollision()
+    {
+        // transform.reproject is claimed by BOTH the managed NTS executor and the native
+        // GDAL ogr2ogr executor (registered in the same provider only by the devkit). The
+        // managed one must win, while the native executor's DISTINCT gdal.* ids survive, so
+        // building the runner must not throw a duplicate-id error.
+        var (exit, stdout, _) = await InvokeAsync("list");
+
+        exit.Should().Be(0);
+        stdout.Should().Contain("transform.reproject");
+        stdout.Should().Contain("gdal.gdalwarp");
+    }
+
+    [Fact]
+    public async Task RunAsync_Describe_PrintsTypedParametersForKnownProcess()
+    {
+        var (exit, stdout, _) = await InvokeAsync("describe", "geometry.buffer");
+
+        exit.Should().Be(0);
+        stdout.Should().Contain("geometry.buffer");
+        // The buffer op's typed schema exposes a distance parameter.
+        stdout.Should().Contain("distance");
+    }
+
+    [Fact]
+    public async Task RunAsync_DescribeJson_EmitsParseableDescriptor()
+    {
+        var (exit, stdout, _) = await InvokeAsync("describe", "geometry.buffer", "--json");
+
+        exit.Should().Be(0);
+
+        // The --json view must be a single machine-parseable object, not free text.
+        var json = ExtractJson(stdout);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public async Task RunAsync_Describe_UnknownProcess_ReturnsUsageExit()
+    {
+        var (exit, _, stderr) = await InvokeAsync("describe", "geometry.does-not-exist");
+
+        exit.Should().Be(2);
+        stderr.Should().Contain("is not registered");
+    }
+
+    [Fact]
+    public async Task RunAsync_Plan_ValidParams_SucceedsAndEstimatesSizeCost()
+    {
+        var (exit, stdout, _) = await InvokeAsync(
+            "plan", "geometry.buffer",
+            "--param", $"wkb={PointWkbBase64}",
+            "--param", "srid=4326",
+            "--param", "distance=10");
+
+        exit.Should().Be(0);
+        stdout.Should().Contain("process      : geometry.buffer");
+        stdout.Should().Contain("valid        : yes");
+        stdout.Should().Contain("size/cost estimate");
+    }
+
+    [Fact]
+    public async Task RunAsync_Plan_UnknownProcess_ReturnsUsageExit()
+    {
+        var (exit, _, stderr) = await InvokeAsync("plan", "geometry.nope", "--param", "x=1");
+
+        exit.Should().Be(2);
+        stderr.Should().Contain("is not registered");
+    }
+
+    [Fact]
+    public async Task RunAsync_Run_ManagedBuffer_SucceedsAndEmitsArtifact()
+    {
+        var (exit, stdout, _) = await InvokeAsync(
+            "run", "geometry.buffer",
+            "--in-process",
+            "--param", $"wkb={PointWkbBase64}",
+            "--param", "srid=4326",
+            "--param", "distance=10");
+
+        exit.Should().Be(0);
+        stdout.Should().Contain("process : geometry.buffer");
+        stdout.Should().Contain("status  :");
+        stdout.Should().Contain("artifact:");
+    }
+
+    [Fact]
+    public async Task RunAsync_Run_WithOut_WritesArtifactBytesToFile()
+    {
+        var outPath = Path.Combine(Path.GetTempPath(), $"gp-cli-out-{Guid.NewGuid():N}.bin");
+        try
+        {
+            var (exit, stdout, _) = await InvokeAsync(
+                "run", "geometry.buffer",
+                "--in-process",
+                "--param", $"wkb={PointWkbBase64}",
+                "--param", "srid=4326",
+                "--param", "distance=10",
+                "--out", outPath);
+
+            exit.Should().Be(0);
+            stdout.Should().Contain("wrote   :");
+            File.Exists(outPath).Should().BeTrue();
+            new FileInfo(outPath).Length.Should().BeGreaterThan(0);
+        }
+        finally
+        {
+            if (File.Exists(outPath))
+            {
+                File.Delete(outPath);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_Run_UnknownProcess_ReturnsUsageExit()
+    {
+        var (exit, _, stderr) = await InvokeAsync("run", "geometry.nope", "--in-process", "--param", "x=1");
+
+        exit.Should().Be(2);
+        stderr.Should().Contain("is not registered");
+    }
+
+    [Fact]
+    public async Task RunAsync_Test_ManagedGoldenFixture_Passes()
+    {
+        var root = ResolveSamplesGpRoot();
+
+        var (exit, stdout, _) = await InvokeAsync(
+            "test", "geometry-buffer-point", "--root", root);
+
+        exit.Should().Be(0);
+        stdout.Should().Contain("PASS");
+        stdout.Should().Contain("geometry-buffer-point");
+        stdout.Should().Contain("0 failed");
+    }
+
+    [Fact]
+    public async Task RunAsync_Test_UnknownFixture_ReturnsUsageExit()
+    {
+        var root = ResolveSamplesGpRoot();
+
+        var (exit, _, stderr) = await InvokeAsync(
+            "test", "no-such-fixture", "--root", root);
+
+        exit.Should().Be(2);
+        stderr.Should().Contain("No GP fixture with id 'no-such-fixture'");
+    }
+
+    /// <summary>
+    /// The headline umbrella proof: the full devkit loop — list -> describe -> plan -> run -> test —
+    /// drives the SAME registered process through every verb and asserts each exits clean. This is the
+    /// "minimal CLI proven end-to-end" exit criterion for GP Devkit Wave 1 (#2130).
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_FullDevkitLoop_ListDescribePlanRunTest_AllSucceed()
+    {
+        var root = ResolveSamplesGpRoot();
+        var bufferParams = new[]
+        {
+            "--param", $"wkb={PointWkbBase64}",
+            "--param", "srid=4326",
+            "--param", "distance=10",
+        };
+
+        var list = await InvokeAsync("list");
+        list.ExitCode.Should().Be(0, "the dev loop starts by discovering registered processes");
+
+        var describe = await InvokeAsync("describe", "geometry.buffer");
+        describe.ExitCode.Should().Be(0, "the author inspects the typed schema next");
+
+        var plan = await InvokeAsync(new[] { "plan", "geometry.buffer" }.Concat(bufferParams).ToArray());
+        plan.ExitCode.Should().Be(0, "the dry-run plan must validate before submit");
+
+        var run = await InvokeAsync(new[] { "run", "geometry.buffer", "--in-process" }.Concat(bufferParams).ToArray());
+        run.ExitCode.Should().Be(0, "the local run must succeed against the canonical runtime");
+
+        var test = await InvokeAsync("test", "geometry-buffer-point", "--root", root);
+        test.ExitCode.Should().Be(0, "the golden fixture must assert the output");
+    }
+
+    /// <summary>
+    /// Invokes <see cref="GpCli.RunAsync"/> with the supplied argv while capturing stdout/stderr.
+    /// Console redirection is process-global, so this collection disables cross-collection
+    /// parallelization (and xUnit serializes the methods within this class).
+    /// </summary>
+    private static async Task<CliResult> InvokeAsync(params string[] args)
+    {
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        try
+        {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            var exit = await GpCli.RunAsync(args);
+            return new CliResult(exit, stdout.ToString(), stderr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+    }
+
+    /// <summary>
+    /// Locates the repo's <c>samples/gp</c> fixtures directory by walking up from the test
+    /// assembly's base directory, so the <c>test</c> verb is exercised against the real fixtures
+    /// regardless of the runner's working directory.
+    /// </summary>
+    private static string ResolveSamplesGpRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "samples", "gp");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the samples/gp fixtures directory above " + AppContext.BaseDirectory);
+    }
+
+    private static string ExtractJson(string output)
+    {
+        var start = output.IndexOf('{', StringComparison.Ordinal);
+        var end = output.LastIndexOf('}');
+        return start >= 0 && end > start ? output[start..(end + 1)] : output;
+    }
+
+    private readonly record struct CliResult(int ExitCode, string StdOut, string StdErr);
+}
+
+/// <summary>
+/// Serializes the console-capturing GP CLI end-to-end tests against every other test
+/// collection in the assembly, since redirecting <see cref="Console.Out"/> is process-global.
+/// </summary>
+[CollectionDefinition(GpCliEndToEndTests.CollectionName, DisableParallelization = true)]
+public sealed class GpCliConsoleCaptureDefinition;


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2130

## Summary
The GP Devkit umbrella (#2130) makes authoring/running/testing geoprocessing feel like writing a typed library function: a sub-second, Redis-free, license-free, fully-testable local loop. Its building blocks (P1-P8, #2122-#2129) all shipped, but the umbrella's Wave-1 exit criterion — "P1+P2 (+ minimal CLI) proven end-to-end with tests" — was never met: the `honua gp` command surface (`GpCli.RunAsync`) itself had zero coverage.

Adding that end-to-end coverage immediately surfaced that `honua gp list`/`run`/`test` **crash on trunk**. The devkit deliberately composes BOTH the managed executor set and the native GDAL executor set into a single in-process provider (so one local runner can drive any process). PR #2213 (native ETL worker) added a native `GdalVectorReprojectJobExecutor` that claims `transform.reproject` — the same id the managed `ReprojectTransformExecutor` already owns. In the real system those run in separate hosts (server vs worker) so they never collide; in the devkit's combined provider the route table rejects the duplicate id and the CLI throws an unhandled exception before doing anything.

This PR proves the spine end-to-end and fixes the regression the missing coverage was hiding.

## Changes Made
- Add `GpCli.ResolveExecutors`: de-duplicates a process id claimed by BOTH a managed and a native GDAL executor. The managed executor wins (the sub-second, binary-free default); a native executor is dropped only when EVERY id it handles is already owned by a managed one, so distinct `gdal.*` ids and the `--real-worker` fidelity path are unaffected, and a partial overlap is still surfaced as the authoring error it is. All five runner/test/scaffold/publish executor-resolution call sites now route through it.
- Add `GpCliEndToEndTests`: drives the REAL verb dispatch and exit codes through the public entry point — `list`, `describe`, `describe --json` (parsed), `plan`, `run`, `run --out` (writes artifact bytes), `test` (managed golden fixture), unknown-verb/unknown-process/unknown-fixture usage errors, a full `list -> describe -> plan -> run -> test` loop, and an explicit regression test pinning the `transform.reproject` managed/native collision resolution. Managed-only fixtures keep every scenario deterministic (no Redis, no job store, no Docker, no GDAL binary on PATH).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

(Verified the real `honua-gp` binary: `list`, `test geometry-buffer-point` now succeed; `transform.reproject` resolves to the managed executor while `gdal.gdalwarp` survives.)

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
