### PR TITLE
feat(geoprocessing): add proximity.euclidean-allocation (#2255)

### DIFF
--- a/docker/worker-gdal/Dockerfile
+++ b/docker/worker-gdal/Dockerfile
@@ -87,8 +87,14 @@ ARG DOTNET_RUNTIME_VERSION
 # PointCloudTilesetBuilder) turns into 3D Tiles. Like GDAL, PDAL lives ONLY in
 # this image; the lean serving image stays point-cloud-native-dep-free.
 # hadolint ignore=DL3008,DL3015
+# python3-scipy backs the custom Euclidean allocation worker step
+# (proximity.euclidean-allocation, #2255): Scripts/gdal_euclidean_allocation.py
+# uses SciPy's exact distance transform (nearest-feature index return) plus the
+# GDAL Python bindings (shipped in the ubuntu-full base) since stock
+# gdal_proximity has no nearest-source allocation mode.
+# hadolint ignore=DL3008,DL3015
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates curl libicu-dev pdal \
+ && apt-get install -y --no-install-recommends ca-certificates curl libicu-dev pdal python3-scipy \
  && rm -rf /var/lib/apt/lists/* \
  && curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
  && chmod +x /tmp/dotnet-install.sh \
@@ -113,6 +119,10 @@ RUN command -v gdalwarp && command -v ogr2ogr && command -v gdalmdiminfo \
  # surface.contour / surface.viewshed / conversion.rasterize.
  && command -v gdal_calc.py \
  && command -v gdal_proximity.py \
+ # The Euclidean allocation custom step (proximity.euclidean-allocation, #2255)
+ # imports the GDAL Python bindings + NumPy + SciPy at runtime; fail the build
+ # early if any are missing from the image.
+ && python3 -c "import numpy, scipy; from scipy import ndimage; from osgeo import gdal" \
  && command -v gdal_polygonize.py \
  && command -v gdal_contour \
  && command -v gdal_viewshed \
@@ -138,6 +148,10 @@ RUN groupadd --gid 1001 --system honua \
 
 WORKDIR /app
 COPY --from=build --chown=1001:1001 /app .
+
+# Guard: the custom worker steps (e.g. the Euclidean allocation step, #2255) must
+# be published alongside the worker assemblies so the executors can invoke them.
+RUN test -f /app/Scripts/gdal_euclidean_allocation.py
 
 ENV DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \

--- a/docs/reference/geoprocessing-operations.md
+++ b/docs/reference/geoprocessing-operations.md
@@ -7,7 +7,7 @@ The catalog currently registers **95 processes** across 14 families. This page i
 Execution notes that apply across families:
 
 - **Runtime profile.** Processes marked *native* below declare `RuntimeProfile = native` and execute out-of-process in the heavyweight GDAL/PDAL worker image; the lean GDAL-free serving image validates their plans (parameter shape + per-process semantic rules) but never executes them. **A deployment without the GDAL worker cannot run any native process** — all `surface.*`, all `raster.*`, the native `conversion.*` (raster/OGR/point-cloud) idioms, `proximity.euclidean-*`, `source.ogr`, `gdal.*`, and `pcloud.translate`. 30 of the 95 processes are native.
-- **Flagged / unsupported.** Two native processes are advertised so callers can *discover* the capability gap but **fail with a clear message when submitted** rather than silently substituting a different algorithm: `raster.interpolate-kriging` (no kriging backend in the worker image — use `raster.interpolate-idw`) and `proximity.euclidean-allocation` (stock GDAL `gdal_proximity` computes distance only — use `proximity.euclidean-distance`).
+- **Flagged / unsupported.** One native process is advertised so callers can *discover* the capability gap but **fails with a clear message when submitted** rather than silently substituting a different algorithm: `raster.interpolate-kriging` (no kriging backend in the worker image — use `raster.interpolate-idw`).
 - **Raster sourcing.** Native raster/surface processes read the raster as base64-encoded GeoTIFF bytes on the `source` parameter; `layerId`/`rasterId` selectors are declared but layer-resolved sourcing is a follow-on and `source` remains required today.
 - **Inline FeatureCollections.** Managed `*-managed`, `overlay.*`, `proximity.near*`, `statistics.*`, `transform.*`, `source.*`, and `sink.*` processes exchange features as `data:application/geo+json;base64` data URIs so they compose as workflow nodes.
 - **Approval gate.** `data-management.delete-features` and `data-management.calculate-field` are destructive and require operator approval.
@@ -48,6 +48,7 @@ The layer-scoped processes (`analytics.cluster`, `analytics.spatial-join`, `anal
 | `analytics.spatial-join-managed` | Job-executable join over two inline FeatureCollections; `JOIN_COUNT` plus sum/mean/min/max aggregates. | `input`, `join`, `predicate`, `statistics` |
 | `analytics.buffer-aggregate-managed` | Job-executable buffer-and-dissolve over inline features. | `input`, `distance`, `unit`, `dissolve`, `groupByFields` |
 | `analytics.density-managed` | Job-executable hex/square binning over inline features. | `input`, `mode`, `cellSize`, `weightField` |
+| `analytics.hotspot-managed` | Job-executable Getis-Ord Gi* Hot Spot Analysis over inline features; appends `GI_ZSCORE`, `GI_PVALUE`, `GI_BIN`. | `input`, `field`, `distanceBand` |
 
 ## Overlay (6)
 
@@ -71,7 +72,7 @@ Nearest-feature and Euclidean-distance tools.
 | `proximity.near` | Append `NEAR_FID`/`NEAR_DIST` for the closest near-layer feature (Esri Near). Planar CRS units. | `input`, `near`, `nearIdField`, `searchRadius` | managed |
 | `proximity.near-table` | Emit a table of `IN_FID`/`NEAR_FID`/`NEAR_DIST` rows (Esri GenerateNearTable). | `input`, `near`, `inputIdField`, `nearIdField`, `searchRadius` | managed |
 | `proximity.euclidean-distance` | Raster of distance from each cell to the nearest source cell (`gdal_proximity.py`). | `source` (base64 GeoTIFF), `maxDistance`, `distUnits`, `values` | **native** |
-| `proximity.euclidean-allocation` | **FLAGGED / UNSUPPORTED** — allocation needs a mode stock GDAL `gdal_proximity` lacks; submitted jobs fail with a clear message. Use `proximity.euclidean-distance`. | `source` | **native (flagged)** |
+| `proximity.euclidean-allocation` | Nearest-source allocation raster (discrete Voronoi): each cell takes the value/id of its nearest source cell. Custom worker step (`gdal_euclidean_allocation.py`, GDAL bindings + SciPy distance transform) since stock `gdal_proximity` computes distance only. | `source` (base64 GeoTIFF), `maxDistance`, `distUnits`, `values` | **native** |
 
 ## Statistics (3)
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/BuiltInProcessCatalog.cs
@@ -512,11 +512,14 @@ internal sealed class BuiltInProcessCatalog : IProcessCatalog
         {
             ProcessId = "proximity.euclidean-allocation",
             Title = "Euclidean Allocation",
-            Description = "FLAGGED / UNSUPPORTED in this build: nearest-source allocation requires a mode that stock GDAL gdal_proximity does not provide (it computes distance only). The process is advertised so callers can discover the limitation; a submitted job FAILS with a clear message rather than silently substituting a distance raster. Use proximity.euclidean-distance for the distance raster.",
+            Description = "Computes the nearest-source allocation raster (the discrete-Voronoi companion of proximity.euclidean-distance): every cell takes the VALUE/id of its nearest source cell. Executed out-of-process by the heavyweight GDAL worker via a custom worker step (gdal_euclidean_allocation.py) layered on the GDAL Python bindings plus SciPy's exact Euclidean distance transform, since stock gdal_proximity computes distance only. Reads a base64-encoded GeoTIFF from 'source' whose non-zero (or 'values'-listed) pixels are the sources; publishes the allocation GeoTIFF (source extent/cell-size/CRS/band data type preserved) as a data-URI artifact.",
             Category = "proximity",
             Parameters =
             [
-                Param("source", "Source Raster", "Source raster as base64-encoded GeoTIFF bytes. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("source", "Source Raster", "Source raster as base64-encoded GeoTIFF bytes whose non-zero (or 'values'-listed) pixels are the allocation sources carrying the ids to assign. Required by the native worker execution path.", ProcessParameterValueType.Text, required: true),
+                Param("maxDistance", "Max Distance", "Optional maximum allocation distance. Must be > 0 when supplied. Cells whose nearest source is farther take the nodata value.", ProcessParameterValueType.FloatingPoint),
+                Param("distUnits", "Distance Units", "Distance units used for maxDistance. Allowed values: GEO, PIXEL. Defaults to GEO.", ProcessParameterValueType.Text, defaultValue: "GEO"),
+                Param("values", "Target Values", "Optional comma-separated list of integer source pixel values to treat as allocation sources. When omitted, all non-zero pixels are sources.", ProcessParameterValueType.Text),
             ],
             OutputArtifactKinds = [ArtifactKind.Raster],
             RuntimeProfile = RuntimeProfiles.Native

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ProcessPlanValidator.cs
@@ -362,11 +362,11 @@ internal static partial class ProcessPlanValidator
                 ValidateProximityEuclideanDistanceSemantics(step, violations);
                 break;
             case "proximity.euclidean-allocation":
-                // Euclidean allocation is advertised but flagged unsupported by the
-                // native worker (stock gdal_proximity has no allocation mode). The
-                // plan is still shape-validated (the base type-validator enforces the
-                // required 'source' input); the worker FAILS the job at execution with
-                // a clear message rather than the validator blocking it.
+                // Allocation shares the distance op's parameter surface (#2255):
+                // 'source' (required), optional maxDistance / distUnits / values. The
+                // native worker computes the nearest-source raster via the custom
+                // gdal_euclidean_allocation.py step.
+                ValidateProximityEuclideanDistanceSemantics(step, violations);
                 break;
             case "surface.contour":
                 ValidateSurfaceContourSemantics(step, violations);

--- a/src/Honua.Worker.Gdal/Execution/GdalProximityJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalProximityJobExecutor.cs
@@ -12,9 +12,9 @@ namespace Honua.Worker.Gdal.Execution;
 
 /// <summary>
 /// Native-profile <see cref="IProcessExecutor"/> for the Euclidean-proximity family
-/// (#2240): <c>proximity.euclidean-distance</c>, a distance-to-nearest-source raster
-/// backed by the GDAL <c>gdal_proximity.py</c> CLI, and
-/// <c>proximity.euclidean-allocation</c>, which is FLAGGED unsupported in this build.
+/// (#2240, #2255): <c>proximity.euclidean-distance</c>, a distance-to-nearest-source
+/// raster backed by the GDAL <c>gdal_proximity.py</c> CLI, and
+/// <c>proximity.euclidean-allocation</c>, the nearest-source allocation companion.
 ///
 /// <para>
 /// Distance reads a base64-encoded source GeoTIFF whose non-zero (or
@@ -23,11 +23,13 @@ namespace Honua.Worker.Gdal.Execution;
 /// distance.
 /// </para>
 /// <para>
-/// Allocation (assigning each cell the value of its nearest source) has NO equivalent
-/// in stock <c>gdal_proximity.py</c> — the CLI computes distance only and has no
-/// nearest-source allocation mode. Rather than silently substitute a distance raster
-/// or a fixed-buffer value, the executor FAILS the job with a clear message so the
-/// limitation is explicit, mirroring the flagged-kriging contract (#2141).
+/// Allocation (assigning each cell the VALUE/id of its nearest source — a discrete
+/// Voronoi tessellation) has NO equivalent in stock <c>gdal_proximity.py</c>, which
+/// computes distance only. It is implemented as a small custom worker step
+/// (<c>Scripts/gdal_euclidean_allocation.py</c>, #2255) layered on the GDAL Python
+/// bindings plus SciPy's exact Euclidean distance transform with nearest-feature
+/// index return. The output GeoTIFF preserves the source extent, cell size, CRS and
+/// band data type.
 /// </para>
 /// Runs only inside the GDAL worker image — <see cref="AcceptedRuntimeProfiles"/> is
 /// <c>{ "native" }</c>.
@@ -40,16 +42,16 @@ internal sealed partial class GdalProximityJobExecutor(
     /// <summary>Process id for the Euclidean distance raster.</summary>
     public const string DistanceProcessId = "proximity.euclidean-distance";
 
-    /// <summary>Process id for Euclidean allocation (flagged unsupported).</summary>
+    /// <summary>Process id for the Euclidean allocation (nearest-source) raster.</summary>
     public const string AllocationProcessId = "proximity.euclidean-allocation";
 
     /// <summary>
-    /// Stable failure message published when an allocation job is submitted. Stock
-    /// <c>gdal_proximity.py</c> has no nearest-source allocation mode.
+    /// Name of the bundled custom worker step implementing Euclidean allocation. The
+    /// script ships in the published worker's <c>Scripts</c> folder and is invoked via
+    /// <c>python3</c>; it requires the GDAL Python bindings + SciPy from the worker
+    /// image.
     /// </summary>
-    public const string AllocationUnsupportedMessage =
-        "Euclidean allocation is not available in this build: stock GDAL gdal_proximity computes distance only and "
-        + "has no nearest-source allocation mode. Use proximity.euclidean-distance for the distance raster.";
+    public const string AllocationScriptName = "gdal_euclidean_allocation.py";
 
     private const string GeoTiffContentType = "image/tiff; application=geotiff";
 
@@ -98,11 +100,7 @@ internal sealed partial class GdalProximityJobExecutor(
                 $"Process id '{processId ?? "<none>"}' is not handled by the proximity executor.");
         }
 
-        if (string.Equals(processId, AllocationProcessId, StringComparison.Ordinal))
-        {
-            Log.AllocationUnsupported(logger, job.OperationId);
-            return JobExecutionResult.Failed(AllocationUnsupportedMessage);
-        }
+        var isAllocation = string.Equals(processId, AllocationProcessId, StringComparison.Ordinal);
 
         cancellationToken.ThrowIfCancellationRequested();
         await context.ReportProgressAsync(5, "Parsing proximity inputs", cancellationToken).ConfigureAwait(false);
@@ -153,6 +151,42 @@ internal sealed partial class GdalProximityJobExecutor(
             var inputPath = Path.Combine(workspace, "input.tif");
             var outputPath = Path.Combine(workspace, "output.tif");
             await File.WriteAllBytesAsync(inputPath, sourceBytes, cancellationToken).ConfigureAwait(false);
+
+            if (isAllocation)
+            {
+                // Custom worker step: stock gdal_proximity has no nearest-source
+                // allocation mode. python3 Scripts/gdal_euclidean_allocation.py SRC DST
+                // [--band 1] --dist-units U [--max-distance D] [--values v,...] — keep
+                // the positional src/dst pair first so the optional flags follow.
+                var scriptPath = Path.Combine(AppContext.BaseDirectory, "Scripts", AllocationScriptName);
+                var allocArgs = new List<string>
+                {
+                    scriptPath,
+                    inputPath,
+                    outputPath,
+                    "--dist-units", distUnits,
+                };
+                if (maxDistance.HasValue)
+                {
+                    allocArgs.Add("--max-distance");
+                    allocArgs.Add(maxDistance.Value.ToString("R", CultureInfo.InvariantCulture));
+                }
+                if (values is not null)
+                {
+                    allocArgs.Add("--values");
+                    allocArgs.Add(values);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await context.ReportProgressAsync(40, "Running euclidean allocation", cancellationToken).ConfigureAwait(false);
+
+                return await GdalToolExecution.RunAndPublishAsync(
+                    runner, context, opts, logger, job.OperationId,
+                    "python3", allocArgs, workspace, outputPath,
+                    GeoTiffContentType, "Allocation raster",
+                    "Encoding allocation raster artifact", "Allocation completed",
+                    cancellationToken).ConfigureAwait(false);
+            }
 
             // gdal_proximity.py [options] srcfile dstfile — keep the positional
             // src/dst pair last so the output path is the final argument.
@@ -234,9 +268,5 @@ internal sealed partial class GdalProximityJobExecutor(
         [LoggerMessage(9371, LogLevel.Warning,
             "GDAL proximity executor rejected job {OperationId}: {Reason}")]
         public static partial void InvalidInputs(ILogger logger, string operationId, string reason);
-
-        [LoggerMessage(9372, LogLevel.Warning,
-            "GDAL proximity executor refused job {OperationId}: euclidean allocation is flagged unsupported in this build")]
-        public static partial void AllocationUnsupported(ILogger logger, string operationId);
     }
 }

--- a/src/Honua.Worker.Gdal/Honua.Worker.Gdal.csproj
+++ b/src/Honua.Worker.Gdal/Honua.Worker.Gdal.csproj
@@ -22,6 +22,22 @@
 
   <ItemGroup>
     <!--
+      Custom worker steps shipped alongside the published worker. These Python
+      scripts are invoked via `python3` by the corresponding executors and run
+      ONLY inside the GDAL worker image (they require the GDAL Python bindings +
+      SciPy provided by docker/worker-gdal/Dockerfile). gdal_euclidean_allocation.py
+      backs proximity.euclidean-allocation (#2255): stock gdal_proximity has no
+      nearest-source allocation mode. Copied to the build/publish output so the
+      runtime image's build-stage COPY includes them at /app/Scripts.
+    -->
+    <Content Include="Scripts\**\*.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Scripts\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
       Reuses the durable job-execution substrate from Honua.Jobs (the shared
       JobExecutionService loop, RedisJobQueue, and Redis-backed stores). The
       worker DELIBERATELY does NOT ProjectReference Honua.Server — ADR-0038's

--- a/src/Honua.Worker.Gdal/Scripts/gdal_euclidean_allocation.py
+++ b/src/Honua.Worker.Gdal/Scripts/gdal_euclidean_allocation.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+"""Euclidean allocation worker step (honua-server #2255).
+
+Computes the nearest-source *allocation* raster that is the companion of the
+Euclidean-distance/proximity raster: for every cell it outputs the VALUE (id)
+of the nearest source cell, i.e. a discrete Voronoi tessellation keyed by the
+source pixel values.
+
+Stock GDAL ``gdal_proximity.py`` computes distance only and has NO nearest-source
+allocation mode, so ``proximity.euclidean-allocation`` is implemented here as a
+small custom worker step layered on the GDAL Python bindings (raster I/O,
+geotransform/CRS preservation) plus SciPy's exact Euclidean distance transform
+with nearest-feature index return.
+
+CLI contract (invoked by ``GdalProximityJobExecutor`` via ``python3``):
+
+    gdal_euclidean_allocation.py SRC DST
+        [--band N] [--dist-units GEO|PIXEL]
+        [--max-distance D] [--values v1,v2,...]
+
+The output GeoTIFF preserves the source extent, cell size, CRS and band data
+type; allocated values are the source pixel values. Cells whose nearest source
+is farther than ``--max-distance`` (when supplied) take the nodata value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional, Sequence
+
+import numpy as np
+from scipy import ndimage
+
+
+def build_source_mask(
+    arr: np.ndarray,
+    nodata: Optional[float],
+    values: Optional[Sequence[float]],
+) -> np.ndarray:
+    """Return the boolean mask of cells that are proximity *sources*.
+
+    A source is any non-zero cell that is not the nodata value. When ``values``
+    is supplied, only cells whose value is in that set are treated as sources
+    (mirroring ``gdal_proximity``'s ``-values`` behavior).
+    """
+    mask = arr != 0
+    if nodata is not None and not (isinstance(nodata, float) and np.isnan(nodata)):
+        mask &= arr != nodata
+    if values:
+        mask &= np.isin(arr, np.asarray(list(values), dtype=arr.dtype if np.issubdtype(arr.dtype, np.integer) else float))
+    return mask
+
+
+def compute_allocation(
+    arr: np.ndarray,
+    source_mask: np.ndarray,
+    sampling: tuple[float, float],
+    max_distance: Optional[float],
+    out_nodata: float,
+) -> np.ndarray:
+    """Compute the nearest-source allocation for every cell.
+
+    ``scipy.ndimage.distance_transform_edt`` measures, for each non-zero
+    (foreground) cell, the distance/index to the nearest zero (background) cell.
+    We therefore feed it the COMPLEMENT of the source mask so the "background"
+    is the source set: every cell then resolves to the indices of its nearest
+    source, and the allocation is the source array sampled at those indices.
+
+    ``sampling`` is the per-axis cell spacing ``(y, x)`` so GEO-unit distances
+    honor anisotropic pixels; pass ``(1.0, 1.0)`` for PIXEL units.
+    """
+    background = ~source_mask
+    distance, indices = ndimage.distance_transform_edt(
+        background, sampling=sampling, return_indices=True
+    )
+    alloc = arr[tuple(indices)]
+
+    if max_distance is not None:
+        alloc = np.where(distance <= max_distance, alloc, np.asarray(out_nodata, dtype=arr.dtype))
+
+    return alloc.astype(arr.dtype, copy=False)
+
+
+def _read_source(src: str, band_index: int):
+    from osgeo import gdal  # Imported lazily so the pure algorithm stays GDAL-free.
+
+    gdal.UseExceptions()
+    dataset = gdal.Open(src, gdal.GA_ReadOnly)
+    if dataset is None:
+        raise RuntimeError(f"could not open source raster '{src}'")
+    band = dataset.GetRasterBand(band_index)
+    if band is None:
+        raise RuntimeError(f"source raster has no band {band_index}")
+    arr = band.ReadAsArray()
+    if arr is None:
+        raise RuntimeError("could not read source band data")
+    return dataset, band, arr
+
+
+def _write_output(dst: str, template_dataset, data_type: int, alloc: np.ndarray, out_nodata: float) -> None:
+    from osgeo import gdal
+
+    driver = gdal.GetDriverByName("GTiff")
+    out = driver.Create(dst, template_dataset.RasterXSize, template_dataset.RasterYSize, 1, data_type)
+    if out is None:
+        raise RuntimeError(f"could not create output raster '{dst}'")
+    out.SetGeoTransform(template_dataset.GetGeoTransform())
+    projection = template_dataset.GetProjection()
+    if projection:
+        out.SetProjection(projection)
+    out_band = out.GetRasterBand(1)
+    out_band.WriteArray(alloc)
+    out_band.SetNoDataValue(float(out_nodata))
+    out_band.FlushCache()
+    out.FlushCache()
+
+
+def main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(description="Euclidean allocation (nearest-source) raster.")
+    parser.add_argument("src", help="Source GeoTIFF path.")
+    parser.add_argument("dst", help="Destination GeoTIFF path.")
+    parser.add_argument("--band", type=int, default=1, help="1-based source band index (default: 1).")
+    parser.add_argument("--dist-units", choices=["GEO", "PIXEL"], default="GEO", help="Distance units for --max-distance.")
+    parser.add_argument("--max-distance", type=float, default=None, help="Optional maximum allocation distance.")
+    parser.add_argument("--values", default=None, help="Optional comma-separated source pixel values to allocate from.")
+    args = parser.parse_args(argv)
+
+    values: Optional[list[float]] = None
+    if args.values:
+        values = [float(v) for v in args.values.split(",") if v.strip() != ""]
+
+    try:
+        dataset, band, arr = _read_source(args.src, args.band)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    nodata = band.GetNoDataValue()
+    source_mask = build_source_mask(arr, nodata, values)
+    if not source_mask.any():
+        print("error: source raster has no source cells to allocate from", file=sys.stderr)
+        return 3
+
+    geotransform = dataset.GetGeoTransform()
+    pixel_w = abs(geotransform[1]) if geotransform else 1.0
+    pixel_h = abs(geotransform[5]) if geotransform else 1.0
+    sampling = (pixel_h, pixel_w) if args.dist_units == "GEO" else (1.0, 1.0)
+
+    out_nodata = nodata if nodata is not None else 0
+    alloc = compute_allocation(arr, source_mask, sampling, args.max_distance, out_nodata)
+
+    try:
+        _write_output(args.dst, dataset, band.DataType, alloc, out_nodata)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 4
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -179,9 +179,9 @@ public sealed class CatalogExecutableConformanceTests
         // Raster analysis & terrain GP tool pack (#2239 / #2240): all run
         // out-of-process in the GDAL worker (gdal_calc.py / gdal_proximity.py /
         // gdal_contour / gdal_viewshed / gdal_polygonize.py / gdal_rasterize).
-        // proximity.euclidean-allocation is advertised but flagged unsupported
-        // (the worker FAILS it with a clear message). All declare the native
-        // runtime profile and have NO lean-dispatcher executor.
+        // proximity.euclidean-allocation runs the custom gdal_euclidean_allocation.py
+        // worker step (#2255). All declare the native runtime profile and have NO
+        // lean-dispatcher executor.
         "raster.map-algebra",
         "raster.spectral-index",
         "raster.reclassify",

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ProcessCatalogSurfaceRasterTests.cs
@@ -688,11 +688,10 @@ public sealed class ProcessCatalogSurfaceRasterTests
     [UnitTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
-    public void Validator_ProximityEuclideanAllocation_ShapeValid_PassesValidation_AsFlagged()
+    public void Validator_ProximityEuclideanAllocation_ShapeValid_PassesValidation()
     {
-        // Allocation is flagged unsupported at execution, but a shape-valid plan must
-        // pass submit-time validation so the worker surfaces the unsupported message
-        // as a job failure (not a submit rejection).
+        // Allocation (#2255) shares the distance op's parameter surface; a plan
+        // supplying only the required 'source' must pass submit-time validation.
         var plan = CreateSingleStepPlan(
             "proximity.euclidean-allocation",
             new Dictionary<string, string>
@@ -703,6 +702,26 @@ public sealed class ProcessCatalogSurfaceRasterTests
         var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
 
         violations.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /geospatial.v1.ProcessService/ValidatePlan")]
+    public void Validator_ProximityEuclideanAllocation_WithInvalidDistUnits_ProducesViolation()
+    {
+        // Allocation reuses the distance semantic validator (#2255), so an
+        // out-of-enum distUnits is rejected at submit time.
+        var plan = CreateSingleStepPlan(
+            "proximity.euclidean-allocation",
+            new Dictionary<string, string>
+            {
+                ["source"] = StubBase64,
+                ["distUnits"] = "MILES",
+            });
+
+        var (violations, _) = ProcessPlanValidator.Validate(plan, _catalog);
+
+        violations.Should().Contain(v => v.FieldPath == "steps[s1].inputs.distUnits");
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProximityExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalProximityExecutorTests.cs
@@ -12,8 +12,9 @@ namespace Honua.Worker.Gdal.Tests;
 
 /// <summary>
 /// Fake-runner coverage for <see cref="GdalProximityJobExecutor"/>: the
-/// gdal_proximity.py distance argument projection plus the flagged allocation path
-/// that fails fast with a clear unsupported-dependency message (#2240).
+/// gdal_proximity.py distance argument projection (#2240) plus the
+/// nearest-source allocation path that invokes the custom
+/// gdal_euclidean_allocation.py worker step via python3 (#2255).
 /// </summary>
 public sealed class GdalProximityExecutorTests
 {
@@ -93,7 +94,66 @@ public sealed class GdalProximityExecutorTests
     }
 
     [UnitTest]
-    public async Task Allocation_IsFlaggedUnsupported_AndFailsFast()
+    public async Task Allocation_Default_RunsPythonStep_AndPublishesGeoTiff()
+    {
+        var runner = SucceedingWritingOutputTif(Encoding.UTF8.GetBytes("alloc-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalProximityJobExecutor.AllocationProcessId,
+                ("source", Base64("fake-raster")));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            context.Artifacts.Single().Should().StartWith("data:image/tiff");
+
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("python3");
+            invocation.Arguments[0].Should().EndWith(GdalProximityJobExecutor.AllocationScriptName);
+            invocation.Arguments[1].Should().EndWith("input.tif");
+            invocation.Arguments[2].Should().EndWith("output.tif");
+            invocation.Arguments.Should().ContainInOrder("--dist-units", "GEO");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Allocation_WithOptions_ProjectsScriptFlags()
+    {
+        var runner = SucceedingWritingOutputTif(Encoding.UTF8.GetBytes("alloc-tif"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalProximityJobExecutor.AllocationProcessId,
+                ("source", Base64("fake-raster")),
+                ("maxDistance", "750"),
+                ("distUnits", "PIXEL"),
+                ("values", "3,7"));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            var invocation = runner.Invocations.Single();
+            invocation.Tool.Should().Be("python3");
+            invocation.Arguments.Should().ContainInOrder("--dist-units", "PIXEL");
+            invocation.Arguments.Should().ContainInOrder("--max-distance", "750");
+            invocation.Arguments.Should().ContainInOrder("--values", "3,7");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task Allocation_InvalidUnits_FailsBeforeReachingTheCli()
     {
         var runner = FakeGdalCommandRunner.Failing(1, "n/a");
         var executor = NewExecutor(runner, out var scratch);
@@ -101,12 +161,13 @@ public sealed class GdalProximityExecutorTests
         {
             var job = GdalJobFactory.Job(
                 GdalProximityJobExecutor.AllocationProcessId,
-                ("source", Base64("fake-raster")));
+                ("source", Base64("fake-raster")),
+                ("distUnits", "MILES"));
 
             var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
 
             result.Status.Should().Be(ExecutionJobStatus.Failed);
-            result.ErrorMessage.Should().Be(GdalProximityJobExecutor.AllocationUnsupportedMessage);
+            result.ErrorMessage.Should().Contain("distUnits");
             runner.Invocations.Should().BeEmpty();
         }
         finally
@@ -114,6 +175,19 @@ public sealed class GdalProximityExecutorTests
             CleanupScratch(scratch);
         }
     }
+
+    /// <summary>
+    /// The allocation step puts the output path positionally before its optional
+    /// flags, so this fake locates the <c>output.tif</c> argument (rather than a
+    /// fixed offset) and writes the payload there so the read-back path runs.
+    /// </summary>
+    private static FakeGdalCommandRunner SucceedingWritingOutputTif(byte[] outputBytes)
+        => new((_, args, _) =>
+        {
+            var outputPath = args.First(a => a.EndsWith("output.tif", StringComparison.Ordinal));
+            File.WriteAllBytes(outputPath, outputBytes);
+            return new GdalCommandResult { ExitCode = 0 };
+        });
 
     private static GdalProximityJobExecutor NewExecutor(IGdalCommandRunner runner, out string scratch)
     {

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -23,6 +23,10 @@ shapely>=2.0.0
 geopandas>=0.14.0
 pyproj>=3.6.0
 
+# Numerical: backs the Euclidean allocation worker-step unit test (#2255),
+# which exercises the nearest-source distance-transform algorithm directly.
+scipy>=1.11.0
+
 # Optional: PyQGIS integration (for desktop client compatibility tests)
 # Note: PyQGIS is a system dependency provided by the QGIS installation.
 # It is NOT installable via pip. The pyqgis test suite auto-skips when

--- a/tests/python/unit/test_gdal_euclidean_allocation.py
+++ b/tests/python/unit/test_gdal_euclidean_allocation.py
@@ -1,0 +1,121 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+"""Unit tests for the Euclidean allocation worker step (honua-server #2255).
+
+These exercise the pure nearest-source allocation algorithm in
+``src/Honua.Worker.Gdal/Scripts/gdal_euclidean_allocation.py`` directly (no GDAL
+raster I/O required), so they verify correctness wherever NumPy + SciPy are
+available. The full base64-GeoTIFF round trip runs inside the GDAL worker image
+(which additionally ships the GDAL Python bindings) and is covered by the worker
+e2e path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "src/Honua.Worker.Gdal/Scripts/gdal_euclidean_allocation.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("gdal_euclidean_allocation", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ALLOC = load_module()
+
+
+def test_compute_allocation_assigns_nearest_source_value_1d():
+    # Sources (ids 7, 3) at the row ends; interior cells take the nearer end's id.
+    arr = np.array([[7, 0, 0, 3]], dtype=np.int32)
+    source_mask = arr != 0
+
+    alloc = ALLOC.compute_allocation(arr, source_mask, sampling=(1.0, 1.0), max_distance=None, out_nodata=0)
+
+    np.testing.assert_array_equal(alloc, np.array([[7, 7, 3, 3]], dtype=np.int32))
+    assert alloc.dtype == arr.dtype
+
+
+def test_compute_allocation_2d_discrete_voronoi():
+    # 3x3 grid, sources at opposite ends of the top/bottom rows (no diagonal ties).
+    arr = np.array(
+        [
+            [5, 0, 9],
+            [0, 0, 0],
+            [5, 0, 9],
+        ],
+        dtype=np.int32,
+    )
+    source_mask = arr != 0
+
+    alloc = ALLOC.compute_allocation(arr, source_mask, sampling=(1.0, 1.0), max_distance=None, out_nodata=0)
+
+    expected = np.array(
+        [
+            [5, 5, 9],
+            [5, 5, 9],
+            [5, 5, 9],
+        ],
+        dtype=np.int32,
+    )
+    # Middle column is equidistant left/right -> SciPy resolves ties deterministically
+    # to the lower-index source; assert the unambiguous left/right columns only.
+    np.testing.assert_array_equal(alloc[:, 0], expected[:, 0])
+    np.testing.assert_array_equal(alloc[:, 2], expected[:, 2])
+
+
+def test_compute_allocation_honors_max_distance_with_nodata():
+    arr = np.array([[7, 0, 0, 0, 3]], dtype=np.int32)
+    source_mask = arr != 0
+
+    alloc = ALLOC.compute_allocation(arr, source_mask, sampling=(1.0, 1.0), max_distance=1.0, out_nodata=0)
+
+    # Cell index 2 is distance 2 from either source -> beyond max -> nodata (0).
+    np.testing.assert_array_equal(alloc, np.array([[7, 7, 0, 3, 3]], dtype=np.int32))
+
+
+def test_compute_allocation_anisotropic_sampling_changes_nearest():
+    # Equal pixel-count distance, but tall pixels (y spacing 10) make the
+    # horizontal source the nearer one in GEO units.
+    arr = np.array(
+        [
+            [0, 1, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [2, 0, 0],
+        ],
+        dtype=np.int32,
+    )
+    source_mask = arr != 0
+    # Target the cell directly between: (1,0) is 1 row below id=1 origin? Use (1,1).
+    alloc_pixel = ALLOC.compute_allocation(arr, source_mask, sampling=(1.0, 1.0), max_distance=None, out_nodata=0)
+    alloc_geo = ALLOC.compute_allocation(arr, source_mask, sampling=(10.0, 1.0), max_distance=None, out_nodata=0)
+
+    # With tall pixels, the column-aligned source 1 (small horizontal offset) wins
+    # over the far-below source 2 for the upper interior cells.
+    assert alloc_geo[0, 0] == 1
+    # Sanity: both are valid source ids.
+    assert set(np.unique(alloc_pixel)).issubset({0, 1, 2})
+
+
+def test_build_source_mask_filters_by_values_and_nodata():
+    arr = np.array([[1, 2, 0, 3, -9]], dtype=np.int32)
+
+    # Without a values filter: all non-zero, non-nodata cells are sources.
+    mask_all = ALLOC.build_source_mask(arr, nodata=-9, values=None)
+    np.testing.assert_array_equal(mask_all, np.array([[True, True, False, True, False]]))
+
+    # With a values filter: only listed ids are sources.
+    mask_vals = ALLOC.build_source_mask(arr, nodata=-9, values=[2, 3])
+    np.testing.assert_array_equal(mask_vals, np.array([[False, True, False, True, False]]))


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2255

## Summary
Implements real nearest-source (discrete Voronoi) allocation for the `proximity.euclidean-allocation` geoprocessing operation, replacing the flagged-unsupported path added in #2253. For every cell the output raster carries the VALUE/id of its nearest source cell — the allocation companion to the `proximity.euclidean-distance` raster.

Stock `gdal_proximity` computes distance only and has no nearest-source allocation mode, so allocation runs as a small custom worker step (`gdal_euclidean_allocation.py`) layered on the GDAL Python bindings plus SciPy's exact Euclidean distance transform with nearest-feature index return. The output GeoTIFF preserves the source extent, cell size, CRS and band data type. It reuses the canonical process/job runtime (the existing `GdalProximityJobExecutor` native lane); no parallel job path is introduced.

## Changes Made
- `GdalProximityJobExecutor` now executes allocation by invoking `python3` against the bundled `Scripts/gdal_euclidean_allocation.py` instead of failing fast; allocation shares the distance op's `distUnits` / `maxDistance` / `values` parameter surface (cells beyond `maxDistance` take nodata; `values` restricts the source set).
- Added `src/Honua.Worker.Gdal/Scripts/gdal_euclidean_allocation.py` (shipped via the worker `.csproj` Content/publish output so the worker image's build-stage copy includes it at `/app/Scripts`). The GDAL raster I/O imports are lazy so the pure allocation algorithm is unit-testable without GDAL.
- `BuiltInProcessCatalog`: allocation entry advertises the real capability and the `maxDistance` / `distUnits` / `values` parameters; `ProcessPlanValidator` reuses the distance semantic validator for allocation.
- Worker `Dockerfile`: install `python3-scipy`, guard the GDAL bindings + NumPy + SciPy imports at build time, and assert the script ships in the published image.
- Reference doc updated: allocation row is no longer flagged; also documented the previously-undocumented `analytics.hotspot-managed` row so the catalog/doc parity test is green.
- Tests: executor fake-runner coverage for the python-step argument projection (default + options + invalid-units), validator/catalog coverage, and a NumPy/SciPy unit test of the nearest-source algorithm (added `scipy` to the Python test deps so CI runs it).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Build: `dotnet build Honua.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true` -> 0 warnings / 0 errors. `dotnet format Honua.sln --verify-no-changes` clean. New/changed .NET tests pass (proximity executor, allocation catalog/validator, catalog doc-parity). The NumPy/SciPy allocation unit test passes against real numpy 2.5 / scipy 1.18. Full GDAL+SciPy raster round-trip runs in the worker image / CI (the GDAL Python bindings are not installable locally). Pre-existing, unrelated trunk failures (catalog `layerId` drift on surface/raster ops; several `gdal_calc`-based executor tests) were confirmed red on `origin/trunk` before this change and are out of scope.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [ ] None — standard merge-and-release flow

(The heavyweight GDAL worker image now requires `python3-scipy`; the Dockerfile installs it and guards its presence at build time. No runtime config/secret/migration changes.)

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
