### PR TITLE
feat(mcp): session streaming, discovery tools, configurable policy

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/DiscoveryJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/DiscoveryJsonContext.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Ai.Protocols.Mcp.Discovery;
+
+/// <summary>
+/// AOT-compatible source-generated JSON context for the discovery MCP tools
+/// (<c>honua_resolve_entity</c>, <c>honua_list_capabilities</c>). Kept separate
+/// from the core MCP JSON context so the discovery slice owns its serializer
+/// surface — mirrors the map-tools and location slices.
+/// </summary>
+[JsonSerializable(typeof(McpResolveEntityArgument))]
+[JsonSerializable(typeof(McpResolveEntityOutput))]
+[JsonSerializable(typeof(McpEntityMatch))]
+[JsonSerializable(typeof(McpListCapabilitiesArgument))]
+[JsonSerializable(typeof(McpListCapabilitiesOutput))]
+[JsonSerializable(typeof(McpCapabilityTool))]
+[JsonSerializable(typeof(McpCapabilityResource))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class DiscoveryJsonContext : JsonSerializerContext;

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/DiscoveryToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/DiscoveryToolModels.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Ai.Protocols.Mcp.Discovery;
+
+/// <summary>
+/// Arguments for <c>honua_resolve_entity</c> (#1949): a natural-language name or
+/// phrase the client LLM wants to resolve to concrete catalog entity references
+/// (services and layers) it can then pass to <c>honua_query_features</c> /
+/// <c>honua_render_map</c>.
+/// </summary>
+internal sealed class McpResolveEntityArgument
+{
+    [JsonPropertyName("text")]
+    public string? Text { get; set; }
+
+    [JsonPropertyName("entityType")]
+    public string? EntityType { get; set; }
+
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+}
+
+/// <summary>
+/// Structured result of <c>honua_resolve_entity</c>: the ranked entity references
+/// the supplied text resolved to, grounded in the live Metadata v2 catalog.
+/// </summary>
+internal sealed class McpResolveEntityOutput
+{
+    [JsonPropertyName("query")]
+    public string Query { get; set; } = string.Empty;
+
+    [JsonPropertyName("entityType")]
+    public string EntityType { get; set; } = "any";
+
+    [JsonPropertyName("matchCount")]
+    public int MatchCount { get; set; }
+
+    [JsonPropertyName("matches")]
+    public IReadOnlyList<McpEntityMatch> Matches { get; set; } = [];
+}
+
+/// <summary>
+/// A single resolved catalog entity reference returned by
+/// <c>honua_resolve_entity</c>. <see cref="ServiceId"/> plus <see cref="LayerId"/>
+/// (for a layer match) are the actionable references the client passes to the
+/// query/render tools.
+/// </summary>
+internal sealed class McpEntityMatch
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; set; } = "layer";
+
+    [JsonPropertyName("serviceId")]
+    public string ServiceId { get; set; } = string.Empty;
+
+    [JsonPropertyName("serviceName")]
+    public string ServiceName { get; set; } = string.Empty;
+
+    [JsonPropertyName("layerId")]
+    public int? LayerId { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("geometryType")]
+    public string? GeometryType { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("score")]
+    public double Score { get; set; }
+}
+
+/// <summary>
+/// Arguments for <c>honua_list_capabilities</c> (#1949). All optional: a cold
+/// client LLM can call it with no arguments to discover the full server surface.
+/// </summary>
+internal sealed class McpListCapabilitiesArgument
+{
+    [JsonPropertyName("includeResources")]
+    public bool? IncludeResources { get; set; }
+
+    [JsonPropertyName("includeGroundingResources")]
+    public bool? IncludeGroundingResources { get; set; }
+}
+
+/// <summary>
+/// Structured result of <c>honua_list_capabilities</c>: a self-describing manifest
+/// of the tools, resources, and grounding resources the live <c>/mcp</c> surface
+/// exposes, so a client LLM with no Honua knowledge can plan a workflow. Sourced
+/// from the same in-process catalog served over both HTTP-SSE and stdio (#1950),
+/// so the manifest is transport-symmetric.
+/// </summary>
+internal sealed class McpListCapabilitiesOutput
+{
+    [JsonPropertyName("serverName")]
+    public string ServerName { get; set; } = string.Empty;
+
+    [JsonPropertyName("serverVersion")]
+    public string ServerVersion { get; set; } = string.Empty;
+
+    [JsonPropertyName("protocolVersions")]
+    public IReadOnlyList<string> ProtocolVersions { get; set; } = [];
+
+    [JsonPropertyName("toolCount")]
+    public int ToolCount { get; set; }
+
+    [JsonPropertyName("tools")]
+    public IReadOnlyList<McpCapabilityTool> Tools { get; set; } = [];
+
+    [JsonPropertyName("resourceCount")]
+    public int ResourceCount { get; set; }
+
+    [JsonPropertyName("resources")]
+    public IReadOnlyList<McpCapabilityResource> Resources { get; set; } = [];
+
+    [JsonPropertyName("groundingResources")]
+    public IReadOnlyList<string> GroundingResources { get; set; } = [];
+}
+
+/// <summary>
+/// A tool entry in the capability manifest: the LLM-grade name, title,
+/// description, read/write classification, and workflow family.
+/// </summary>
+internal sealed class McpCapabilityTool
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("readOnly")]
+    public bool ReadOnly { get; set; }
+
+    [JsonPropertyName("workflowFamily")]
+    public string WorkflowFamily { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A resource entry in the capability manifest: the URI (or URI template), name,
+/// description, and telemetry family.
+/// </summary>
+internal sealed class McpCapabilityResource
+{
+    [JsonPropertyName("uri")]
+    public string Uri { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("family")]
+    public string Family { get; set; } = string.Empty;
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/DiscoveryToolSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/DiscoveryToolSchemas.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Ai.Protocols.Mcp.Discovery;
+
+/// <summary>
+/// JSON-schema documents advertised in <c>tools/list</c> for the discovery tools
+/// (<c>honua_resolve_entity</c>, <c>honua_list_capabilities</c>). Schemas are
+/// immutable <see cref="JsonElement"/> values parsed at type-load time to keep the
+/// MCP surface AOT-safe (no runtime schema reflection). Mirrors
+/// <see cref="Honua.Ai.Protocols.Mcp.MapTools.MapToolSchemas"/>.
+/// </summary>
+internal static class DiscoveryToolSchemas
+{
+    /// <summary>Default number of ranked matches returned by <c>honua_resolve_entity</c>.</summary>
+    public const int DefaultResolveLimit = 10;
+
+    /// <summary>Hard ceiling on ranked matches returned by <c>honua_resolve_entity</c>.</summary>
+    public const int MaxResolveLimit = 50;
+
+    private const string ResolveEntityArgumentSchemaJson = """
+        {
+          "type": "object",
+          "required": ["text"],
+          "properties": {
+            "text": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Natural-language name or phrase to resolve to catalog entities (e.g. \"parcels\", \"flood zones\", \"roads\"). The server lexically grounds it against the live published catalog and returns ranked service/layer references."
+            },
+            "entityType": {
+              "type": "string",
+              "enum": ["any", "service", "layer"],
+              "default": "any",
+              "description": "Restrict matches to services, to layers, or to both (default)."
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10,
+              "description": "Maximum number of ranked matches to return (capped at 50)."
+            }
+          }
+        }
+        """;
+
+    private const string ListCapabilitiesArgumentSchemaJson = """
+        {
+          "type": "object",
+          "properties": {
+            "includeResources": {
+              "type": "boolean",
+              "default": true,
+              "description": "Include the resource catalog (job, catalog, and promotion URIs) in the manifest."
+            },
+            "includeGroundingResources": {
+              "type": "boolean",
+              "default": true,
+              "description": "Include the grounding/catalog resource URIs a client LLM should read first to ground a workflow."
+            }
+          }
+        }
+        """;
+
+    private const string ResolveEntityOutputSchemaJson = """
+        {
+          "type": "object",
+          "required": ["query", "matchCount", "matches"],
+          "properties": {
+            "query": { "type": "string" },
+            "entityType": { "type": "string" },
+            "matchCount": { "type": "integer" },
+            "matches": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "kind": { "type": "string", "enum": ["service", "layer"] },
+                  "serviceId": { "type": "string" },
+                  "serviceName": { "type": "string" },
+                  "layerId": { "type": ["integer", "null"] },
+                  "name": { "type": "string" },
+                  "type": { "type": ["string", "null"] },
+                  "geometryType": { "type": ["string", "null"] },
+                  "description": { "type": ["string", "null"] },
+                  "score": { "type": "number" }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    private const string ListCapabilitiesOutputSchemaJson = """
+        {
+          "type": "object",
+          "required": ["serverName", "toolCount", "tools"],
+          "properties": {
+            "serverName": { "type": "string" },
+            "serverVersion": { "type": "string" },
+            "protocolVersions": { "type": "array", "items": { "type": "string" } },
+            "toolCount": { "type": "integer" },
+            "tools": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "title": { "type": ["string", "null"] },
+                  "description": { "type": "string" },
+                  "readOnly": { "type": "boolean" },
+                  "workflowFamily": { "type": "string" }
+                }
+              }
+            },
+            "resourceCount": { "type": "integer" },
+            "resources": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "uri": { "type": "string" },
+                  "name": { "type": "string" },
+                  "description": { "type": "string" },
+                  "family": { "type": "string" }
+                }
+              }
+            },
+            "groundingResources": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+        """;
+
+    /// <summary>Input schema for <see cref="McpResolveEntityArgument"/>.</summary>
+    public static readonly JsonElement ResolveEntityArgumentSchema = Parse(ResolveEntityArgumentSchemaJson);
+
+    /// <summary>Input schema for <see cref="McpListCapabilitiesArgument"/>.</summary>
+    public static readonly JsonElement ListCapabilitiesArgumentSchema = Parse(ListCapabilitiesArgumentSchemaJson);
+
+    /// <summary>Output schema for <see cref="McpResolveEntityOutput"/>.</summary>
+    public static readonly JsonElement ResolveEntityOutputSchema = Parse(ResolveEntityOutputSchemaJson);
+
+    /// <summary>Output schema for <see cref="McpListCapabilitiesOutput"/>.</summary>
+    public static readonly JsonElement ListCapabilitiesOutputSchema = Parse(ListCapabilitiesOutputSchemaJson);
+
+    private static JsonElement Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ListCapabilitiesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ListCapabilitiesTool.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Ai.Protocols.Mcp.Discovery;
+
+/// <summary>
+/// MCP tool that returns a self-describing manifest of the tools, resources, and
+/// grounding resources the live <c>/mcp</c> surface exposes (#1949), so a client
+/// LLM with no Honua-specific knowledge can discover the full composable surface
+/// and plan a workflow. It projects the same in-process catalog the dispatcher
+/// serves over both the HTTP-SSE and stdio transports (#1950), so the manifest is
+/// transport-symmetric by construction.
+/// </summary>
+/// <remarks>
+/// This is a Honua extension over the bare geospatial-mcp taxonomy (which models
+/// capability discovery as a CapabilityCatalog read); the reference implementation
+/// exposes it as a first-class tool. A vendored conformance schema is shipped under
+/// <c>ConformanceSchemas/geospatial-mcp/tools/list_capabilities.schema.json</c>.
+/// </remarks>
+internal sealed class ListCapabilitiesTool : IMcpTool
+{
+    /// <summary>The tool name published in <c>tools/list</c>.</summary>
+    public const string ToolName = "honua_list_capabilities";
+
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly ILogger<ListCapabilitiesTool> _logger;
+
+    public ListCapabilitiesTool(IGeoprocessingJobService jobService, ILogger<ListCapabilitiesTool> logger)
+    {
+        _jobService = jobService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    /// <inheritdoc />
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "List capabilities",
+        Description = "List every tool and resource this server exposes, with LLM-grade descriptions and read/write hints, plus the grounding resource URIs to read first. Call this first to discover the full workflow surface (discover, ground, query, analyze, compose, publish) before composing a plan.",
+        InputSchema = DiscoveryToolSchemas.ListCapabilitiesArgumentSchema,
+        OutputSchema = DiscoveryToolSchemas.ListCapabilitiesOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("List capabilities")
+    };
+
+    /// <inheritdoc />
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("ListCapabilities");
+        McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        await _jobService
+            .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Catalog, OperatorOperation.Discover, cancellationToken)
+            .ConfigureAwait(false);
+
+        var includeResources = true;
+        var includeGroundingResources = true;
+        if (arguments is { ValueKind: not JsonValueKind.Null and not JsonValueKind.Undefined })
+        {
+            var argument = McpToolHelpers.ParseArguments(arguments, DiscoveryJsonContext.Default.McpListCapabilitiesArgument);
+            includeResources = argument.IncludeResources ?? true;
+            includeGroundingResources = argument.IncludeGroundingResources ?? true;
+        }
+
+        var serverInfo = new McpServerInfo();
+        var output = new McpListCapabilitiesOutput
+        {
+            ServerName = serverInfo.Name,
+            ServerVersion = serverInfo.Version,
+            ProtocolVersions = McpOperatorSurface.SupportedProtocolVersions
+        };
+
+        // Project the live in-process catalog. Resolved leniently so a lightweight
+        // host that did not register the surface still returns a valid (if empty)
+        // manifest rather than throwing.
+        var surface = httpContext.RequestServices.GetService<McpOperatorSurface>();
+        if (surface is not null)
+        {
+            output.Tools = BuildToolManifest(surface);
+            output.ToolCount = output.Tools.Count;
+
+            if (includeResources || includeGroundingResources)
+            {
+                var resources = BuildResourceManifest(surface);
+
+                if (includeResources)
+                {
+                    output.Resources = resources;
+                    output.ResourceCount = resources.Count;
+                }
+
+                if (includeGroundingResources)
+                {
+                    output.GroundingResources = resources
+                        .Where(r => string.Equals(r.Family, McpTelemetry.ResourceFamily.Catalog, StringComparison.Ordinal))
+                        .Select(r => r.Uri)
+                        .ToList();
+                }
+            }
+        }
+
+        return McpToolHelpers.SuccessResult(output, DiscoveryJsonContext.Default.McpListCapabilitiesOutput);
+    }
+
+    private static List<McpCapabilityTool> BuildToolManifest(McpOperatorSurface surface)
+    {
+        var tools = new List<McpCapabilityTool>();
+        foreach (var tool in surface.ToolHandlers)
+        {
+            var descriptor = tool.Describe();
+            tools.Add(new McpCapabilityTool
+            {
+                Name = descriptor.Name,
+                Title = descriptor.Title,
+                Description = descriptor.Description,
+                ReadOnly = descriptor.Annotations?.ReadOnlyHint ?? false,
+                WorkflowFamily = tool.WorkflowFamily
+            });
+        }
+
+        tools.Sort(static (a, b) => string.CompareOrdinal(a.Name, b.Name));
+        return tools;
+    }
+
+    private static List<McpCapabilityResource> BuildResourceManifest(McpOperatorSurface surface)
+    {
+        var resources = new List<McpCapabilityResource>();
+        foreach (var resource in surface.Resources)
+        {
+            foreach (var descriptor in resource.Describe())
+            {
+                resources.Add(new McpCapabilityResource
+                {
+                    Uri = descriptor.Uri,
+                    Name = descriptor.Name,
+                    Description = descriptor.Description,
+                    Family = resource.Family
+                });
+            }
+
+            foreach (var template in resource.DescribeTemplates())
+            {
+                resources.Add(new McpCapabilityResource
+                {
+                    Uri = template.UriTemplate,
+                    Name = template.Name,
+                    Description = template.Description,
+                    Family = resource.Family
+                });
+            }
+        }
+
+        resources.Sort(static (a, b) => string.CompareOrdinal(a.Uri, b.Uri));
+        return resources;
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ResolveEntityTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ResolveEntityTool.cs
@@ -1,0 +1,270 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Ai.Protocols.Mcp.Discovery;
+
+/// <summary>
+/// MCP tool that resolves a natural-language name or phrase to concrete catalog
+/// entity references (services and layers) so a client LLM can ground an entity
+/// it heard from the user before composing a workflow (#1949). It is a thin,
+/// deterministic adapter over the canonical
+/// <see cref="IMetadataV2GraphProvider"/> graph — the same metadata snapshot that
+/// backs <c>/rest/services</c>, <c>honua_list_layers</c>, FeatureServer, and the
+/// feature catalog — so resolution grounds only on capabilities that exist (no
+/// hallucinated layers). The returned <c>serviceId</c>/<c>layerId</c> pairs feed
+/// directly into <c>honua_query_features</c> and <c>honua_render_map</c>.
+/// </summary>
+/// <remarks>
+/// This is a Honua extension over the bare geospatial-mcp taxonomy: the standard
+/// models entity resolution as a CapabilityCatalog/grounding read; the reference
+/// implementation exposes it as a first-class tool. A vendored conformance schema
+/// is shipped under <c>ConformanceSchemas/geospatial-mcp/tools/resolve_entity.schema.json</c>.
+/// </remarks>
+internal sealed class ResolveEntityTool : IMcpTool
+{
+    /// <summary>The tool name published in <c>tools/list</c>.</summary>
+    public const string ToolName = "honua_resolve_entity";
+
+    private const string EntityTypeAny = "any";
+    private const string EntityTypeService = "service";
+    private const string EntityTypeLayer = "layer";
+
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly ILogger<ResolveEntityTool> _logger;
+
+    public ResolveEntityTool(IGeoprocessingJobService jobService, ILogger<ResolveEntityTool> logger)
+    {
+        _jobService = jobService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    /// <inheritdoc />
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "Resolve entity",
+        Description = "Resolve a natural-language name or phrase (e.g. \"parcels\", \"flood zones\") to concrete published service/layer references, ranked by match quality. Use the returned serviceId/layerId with honua_query_features and honua_render_map. Resolves only against the live catalog, so it never invents layers that do not exist.",
+        InputSchema = DiscoveryToolSchemas.ResolveEntityArgumentSchema,
+        OutputSchema = DiscoveryToolSchemas.ResolveEntityOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Resolve entity")
+    };
+
+    /// <inheritdoc />
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("ResolveEntity");
+        McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        await _jobService
+            .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Catalog, OperatorOperation.Discover, cancellationToken)
+            .ConfigureAwait(false);
+
+        var argument = McpToolHelpers.ParseArguments(arguments, DiscoveryJsonContext.Default.McpResolveEntityArgument);
+        var text = argument.Text?.Trim();
+        if (string.IsNullOrEmpty(text))
+        {
+            throw new GeoprocessingValidationException("'text' is required and must be a non-empty string.");
+        }
+
+        var entityType = NormalizeEntityType(argument.EntityType);
+        var limit = NormalizeLimit(argument.Limit);
+
+        var graphProvider = httpContext.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+        var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+
+        var matches = new List<McpEntityMatch>();
+        foreach (var service in snapshot.Graph.Services)
+        {
+            if (entityType is EntityTypeAny or EntityTypeService)
+            {
+                var serviceScore = Score(text, service.Metadata.Name, service.Metadata.Title, service.Metadata.Id);
+                if (serviceScore > 0)
+                {
+                    matches.Add(new McpEntityMatch
+                    {
+                        Kind = EntityTypeService,
+                        ServiceId = service.Metadata.Id,
+                        ServiceName = service.Metadata.Name,
+                        Name = !string.IsNullOrWhiteSpace(service.Metadata.Title)
+                            ? service.Metadata.Title!
+                            : service.Metadata.Name,
+                        Description = service.Metadata.Description,
+                        Score = serviceScore
+                    });
+                }
+            }
+
+            if (entityType is EntityTypeAny or EntityTypeLayer)
+            {
+                AddLayerMatches(snapshot, service, text, matches);
+            }
+        }
+
+        matches.Sort(static (a, b) =>
+        {
+            var byScore = b.Score.CompareTo(a.Score);
+            if (byScore != 0)
+            {
+                return byScore;
+            }
+
+            var byService = string.CompareOrdinal(a.ServiceName, b.ServiceName);
+            return byService != 0 ? byService : Nullable.Compare(a.LayerId, b.LayerId);
+        });
+
+        var page = matches.Count > limit ? matches.GetRange(0, limit) : matches;
+        var output = new McpResolveEntityOutput
+        {
+            Query = text,
+            EntityType = entityType,
+            MatchCount = page.Count,
+            Matches = page
+        };
+
+        return McpToolHelpers.SuccessResult(output, DiscoveryJsonContext.Default.McpResolveEntityOutput);
+    }
+
+    private static void AddLayerMatches(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service service,
+        string text,
+        List<McpEntityMatch> matches)
+    {
+        foreach (var publication in snapshot.PublicationsForService(service.Metadata.Id))
+        {
+            var resource = snapshot.ResolveResource(publication);
+            if (resource is null || publication.LayerIndex is not { } layerIndex)
+            {
+                continue;
+            }
+
+            var layerName = !string.IsNullOrWhiteSpace(publication.TitleOverride)
+                ? publication.TitleOverride!
+                : (!string.IsNullOrWhiteSpace(resource.Metadata.Title)
+                    ? resource.Metadata.Title!
+                    : resource.Metadata.Name);
+
+            var score = Score(text, layerName, resource.Metadata.Name, resource.Metadata.Description);
+            if (score <= 0)
+            {
+                continue;
+            }
+
+            matches.Add(new McpEntityMatch
+            {
+                Kind = EntityTypeLayer,
+                ServiceId = service.Metadata.Id,
+                ServiceName = service.Metadata.Name,
+                LayerId = layerIndex,
+                Name = layerName,
+                Type = resource.Type.ToString(),
+                GeometryType = (resource.Spatial?.GeometryType ?? MetadataV2GeometryType.None).ToString(),
+                Description = resource.Metadata.Description,
+                Score = score
+            });
+        }
+    }
+
+    /// <summary>
+    /// Deterministic lexical match score in (0, 1]. Exact (case-insensitive) name
+    /// match scores highest, then prefix, then substring, then token overlap.
+    /// Returns 0 when no candidate field matches so the entity is excluded.
+    /// </summary>
+    private static double Score(string query, params string?[] candidates)
+    {
+        var best = 0d;
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                continue;
+            }
+
+            var value = candidate.Trim();
+            if (string.Equals(value, query, StringComparison.OrdinalIgnoreCase))
+            {
+                return 1.0;
+            }
+
+            if (value.StartsWith(query, StringComparison.OrdinalIgnoreCase))
+            {
+                best = Math.Max(best, 0.85);
+            }
+            else if (value.Contains(query, StringComparison.OrdinalIgnoreCase))
+            {
+                best = Math.Max(best, 0.6);
+            }
+            else if (TokenOverlap(query, value))
+            {
+                best = Math.Max(best, 0.4);
+            }
+        }
+
+        return best;
+    }
+
+    private static bool TokenOverlap(string query, string value)
+    {
+        foreach (var token in query.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (token.Length >= 3 && value.Contains(token, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string NormalizeEntityType(string? entityType)
+    {
+        if (string.IsNullOrWhiteSpace(entityType))
+        {
+            return EntityTypeAny;
+        }
+
+        var normalized = entityType.Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            EntityTypeService => EntityTypeService,
+            EntityTypeLayer => EntityTypeLayer,
+            EntityTypeAny => EntityTypeAny,
+            _ => throw new GeoprocessingValidationException(
+                $"Unsupported entityType '{entityType}'. Expected one of: any, service, layer.")
+        };
+    }
+
+    private static int NormalizeLimit(int? limit)
+    {
+        if (limit is not { } value)
+        {
+            return DiscoveryToolSchemas.DefaultResolveLimit;
+        }
+
+        if (value < 1)
+        {
+            throw new GeoprocessingValidationException("'limit' must be a positive integer.");
+        }
+
+        return Math.Min(value, DiscoveryToolSchemas.MaxResolveLimit);
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
@@ -177,9 +177,11 @@ internal static class McpEndpointExtensions
     /// <summary>
     /// Handles <c>GET /mcp</c>: opens the server-to-client SSE stream defined by
     /// the Streamable-HTTP transport. A valid <c>Mcp-Session-Id</c> is required;
-    /// the client must also accept <c>text/event-stream</c>. The stream stays
-    /// open (emitting no events in this increment — server-initiated progress and
-    /// listChanged notifications are a follow-up) until the client disconnects.
+    /// the client must also accept <c>text/event-stream</c>. The handler drains the
+    /// session's notification channel (honua-server#1954), writing each queued
+    /// <c>notifications/progress</c> / <c>*/list_changed</c> frame as an SSE
+    /// <c>message</c> event until the session is terminated or the client
+    /// disconnects.
     /// </summary>
     private static async Task HandleGetAsync(HttpContext context, CancellationToken cancellationToken)
     {
@@ -195,7 +197,7 @@ internal static class McpEndpointExtensions
         }
 
         var sessionId = context.Request.Headers[McpSessionManager.SessionHeaderName].ToString();
-        if (string.IsNullOrEmpty(sessionId) || !sessions.IsValid(sessionId))
+        if (string.IsNullOrEmpty(sessionId) || !sessions.TryGetReader(sessionId, out var reader))
         {
             McpLog.SessionRejected(logger, "stream-requires-valid-session");
             context.Response.StatusCode = StatusCodes.Status404NotFound;
@@ -204,19 +206,37 @@ internal static class McpEndpointExtensions
 
         StartEventStream(context);
         // Flush the response head so the client (and proxies) see the open SSE
-        // stream immediately, before any server-initiated frame is available.
+        // stream immediately, before the first server-initiated frame is available.
         await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-        // Hold the stream open for server-initiated messages. No frames are
-        // pushed yet (progress/listChanged land in a follow-up); the stream
-        // closes when the client cancels or disconnects.
+        // Close the stream when the client disconnects OR the session is terminated
+        // (DELETE /mcp completes the channel, which ends the drain loop below).
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, sessions.GetLifetimeToken(sessionId));
         try
         {
-            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            await PumpSessionStreamAsync(context.Response.Body, reader, linked.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            // Client disconnected — normal stream teardown.
+            // Client disconnected or session terminated — normal stream teardown.
+        }
+    }
+
+    /// <summary>
+    /// Drains a session's notification channel onto an output stream, writing each
+    /// queued JSON-RPC notification as one SSE <c>message</c> frame. Returns when
+    /// the channel completes (session terminated) or the token cancels. Extracted
+    /// so the SSE pump is unit-testable without an HTTP host.
+    /// </summary>
+    internal static async Task PumpSessionStreamAsync(
+        Stream output,
+        System.Threading.Channels.ChannelReader<string> reader,
+        CancellationToken cancellationToken)
+    {
+        await foreach (var payload in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await WriteEventToStreamAsync(output, payload, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -460,7 +480,10 @@ internal static class McpEndpointExtensions
     /// the JSON-RPC payload, terminated by the blank line the SSE wire format
     /// requires, then flushes so the client receives the frame promptly.
     /// </summary>
-    private static async Task WriteEventAsync(HttpContext context, string json, CancellationToken cancellationToken)
+    private static Task WriteEventAsync(HttpContext context, string json, CancellationToken cancellationToken) =>
+        WriteEventToStreamAsync(context.Response.Body, json, cancellationToken);
+
+    private static async Task WriteEventToStreamAsync(Stream output, string json, CancellationToken cancellationToken)
     {
         var builder = new StringBuilder();
         builder.Append("event: message\n");
@@ -470,8 +493,8 @@ internal static class McpEndpointExtensions
         builder.Append("data: ").Append(json).Append("\n\n");
 
         var bytes = Encoding.UTF8.GetBytes(builder.ToString());
-        await context.Response.Body.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
-        await context.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await output.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static McpJsonRpcResponse ErrorResponse(JsonElement id, McpJsonRpcError error) => new()

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpJobProgressBridge.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpJobProgressBridge.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Threads geoprocessing job progress onto the owning MCP session's SSE stream as
+/// <c>notifications/progress</c> frames (honua-server#1954). It does NOT fork the
+/// job runtime: it polls the canonical <see cref="IGeoprocessingJobService"/> (the
+/// same record the <c>honua://jobs/{id}</c> resource projects) and emits a
+/// progress notification whenever the reported <c>PercentComplete</c> or current
+/// phase changes, replacing client-side polling of <c>honua://jobs/{id}</c> with
+/// a server push. The bridge stops when the job reaches a terminal status, the
+/// session is terminated, or a safety cap elapses.
+/// </summary>
+internal sealed class McpJobProgressBridge
+{
+    /// <summary>Total used for the 0–100 completion ratio the runtime reports.</summary>
+    private const double ProgressTotal = 100d;
+
+    /// <summary>Default interval between job-status polls.</summary>
+    private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(750);
+
+    /// <summary>
+    /// Safety cap on how long a single job is tracked, so a wedged or never-terminal
+    /// job cannot leak a background poll for the lifetime of the process.
+    /// </summary>
+    private static readonly TimeSpan MaxTrackingDuration = TimeSpan.FromMinutes(30);
+
+    private readonly IMcpNotificationPublisher _publisher;
+    private readonly McpSessionManager _sessions;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<McpJobProgressBridge> _logger;
+
+    public McpJobProgressBridge(
+        IMcpNotificationPublisher publisher,
+        McpSessionManager sessions,
+        IServiceScopeFactory scopeFactory,
+        ILogger<McpJobProgressBridge> logger)
+    {
+        _publisher = publisher;
+        _sessions = sessions;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Starts a detached background poll that streams the job's progress to the
+    /// session. Fire-and-forget: the HTTP request that submitted the job returns
+    /// immediately while progress streams over the separate <c>GET /mcp</c> SSE
+    /// channel. Exceptions are swallowed (logged) so a background poll can never
+    /// surface on an unrelated request thread.
+    /// </summary>
+    public void Track(string sessionId, string jobId, ClaimsPrincipal principal)
+    {
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(jobId))
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var jobService = scope.ServiceProvider.GetRequiredService<IGeoprocessingJobService>();
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(
+                    _sessions.GetLifetimeToken(sessionId));
+                linked.CancelAfter(MaxTrackingDuration);
+                await PumpAsync(sessionId, jobId, principal, jobService, DefaultPollInterval, linked.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                McpLog.ProgressBridgeStopped(_logger, sessionId, jobId, "cancelled");
+            }
+            catch (Exception ex)
+            {
+                // A background poll must never crash the host; record and stop.
+                McpLog.ResourceReadFailed(_logger, "jobs", jobId, ex);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Polls the job until it reaches a terminal status (or the token cancels) and
+    /// pushes a progress notification on every observed change. Exposed for unit
+    /// testing with a substitute job service and a zero poll interval. The first
+    /// observed state is always emitted so the client sees an immediate frame.
+    /// </summary>
+    public async Task PumpAsync(
+        string sessionId,
+        string jobId,
+        ClaimsPrincipal principal,
+        IGeoprocessingJobService jobService,
+        TimeSpan interval,
+        CancellationToken cancellationToken)
+    {
+        double? lastProgress = null;
+        string? lastPhase = null;
+        var first = true;
+
+        while (!cancellationToken.IsCancellationRequested && _sessions.IsValid(sessionId))
+        {
+            ExecutionJobRecord record;
+            try
+            {
+                record = await jobService.GetJobAsync(jobId, principal, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                // The job vanished or the read failed; stop tracking rather than
+                // spinning. The client can still read honua://jobs/{id} directly.
+                McpLog.ProgressBridgeStopped(_logger, sessionId, jobId, "job-unreadable");
+                return;
+            }
+
+            var terminal = IsTerminal(record.Status);
+            var phase = record.CurrentPhase ?? record.Status.ToString();
+            var progress = record.PercentComplete ?? (terminal ? ProgressTotal : 0d);
+
+            if (first || progress != lastProgress || !string.Equals(phase, lastPhase, StringComparison.Ordinal))
+            {
+                _publisher.PublishProgress(sessionId, jobId, progress, ProgressTotal, phase);
+                lastProgress = progress;
+                lastPhase = phase;
+                first = false;
+            }
+
+            if (terminal)
+            {
+                McpLog.ProgressBridgeStopped(_logger, sessionId, jobId, record.Status.ToString());
+                return;
+            }
+
+            if (interval > TimeSpan.Zero)
+            {
+                await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsTerminal(ExecutionJobStatus status) =>
+        status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed or ExecutionJobStatus.Cancelled;
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpLog.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpLog.cs
@@ -65,4 +65,13 @@ internal static partial class McpLog
 
     [LoggerMessage(8168, LogLevel.Debug, "MCP session terminated: SessionId={SessionId}, Found={Found}")]
     public static partial void SessionTerminated(ILogger logger, string sessionId, bool found);
+
+    [LoggerMessage(8169, LogLevel.Debug, "MCP notification published: Method={Method}, SessionId={SessionId}")]
+    public static partial void NotificationPublished(ILogger logger, string method, string sessionId);
+
+    [LoggerMessage(8170, LogLevel.Debug, "MCP notification broadcast: Method={Method}, Sessions={SessionCount}")]
+    public static partial void NotificationBroadcast(ILogger logger, string method, int sessionCount);
+
+    [LoggerMessage(8171, LogLevel.Debug, "MCP job progress bridge stopped: SessionId={SessionId}, JobId={JobId}, Reason={Reason}")]
+    public static partial void ProgressBridgeStopped(ILogger logger, string sessionId, string jobId, string reason);
 }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpNotificationPublisher.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpNotificationPublisher.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Ai.Protocols.Mcp.Models;
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Builds server-to-client MCP JSON-RPC notifications and enqueues them onto the
+/// owning session's SSE stream (honua-server#1954). Centralizing the wire shape
+/// here keeps the <c>notifications/progress</c> and <c>*/list_changed</c> frames
+/// consistent and AOT-safe (source-generated serialization). A separate
+/// <see cref="McpJobProgressBridge"/> sources progress from the canonical job
+/// runtime and calls <see cref="PublishProgress"/>; the publish path calls the
+/// broadcast methods when the catalog mutates.
+/// </summary>
+internal interface IMcpNotificationPublisher
+{
+    /// <summary>
+    /// Pushes a <c>notifications/progress</c> frame to a single session. The
+    /// <paramref name="progressToken"/> is the durable job id so a client can
+    /// correlate the stream with the job it started. Returns <c>false</c> when the
+    /// session is unknown/terminated (the frame is dropped).
+    /// </summary>
+    bool PublishProgress(string sessionId, string progressToken, double progress, double? total, string? message);
+
+    /// <summary>
+    /// Broadcasts <c>notifications/tools/list_changed</c> to every active session.
+    /// Returns the number of sessions the frame was enqueued onto.
+    /// </summary>
+    int BroadcastToolsListChanged();
+
+    /// <summary>
+    /// Broadcasts <c>notifications/resources/list_changed</c> to every active
+    /// session. Returns the number of sessions the frame was enqueued onto.
+    /// </summary>
+    int BroadcastResourcesListChanged();
+}
+
+/// <inheritdoc />
+internal sealed class McpNotificationPublisher : IMcpNotificationPublisher
+{
+    /// <summary>JSON-RPC method for an MCP progress notification.</summary>
+    public const string ProgressMethod = "notifications/progress";
+
+    /// <summary>JSON-RPC method broadcast when the tool catalog changes.</summary>
+    public const string ToolsListChangedMethod = "notifications/tools/list_changed";
+
+    /// <summary>JSON-RPC method broadcast when the resource catalog changes.</summary>
+    public const string ResourcesListChangedMethod = "notifications/resources/list_changed";
+
+    private readonly McpSessionManager _sessions;
+    private readonly ILogger<McpNotificationPublisher> _logger;
+
+    public McpNotificationPublisher(McpSessionManager sessions, ILogger<McpNotificationPublisher> logger)
+    {
+        _sessions = sessions;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool PublishProgress(string sessionId, string progressToken, double progress, double? total, string? message)
+    {
+        var parameters = new McpProgressNotificationParams
+        {
+            ProgressToken = progressToken,
+            Progress = progress,
+            Total = total,
+            Message = message
+        };
+
+        var paramsJson = JsonSerializer.Serialize(parameters, McpJsonContext.Default.McpProgressNotificationParams);
+        using var document = JsonDocument.Parse(paramsJson);
+        var notification = Serialize(ProgressMethod, document.RootElement.Clone());
+        var enqueued = _sessions.TryEnqueue(sessionId, notification);
+        if (enqueued)
+        {
+            McpLog.NotificationPublished(_logger, ProgressMethod, sessionId);
+        }
+
+        return enqueued;
+    }
+
+    /// <inheritdoc />
+    public int BroadcastToolsListChanged() => Broadcast(ToolsListChangedMethod);
+
+    /// <inheritdoc />
+    public int BroadcastResourcesListChanged() => Broadcast(ResourcesListChangedMethod);
+
+    private int Broadcast(string method)
+    {
+        var notification = Serialize(method, parameters: null);
+        var delivered = 0;
+        foreach (var sessionId in _sessions.ActiveSessionIds)
+        {
+            if (_sessions.TryEnqueue(sessionId, notification))
+            {
+                delivered++;
+            }
+        }
+
+        if (delivered > 0)
+        {
+            McpLog.NotificationBroadcast(_logger, method, delivered);
+        }
+
+        return delivered;
+    }
+
+    private static string Serialize(string method, JsonElement? parameters)
+    {
+        var notification = new McpJsonRpcNotification
+        {
+            Method = method,
+            Params = parameters
+        };
+
+        return JsonSerializer.Serialize(notification, McpJsonContext.Default.McpJsonRpcNotification);
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
@@ -63,6 +63,15 @@ internal sealed class McpOperatorSurface
 
     public IReadOnlyCollection<string> ToolNames => (IReadOnlyCollection<string>)_tools.Keys;
 
+    /// <summary>
+    /// The registered tool handlers, exposed so the <c>honua_list_capabilities</c>
+    /// tool (#1949) can project the live tool catalog into a self-describing
+    /// manifest. This is the same single source-of-truth catalog served over both
+    /// the HTTP-SSE and stdio transports (#1950), so the manifest is
+    /// transport-symmetric.
+    /// </summary>
+    public IReadOnlyCollection<IMcpTool> ToolHandlers => (IReadOnlyCollection<IMcpTool>)_tools.Values;
+
     public IReadOnlyList<IMcpResource> Resources => _resources;
 
     /// <summary>
@@ -198,7 +207,21 @@ internal sealed class McpOperatorSurface
         }
 
         var negotiatedVersion = NegotiateProtocolVersion(parameters.ProtocolVersion);
-        var result = new McpInitializeResult { ProtocolVersion = negotiatedVersion };
+        var result = new McpInitializeResult
+        {
+            ProtocolVersion = negotiatedVersion,
+            // honua-server#1954: the server now emits notifications/tools/list_changed
+            // and notifications/resources/list_changed over the session SSE stream
+            // (e.g. when a publish mutates the catalog), so advertise the listChanged
+            // capability instead of leaving the flags inert. The prompt catalog stays
+            // static, so prompts.listChanged remains false.
+            Capabilities = new McpServerCapabilities
+            {
+                Tools = new McpCapabilityFlag { ListChanged = true },
+                Resources = new McpCapabilityFlag { ListChanged = true },
+                Prompts = new McpCapabilityFlag { ListChanged = false }
+            }
+        };
         return SuccessResponse(request.Id, result, McpJsonContext.Default.McpInitializeResult);
     }
 

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -84,6 +84,13 @@ internal static class McpServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, GroundCandidatesTool>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ClarifyIntentTool>());
 
+        // honua_list_capabilities (#1949): a self-describing manifest of the live
+        // tool/resource surface for a cold client LLM. Registered unconditionally
+        // because it only reflects whatever catalog the composition wired — it has
+        // no external service dependency and never advertises an empty capability
+        // it cannot back.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, Discovery.ListCapabilitiesTool>());
+
         // Geocode/route tools (#1597) are only advertised when the host
         // composition has wired the underlying canonical services (AddGeocoding
         // / AddRouting run before AddMcpOperatorSurface in the server
@@ -110,6 +117,11 @@ internal static class McpServiceCollectionExtensions
         if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider)))
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, MapTools.ListLayersTool>());
+
+            // honua_resolve_entity (#1949): NL/text → ranked service/layer refs over
+            // the same Metadata v2 catalog ListLayersTool reads, so it is gated on
+            // the same provider being wired.
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, Discovery.ResolveEntityTool>());
 
             if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.FeatureStore.Abstractions.IFeatureReader)))
             {
@@ -154,6 +166,14 @@ internal static class McpServiceCollectionExtensions
         // singleton so a session id issued on initialize is recognized on every
         // subsequent POST/GET/DELETE handled by the same host.
         services.TryAddSingleton<McpSessionManager>();
+
+        // Server-push notifications over the session SSE stream (honua-server#1954):
+        // the publisher builds notifications/progress + */list_changed frames and
+        // enqueues them onto the owning session; the progress bridge polls the
+        // canonical job runtime and forwards progress to the session that started
+        // the job. Both are process-wide singletons.
+        services.TryAddSingleton<IMcpNotificationPublisher, McpNotificationPublisher>();
+        services.TryAddSingleton<McpJobProgressBridge>();
 
         return services;
     }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpSessionManager.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpSessionManager.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
+using System.Threading.Channels;
 
 namespace Honua.Ai.Protocols.Mcp;
 
@@ -25,6 +26,15 @@ namespace Honua.Ai.Protocols.Mcp;
 /// follow-up).
 /// </para>
 /// <para>
+/// Each session owns a bounded notification channel (honua-server#1954). The
+/// <c>GET /mcp</c> SSE handler drains the channel and writes each queued payload
+/// as one Server-Sent-Events <c>message</c> frame; the notification publisher and
+/// job-progress bridge enqueue onto it. The channel drops the oldest frame under
+/// backpressure because progress is intentionally lossy — a slow or absent reader
+/// must never block the producing job. The session also records the job ids it
+/// owns so progress for a job routes back to the session that started it.
+/// </para>
+/// <para>
 /// Session ids are required by the spec to be globally unique, cryptographically
 /// secure, and to contain only visible ASCII characters (0x21–0x7E). A 256-bit
 /// random value rendered as lowercase hex satisfies all three.
@@ -40,7 +50,15 @@ internal sealed class McpSessionManager
 
     private const int SessionIdByteLength = 32; // 256 bits.
 
-    private readonly ConcurrentDictionary<string, byte> _sessions = new(StringComparer.Ordinal);
+    /// <summary>
+    /// Maximum number of buffered notification frames per session. Bounded so a
+    /// disconnected or slow client cannot grow host memory without limit; the
+    /// oldest frame is dropped when the buffer is full.
+    /// </summary>
+    private const int NotificationBufferCapacity = 256;
+
+    private readonly ConcurrentDictionary<string, McpSession> _sessions = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, string> _jobSessions = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Creates and registers a new session, returning its id. Invoked when the
@@ -50,7 +68,7 @@ internal sealed class McpSessionManager
     public string CreateSession()
     {
         var id = GenerateSessionId();
-        _sessions[id] = 0;
+        _sessions[id] = new McpSession();
         return id;
     }
 
@@ -62,16 +80,128 @@ internal sealed class McpSessionManager
 
     /// <summary>
     /// Terminates a session so subsequent requests bearing its id are rejected
-    /// with HTTP 404. Returns <c>true</c> when an active session was removed.
-    /// Invoked when a client issues <c>DELETE /mcp</c> to end the session.
+    /// with HTTP 404. Completes the session's notification channel (so any open
+    /// SSE reader unblocks and the stream closes) and cancels its lifetime token
+    /// (so any in-flight progress bridge stops). Returns <c>true</c> when an
+    /// active session was removed. Invoked when a client issues <c>DELETE /mcp</c>.
     /// </summary>
-    public bool Terminate(string sessionId) =>
-        !string.IsNullOrEmpty(sessionId) && _sessions.TryRemove(sessionId, out _);
+    public bool Terminate(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId) || !_sessions.TryRemove(sessionId, out var session))
+        {
+            return false;
+        }
+
+        session.Channel.Writer.TryComplete();
+        session.Lifetime.Cancel();
+        session.Lifetime.Dispose();
+        return true;
+    }
+
+    /// <summary>
+    /// Obtains the notification-stream reader for a session so the SSE handler can
+    /// drain queued server-to-client frames. Returns <c>false</c> when the session
+    /// is unknown or terminated.
+    /// </summary>
+    public bool TryGetReader(string sessionId, out ChannelReader<string> reader)
+    {
+        if (!string.IsNullOrEmpty(sessionId) && _sessions.TryGetValue(sessionId, out var session))
+        {
+            reader = session.Channel.Reader;
+            return true;
+        }
+
+        reader = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// A cancellation token tied to the session lifetime. Cancels when the session
+    /// is terminated. Returns <see cref="CancellationToken.None"/> for an unknown
+    /// session (already-terminated work simply ends).
+    /// </summary>
+    public CancellationToken GetLifetimeToken(string sessionId) =>
+        !string.IsNullOrEmpty(sessionId) && _sessions.TryGetValue(sessionId, out var session)
+            ? session.Lifetime.Token
+            : CancellationToken.None;
+
+    /// <summary>
+    /// Enqueues a pre-serialized notification frame for delivery over the session's
+    /// SSE stream. Returns <c>false</c> when the session is unknown/terminated.
+    /// Under buffer pressure the oldest queued frame is dropped, so this never
+    /// blocks the caller.
+    /// </summary>
+    public bool TryEnqueue(string sessionId, string payload)
+    {
+        if (string.IsNullOrEmpty(sessionId) || !_sessions.TryGetValue(sessionId, out var session))
+        {
+            return false;
+        }
+
+        return session.Channel.Writer.TryWrite(payload);
+    }
+
+    /// <summary>
+    /// Records that <paramref name="jobId"/> was started within
+    /// <paramref name="sessionId"/> so the progress bridge can route the job's
+    /// progress notifications back to the owning session's SSE stream.
+    /// </summary>
+    public void AssociateJob(string sessionId, string jobId)
+    {
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(jobId))
+        {
+            return;
+        }
+
+        if (_sessions.TryGetValue(sessionId, out var session))
+        {
+            session.Jobs[jobId] = 0;
+            _jobSessions[jobId] = sessionId;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the session that owns a job, if any, so a job-progress source can
+    /// find the SSE stream to notify.
+    /// </summary>
+    public bool TryGetJobSession(string jobId, out string sessionId)
+    {
+        if (!string.IsNullOrEmpty(jobId) && _jobSessions.TryGetValue(jobId, out var resolved))
+        {
+            sessionId = resolved;
+            return true;
+        }
+
+        sessionId = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Snapshot of the currently active session ids, used to broadcast
+    /// catalog-change notifications (<c>tools/list_changed</c> /
+    /// <c>resources/list_changed</c>) to every connected client.
+    /// </summary>
+    public IReadOnlyCollection<string> ActiveSessionIds => _sessions.Keys.ToArray();
 
     private static string GenerateSessionId()
     {
         Span<byte> buffer = stackalloc byte[SessionIdByteLength];
         RandomNumberGenerator.Fill(buffer);
         return Convert.ToHexStringLower(buffer);
+    }
+
+    private sealed class McpSession
+    {
+        public Channel<string> Channel { get; } = System.Threading.Channels.Channel.CreateBounded<string>(
+            new BoundedChannelOptions(NotificationBufferCapacity)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = true,
+                SingleWriter = false
+            });
+
+        public ConcurrentDictionary<string, byte> Jobs { get; } = new(StringComparer.Ordinal);
+
+        public CancellationTokenSource Lifetime { get; } = new();
     }
 }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
@@ -20,6 +20,8 @@ namespace Honua.Ai.Protocols.Mcp.Models;
 [JsonSerializable(typeof(McpJsonRpcError))]
 [JsonSerializable(typeof(McpErrorData))]
 [JsonSerializable(typeof(McpValidationViolation))]
+[JsonSerializable(typeof(McpJsonRpcNotification))]
+[JsonSerializable(typeof(McpProgressNotificationParams))]
 [JsonSerializable(typeof(McpInitializeParams))]
 [JsonSerializable(typeof(McpClientInfo))]
 [JsonSerializable(typeof(McpInitializeResult))]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
@@ -103,6 +103,51 @@ internal sealed class McpValidationViolation
     public string? FieldPath { get; set; }
 }
 
+/// <summary>
+/// JSON-RPC 2.0 notification envelope pushed from the server to the client over
+/// the Streamable-HTTP <c>GET /mcp</c> Server-Sent-Events stream (honua-server#1954).
+/// A notification carries no <c>id</c> per JSON-RPC 2.0; the client never replies.
+/// Used for <c>notifications/progress</c> (long-running job progress) and the
+/// <c>notifications/tools/list_changed</c> / <c>notifications/resources/list_changed</c>
+/// catalog-change signals.
+/// </summary>
+internal sealed class McpJsonRpcNotification
+{
+    [JsonPropertyName("jsonrpc")]
+    public string JsonRpc { get; set; } = "2.0";
+
+    [JsonPropertyName("method")]
+    public string Method { get; set; } = string.Empty;
+
+    [JsonPropertyName("params")]
+    public JsonElement? Params { get; set; }
+}
+
+/// <summary>
+/// Parameters for an MCP <c>notifications/progress</c> message. The
+/// <see cref="ProgressToken"/> correlates the progress stream with the work the
+/// client started; Honua uses the durable job id as the token so a client that
+/// received a job id from <c>honua_execute_plan</c> can correlate streamed
+/// progress with that job. <see cref="Progress"/>/<see cref="Total"/> express a
+/// 0–100 completion ratio sourced from the canonical job runtime's
+/// <c>PercentComplete</c>, and <see cref="Message"/> mirrors the job's current
+/// phase. See https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress.
+/// </summary>
+internal sealed class McpProgressNotificationParams
+{
+    [JsonPropertyName("progressToken")]
+    public string ProgressToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("progress")]
+    public double Progress { get; set; }
+
+    [JsonPropertyName("total")]
+    public double? Total { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}
+
 // -----------------------------------------------------------------------
 // MCP protocol payloads
 // -----------------------------------------------------------------------

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ExecutePlanTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ExecutePlanTool.cs
@@ -110,6 +110,12 @@ internal sealed class ExecutePlanTool : IMcpTool
             .SubmitJobAsync(plan, idempotencyKey, principal, metadata, cancellationToken)
             .ConfigureAwait(false);
 
+        // honua-server#1954: when the call is part of a streamable-HTTP session,
+        // stream the job's progress to the session's GET /mcp SSE channel instead
+        // of forcing the client to poll honua://jobs/{id}. Resolved leniently so a
+        // lightweight test host (no session services registered) keeps working.
+        StartProgressStreaming(httpContext, jobRecord.OperationId, principal);
+
         var output = new McpExecuteOutput
         {
             JobId = jobRecord.OperationId,
@@ -119,6 +125,25 @@ internal sealed class ExecutePlanTool : IMcpTool
         };
 
         return McpToolHelpers.SuccessResult(output, McpJsonContext.Default.McpExecuteOutput);
+    }
+
+    private static void StartProgressStreaming(HttpContext httpContext, string jobId, System.Security.Claims.ClaimsPrincipal principal)
+    {
+        var sessionId = httpContext.Request.Headers[McpSessionManager.SessionHeaderName].ToString();
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            return;
+        }
+
+        var sessions = httpContext.RequestServices.GetService<McpSessionManager>();
+        var bridge = httpContext.RequestServices.GetService<McpJobProgressBridge>();
+        if (sessions is null || bridge is null || !sessions.IsValid(sessionId))
+        {
+            return;
+        }
+
+        sessions.AssociateJob(sessionId, jobId);
+        bridge.Track(sessionId, jobId, principal);
     }
 
     private static void EnforceGuardrails(HttpContext httpContext)

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishServiceTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishServiceTool.cs
@@ -94,6 +94,22 @@ internal sealed class PublishServiceTool : IMcpTool
 
         var handle = await invoker.SubmitAsync(request, context, cancellationToken).ConfigureAwait(false);
 
+        // honua-server#1954: a completed publish mutates the promotion-resource
+        // catalog (a new honua://published-services/{id} appears) and the
+        // capability surface, so fire the listChanged notifications to every
+        // active streamable-HTTP session. Queued/RequiresApproval/Denied did not
+        // change the catalog yet, so they emit nothing. Resolved leniently so a
+        // host without the session services keeps working.
+        if (handle.Status == OperationHandleStatus.Completed)
+        {
+            var publisher = httpContext.RequestServices.GetService<IMcpNotificationPublisher>();
+            if (publisher is not null)
+            {
+                publisher.BroadcastResourcesListChanged();
+                publisher.BroadcastToolsListChanged();
+            }
+        }
+
         return McpToolHelpers.SuccessResult(Project(handle), McpJsonContext.Default.McpPublishServiceOutput);
     }
 

--- a/src/Honua.Core/Features/Operations/Policy/OperationPolicyOptions.cs
+++ b/src/Honua.Core/Features/Operations/Policy/OperationPolicyOptions.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Domain;
+
+namespace Honua.Core.Features.Operations.Policy;
+
+/// <summary>
+/// Configurable guardrail policy bound from the <c>Operations:Policy</c> configuration section.
+/// This is the product surface over the <c>IOperationPolicyDecisionPoint</c> seam: instead of
+/// the hard-coded pass-through Community default, an operator can allow / deny / require-approval
+/// / require-dry-run per operation id, tier, and role without a code change.
+/// </summary>
+/// <remarks>
+/// When <see cref="Enabled"/> is <see langword="false"/> (the default) the policy is inert and
+/// behavior is identical to <c>AllowAllPolicyDecisionPoint</c> — every operation is allowed.
+/// Rules are evaluated first-match-wins in declared order; when no rule matches, the
+/// <see cref="DefaultDecision"/> applies.
+/// </remarks>
+public sealed class OperationPolicyOptions
+{
+    /// <summary>
+    /// Configuration section name: <c>Operations:Policy</c>.
+    /// </summary>
+    public const string SectionName = "Operations:Policy";
+
+    /// <summary>
+    /// Whether the configurable policy is enforced. When <see langword="false"/> (default) the
+    /// decision point is a pass-through allow, preserving the permissive Community default.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Decision applied when no rule in <see cref="Rules"/> matches the invocation. Defaults to
+    /// <see cref="PolicyDecisionKind.Allow"/> so an enabled-but-ruleless policy stays permissive.
+    /// </summary>
+    public PolicyDecisionKind DefaultDecision { get; set; } = PolicyDecisionKind.Allow;
+
+    /// <summary>
+    /// Optional reason attached to a decision produced by <see cref="DefaultDecision"/>.
+    /// </summary>
+    public string? DefaultReason { get; set; }
+
+    /// <summary>
+    /// Optional approval lane attached to a <see cref="DefaultDecision"/> of
+    /// <see cref="PolicyDecisionKind.RequireApproval"/>.
+    /// </summary>
+    public string? DefaultApprovalLane { get; set; }
+
+    /// <summary>
+    /// Ordered rule set. The first rule whose match criteria are satisfied wins; remaining rules
+    /// are not evaluated. Empty by default.
+    /// </summary>
+    public IList<OperationPolicyRule> Rules { get; set; } = [];
+}
+
+/// <summary>
+/// A single first-match-wins guardrail rule within <see cref="OperationPolicyOptions"/>. A rule
+/// matches when every populated criterion matches the invocation; unset (null/empty) criteria are
+/// wildcards. An <see cref="OperationId"/> of <c>"*"</c> (or empty) matches any operation.
+/// </summary>
+public sealed class OperationPolicyRule
+{
+    /// <summary>
+    /// Operation id this rule targets, or <c>"*"</c> (the default) to match any operation.
+    /// Matched case-sensitively (ordinal) against <c>OperationRequest.OperationId</c>.
+    /// </summary>
+    public string OperationId { get; set; } = "*";
+
+    /// <summary>
+    /// Optional tier this rule is scoped to (for example <c>pro</c>, <c>enterprise</c>). When set,
+    /// the rule only matches when the caller's tier equals it (case-insensitive). Null matches any tier.
+    /// </summary>
+    public string? Tier { get; set; }
+
+    /// <summary>
+    /// Optional role this rule is scoped to (for example <c>operator</c>, <c>publisher</c>). When set,
+    /// the rule only matches when the caller holds it (case-insensitive). Null matches any role.
+    /// </summary>
+    public string? Role { get; set; }
+
+    /// <summary>
+    /// Decision produced when this rule matches.
+    /// </summary>
+    public PolicyDecisionKind Decision { get; set; } = PolicyDecisionKind.Allow;
+
+    /// <summary>
+    /// Optional human-readable reason carried on the produced decision.
+    /// </summary>
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Optional approval lane carried on a <see cref="PolicyDecisionKind.RequireApproval"/> decision.
+    /// </summary>
+    public string? ApprovalLane { get; set; }
+}

--- a/src/Honua.Core/Features/Operations/Services/ConfigurableOperationPolicyDecisionPoint.cs
+++ b/src/Honua.Core/Features/Operations/Services/ConfigurableOperationPolicyDecisionPoint.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.Operations.Policy;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Features.Operations.Services;
+
+/// <summary>
+/// Configuration-driven <see cref="IOperationPolicyDecisionPoint"/>. Evaluates the ordered
+/// <see cref="OperationPolicyOptions.Rules"/> against the operation id, caller tier, and caller
+/// role(s) on a first-match-wins basis, falling back to <see cref="OperationPolicyOptions.DefaultDecision"/>.
+/// When <see cref="OperationPolicyOptions.Enabled"/> is <see langword="false"/> it is a pass-through
+/// allow, identical to <see cref="AllowAllPolicyDecisionPoint"/>, so the default deployment stays
+/// permissive. Evaluation is deterministic and reflection-free (AOT-safe).
+/// </summary>
+public sealed class ConfigurableOperationPolicyDecisionPoint : IOperationPolicyDecisionPoint
+{
+    private readonly OperationPolicyOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ConfigurableOperationPolicyDecisionPoint"/>.
+    /// </summary>
+    /// <param name="options">The bound policy options.</param>
+    public ConfigurableOperationPolicyDecisionPoint(IOptions<OperationPolicyOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value ?? new OperationPolicyOptions();
+    }
+
+    /// <inheritdoc />
+    public Task<PolicyDecision> EvaluateAsync(
+        IOperationDescriptor descriptor,
+        OperationRequest request,
+        OperationPolicyContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Disabled policy is a pass-through allow — identical to the Community default.
+        if (!_options.Enabled)
+        {
+            return Task.FromResult(PolicyDecision.Allowed);
+        }
+
+        foreach (var rule in _options.Rules)
+        {
+            if (rule is not null && Matches(rule, request, context))
+            {
+                return Task.FromResult(ResolveDecision(rule.Decision, rule.Reason, rule.ApprovalLane, request));
+            }
+        }
+
+        return Task.FromResult(ResolveDecision(
+            _options.DefaultDecision,
+            _options.DefaultReason,
+            _options.DefaultApprovalLane,
+            request));
+    }
+
+    private static bool Matches(OperationPolicyRule rule, OperationRequest request, OperationPolicyContext context)
+    {
+        // Operation id: "*" or empty is a wildcard; otherwise an exact (ordinal) match.
+        if (!string.IsNullOrEmpty(rule.OperationId)
+            && rule.OperationId != "*"
+            && !string.Equals(rule.OperationId, request.OperationId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Tier: unset is a wildcard; otherwise case-insensitive equality.
+        if (!string.IsNullOrEmpty(rule.Tier)
+            && !string.Equals(rule.Tier, context.Tier, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Role: unset is a wildcard; otherwise the caller must hold the role (case-insensitive).
+        if (!string.IsNullOrEmpty(rule.Role)
+            && !ContainsRole(context.Roles, rule.Role))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool ContainsRole(IReadOnlyList<string> roles, string role)
+    {
+        for (var i = 0; i < roles.Count; i++)
+        {
+            if (string.Equals(roles[i], role, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static PolicyDecision ResolveDecision(
+        PolicyDecisionKind kind,
+        string? reason,
+        string? approvalLane,
+        OperationRequest request)
+    {
+        // Honor the dry-run contract: when the policy demands a dry-run/preview first and the
+        // caller already requested one, the precondition is satisfied — allow it through.
+        if (kind == PolicyDecisionKind.DryRunFirst && request.DryRun)
+        {
+            return PolicyDecision.Allowed;
+        }
+
+        if (kind == PolicyDecisionKind.Allow)
+        {
+            return PolicyDecision.Allowed;
+        }
+
+        return new PolicyDecision
+        {
+            Kind = kind,
+            Reason = reason,
+
+            // Only a require-approval decision carries an approval lane.
+            ApprovalLane = kind == PolicyDecisionKind.RequireApproval ? approvalLane : null
+        };
+    }
+}

--- a/src/Honua.Server/Features/Operations/OperationsServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Operations/OperationsServiceCollectionExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Policy;
 using Honua.Core.Features.Operations.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -14,9 +16,10 @@ namespace Honua.Server.Features.Operations;
 /// </summary>
 internal static class OperationsServiceCollectionExtensions
 {
-    public static IServiceCollection AddOperationsToolset(this IServiceCollection services)
+    public static IServiceCollection AddOperationsToolset(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<OperationHandleStore>();
@@ -33,8 +36,23 @@ internal static class OperationsServiceCollectionExtensions
         services.TryAddEnumerable(
             ServiceDescriptor.Scoped<IOperationExecutor, ServicePublishExecutor>());
 
-        // Policy seam: no-op pass-through default (Community tier). Pro/Enterprise swap this.
-        services.TryAddSingleton<IOperationPolicyDecisionPoint, AllowAllPolicyDecisionPoint>();
+        // Policy seam. Bind the configurable guardrail policy from "Operations:Policy".
+        // When it is enabled, the configurable decision point enforces the rule set; otherwise
+        // the no-op pass-through default (Community tier) stays in place. TryAdd is used so an
+        // explicitly-registered stricter PDP (Pro/Enterprise) registered earlier still wins.
+        services
+            .AddOptions<OperationPolicyOptions>()
+            .Bind(configuration.GetSection(OperationPolicyOptions.SectionName));
+
+        var policyOptions = configuration.GetSection(OperationPolicyOptions.SectionName).Get<OperationPolicyOptions>();
+        if (policyOptions?.Enabled == true)
+        {
+            services.TryAddSingleton<IOperationPolicyDecisionPoint, ConfigurableOperationPolicyDecisionPoint>();
+        }
+        else
+        {
+            services.TryAddSingleton<IOperationPolicyDecisionPoint, AllowAllPolicyDecisionPoint>();
+        }
 
         // Dispatcher: resolves descriptor + executor, runs policy, executes on Allow.
         services.TryAddScoped<IOperationInvoker>(sp =>

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -654,7 +654,7 @@ builder.Services.AddValidationServices();
 builder.Services.AddServerFeatures(builder.Configuration);
 builder.Services.AddOperateObservabilityFixtures(builder.Configuration, builder.Environment);
 builder.Services.AddWorkflowPackages();
-builder.Services.AddOperationsToolset();
+builder.Services.AddOperationsToolset(builder.Configuration);
 builder.Services.AddAdminRealtime();
 if (!isTestEnvironment)
 {

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
@@ -20,3 +20,23 @@ implements today. Standard tools Honua does not yet implement as discrete MCP
 tools (the map/app composition and publish families) are tracked as
 **known-gaps**: their absence does not fail the suite; only NON-CONFORMANCE of
 an implemented tool fails.
+
+## Honua extensions (`x-honua-extension`)
+
+A few schemas under `geospatial-mcp/tools/` are **documented Honua extensions**
+over the bare standard taxonomy rather than copies of an upstream schema. They
+carry `"x-honua-extension": true` in the schema body:
+
+- `resolve_entity.schema.json` — `honua_resolve_entity` (#1949): natural-language
+  text → ranked service/layer references grounded in the live catalog.
+- `list_capabilities.schema.json` — `honua_list_capabilities` (#1949): a
+  self-describing manifest of the live tool/resource surface for a cold client
+  LLM.
+
+These are exposed as first-class reference-implementation tools while the
+`geospatial-mcp` standard formalizes capability discovery / entity resolution
+(the standard currently models them as `CapabilityCatalog` reads). When the
+upstream standard publishes canonical schemas for them, re-vendor and drop the
+extension marker. They participate in the full conformance assertions (required
+fields + fixture validation) because their live and vendored shapes are authored
+together.

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/list_capabilities/list_capabilities.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/list_capabilities/list_capabilities.json
@@ -1,0 +1,8 @@
+{
+  "id": "list_capabilities.default",
+  "schemaRef": "tools/list_capabilities.schema.json",
+  "validates": "inputs",
+  "inputs": { "includeResources": true, "includeGroundingResources": true },
+  "expected": "tool_result",
+  "canonicalRefs": ["CapabilityCatalog"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/resolve_entity/resolve_entity.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/resolve_entity/resolve_entity.json
@@ -1,0 +1,8 @@
+{
+  "id": "resolve_entity.text",
+  "schemaRef": "tools/resolve_entity.schema.json",
+  "validates": "inputs",
+  "inputs": { "text": "parcels", "entityType": "any", "limit": 10 },
+  "expected": "tool_result",
+  "canonicalRefs": ["CapabilityCatalog", "LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
@@ -153,6 +153,22 @@
       "family": "Control-plane proposal (reference shape)",
       "schema": "tools/propose_operation.schema.json",
       "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "resolve_entity",
+      "referenceToolName": "honua_resolve_entity",
+      "family": "Discovery and grounding (Honua extension)",
+      "schema": "tools/resolve_entity.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Honua extension (#1949): NL/text -> ranked service/layer references grounded in the live catalog. Pending formalization in the geospatial-mcp standard; schema marks x-honua-extension."
+    },
+    {
+      "standardName": "list_capabilities",
+      "referenceToolName": "honua_list_capabilities",
+      "family": "Discovery and grounding (Honua extension)",
+      "schema": "tools/list_capabilities.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Honua extension (#1949): self-describing manifest of the live tool/resource surface for a cold client LLM. Pending formalization in the geospatial-mcp standard; schema marks x-honua-extension."
     }
   ],
   "resources": [

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/list_capabilities.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/list_capabilities.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/list_capabilities.schema.json",
+  "title": "list_capabilities inputSchema",
+  "description": "Argument shape for enumerating the server's full tool/resource surface plus grounding resources for a cold client LLM. The bare standard taxonomy models capability discovery as a CapabilityCatalog read; the reference implementation exposes it as a discrete tool (advertised name honua_list_capabilities). x-honua-extension: this is a documented Honua extension over the bare taxonomy, pending formalization in the geospatial-mcp standard. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-extension": true,
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {
+    "includeResources": {
+      "type": "boolean",
+      "default": true,
+      "description": "Include the resource catalog (job, catalog, and promotion URIs) in the manifest."
+    },
+    "includeGroundingResources": {
+      "type": "boolean",
+      "default": true,
+      "description": "Include the grounding/catalog resource URIs a client LLM should read first to ground a workflow."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/resolve_entity.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/resolve_entity.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/resolve_entity.schema.json",
+  "title": "resolve_entity inputSchema",
+  "description": "Argument shape for resolving a natural-language name or phrase to concrete catalog entity references (services/layers). The bare standard taxonomy models entity resolution as a CapabilityCatalog/grounding read; the reference implementation exposes it as a discrete tool (advertised name honua_resolve_entity). x-honua-extension: this is a documented Honua extension over the bare taxonomy, pending formalization in the geospatial-mcp standard. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-extension": true,
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["text"],
+  "properties": {
+    "text": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Natural-language name or phrase to resolve to catalog entities (e.g. \"parcels\", \"flood zones\", \"roads\")."
+    },
+    "entityType": {
+      "type": "string",
+      "enum": ["any", "service", "layer"],
+      "default": "any",
+      "description": "Restrict matches to services, to layers, or to both (default)."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 50,
+      "default": 10,
+      "description": "Maximum number of ranked matches to return (capped at 50)."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpDiscoveryToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpDiscoveryToolTests.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Discovery;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Resources;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Focused coverage for the client-agnostic discovery tools (#1949):
+/// <c>honua_resolve_entity</c> (NL/text → ranked catalog references) and
+/// <c>honua_list_capabilities</c> (self-describing surface manifest). They run
+/// through the JSON-RPC dispatcher with a substituted Metadata v2 catalog, so they
+/// validate the MCP adapter behavior without a database.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class McpDiscoveryToolTests
+{
+    private readonly IGeoprocessingJobService _jobService = Substitute.For<IGeoprocessingJobService>();
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_resolve_entity")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ResolveEntity_RanksMatchingLayerByName()
+    {
+        var surface = BuildSurface();
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices()),
+            ToolCall("resolve-1", ResolveEntityTool.ToolName, """{"text":"parcels"}"""),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeFalse();
+
+        var structured = result.GetProperty("structuredContent");
+        structured.GetProperty("query").GetString().Should().Be("parcels");
+        structured.GetProperty("matchCount").GetInt32().Should().BeGreaterThan(0);
+
+        var matches = structured.GetProperty("matches").EnumerateArray().ToArray();
+        var top = matches[0];
+        top.GetProperty("serviceId").GetString().Should().Be("svc-parcels");
+        // The exact-name layer match must outrank the unrelated "Roads" layer.
+        matches.Should().Contain(m =>
+            m.GetProperty("kind").GetString() == "layer"
+            && m.GetProperty("name").GetString()!.Contains("Parcels", StringComparison.OrdinalIgnoreCase));
+        matches.Should().NotContain(m =>
+            m.GetProperty("name").GetString()!.Contains("Roads", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_resolve_entity")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ResolveEntity_MissingText_ReturnsStructuredError()
+    {
+        var surface = BuildSurface();
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices()),
+            ToolCall("resolve-2", ResolveEntityTool.ToolName, """{"text":"   "}"""),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeTrue("blank text is an invalid argument");
+    }
+
+    [UnitTest]
+    [Operation(Operations.GetMetadata)]
+    [Endpoint("POST /mcp tools/call honua_list_capabilities")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ListCapabilities_ProjectsLiveToolAndResourceCatalog()
+    {
+        var surface = BuildSurface();
+        var services = BuildServices(surface);
+
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(services),
+            ToolCall("caps-1", ListCapabilitiesTool.ToolName, "{}"),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeFalse();
+
+        var structured = result.GetProperty("structuredContent");
+        structured.GetProperty("serverName").GetString().Should().Be("honua.operator.mcp");
+        structured.GetProperty("protocolVersions").EnumerateArray()
+            .Select(v => v.GetString())
+            .Should().Contain("2025-06-18");
+
+        var toolNames = structured.GetProperty("tools").EnumerateArray()
+            .Select(t => t.GetProperty("name").GetString())
+            .ToArray();
+        toolNames.Should().Contain(ListCapabilitiesTool.ToolName);
+        toolNames.Should().Contain(ResolveEntityTool.ToolName);
+        structured.GetProperty("toolCount").GetInt32().Should().Be(toolNames.Length);
+
+        // Every tool entry carries the LLM-grade metadata a cold client needs.
+        foreach (var tool in structured.GetProperty("tools").EnumerateArray())
+        {
+            tool.GetProperty("description").GetString().Should().NotBeNullOrWhiteSpace();
+            tool.TryGetProperty("readOnly", out _).Should().BeTrue();
+            tool.GetProperty("workflowFamily").GetString().Should().NotBeNullOrWhiteSpace();
+        }
+
+        // The feature catalog grounding resource is surfaced for the client LLM.
+        structured.GetProperty("groundingResources").EnumerateArray()
+            .Select(u => u.GetString())
+            .Should().Contain("honua://catalog/features");
+    }
+
+    [UnitTest]
+    public void DiscoveryModels_AreResolvableFromSourceGeneratedContext()
+    {
+        // AOT guard: the discovery DTOs must be source-generated for the explicit
+        // serialization the tools perform.
+        DiscoveryJsonContext.Default.McpResolveEntityArgument.Should().NotBeNull();
+        DiscoveryJsonContext.Default.McpResolveEntityOutput.Should().NotBeNull();
+        DiscoveryJsonContext.Default.McpListCapabilitiesArgument.Should().NotBeNull();
+        DiscoveryJsonContext.Default.McpListCapabilitiesOutput.Should().NotBeNull();
+    }
+
+    private McpOperatorSurface BuildSurface() => new(
+        [
+            new ResolveEntityTool(_jobService, NullLogger<ResolveEntityTool>.Instance),
+            new ListCapabilitiesTool(_jobService, NullLogger<ListCapabilitiesTool>.Instance)
+        ],
+        [
+            new FeatureCatalogResource(_jobService, NullLogger<FeatureCatalogResource>.Instance)
+        ],
+        NullLogger<McpOperatorSurface>.Instance);
+
+    private static TestMetadataV2GraphProvider BuildGraphProvider() =>
+        new TestMetadataV2GraphBuilder()
+            .AddResource("res-parcels", "Parcels")
+            .AddStorageBinding("bind-parcels", "res-parcels", "public.parcels", storageLayerId: 1)
+            .AddResource("res-roads", "Roads")
+            .AddStorageBinding("bind-roads", "res-roads", "public.roads", storageLayerId: 2)
+            .AddService("svc-parcels", "Parcels")
+            .AddPublication("pub-parcels", "svc-parcels", "res-parcels", layerIndex: 0, storageBindingId: "bind-parcels")
+            .AddService("svc-roads", "Roads")
+            .AddPublication("pub-roads", "svc-roads", "res-roads", layerIndex: 0, storageBindingId: "bind-roads")
+            .BuildProvider();
+
+    private static ServiceProvider BuildServices(McpOperatorSurface? surface = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMetadataV2GraphProvider>(BuildGraphProvider());
+        if (surface is not null)
+        {
+            services.AddSingleton(surface);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static DefaultHttpContext AuthenticatedContext(IServiceProvider services)
+    {
+        var context = McpTestFactory.AuthenticatedHttpContext();
+        context.RequestServices = services;
+        return context;
+    }
+
+    private static McpJsonRpcRequest ToolCall(string id, string toolName, string argumentsJson) => new()
+    {
+        JsonRpc = "2.0",
+        Id = JsonString(id),
+        Method = "tools/call",
+        Params = Json($$"""{"name":"{{toolName}}","arguments":{{argumentsJson}}}""")
+    };
+
+    private static JsonElement JsonString(string value)
+    {
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(value));
+        return document.RootElement.Clone();
+    }
+
+    private static JsonElement Json(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -59,6 +59,15 @@ public sealed partial class McpTaxonomyAlignmentTests
             ["honua_query_features"] = "query_features",
             ["honua_render_map"] = "render_map",
             ["honua_publish_service"] = "publish_service",
+            // Honua extensions over the bare taxonomy (#1949): the standard models
+            // entity resolution and capability discovery as CapabilityCatalog reads;
+            // the reference implementation exposes them as discrete tools and ships
+            // vendored conformance schemas marked x-honua-extension. Their live and
+            // vendored required sets agree, so they participate in the full
+            // required-field + fixture conformance assertions (unlike the
+            // publish_service divergence recorded below).
+            ["honua_resolve_entity"] = "resolve_entity",
+            ["honua_list_capabilities"] = "list_capabilities",
         };
 
     /// <summary>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpStreamingTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpStreamingTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Unit tests for the MCP sessions + streaming spine (honua-server#1954):
+/// per-session notification channels, the JSON-RPC notification publisher,
+/// job-progress threading from the canonical job runtime, and the SSE pump. These
+/// run without Docker/PostGIS so the server-push contract is covered even when the
+/// full integration harness is unavailable.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class McpStreamingTests
+{
+    private static readonly ClaimsPrincipal Principal =
+        new(new ClaimsIdentity([new Claim(ClaimTypes.Name, "test-user")], "Test"));
+
+    [UnitTest]
+    public void Session_EnqueueAndRead_DeliversFramesInOrder()
+    {
+        var sessions = new McpSessionManager();
+        var id = sessions.CreateSession();
+
+        sessions.TryEnqueue(id, "frame-1").Should().BeTrue();
+        sessions.TryEnqueue(id, "frame-2").Should().BeTrue();
+        sessions.TryEnqueue("never-issued", "x").Should().BeFalse();
+
+        sessions.TryGetReader(id, out var reader).Should().BeTrue();
+        reader.TryRead(out var first).Should().BeTrue();
+        reader.TryRead(out var second).Should().BeTrue();
+        first.Should().Be("frame-1");
+        second.Should().Be("frame-2");
+    }
+
+    [UnitTest]
+    public void Session_AssociateJob_RoutesJobToOwningSession()
+    {
+        var sessions = new McpSessionManager();
+        var id = sessions.CreateSession();
+        sessions.AssociateJob(id, "job-7");
+
+        sessions.TryGetJobSession("job-7", out var resolved).Should().BeTrue();
+        resolved.Should().Be(id);
+        sessions.TryGetJobSession("unknown-job", out _).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Session_Terminate_CompletesChannelAndCancelsLifetime()
+    {
+        var sessions = new McpSessionManager();
+        var id = sessions.CreateSession();
+        sessions.TryGetReader(id, out var reader).Should().BeTrue();
+        var token = sessions.GetLifetimeToken(id);
+
+        sessions.Terminate(id).Should().BeTrue();
+
+        token.IsCancellationRequested.Should().BeTrue("terminating a session cancels its lifetime token");
+        reader.Completion.IsCompleted.Should().BeTrue("terminating a session completes its notification channel");
+        sessions.TryGetReader(id, out _).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Publisher_PublishProgress_EnqueuesWellFormedJsonRpcNotification()
+    {
+        var sessions = new McpSessionManager();
+        var id = sessions.CreateSession();
+        var publisher = new McpNotificationPublisher(sessions, NullLogger<McpNotificationPublisher>.Instance);
+
+        publisher.PublishProgress(id, "job-9", progress: 42, total: 100, message: "Running").Should().BeTrue();
+
+        sessions.TryGetReader(id, out var reader).Should().BeTrue();
+        reader.TryRead(out var frame).Should().BeTrue();
+
+        using var document = JsonDocument.Parse(frame!);
+        var root = document.RootElement;
+        root.GetProperty("jsonrpc").GetString().Should().Be("2.0");
+        root.GetProperty("method").GetString().Should().Be("notifications/progress");
+        var parameters = root.GetProperty("params");
+        parameters.GetProperty("progressToken").GetString().Should().Be("job-9");
+        parameters.GetProperty("progress").GetDouble().Should().Be(42);
+        parameters.GetProperty("total").GetDouble().Should().Be(100);
+        parameters.GetProperty("message").GetString().Should().Be("Running");
+    }
+
+    [UnitTest]
+    public void Publisher_Broadcast_ReachesEveryActiveSession()
+    {
+        var sessions = new McpSessionManager();
+        var first = sessions.CreateSession();
+        var second = sessions.CreateSession();
+        var publisher = new McpNotificationPublisher(sessions, NullLogger<McpNotificationPublisher>.Instance);
+
+        publisher.BroadcastResourcesListChanged().Should().Be(2);
+
+        foreach (var id in new[] { first, second })
+        {
+            sessions.TryGetReader(id, out var reader).Should().BeTrue();
+            reader.TryRead(out var frame).Should().BeTrue();
+            using var document = JsonDocument.Parse(frame!);
+            document.RootElement.GetProperty("method").GetString()
+                .Should().Be("notifications/resources/list_changed");
+        }
+    }
+
+    [UnitTest]
+    public async Task ProgressBridge_PumpsCanonicalJobProgress_ToOwningSessionUntilTerminal()
+    {
+        var sessions = new McpSessionManager();
+        var id = sessions.CreateSession();
+        sessions.AssociateJob(id, "job-1");
+
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobAsync("job-1", Principal, Arg.Any<CancellationToken>())
+            .Returns(
+                JobRecord(ExecutionJobStatus.Running, 10, "Provisioning"),
+                JobRecord(ExecutionJobStatus.Running, 60, "Executing"),
+                JobRecord(ExecutionJobStatus.Succeeded, 100, "Complete"));
+
+        var publisher = new McpNotificationPublisher(sessions, NullLogger<McpNotificationPublisher>.Instance);
+        var bridge = new McpJobProgressBridge(
+            publisher,
+            sessions,
+            Substitute.For<IServiceScopeFactory>(),
+            NullLogger<McpJobProgressBridge>.Instance);
+
+        await bridge.PumpAsync(id, "job-1", Principal, jobService, TimeSpan.Zero, CancellationToken.None);
+
+        sessions.TryGetReader(id, out var reader).Should().BeTrue();
+        var progresses = new List<double>();
+        while (reader.TryRead(out var frame))
+        {
+            using var document = JsonDocument.Parse(frame!);
+            var root = document.RootElement;
+            root.GetProperty("method").GetString().Should().Be("notifications/progress");
+            root.GetProperty("params").GetProperty("progressToken").GetString().Should().Be("job-1");
+            progresses.Add(root.GetProperty("params").GetProperty("progress").GetDouble());
+        }
+
+        var expectedProgress = new[] { 10d, 60d, 100d };
+        progresses.Should().Equal(expectedProgress,
+            "the bridge emits a frame on each observed progress change and a final terminal frame");
+        await jobService.Received(3).GetJobAsync("job-1", Principal, Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    public async Task PumpSessionStream_WritesQueuedFramesAsSseMessageEvents()
+    {
+        var channel = Channel.CreateUnbounded<string>();
+        channel.Writer.TryWrite("""{"method":"notifications/resources/list_changed"}""");
+        channel.Writer.Complete();
+
+        using var output = new MemoryStream();
+        await McpEndpointExtensions.PumpSessionStreamAsync(output, channel.Reader, CancellationToken.None);
+
+        var text = Encoding.UTF8.GetString(output.ToArray());
+        text.Should().Contain("event: message\n");
+        text.Should().Contain("""data: {"method":"notifications/resources/list_changed"}""");
+        text.Should().EndWith("\n\n", "each SSE event is terminated by a blank line");
+    }
+
+    [UnitTest]
+    public void NotificationModels_AreResolvableFromSourceGeneratedContext()
+    {
+        // AOT guard: the new wire types must be source-generated, not reflection
+        // fallback, since the MCP path serializes them with the slice context.
+        McpJsonContext.Default.McpJsonRpcNotification.Should().NotBeNull();
+        McpJsonContext.Default.McpProgressNotificationParams.Should().NotBeNull();
+    }
+
+    private static ExecutionJobRecord JobRecord(ExecutionJobStatus status, double percent, string phase) => new()
+    {
+        OperationId = "job-1",
+        Status = status,
+        CreatedAt = DateTimeOffset.UnixEpoch,
+        UpdatedAt = DateTimeOffset.UnixEpoch,
+        PercentComplete = percent,
+        CurrentPhase = phase,
+        Spec = new ExecutionJobSpec
+        {
+            TargetKind = default,
+            Backend = "test",
+            Kind = default,
+            WorkloadName = "workload"
+        }
+    };
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -44,7 +44,9 @@ public sealed partial class McpTaxonomyAlignmentTests
         "honua_solve_route",
         "honua_list_layers",
         "honua_query_features",
-        "honua_render_map"
+        "honua_render_map",
+        "honua_resolve_entity",
+        "honua_list_capabilities"
     };
 
     private static readonly string[] TaxonomyResourceUris =
@@ -214,6 +216,8 @@ public sealed partial class McpTaxonomyAlignmentTests
         "honua_list_layers",
         "honua_query_features",
         "honua_render_map",
+        "honua_resolve_entity",
+        "honua_list_capabilities",
     };
 
     /// <summary>
@@ -571,7 +575,11 @@ public sealed partial class McpTaxonomyAlignmentTests
             new Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool(
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool(
-                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool>.Instance)
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.Discovery.ResolveEntityTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.Discovery.ResolveEntityTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.Discovery.ListCapabilitiesTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.Discovery.ListCapabilitiesTool>.Instance)
         ];
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/OperationsToolset/Policy/ConfigurableOperationPolicyDecisionPointTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/OperationsToolset/Policy/ConfigurableOperationPolicyDecisionPointTests.cs
@@ -1,0 +1,313 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.Operations.Policy;
+using Honua.Core.Features.Operations.Services;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Tests.Features.OperationsToolset.Policy;
+
+/// <summary>
+/// Unit coverage for <see cref="ConfigurableOperationPolicyDecisionPoint"/>: the configurable
+/// guardrail policy decision point. Proves the default-permissive behavior, default-decision
+/// fallback, per-operation / tier / role rule matching, first-match-wins ordering, dry-run
+/// honouring, and an end-to-end <see cref="OperationDispatcher"/> integration showing a
+/// require-approval rule routes to the approval lane WITHOUT touching the executor.
+/// </summary>
+public sealed class ConfigurableOperationPolicyDecisionPointTests
+{
+    private const string PublishOperationId = "service.publish";
+
+    [UnitTest]
+    public async Task EvaluateAsync_When_Disabled_Returns_Allow()
+    {
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = false,
+            DefaultDecision = PolicyDecisionKind.Deny,
+            Rules = [new OperationPolicyRule { OperationId = "*", Decision = PolicyDecisionKind.Deny }]
+        });
+
+        var decision = await Evaluate(pdp);
+
+        decision.Kind.Should().Be(PolicyDecisionKind.Allow);
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_When_Enabled_With_No_Rules_Uses_DefaultDecision_Deny()
+    {
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = true,
+            DefaultDecision = PolicyDecisionKind.Deny,
+            DefaultReason = "deny by default"
+        });
+
+        var decision = await Evaluate(pdp);
+
+        decision.Kind.Should().Be(PolicyDecisionKind.Deny);
+        decision.Reason.Should().Be("deny by default");
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_With_PerOperation_Deny_Rule_Denies_That_Operation()
+    {
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = true,
+            DefaultDecision = PolicyDecisionKind.Allow,
+            Rules =
+            [
+                new OperationPolicyRule
+                {
+                    OperationId = PublishOperationId,
+                    Decision = PolicyDecisionKind.Deny,
+                    Reason = "publishing is locked"
+                }
+            ]
+        });
+
+        var decision = await Evaluate(pdp);
+
+        decision.Kind.Should().Be(PolicyDecisionKind.Deny);
+        decision.Reason.Should().Be("publishing is locked");
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_With_RequireApproval_Rule_Routes_ApprovalLane()
+    {
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = true,
+            Rules =
+            [
+                new OperationPolicyRule
+                {
+                    OperationId = PublishOperationId,
+                    Decision = PolicyDecisionKind.RequireApproval,
+                    Reason = "operator approval required",
+                    ApprovalLane = "studio-publish-requests"
+                }
+            ]
+        });
+
+        var decision = await Evaluate(pdp);
+
+        decision.Kind.Should().Be(PolicyDecisionKind.RequireApproval);
+        decision.ApprovalLane.Should().Be("studio-publish-requests");
+        decision.Reason.Should().Be("operator approval required");
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_Matches_On_Tier_And_Role()
+    {
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = true,
+            DefaultDecision = PolicyDecisionKind.Allow,
+            Rules =
+            [
+                new OperationPolicyRule
+                {
+                    OperationId = "*",
+                    Tier = "enterprise",
+                    Role = "viewer",
+                    Decision = PolicyDecisionKind.Deny,
+                    Reason = "viewers may not run operations"
+                }
+            ]
+        });
+
+        // Matches: enterprise tier + viewer role.
+        var denied = await Evaluate(pdp, new OperationPolicyContext
+        {
+            Tier = "Enterprise", // case-insensitive
+            Roles = ["operator", "viewer"]
+        });
+        denied.Kind.Should().Be(PolicyDecisionKind.Deny);
+
+        // Does not match (wrong tier) → falls back to default Allow.
+        var allowedWrongTier = await Evaluate(pdp, new OperationPolicyContext
+        {
+            Tier = "pro",
+            Roles = ["viewer"]
+        });
+        allowedWrongTier.Kind.Should().Be(PolicyDecisionKind.Allow);
+
+        // Does not match (missing role) → falls back to default Allow.
+        var allowedNoRole = await Evaluate(pdp, new OperationPolicyContext
+        {
+            Tier = "enterprise",
+            Roles = ["operator"]
+        });
+        allowedNoRole.Kind.Should().Be(PolicyDecisionKind.Allow);
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_Is_FirstMatchWins()
+    {
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = true,
+            Rules =
+            [
+                new OperationPolicyRule
+                {
+                    OperationId = PublishOperationId,
+                    Decision = PolicyDecisionKind.RequireApproval,
+                    Reason = "first rule wins"
+                },
+                new OperationPolicyRule
+                {
+                    OperationId = PublishOperationId,
+                    Decision = PolicyDecisionKind.Deny,
+                    Reason = "second rule (should be unreached)"
+                }
+            ]
+        });
+
+        var decision = await Evaluate(pdp);
+
+        decision.Kind.Should().Be(PolicyDecisionKind.RequireApproval);
+        decision.Reason.Should().Be("first rule wins");
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_DryRunFirst_With_DryRun_Request_Allows()
+    {
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = true,
+            Rules =
+            [
+                new OperationPolicyRule
+                {
+                    OperationId = PublishOperationId,
+                    Decision = PolicyDecisionKind.DryRunFirst,
+                    Reason = "preview required"
+                }
+            ]
+        });
+
+        // Without a dry-run the policy demands the preview first.
+        var demandsPreview = await Evaluate(pdp, request: BuildRequest(dryRun: false));
+        demandsPreview.Kind.Should().Be(PolicyDecisionKind.DryRunFirst);
+
+        // With the caller already requesting a dry-run, the precondition is met → Allow.
+        var previewSatisfied = await Evaluate(pdp, request: BuildRequest(dryRun: true));
+        previewSatisfied.Kind.Should().Be(PolicyDecisionKind.Allow);
+    }
+
+    [UnitTest]
+    public async Task Dispatcher_With_RequireApproval_Rule_ShortCircuits_Executor()
+    {
+        var executor = new RecordingExecutor();
+        var pdp = BuildPdp(new OperationPolicyOptions
+        {
+            Enabled = true,
+            Rules =
+            [
+                new OperationPolicyRule
+                {
+                    OperationId = PublishOperationId,
+                    Decision = PolicyDecisionKind.RequireApproval,
+                    Reason = "operator approval required",
+                    ApprovalLane = "studio-publish-requests"
+                }
+            ]
+        });
+
+        var dispatcher = new OperationDispatcher(
+            new OperationCatalog([new StubDescriptorProvider()], TimeProvider.System),
+            [executor],
+            pdp,
+            TimeProvider.System);
+
+        var handle = await dispatcher.SubmitAsync(BuildRequest(), new OperationPolicyContext(), CancellationToken.None);
+
+        handle.Status.Should().Be(OperationHandleStatus.RequiresApproval);
+        handle.ApprovalLane.Should().Be("studio-publish-requests");
+        handle.Result.Should().BeNull();
+
+        // Guardrail seam: the executor was never invoked.
+        executor.SubmitCount.Should().Be(0);
+    }
+
+    private static ConfigurableOperationPolicyDecisionPoint BuildPdp(OperationPolicyOptions options)
+        => new(Options.Create(options));
+
+    private static Task<PolicyDecision> Evaluate(
+        ConfigurableOperationPolicyDecisionPoint pdp,
+        OperationPolicyContext? context = null,
+        OperationRequest? request = null)
+        => pdp.EvaluateAsync(
+            BuildDescriptor(),
+            request ?? BuildRequest(),
+            context ?? new OperationPolicyContext(),
+            CancellationToken.None);
+
+    private static OperationRequest BuildRequest(bool dryRun = false)
+        => new() { OperationId = PublishOperationId, DryRun = dryRun };
+
+    private static OperationDescriptor BuildDescriptor()
+        => new()
+        {
+            OperationId = PublishOperationId,
+            ProviderId = "test",
+            Title = "Publish",
+            Description = "Publish a layer",
+            Category = "Publishing",
+            ExecutionKind = OperationExecutionKind.Synchronous,
+            ApprovalModel = OperationApprovalModel.OperatorGate,
+            Policy = new OperationPolicyMetadata
+            {
+                BlastRadiusClass = OperationBlastRadiusClass.ServiceScope,
+                SideEffectClass = OperationSideEffectClass.CreatesMetadata,
+                Determinism = OperationDeterminism.Deterministic,
+                SupportsDryRun = true
+            }
+        };
+
+    private sealed class StubDescriptorProvider : IOperationDescriptorProvider
+    {
+        public string ProviderId => "test";
+
+        public Task<IReadOnlyList<IOperationDescriptor>> ListDescriptorsAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<IOperationDescriptor>>([BuildDescriptor()]);
+    }
+
+    private sealed class RecordingExecutor : IOperationExecutor
+    {
+        public int SubmitCount { get; private set; }
+
+        public string OperationId => PublishOperationId;
+
+        public Task<OperationValidation> ValidateAsync(OperationRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new OperationValidation { IsValid = true, Status = "valid" });
+
+        public Task<OperationHandle> SubmitAsync(
+            OperationRequest request,
+            OperationPolicyContext context,
+            CancellationToken cancellationToken = default)
+        {
+            SubmitCount++;
+            return Task.FromResult(new OperationHandle
+            {
+                OperationId = OperationId,
+                HandleId = "handle",
+                Status = OperationHandleStatus.Completed
+            });
+        }
+
+        public Task<OperationStatus> GetStatusAsync(OperationHandle handle, CancellationToken cancellationToken = default)
+            => Task.FromResult(new OperationStatus
+            {
+                OperationId = OperationId,
+                HandleId = handle.HandleId,
+                Status = handle.Status
+            });
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1948
Related to #1954
Related to #1949
Related to #1952
Related to #1950

<!-- Each child issue still has cross-repo or live-demo acceptance criteria that
this server-only PR cannot fully satisfy, so they stay open under the epic. -->

## Summary

Lands the remaining **server-side** slices of the MCP redesign epic #1948. The
prior PR (#2301) delivered 2025-06-18 negotiation + output schemas, the
capability/grounding tool surface, discovery/query tools on `/mcp`, and the PDP
consultation on every `OperationDispatcher` submit. This PR closes the genuine
remaining gaps:

- **#1954 — sessions & streaming spine:** server-push notifications over the
  per-session SSE stream (`notifications/progress` threaded from running jobs to
  the owning `Mcp-Session-Id`, plus `tools/list_changed` + `resources/list_changed`
  emission). Progress adapts the canonical job runtime rather than forking it.
- **#1949 — the deferred `resolve_entity` + `list_capabilities` tools** as
  first-class MCP tools with input/output schemas, annotations, taxonomy roster
  entries, vendored conformance schemas + fixtures, and tests.
- **#1952 — configurable policy decision point** (the guardrails product surface)
  over the existing `IOperationPolicyDecisionPoint` seam; default stays permissive.
- **#1950 — transport-symmetric catalog:** `list_capabilities` projects the
  single in-process catalog the SDK stdio proxy consumes for parity (server-side).

## Changes Made

- **#1954 streaming:** `McpSessionManager` gains a per-session bounded
  notification `Channel<string>` (drop-oldest), a job->session map, and a
  lifetime token; `GET /mcp` drains the channel as SSE `message` frames
  (`PumpSessionStreamAsync`). New `McpNotificationPublisher` builds
  `notifications/progress` + `*/list_changed` JSON-RPC frames; new
  `McpJobProgressBridge` polls the canonical `IGeoprocessingJobService` and pushes
  progress to the owning session. `execute_plan` starts the bridge when in a
  session; `publish_service` broadcasts `list_changed` on a completed publish.
  `initialize` now advertises `tools.listChanged`/`resources.listChanged = true`.
- **#1949 tools:** new `Discovery/` slice — `ResolveEntityTool`
  (`honua_resolve_entity`, deterministic lexical grounding over the Metadata v2
  catalog -> ranked service/layer refs) and `ListCapabilitiesTool`
  (`honua_list_capabilities`, self-describing manifest of the live tool/resource
  surface + grounding resources). Added to DI, taxonomy + read-only rosters,
  conformance `ImplementedToolStandardNames`, with vendored
  `resolve_entity`/`list_capabilities` schemas + fixtures (`x-honua-extension`)
  and `index.json`/README updates.
- **#1952 policy:** `OperationPolicyOptions` + `ConfigurableOperationPolicyDecisionPoint`
  (first-match-wins rules by operationId/tier/role -> allow/deny/require-approval/
  dry-run-first), bound from `Operations:Policy`; `AddOperationsToolset` wires it
  when enabled, else keeps `AllowAllPolicyDecisionPoint`.
- **AOT:** new wire DTOs registered in source-generated `McpJsonContext` /
  `DiscoveryJsonContext`; resolver guard tests assert `GetTypeInfo` resolves.
- **Tests:** `McpStreamingTests`, `McpDiscoveryToolTests`,
  `ConfigurableOperationPolicyDecisionPointTests`; taxonomy + conformance rosters
  updated for the two new tools.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

<!-- No Docker available locally: the Docker-gated integration shards
(`[Collection("Database")]`, e.g. McpEndpointIntegrationTests) were NOT run here;
the merge-train batch CI validates them. Verified locally: full-solution Release
build with TreatWarningsAsErrors = 0/0; `dotnet format --verify-no-changes` clean;
59 affected MCP unit/conformance tests + 71 broader MCP unit tests + 8 policy
tests all green. The new tools/wire-DTOs are serialized via slice JSON contexts
explicitly (not the ASP.NET resolver), and the new SSE notifications use the same
path, so they do not touch AddHonuaJsonContexts. -->

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed

<!-- WIRE-CONTRACT ADDITIONS FOR REVIEW: two new MCP tools (honua_resolve_entity,
honua_list_capabilities) with input/output schemas; two new server-push
notification frames (notifications/progress, notifications/{tools,resources}/list_changed);
initialize now advertises listChanged=true. The two new tools are documented Honua
extensions over the bare geospatial-mcp taxonomy (vendored schemas marked
x-honua-extension); a sibling effort formalizes them in the geospatial-mcp
standard repo. New config surface: Operations:Policy. -->

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The policy default stays AllowAll; streaming is additive; new tools are
gated/registered without removing any existing surface.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
