### PR TITLE
feat: per-job GP resource profile + GP health-gating for serverless Batch (#2165)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -14487,6 +14487,8 @@
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ToolsCall_WithMalformedParams_ReturnsInvalidArgumentJsonRpcError",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ToolsCall_WithToolExecutionFailure_SurfacesIsErrorInsideResult",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ToolsList_DefaultComposition_AdvertisesGeocodeAndRouteTools",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ToolsList_WhenSinglePage_OmitsNextCursor",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ToolsList_WithInvalidCursor_ReturnsInvalidParamsJsonRpcError",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.UnknownMethod_ReturnsMethodNotFoundJsonRpcError",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.UnknownNotification_AcceptedSilentlyWithoutBody",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.UnknownNotification_WithId_IsRejectedAsInvalidRequest"

--- a/docs/operator/geoprocessing-aws-batch.md
+++ b/docs/operator/geoprocessing-aws-batch.md
@@ -53,15 +53,48 @@ The four tiers differ only by ephemeral (scratch) storage:
 `s` = 20 GiB, `m` = 50 GiB, `l` = 100 GiB, `xl` = 200 GiB. vCPU / memory /
 timeout / retry stay per-submit overrides and are unaffected by tier selection.
 
-> **Tier selection (dependency).** The runtime tier selector that maps
-> `batch.ephemeral_gib` to the right `batch.job_definition_arn.{tier}` lands with
-> [#2181 / `feat/gp-batch-tier-selection`](https://github.com/honua-io/honua-server/pull/2181).
-> Until that PR merges, the backend honors only the **single**
-> `batch.job_definition_arn` key. You can wire AWS Batch today by setting that
-> single key (point it at one job definition); the per-tier keys begin selecting
-> automatically once #2181 is on `trunk`. The parameter-key contract
+> **Tier selection.** The runtime tier selector that maps `batch.ephemeral_gib`
+> to the right `batch.job_definition_arn.{tier}` is on `trunk` (#2181). When no
+> per-tier keys are configured the backend honors the **single**
+> `batch.job_definition_arn` key for back-compat. The parameter-key contract
 > (`batch.job_queue_arn`, `batch.region`, `batch.job_definition_arn`,
 > `batch.job_definition_arn.{s,m,l,xl}`) is identical on both sides.
+
+## Per-job resource sizing (#2165)
+
+Per-job sizing is **runtime and instant** — no terraform, no agent in the job
+path. Each GP job carries a resource profile that is mapped onto the
+`batch.*` submit parameters the backend reads:
+
+| Profile dimension | Spec param the backend reads | Effect |
+|---|---|---|
+| vCPU | `batch.vcpus` | `SubmitJob` resource override |
+| Memory (MiB) | `batch.memory_mib` | `SubmitJob` resource override |
+| GPU count | `batch.gpu_count` | `SubmitJob` resource override |
+| Attempt timeout (s) | `batch.timeout_seconds` | `SubmitJob` timeout override |
+| Retry attempts | `batch.retry_attempts` | `SubmitJob` retry override |
+| Ephemeral (GiB) | `batch.ephemeral_gib` | selects the job-definition **tier** |
+| CPU architecture | `batch.arch` | reserved for the iac arch/image tier set |
+
+The effective profile is the **heaviest catalog-derived default** across the
+plan's steps (raster/surface → largest tier, native GDAL → mid tier, ordinary
+managed → smallest tier), then overridden field-by-field by any explicit
+per-job request values supplied under the `gp.resource.*` keys (for example
+`gp.resource.vcpus`, `gp.resource.memory_mib`, `gp.resource.ephemeral_gib`,
+`gp.resource.arch`). Precedence is: explicit request &gt; per-job derived
+profile &gt; workload baseline. The local/Kubernetes baseline does **not**
+carry these keys (they are meaningless off AWS Batch), preserving the GP Devkit
+local-runner spec parity.
+
+## Health-gating a GP substrate deploy
+
+When the durable GP substrate (compute-env / queue / IAM / ECR / job-def tier
+set) is deployed via GitOps, gate it with the **`gp-batch`** deploy telemetry
+policy preset. GP per-job metrics are burstier than steady HTTP traffic, so the
+preset bakes longer (5 min) and the anti-flap gate defaults to requiring
+several consecutive breaching scrapes (rather than one) before an automatic
+rollback fires — set `telemetry.policy=gp-batch` on the deploy operation. An
+explicit `telemetry.rollback.consecutive_breaches` still overrides the default.
 
 ### appsettings override
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobService.cs
@@ -295,7 +295,12 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         var requiredRuntimeProfile = isCustomCode
             ? CustomCodeJobContract.RuntimeProfile
             : ResolveRequiredRuntimeProfile(plan);
-        var spec = BuildSpec(plan, specParams, workload, requiredRuntimeProfile);
+        // Per-job serverless sizing (#2165): the heaviest catalog-derived resource profile across
+        // the plan's steps, overridden by any explicit gp.resource.* request values. Projected onto
+        // the spec's batch.* params so AwsBatchComputeBackend.SubmitJob sizes vCPU/memory/timeout/
+        // retry/GPU and selects the ephemeral job-def tier per job. Instant and terraform-free.
+        var resourceProfile = ResolveResourceProfile(plan, specParams, isCustomCode);
+        var spec = BuildSpec(plan, specParams, workload, requiredRuntimeProfile, resourceProfile);
 
         var jobRecord = new ExecutionJobRecord
         {
@@ -540,24 +545,66 @@ internal sealed class GeoprocessingJobService : IGeoprocessingJobService
         return ManagedReprojectFastPath.RequiresNativeWorker(fromSrid, toSrid);
     }
 
+    /// <summary>
+    /// Resolves the effective per-job <see cref="GpResourceProfile"/>: the heaviest catalog-derived
+    /// default across the plan's steps, overridden field-by-field by any explicit
+    /// <c>gp.resource.*</c> request values. Custom-code jobs are param-driven (no catalog process),
+    /// so they take only the explicit request values.
+    /// </summary>
+    private GpResourceProfile ResolveResourceProfile(
+        AnalysisPlan plan,
+        IReadOnlyDictionary<string, string> specParams,
+        bool isCustomCode)
+    {
+        var derived = GpResourceProfile.Empty;
+        if (!isCustomCode)
+        {
+            foreach (var step in plan.Steps)
+            {
+                if (string.IsNullOrWhiteSpace(step.ProcessId))
+                {
+                    continue;
+                }
+
+                var definition = _processCatalog.GetProcess(step.ProcessId);
+                if (definition == null)
+                {
+                    continue;
+                }
+
+                derived = derived.MergeMax(GpResourceProfile.ForProcess(definition));
+            }
+        }
+
+        return derived.OverrideWith(GpResourceProfile.FromRequestParameters(specParams));
+    }
+
     private static ExecutionJobSpec BuildSpec(
         AnalysisPlan plan,
         Dictionary<string, string> specParams,
         ExecutionJobDefinition? workload,
-        string? requiredRuntimeProfile)
+        string? requiredRuntimeProfile,
+        GpResourceProfile resourceProfile)
     {
         if (workload == null)
         {
             // The no-registered-workload case (the default) is built through the shared
             // spec builder so the durable spec — parameter bag AND envelope — is
             // identical to the one the GP Devkit local runner produces for the same
-            // plan (issue #2180).
+            // plan (issue #2180). The per-job resource profile is NOT projected here: the
+            // batch.* sizing keys are meaningless to the local/Kubernetes baseline and would
+            // break the local-runner spec-parity invariant.
             return GeoprocessingSpecBuilder.BuildNoWorkloadSpec(plan, specParams, requiredRuntimeProfile);
         }
 
         // Project the plan's id / process-definitions / output kinds / step inputs onto
         // the workload-supplied parameter bag through the same shared projection.
         GeoprocessingSpecBuilder.ProjectPlanParameters(plan, specParams);
+
+        // Project the per-job resource profile onto the batch.* params BEFORE merging the workload
+        // defaults: set-if-absent semantics make explicit request params win over the per-job
+        // profile, and the per-job profile win over the workload's baseline sizing.
+        resourceProfile.ProjectOnto(specParams);
 
         foreach (var kv in workload.Parameters)
         {

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GpResourceProfile.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GpResourceProfile.cs
@@ -1,0 +1,296 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Geoprocessing;
+
+/// <summary>
+/// Typed, per-job geoprocessing resource profile — vCPU, memory, GPU, timeout, retry,
+/// ephemeral (scratch) storage, and CPU architecture — that the GP job spec carries so the
+/// canonical job runtime can size a serverless backend (AWS Batch today) PER JOB.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the server leg of the corrected serverless-GP design (honua-server#2165): per-job
+/// sizing is RUNTIME and instant. The profile maps onto the durable
+/// <see cref="ExecutionJobSpec.Parameters"/> bag under the <c>batch.*</c> contract keys that
+/// <c>AwsBatchComputeBackend.StartAsync</c> already consumes — vCPU / memory / timeout / retry /
+/// GPU become <c>SubmitJob</c> overrides, and the ephemeral need selects a job-definition TIER
+/// from the pre-registered honua-iac pool (honua-iac#70). There is no per-job terraform and no
+/// devops-agent call in the job path.
+/// </para>
+/// <para>
+/// The effective profile is the heaviest catalog-derived default across a plan's steps
+/// (<see cref="ForProcess"/> + <see cref="MergeMax"/>), then overridden field-by-field by any
+/// explicit per-job request values (<see cref="FromRequestParameters"/> +
+/// <see cref="OverrideWith"/>). Defaults are deliberately conservative HEURISTICS, mirroring the
+/// honest tone of <see cref="GpSizeEstimator"/> — an operator can always pin exact values with the
+/// <c>gp.resource.*</c> request keys.
+/// </para>
+/// <para>
+/// The <c>batch.*</c> keys are written as literal contract strings so this type takes no hard
+/// dependency on the optionally-excluded <c>Honua.Aws</c> assembly, mirroring the
+/// <c>ExecutionWorkloadGate</c> pattern.
+/// </para>
+/// </remarks>
+internal sealed record GpResourceProfile
+{
+    /// <summary>An empty profile that contributes no sizing (the no-hint baseline).</summary>
+    public static readonly GpResourceProfile Empty = new();
+
+    /// <summary>Requested vCPU count, or <see langword="null"/> to leave the backend/job-def default.</summary>
+    public int? Vcpus { get; init; }
+
+    /// <summary>Requested memory in MiB, or <see langword="null"/> for the backend/job-def default.</summary>
+    public int? MemoryMib { get; init; }
+
+    /// <summary>Requested GPU count, or <see langword="null"/>/0 for a CPU-only job.</summary>
+    public int? GpuCount { get; init; }
+
+    /// <summary>Per-job attempt timeout in seconds, or <see langword="null"/> for the default.</summary>
+    public int? TimeoutSeconds { get; init; }
+
+    /// <summary>Per-job retry attempts, or <see langword="null"/> for the default.</summary>
+    public int? RetryAttempts { get; init; }
+
+    /// <summary>
+    /// Ephemeral (scratch) storage need in GiB. This is the one knob <c>SubmitJob</c> cannot
+    /// override, so it selects a job-definition tier from the honua-iac pool rather than an override.
+    /// </summary>
+    public int? EphemeralGib { get; init; }
+
+    /// <summary>
+    /// CPU architecture hint (for example <c>x86_64</c> or <c>arm64</c>). Architecture is a
+    /// job-definition/image property, not a <c>SubmitJob</c> override, so it is carried for the
+    /// substrate's arch/image tier contract; the current backend selects tiers by ephemeral need
+    /// only and ignores it until the iac pool exposes arch variants.
+    /// </summary>
+    public string? Arch { get; init; }
+
+    /// <summary>True when the profile carries no sizing values at all.</summary>
+    public bool IsEmpty =>
+        Vcpus is null
+        && MemoryMib is null
+        && GpuCount is null
+        && TimeoutSeconds is null
+        && RetryAttempts is null
+        && EphemeralGib is null
+        && string.IsNullOrWhiteSpace(Arch);
+
+    // Per-job request keys — the GP-job-facing contract the submitter/AI sets. Decoupled from the
+    // AWS-Batch param keys so the same profile can target other serverless backends later.
+    internal const string VcpusRequestKey = "gp.resource.vcpus";
+    internal const string MemoryMibRequestKey = "gp.resource.memory_mib";
+    internal const string GpuCountRequestKey = "gp.resource.gpu_count";
+    internal const string TimeoutSecondsRequestKey = "gp.resource.timeout_seconds";
+    internal const string RetryAttemptsRequestKey = "gp.resource.retry_attempts";
+    internal const string EphemeralGibRequestKey = "gp.resource.ephemeral_gib";
+    internal const string ArchRequestKey = "gp.resource.arch";
+
+    // AWS Batch parameter contract keys (literal — see remarks). These mirror AwsBatchParameterKeys
+    // in the Honua.Aws assembly, which the backend reads back.
+    internal const string BatchVcpusKey = "batch.vcpus";
+    internal const string BatchMemoryMibKey = "batch.memory_mib";
+    internal const string BatchGpuCountKey = "batch.gpu_count";
+    internal const string BatchTimeoutSecondsKey = "batch.timeout_seconds";
+    internal const string BatchRetryAttemptsKey = "batch.retry_attempts";
+    internal const string BatchEphemeralGibKey = "batch.ephemeral_gib";
+    internal const string BatchArchKey = "batch.arch";
+
+    // Conservative per-class default tiers (heuristic). Ephemeral GiB values line up with the
+    // honua-iac job-definition pool ceilings (s=20, m=50, l=100).
+    private const int ManagedVcpus = 1;
+    private const int ManagedMemoryMib = 2048;
+    private const int ManagedEphemeralGib = 20;
+
+    private const int NativeVcpus = 2;
+    private const int NativeMemoryMib = 4096;
+    private const int NativeEphemeralGib = 50;
+
+    private const int RasterVcpus = 4;
+    private const int RasterMemoryMib = 8192;
+    private const int RasterEphemeralGib = 100;
+    private const int RasterTimeoutSeconds = 3600;
+
+    /// <summary>
+    /// Derives the conservative default profile for a single catalog process from its class:
+    /// raster/surface processes (heavier, potentially long-running) get the largest default tier,
+    /// native (out-of-process GDAL) processes a mid tier, and ordinary managed processes the
+    /// smallest tier. Pure data-driven defaults; explicit request values always win via
+    /// <see cref="OverrideWith"/>.
+    /// </summary>
+    public static GpResourceProfile ForProcess(ProcessDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        if (GpSizeEstimator.IsRasterClass(definition))
+        {
+            return new GpResourceProfile
+            {
+                Vcpus = RasterVcpus,
+                MemoryMib = RasterMemoryMib,
+                EphemeralGib = RasterEphemeralGib,
+                TimeoutSeconds = RasterTimeoutSeconds,
+            };
+        }
+
+        var profile = RuntimeProfiles.Normalize(definition.RuntimeProfile);
+        if (string.Equals(profile, RuntimeProfiles.Native, StringComparison.Ordinal))
+        {
+            return new GpResourceProfile
+            {
+                Vcpus = NativeVcpus,
+                MemoryMib = NativeMemoryMib,
+                EphemeralGib = NativeEphemeralGib,
+            };
+        }
+
+        return new GpResourceProfile
+        {
+            Vcpus = ManagedVcpus,
+            MemoryMib = ManagedMemoryMib,
+            EphemeralGib = ManagedEphemeralGib,
+        };
+    }
+
+    /// <summary>
+    /// Reads an explicit per-job profile from the <c>gp.resource.*</c> request parameters. Absent,
+    /// blank, non-numeric, or non-positive numeric values are ignored (leaving the field unset).
+    /// </summary>
+    public static GpResourceProfile FromRequestParameters(IReadOnlyDictionary<string, string> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        return new GpResourceProfile
+        {
+            Vcpus = ReadPositiveInt(parameters, VcpusRequestKey),
+            MemoryMib = ReadPositiveInt(parameters, MemoryMibRequestKey),
+            GpuCount = ReadNonNegativeInt(parameters, GpuCountRequestKey),
+            TimeoutSeconds = ReadPositiveInt(parameters, TimeoutSecondsRequestKey),
+            RetryAttempts = ReadPositiveInt(parameters, RetryAttemptsRequestKey),
+            EphemeralGib = ReadPositiveInt(parameters, EphemeralGibRequestKey),
+            Arch = ReadString(parameters, ArchRequestKey),
+        };
+    }
+
+    /// <summary>
+    /// Aggregates two catalog-derived profiles by taking the heavier value of each dimension, so a
+    /// single heavy step in a multi-step plan sizes the whole job. Architecture takes the
+    /// other profile's value when set (the later step in the fold).
+    /// </summary>
+    public GpResourceProfile MergeMax(GpResourceProfile other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        return new GpResourceProfile
+        {
+            Vcpus = Max(Vcpus, other.Vcpus),
+            MemoryMib = Max(MemoryMib, other.MemoryMib),
+            GpuCount = Max(GpuCount, other.GpuCount),
+            TimeoutSeconds = Max(TimeoutSeconds, other.TimeoutSeconds),
+            RetryAttempts = Max(RetryAttempts, other.RetryAttempts),
+            EphemeralGib = Max(EphemeralGib, other.EphemeralGib),
+            Arch = !string.IsNullOrWhiteSpace(other.Arch) ? other.Arch : Arch,
+        };
+    }
+
+    /// <summary>
+    /// Overlays <paramref name="overrides"/> field-by-field: any value set on the override wins,
+    /// otherwise the current value is kept. Used to let an explicit per-job request profile win over
+    /// the catalog-derived defaults.
+    /// </summary>
+    public GpResourceProfile OverrideWith(GpResourceProfile overrides)
+    {
+        ArgumentNullException.ThrowIfNull(overrides);
+
+        return new GpResourceProfile
+        {
+            Vcpus = overrides.Vcpus ?? Vcpus,
+            MemoryMib = overrides.MemoryMib ?? MemoryMib,
+            GpuCount = overrides.GpuCount ?? GpuCount,
+            TimeoutSeconds = overrides.TimeoutSeconds ?? TimeoutSeconds,
+            RetryAttempts = overrides.RetryAttempts ?? RetryAttempts,
+            EphemeralGib = overrides.EphemeralGib ?? EphemeralGib,
+            Arch = !string.IsNullOrWhiteSpace(overrides.Arch) ? overrides.Arch : Arch,
+        };
+    }
+
+    /// <summary>
+    /// Projects the set fields onto the durable spec parameter bag under the <c>batch.*</c> contract
+    /// keys the AWS Batch backend reads. Uses set-if-absent semantics so an explicit raw
+    /// <c>batch.*</c> value already on the bag (or a workload default merged earlier) is never
+    /// clobbered; callers project the per-job profile BEFORE merging workload defaults so per-job
+    /// sizing wins over the workload baseline.
+    /// </summary>
+    public void ProjectOnto(IDictionary<string, string> specParams)
+    {
+        ArgumentNullException.ThrowIfNull(specParams);
+
+        Set(specParams, BatchVcpusKey, Vcpus);
+        Set(specParams, BatchMemoryMibKey, MemoryMib);
+        Set(specParams, BatchGpuCountKey, GpuCount);
+        Set(specParams, BatchTimeoutSecondsKey, TimeoutSeconds);
+        Set(specParams, BatchRetryAttemptsKey, RetryAttempts);
+        Set(specParams, BatchEphemeralGibKey, EphemeralGib);
+
+        if (!string.IsNullOrWhiteSpace(Arch))
+        {
+            specParams.TryAdd(BatchArchKey, Arch);
+        }
+    }
+
+    private static void Set(IDictionary<string, string> specParams, string key, int? value)
+    {
+        if (value.HasValue)
+        {
+            specParams.TryAdd(key, value.Value.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+    private static int? Max(int? a, int? b)
+    {
+        if (a is null)
+        {
+            return b;
+        }
+
+        if (b is null)
+        {
+            return a;
+        }
+
+        return Math.Max(a.Value, b.Value);
+    }
+
+    private static int? ReadPositiveInt(IReadOnlyDictionary<string, string> parameters, string key)
+    {
+        var value = ReadInt(parameters, key);
+        return value is > 0 ? value : null;
+    }
+
+    private static int? ReadNonNegativeInt(IReadOnlyDictionary<string, string> parameters, string key)
+    {
+        var value = ReadInt(parameters, key);
+        return value is >= 0 ? value : null;
+    }
+
+    private static int? ReadInt(IReadOnlyDictionary<string, string> parameters, string key)
+    {
+        if (parameters.TryGetValue(key, out var raw)
+            && !string.IsNullOrWhiteSpace(raw)
+            && int.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, string> parameters, string key)
+        => parameters.TryGetValue(key, out var raw) && !string.IsNullOrWhiteSpace(raw)
+            ? raw.Trim()
+            : null;
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GpSizeEstimator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GpSizeEstimator.cs
@@ -100,7 +100,13 @@ internal static class GpSizeEstimator
     // stats document) is on the order of a few hundred bytes.
     private const long ScalarOutputBytes = 512;
 
-    private static bool IsRasterClass(ProcessDefinition definition)
+    /// <summary>
+    /// True when <paramref name="definition"/> is a raster/surface-class process — heavier and
+    /// potentially long-running, so both the size estimate and the serverless
+    /// <see cref="GpResourceProfile"/> default treat it as the largest tier. Shared so the size
+    /// heuristic and the resource-profile derivation classify a process identically.
+    /// </summary>
+    internal static bool IsRasterClass(ProcessDefinition definition)
     {
         if (definition.OutputArtifactKinds.Contains(ArtifactKind.Raster))
         {

--- a/src/Honua.Server/Features/ControlPlane/DeployTelemetryPolicy.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployTelemetryPolicy.cs
@@ -22,6 +22,15 @@ internal sealed record DeployTelemetryPolicy
     private const string DefaultPrometheusJob = "honua";
     private const string DefaultCanaryPrometheusJob = "honua-canary";
 
+    /// <summary>
+    /// Telemetry-policy preset name for a serverless geoprocessing (AWS Batch) substrate deploy
+    /// (honua-server#2165). GP per-job metrics are burstier and sparser than steady HTTP traffic, so
+    /// this preset bakes longer and tolerates a lower sample floor, and pairs with the GP-aware
+    /// anti-flap default in <see cref="DeployTelemetrySignalEvaluator"/> so a single noisy scrape
+    /// does not trigger a production rollback.
+    /// </summary>
+    public const string GpBatchPolicyName = "gp-batch";
+
     public required string ConnectionId { get; init; }
 
     public string? ErrorRateQuery { get; init; }
@@ -186,6 +195,7 @@ internal sealed record DeployTelemetryPolicy
         return policyName.ToLowerInvariant() switch
         {
             "honua-http" or "kubernetes-honua-http" => CreateHonuaHttpPreset(parameters),
+            GpBatchPolicyName or "serverless-gp" => CreateGpBatchPreset(parameters),
             "aws-alb-canary" => CreateAwsAlbCanaryPreset(parameters),
             "aws-lambda-canary" => CreateAwsLambdaCanaryPreset(parameters),
             "azure-aca-canary" => CreateAzureAcaCanaryPreset(parameters),
@@ -238,6 +248,21 @@ internal sealed record DeployTelemetryPolicy
         return string.IsNullOrWhiteSpace(selector)
             ? InvalidPreset("Deploy telemetry policy 'kubernetes-honua-http' requires a Prometheus selector or job.")
             : CreateHonuaHttpPolicy(selector, warmupDuration: TimeSpan.FromMinutes(2));
+    }
+
+    private static DeployTelemetryPolicy CreateGpBatchPreset(IReadOnlyDictionary<string, string> parameters)
+    {
+        var selector = BuildPrometheusSelector(
+            parameters,
+            selectorKey: "telemetry.prometheus.selector",
+            jobKey: "telemetry.prometheus.job",
+            defaultJob: DefaultPrometheusJob);
+
+        // Longer bake (5m) and a low sample floor (10) suit GP's sparse/bursty per-job metrics;
+        // operators typically override the synthesized PromQL with GP-specific queries.
+        return string.IsNullOrWhiteSpace(selector)
+            ? InvalidPreset($"Deploy telemetry policy '{GpBatchPolicyName}' requires a Prometheus selector or job.")
+            : CreateHonuaHttpPolicy(selector, warmupDuration: TimeSpan.FromMinutes(5), minimumSampleCount: 10);
     }
 
     private static DeployTelemetryPolicy CreateAwsAlbCanaryPreset(IReadOnlyDictionary<string, string> parameters)

--- a/src/Honua.Server/Features/ControlPlane/DeployTelemetrySignalEvaluator.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployTelemetrySignalEvaluator.cs
@@ -397,12 +397,32 @@ internal sealed class DeployTelemetrySignalEvaluator(
         };
     }
 
+    /// <summary>
+    /// GP-aware anti-flap default. A serverless geoprocessing (AWS Batch) substrate deploy
+    /// (<c>telemetry.policy = gp-batch</c>) carries burstier per-job metrics, so when the operator
+    /// has not pinned an explicit consecutive-breach threshold it defaults to requiring several
+    /// breaching scrapes rather than the single-scrape default, so one noisy GP burst does not
+    /// trigger a production rollback (honua-server#2165, building on the #2161 anti-flap gate).
+    /// </summary>
+    internal const int GpBatchDefaultBreachDebounceThreshold = 3;
+
     private static int ResolveBreachDebounceThreshold(DeployOperationSpec spec)
-        => spec.Parameters.TryGetValue(BreachDebounceThresholdParameterKey, out var raw) &&
+    {
+        if (spec.Parameters.TryGetValue(BreachDebounceThresholdParameterKey, out var raw) &&
             int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) &&
-            parsed > 0
-                ? parsed
-                : 1;
+            parsed > 0)
+        {
+            return parsed;
+        }
+
+        // No explicit threshold: GP substrate deploys default to the burst-tolerant streak.
+        return IsGpBatchDeploy(spec) ? GpBatchDefaultBreachDebounceThreshold : 1;
+    }
+
+    private static bool IsGpBatchDeploy(DeployOperationSpec spec)
+        => spec.Parameters.TryGetValue("telemetry.policy", out var policyName)
+            && (string.Equals(policyName?.Trim(), DeployTelemetryPolicy.GpBatchPolicyName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(policyName?.Trim(), "serverless-gp", StringComparison.OrdinalIgnoreCase));
 
     private static int ResolveBreachStreak(DeployOperationSpec spec)
         => spec.Parameters.TryGetValue(BreachStreakParameterKey, out var raw) &&

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GeoprocessingJobServiceTests.cs
@@ -631,6 +631,109 @@ public sealed class GeoprocessingJobServiceTests
     [UnitTest]
     [Operation(Operations.Create)]
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_WithBatchWorkload_CarriesPerJobResourceProfileSizing()
+    {
+        // The per-job resource profile derived from the plan's process (geometry.buffer is
+        // managed → smallest tier) must be projected onto the spec's batch.* params so
+        // AwsBatchComputeBackend sizes SubmitJob and selects the ephemeral tier per job.
+        var sut = BuildBatchWorkloadService(out _);
+
+        var job = await sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal());
+
+        job.Spec.Parameters.Should().ContainKey("batch.vcpus").WhoseValue.Should().Be("1");
+        job.Spec.Parameters.Should().ContainKey("batch.memory_mib").WhoseValue.Should().Be("2048");
+        job.Spec.Parameters.Should().ContainKey("batch.ephemeral_gib").WhoseValue.Should().Be("20");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_WithExplicitResourceRequest_OverridesDerivedProfile()
+    {
+        // An explicit gp.resource.* request wins over the catalog-derived default.
+        var sut = BuildBatchWorkloadService(out _);
+
+        var job = await sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal(), new Dictionary<string, string>
+        {
+            ["gp.resource.vcpus"] = "8",
+            ["gp.resource.ephemeral_gib"] = "150",
+        });
+
+        job.Spec.Parameters.Should().ContainKey("batch.vcpus").WhoseValue.Should().Be("8");
+        job.Spec.Parameters.Should().ContainKey("batch.ephemeral_gib").WhoseValue.Should().Be("150");
+        // Unspecified dimensions still come from the derived default.
+        job.Spec.Parameters.Should().ContainKey("batch.memory_mib").WhoseValue.Should().Be("2048");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_WithLocalDefault_DoesNotCarryBatchSizingParams()
+    {
+        // The no-remote-workload local baseline must NOT carry batch.* sizing — the keys are
+        // meaningless to the local/Kubernetes backend and would break local-runner spec parity.
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var job = await _sut.SubmitJobAsync(CreateValidPlan(), null, CreatePrincipal());
+
+        job.Spec.Parameters.Should().NotContainKey("batch.vcpus");
+        job.Spec.Parameters.Should().NotContainKey("batch.ephemeral_gib");
+    }
+
+    private GeoprocessingJobService BuildBatchWorkloadService(out IBatchComputeBackend backend)
+    {
+        var workloadRegistry = Substitute.For<IExecutionJobDefinitionRegistry>();
+        backend = Substitute.For<IBatchComputeBackend>();
+        backend.BackendName.Returns("honua-aws-batch");
+        backend.TargetKind.Returns(BatchComputeTargetKind.AwsBatch);
+        workloadRegistry.ListAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new ExecutionJobDefinition
+            {
+                WorkloadId = "geoprocessing-aws-batch",
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = "honua-aws-batch",
+                WorkloadName = "Geoprocessing (AWS Batch)",
+                Parameters = new Dictionary<string, string>
+                {
+                    ["batch.job_queue_arn"] = "arn:aws:batch:us-east-1:123:job-queue/honua-gp",
+                    ["batch.region"] = "us-east-1",
+                    ["batch.job_definition_arn.s"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-s:1",
+                    ["batch.job_definition_arn.m"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-m:1",
+                    ["batch.job_definition_arn.l"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-l:1",
+                    ["batch.job_definition_arn.xl"] = "arn:aws:batch:us-east-1:123:job-definition/honua-gp-xl:1",
+                },
+            },
+        });
+        backend.StartAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<CancellationToken>())
+            .Returns(new BatchComputeSubmissionResult
+            {
+                Status = ExecutionJobStatus.Provisioning,
+                ProviderOperationId = "job-batch-profile",
+                Message = "Submitted to AWS Batch",
+            });
+        _jobStore.TryCreateAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        return new GeoprocessingJobService(
+            _progressStore,
+            [_cancellationNotifier],
+            _authEvaluator,
+            _approvalEvaluator,
+            new BuiltInProcessCatalog(),
+            NullLogger<GeoprocessingJobService>.Instance,
+            DefaultExecutorOptions,
+            _jobStore,
+            _jobQueue,
+            workloadRegistry: workloadRegistry,
+            backends: [backend]);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJob_WithOnlyLocalWorkload_FallsBackToLocalBackend()
     {
         // Without an activated remote workload (the AWS Batch row gated off / absent),

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GpResourceProfileTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/GpResourceProfileTests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Geoprocessing;
+
+/// <summary>
+/// Unit coverage for the per-job <see cref="GpResourceProfile"/> (honua-server#2165): the typed
+/// vCPU/memory/GPU/timeout/retry/ephemeral/arch profile the GP job spec carries and the mapping
+/// onto the <c>batch.*</c> contract keys that <c>AwsBatchComputeBackend</c> consumes for SubmitJob
+/// overrides and ephemeral job-definition tier selection. Fully offline — no AWS, no Redis.
+/// </summary>
+public sealed class GpResourceProfileTests
+{
+    private static ProcessDefinition Process(
+        string processId,
+        string category,
+        string runtimeProfile = RuntimeProfilesManaged,
+        params ArtifactKind[] outputs)
+        => new()
+        {
+            ProcessId = processId,
+            Title = processId,
+            Description = processId,
+            Category = category,
+            Parameters = [],
+            OutputArtifactKinds = outputs.Length > 0 ? outputs : [ArtifactKind.File],
+            RuntimeProfile = runtimeProfile,
+        };
+
+    private const string RuntimeProfilesManaged = "managed";
+    private const string RuntimeProfilesNative = "native";
+
+    [UnitTest]
+    public void ForProcess_ManagedFeatureProcess_UsesSmallestTier()
+    {
+        var profile = GpResourceProfile.ForProcess(
+            Process("geometry.buffer", "geometry", outputs: ArtifactKind.FeatureLayer));
+
+        profile.Vcpus.Should().Be(1);
+        profile.MemoryMib.Should().Be(2048);
+        profile.EphemeralGib.Should().Be(20);
+        profile.GpuCount.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void ForProcess_NativeProcess_UsesMidTier()
+    {
+        var profile = GpResourceProfile.ForProcess(
+            Process("gdal.gdalwarp", "conversion", RuntimeProfilesNative, ArtifactKind.File));
+
+        profile.Vcpus.Should().Be(2);
+        profile.MemoryMib.Should().Be(4096);
+        profile.EphemeralGib.Should().Be(50);
+    }
+
+    [UnitTest]
+    public void ForProcess_RasterClassProcess_UsesLargestTierWithTimeout()
+    {
+        var profile = GpResourceProfile.ForProcess(
+            Process("surface.hillshade", "surface", RuntimeProfilesNative, ArtifactKind.Raster));
+
+        profile.Vcpus.Should().Be(4);
+        profile.MemoryMib.Should().Be(8192);
+        profile.EphemeralGib.Should().Be(100);
+        profile.TimeoutSeconds.Should().Be(3600);
+    }
+
+    [UnitTest]
+    public void FromRequestParameters_ReadsExplicitValuesAndIgnoresNonPositive()
+    {
+        var profile = GpResourceProfile.FromRequestParameters(new Dictionary<string, string>
+        {
+            ["gp.resource.vcpus"] = "8",
+            ["gp.resource.memory_mib"] = "16384",
+            ["gp.resource.gpu_count"] = "1",
+            ["gp.resource.timeout_seconds"] = "7200",
+            ["gp.resource.retry_attempts"] = "2",
+            ["gp.resource.ephemeral_gib"] = "150",
+            ["gp.resource.arch"] = "arm64",
+            ["unrelated"] = "x",
+        });
+
+        profile.Vcpus.Should().Be(8);
+        profile.MemoryMib.Should().Be(16384);
+        profile.GpuCount.Should().Be(1);
+        profile.TimeoutSeconds.Should().Be(7200);
+        profile.RetryAttempts.Should().Be(2);
+        profile.EphemeralGib.Should().Be(150);
+        profile.Arch.Should().Be("arm64");
+    }
+
+    [UnitTest]
+    public void FromRequestParameters_IgnoresBlankAndUnparseable()
+    {
+        var profile = GpResourceProfile.FromRequestParameters(new Dictionary<string, string>
+        {
+            ["gp.resource.vcpus"] = "",
+            ["gp.resource.memory_mib"] = "lots",
+            ["gp.resource.ephemeral_gib"] = "0",
+        });
+
+        profile.IsEmpty.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void FromRequestParameters_AllowsZeroGpuCount()
+    {
+        var profile = GpResourceProfile.FromRequestParameters(new Dictionary<string, string>
+        {
+            ["gp.resource.gpu_count"] = "0",
+        });
+
+        profile.GpuCount.Should().Be(0);
+    }
+
+    [UnitTest]
+    public void MergeMax_TakesHeavierValueOfEachDimension()
+    {
+        var light = GpResourceProfile.ForProcess(
+            Process("geometry.buffer", "geometry", outputs: ArtifactKind.FeatureLayer));
+        var heavy = GpResourceProfile.ForProcess(
+            Process("surface.hillshade", "surface", RuntimeProfilesNative, ArtifactKind.Raster));
+
+        var merged = light.MergeMax(heavy);
+
+        merged.Vcpus.Should().Be(4);
+        merged.MemoryMib.Should().Be(8192);
+        merged.EphemeralGib.Should().Be(100);
+        merged.TimeoutSeconds.Should().Be(3600);
+    }
+
+    [UnitTest]
+    public void OverrideWith_ExplicitValuesWinFieldByField()
+    {
+        var derived = GpResourceProfile.ForProcess(
+            Process("geometry.buffer", "geometry", outputs: ArtifactKind.FeatureLayer));
+        var overrides = new GpResourceProfile { Vcpus = 16, EphemeralGib = 200 };
+
+        var effective = derived.OverrideWith(overrides);
+
+        effective.Vcpus.Should().Be(16);
+        effective.EphemeralGib.Should().Be(200);
+        // Unset override fields keep the derived value.
+        effective.MemoryMib.Should().Be(2048);
+    }
+
+    [UnitTest]
+    public void ProjectOnto_WritesBatchKeysForSetFields()
+    {
+        var profile = new GpResourceProfile
+        {
+            Vcpus = 4,
+            MemoryMib = 8192,
+            GpuCount = 1,
+            TimeoutSeconds = 3600,
+            RetryAttempts = 2,
+            EphemeralGib = 100,
+            Arch = "arm64",
+        };
+        var specParams = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        profile.ProjectOnto(specParams);
+
+        specParams["batch.vcpus"].Should().Be("4");
+        specParams["batch.memory_mib"].Should().Be("8192");
+        specParams["batch.gpu_count"].Should().Be("1");
+        specParams["batch.timeout_seconds"].Should().Be("3600");
+        specParams["batch.retry_attempts"].Should().Be("2");
+        specParams["batch.ephemeral_gib"].Should().Be("100");
+        specParams["batch.arch"].Should().Be("arm64");
+    }
+
+    [UnitTest]
+    public void ProjectOnto_DoesNotOverwriteExistingKeys()
+    {
+        var profile = new GpResourceProfile { Vcpus = 4, EphemeralGib = 100 };
+        var specParams = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["batch.vcpus"] = "16",
+        };
+
+        profile.ProjectOnto(specParams);
+
+        // An explicit raw batch.* value already on the bag wins (set-if-absent semantics).
+        specParams["batch.vcpus"].Should().Be("16");
+        specParams["batch.ephemeral_gib"].Should().Be("100");
+    }
+
+    [UnitTest]
+    public void ProjectOnto_EmptyProfileWritesNothing()
+    {
+        var specParams = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        GpResourceProfile.Empty.ProjectOnto(specParams);
+
+        specParams.Should().BeEmpty();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployTelemetryPolicyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployTelemetryPolicyTests.cs
@@ -157,6 +157,24 @@ public sealed class DeployTelemetryPolicyTests
     }
 
     [Fact]
+    public void Parse_GpBatchPreset_ProducesValidPolicyWithLongerWarmup()
+    {
+        // The serverless-GP substrate preset bakes longer (5m) than the standard 2m HTTP preset
+        // because GP per-job metrics are sparse/bursty (honua-server#2165).
+        var policy = DeployTelemetryPolicy.Parse(CreateSpec(new Dictionary<string, string>
+        {
+            ["telemetry.connection"] = "prod-prom",
+            ["telemetry.policy"] = "gp-batch",
+            ["telemetry.prometheus.job"] = "honua-gp"
+        }));
+
+        policy.Should().NotBeNull();
+        policy!.IsValid.Should().BeTrue();
+        policy.WarmupDuration.Should().Be(TimeSpan.FromMinutes(5));
+        policy.HasMetricSignals.Should().BeTrue();
+    }
+
+    [Fact]
     public void Parse_HealthProbe_AugmentsMetricGate_WithDefaults()
     {
         // The synthetic /healthz/ready gate (#1849) is provider-independent and layers onto the metric

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployTelemetrySignalEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployTelemetrySignalEvaluatorTests.cs
@@ -604,6 +604,74 @@ public sealed class DeployTelemetrySignalEvaluatorTests
         decision.UpdatedDeployParameters.Should().BeNull("no debounce configured means no streak bookkeeping");
     }
 
+    [Fact]
+    public async Task EvaluateAsync_GpBatchPolicy_SingleBreach_DefaultsToBurstTolerantAntiFlap()
+    {
+        // GP substrate deploys (telemetry.policy = gp-batch) are burstier, so with NO explicit
+        // consecutive-breach param the gate defaults to the burst-tolerant streak (3) rather than
+        // the single-scrape default — one breaching scrape must NOT roll back (honua-server#2165).
+        var fakeProvider = new FakeProviderEvaluator("fake-metrics", new DeployTelemetryReadings
+        {
+            SampleCount = 50,
+            ErrorRate = 0.5,
+            LatencyP95 = 120
+        });
+
+        var evaluator = CreateProviderEvaluator(fakeProvider);
+
+        var decision = await evaluator.EvaluateAsync(CreateOperation(
+            DeployTargetKind.AwsEcs,
+            new Dictionary<string, string>
+            {
+                ["telemetry.connection"] = "prod-metrics",
+                ["telemetry.policy"] = "gp-batch",
+                ["telemetry.prometheus.job"] = "honua-gp",
+                ["telemetry.error_rate.query"] = "errors / requests",
+                ["telemetry.error_rate.threshold"] = "0.05",
+                ["telemetry.sample_count.query"] = "requests",
+                ["telemetry.sample_count.minimum"] = "10"
+            },
+            createdAt: DateTimeOffset.UtcNow.AddMinutes(-6)));
+
+        decision.Should().NotBeNull();
+        decision!.RollbackRecommended.Should().BeFalse("the GP-batch policy defaults to a burst-tolerant anti-flap streak");
+        decision.WaitForMoreTelemetry.Should().BeTrue();
+        decision.UpdatedDeployParameters!["telemetry.rollback.breach_streak"].Should().Be("1");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_GpBatchPolicy_ExplicitThreshold_OverridesGpDefault()
+    {
+        // An operator can still pin the threshold: an explicit consecutive_breaches=1 on a GP-batch
+        // deploy rolls back on the first breach, overriding the GP burst-tolerant default.
+        var fakeProvider = new FakeProviderEvaluator("fake-metrics", new DeployTelemetryReadings
+        {
+            SampleCount = 50,
+            ErrorRate = 0.5,
+            LatencyP95 = 120
+        });
+
+        var evaluator = CreateProviderEvaluator(fakeProvider);
+
+        var decision = await evaluator.EvaluateAsync(CreateOperation(
+            DeployTargetKind.AwsEcs,
+            new Dictionary<string, string>
+            {
+                ["telemetry.connection"] = "prod-metrics",
+                ["telemetry.policy"] = "gp-batch",
+                ["telemetry.prometheus.job"] = "honua-gp",
+                ["telemetry.error_rate.query"] = "errors / requests",
+                ["telemetry.error_rate.threshold"] = "0.05",
+                ["telemetry.sample_count.query"] = "requests",
+                ["telemetry.sample_count.minimum"] = "10",
+                ["telemetry.rollback.consecutive_breaches"] = "1"
+            },
+            createdAt: DateTimeOffset.UtcNow.AddMinutes(-6)));
+
+        decision.Should().NotBeNull();
+        decision!.RollbackRecommended.Should().BeTrue("an explicit threshold of 1 overrides the GP burst-tolerant default");
+    }
+
     // ---- synthetic /healthz/ready gate (#1849) ---------------------------
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2165
Related to #2166

## Summary
honua-server slice of the **corrected** serverless-GP design (#2165, "DESIGN
CORRECTION 2026-06-25"). Per-job GP sizing is **runtime and instant** — there is
**no per-job `terraform apply`** and **no devops-agent call** in the job path.
The durable per-env substrate (Batch compute-env / queue / IAM / ECR + the
pre-registered job-definition TIER set) is owned by terraform/GitOps and is
already merged in honua-iac#70; the devops gp runtime adapter is honua-devops#107.

Audit of `trunk` found most of the server leg already landed: the
`AwsBatchComputeBackend.StartAsync` per-job vCPU/memory/timeout/retry/GPU
`SubmitJob` overrides and the ephemeral-need → job-definition tier selection are
on `trunk` (#2186, #2181), and the #2161 anti-flap deploy-safety gate is generic,
landed, and explicitly GP-aware. This PR closes the two genuine remaining gaps in
the issue's honua-server bullet:

1. **The GP job spec now carries a typed resource profile** that maps onto the
   `batch.*` submit params the backend already consumes.
2. **GP health-gating is wired into the existing deploy-safety/anti-flap
   machinery** via a GP-tuned telemetry preset and a burst-tolerant anti-flap
   default — without rebuilding the gate.

Followed the corrected design: runtime sizing only, no per-job terraform, no
agent in the job path. Real-AWS Batch provisioning/cert is owned by honua-iac#70
+ CI and is out of scope here; the mapping/selection/gating logic is unit-tested
with fakes (no live AWS).

## Changes Made
- Add `GpResourceProfile` (Honua.Geoprocessing): typed per-job vCPU / memory /
  GPU / timeout / retry / ephemeral / arch. Derives a conservative per-class
  default from the catalog (raster/surface → largest tier, native GDAL → mid,
  managed → smallest), aggregates the heaviest across a plan's steps
  (`MergeMax`), and is overridden field-by-field by explicit `gp.resource.*`
  request values (`OverrideWith`). Projects onto the `batch.*` contract keys as
  literal strings (no hard `Honua.Aws` dependency, mirroring `ExecutionWorkloadGate`).
- Wire the effective profile into `GeoprocessingJobService.BuildSpec`: projected
  for remote AWS Batch workloads only, BEFORE the workload-defaults merge, so
  precedence is explicit request > per-job profile > workload baseline. The
  local/Kubernetes baseline spec is unchanged (preserves GP Devkit local-runner
  spec parity, #2180).
- Extract `GpSizeEstimator.IsRasterClass` to `internal` so the size heuristic and
  the resource-profile derivation classify a process identically (DRY).
- Add the `gp-batch` deploy telemetry preset (`DeployTelemetryPolicy`): longer
  5-min bake for GP's sparse/bursty per-job metrics.
- Default the anti-flap consecutive-breach threshold to a burst-tolerant value
  (3) for `gp-batch` deploys when no explicit threshold is set
  (`DeployTelemetrySignalEvaluator`); an explicit
  `telemetry.rollback.consecutive_breaches` still wins.
- Tests: `GpResourceProfile` mapping/aggregation/override/projection; GP
  submit→spec wiring (Batch carries sizing, explicit override wins, local carries
  none); GP anti-flap default + explicit override; `gp-batch` preset parse.
- Regenerate `docs/gis/data/feature-catalog.json` (picked up two pre-existing,
  unrelated MCP `tools/list` proving-test entries that were missing on `trunk`).
- Document `gp.resource.*` per-job sizing and the `gp-batch` health-gating preset
  in `docs/operator/geoprocessing-aws-batch.md` (and refresh the now-merged #2181
  tier-selection note).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Real-AWS Batch provisioning/submission is Docker/cloud-gated and certified by the
honua-iac#70 cert tier + CI; it is out of scope for this runtime PR. All new
logic is covered by fakes/mocks (no live AWS). `dotnet build Honua.sln -c Release
/p:TreatWarningsAsErrors=true` → 0/0; `dotnet format --verify-no-changes` clean;
new + related unit tests green (169 in the GP/control-plane filter); architecture
suite green (118).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

The `gp.resource.*` request keys and `batch.arch` are additive; the existing
`batch.*` contract is unchanged.

## Release/Deploy Impact
- [ ] None — standard merge-and-release flow

Pairs with honua-iac#70 (substrate + job-def tier set) and honua-devops#107 (gp
runtime adapter). No infrastructure change is required to merge this runtime PR.

## Breaking Changes
None

---

## Remaining scope (why this is `Related to`, not `Closes`)
The #2165 honua-server bullet is satisfied by this PR. The umbrella issue spans
repos — the durable substrate (honua-iac#70) and the gp runtime adapter
(honua-devops#107) live elsewhere, and real-AWS Batch provisioning/cert is
CI/cert-tier validated. Leave #2165 open until the cross-repo provisioning lane
is confirmed landed; this PR is the server runtime slice.

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
