### PR TITLE
test(control-plane): broaden emulated cloud-integration matrix and add real-AWS cert lane (#2166)

### DIFF
--- a/.github/workflows/cloud-integration-harness.yml
+++ b/.github/workflows/cloud-integration-harness.yml
@@ -24,9 +24,12 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_NOLOGO: true
   CSPROJ: tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
-  # Self-terminating worker image the kind-backed Job lifecycle test submits. Built and loaded
-  # into the kind node below; ImagePullPolicy=Never in the test keeps it local-only.
+  # Worker images the kind-backed Job lifecycle tests submit. Built and loaded into the kind node
+  # below; ImagePullPolicy=Never in the tests keeps them local-only.
+  #   succeed -> exits 0 (happy path), fail -> exits 1 (failure path), sleep -> long-running (cancel path).
   JOB_IMAGE: honua-ci/job-succeed:latest
+  JOB_FAIL_IMAGE: honua-ci/job-fail:latest
+  JOB_SLEEP_IMAGE: honua-ci/job-sleep:latest
 
 concurrency:
   group: cloud-integration-harness-${{ github.ref }}
@@ -64,19 +67,29 @@ jobs:
         with:
           cluster_name: honua-cloud-integration
 
-      - name: Build and load the self-terminating worker image into kind
+      - name: Build and load the self-terminating worker images into kind
         shell: bash
         run: |
-          # A minimal image whose entrypoint runs to completion and exits 0 — stands in for a GP
-          # worker. The lifecycle test sets ImagePullPolicy=Never, so the image must be present
-          # on the kind node (no registry pull).
-          workdir="$(mktemp -d)"
-          cat > "${workdir}/Dockerfile" <<'EOF'
+          # Minimal busybox images standing in for GP workers across the success, failure, and
+          # cancellation lifecycle paths. The tests set ImagePullPolicy=Never, so each image must
+          # be present on the kind node (no registry pull). BuildManifest does not set a container
+          # command/args, so each image self-selects behaviour via its own ENTRYPOINT.
+          build_and_load() {
+            local image="$1" entrypoint="$2"
+            local workdir
+            workdir="$(mktemp -d)"
+            cat > "${workdir}/Dockerfile" <<EOF
           FROM busybox:1.36
-          ENTRYPOINT ["/bin/true"]
+          ENTRYPOINT ${entrypoint}
           EOF
-          docker build -t "${JOB_IMAGE}" "${workdir}"
-          kind load docker-image "${JOB_IMAGE}" --name honua-cloud-integration
+            docker build -t "${image}" "${workdir}"
+            kind load docker-image "${image}" --name honua-cloud-integration
+          }
+
+          # Succeed (exit 0), fail (exit 1), and sleep (long-running, for the cancel path).
+          build_and_load "${JOB_IMAGE}"       '["/bin/true"]'
+          build_and_load "${JOB_FAIL_IMAGE}"  '["/bin/false"]'
+          build_and_load "${JOB_SLEEP_IMAGE}" '["/bin/sleep", "600"]'
 
       - name: Export kind cluster inputs for the harness
         shell: bash
@@ -102,6 +115,8 @@ jobs:
             echo "HONUA_TEST_K8S_BEARER_TOKEN=${token}"
             echo "HONUA_TEST_K8S_NAMESPACE=default"
             echo "HONUA_TEST_K8S_JOB_IMAGE=${JOB_IMAGE}"
+            echo "HONUA_TEST_K8S_FAIL_IMAGE=${JOB_FAIL_IMAGE}"
+            echo "HONUA_TEST_K8S_SLEEP_IMAGE=${JOB_SLEEP_IMAGE}"
           } >> "$GITHUB_ENV"
 
       - name: Run cloud-integration tests

--- a/.github/workflows/real-aws-certification.yml
+++ b/.github/workflows/real-aws-certification.yml
@@ -1,0 +1,102 @@
+name: Real AWS Certification
+
+# Real-AWS certification lane (#2164). UNLIKE the emulated cloud-integration-harness.yml (kind +
+# LocalStack), this lane runs the [Trait("Category","RealAwsCertification")] tests against a LIVE
+# AWS account to certify the cloud control-plane seams Honua depends on.
+#
+# It is GATED, BUDGETED, and TEARDOWN-GUARANTEED:
+#   * Gated   — runs the live tests ONLY when the maintainer OIDC role variable
+#               `vars.REALAWS_CERT_ROLE_ARN` is configured. On forks, PRs, and any repo without
+#               that variable the live step is skipped and the lane is an explicit no-op (it never
+#               costs money and never fails for lack of credentials).
+#   * Budgeted — the seeded test (RegisterThenDeregisterJobDefinition) only REGISTERS a job
+#               definition; it never submits a job, so there is no compute and ZERO cost.
+#   * Teardown — every test namespaces its resources honua-cert-* and deregisters them in a
+#               finally block, so no standing resources remain.
+#
+# Never runs on pull_request, so it cannot be triggered by forks or untrusted contributors.
+
+on:
+  schedule:
+    # Weekly; the live lane is intentionally infrequent.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write   # OIDC for aws-actions/configure-aws-credentials (no-op when no role is set)
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+  CSPROJ: tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
+
+concurrency:
+  group: real-aws-certification-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    name: Certify (live AWS Batch control-plane)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Honua.sln
+
+      # Always build the lane so a compile regression is caught even when the live run is dormant.
+      - name: Build certification test binaries
+        timeout-minutes: 25
+        run: dotnet build ${{ env.CSPROJ }} --no-restore --configuration Release
+
+      # Live credentials via OIDC, ONLY when a maintainer role is configured. Without it this step
+      # is skipped and the lane stays dormant — exactly the fork/no-secret safe path.
+      - name: Configure AWS credentials (OIDC)
+        id: aws
+        if: ${{ vars.REALAWS_CERT_ROLE_ARN != '' }}
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
+        with:
+          role-to-assume: ${{ vars.REALAWS_CERT_ROLE_ARN }}
+          aws-region: ${{ vars.REALAWS_CERT_REGION || 'us-west-2' }}
+          role-session-name: honua-real-aws-certification
+
+      - name: Run real-AWS certification tests
+        if: ${{ vars.REALAWS_CERT_ROLE_ARN != '' }}
+        env:
+          # Master switch the RealAwsCertificationFixture reads; only set when creds are present.
+          HONUA_REALAWS_CERT_ENABLED: 'true'
+          HONUA_REALAWS_CERT_REGION: ${{ vars.REALAWS_CERT_REGION || 'us-west-2' }}
+        run: |
+          mkdir -p ./tests/TestResults
+          dotnet test ${{ env.CSPROJ }} \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "Category=RealAwsCertification" \
+            --logger "trx;LogFileName=real-aws-certification.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Lane dormant (no OIDC role configured)
+        if: ${{ vars.REALAWS_CERT_ROLE_ARN == '' }}
+        run: |
+          echo "::notice::Real-AWS certification lane is dormant — vars.REALAWS_CERT_ROLE_ARN is not set."
+          echo "Configure an OIDC role with least-privilege AWS Batch register/describe/deregister"
+          echo "permissions and set vars.REALAWS_CERT_ROLE_ARN (and optionally vars.REALAWS_CERT_REGION)"
+          echo "to enable live certification. No tests ran; no resources were created."
+
+      - name: Upload results
+        if: ${{ always() && vars.REALAWS_CERT_ROLE_ARN != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: real-aws-certification-results
+          path: tests/TestResults/
+          retention-days: 14

--- a/docs/internal/contributor/testkit.md
+++ b/docs/internal/contributor/testkit.md
@@ -572,6 +572,55 @@ HONUA_EVAL_CORPUS_VERSION=core@0001 \
   dotnet test --filter "Protocol=OperatorEval"
 ```
 
+## Cloud-integration harness (#2163 / #2166 / #2164)
+
+`tests/dotnet/Honua.CloudIntegration.Tests` is a standalone project (not in the ADR-0037 server
+shard matrix, never AOT-published) that exercises Honua's cloud control-plane and artifact seams
+against REAL backends. Every test carries a `Category` trait so the default PR run never invokes
+it; the dedicated workflows opt in by filter.
+
+### Emulated lanes — `Category=CloudIntegration` (free, no paid token)
+
+Runs in `.github/workflows/cloud-integration-harness.yml` (nightly + manual). All tests are
+`[SkippableFact]` and skip — never fail — when Docker/kind is unavailable.
+
+| Scenario | Backend | Emulator |
+|----------|---------|----------|
+| `S3ArtifactRoundTripCloudIntegrationTests` | `AwsS3FileStorage` ServiceURL seam | LocalStack Community S3 |
+| `S3ArtifactRollbackCloudIntegrationTests` | versioned-artifact rollback (enable versioning → publish v1/v2 → delete bad version → prior promoted live) | LocalStack Community S3 |
+| `KubernetesJobLifecycleCloudIntegrationTests` | `KubernetesJobBatchComputeBackend` submit → succeeded | kind (real Kubernetes-in-Docker) |
+| `KubernetesJobNegativePathCloudIntegrationTests` | same backend: non-zero exit → `Failed`; cancel running Job → `Cancelled` | kind |
+
+The kind lane builds three busybox worker images (`/bin/true`, `/bin/false`, `/bin/sleep`) loaded
+with `ImagePullPolicy=Never`; the backend's `BuildManifest` sets no container command, so each
+image self-selects behaviour via its `ENTRYPOINT`.
+
+### Real-AWS certification lane — `Category=RealAwsCertification`
+
+Runs in `.github/workflows/real-aws-certification.yml` (weekly + manual, never on `pull_request`)
+and targets a LIVE AWS account. It is gated, budgeted, and teardown-guaranteed:
+
+- **Gated** — the live test step runs only when `vars.REALAWS_CERT_ROLE_ARN` is configured
+  (OIDC role assumption). Without it the lane is an explicit no-op; the tests also self-skip
+  unless `HONUA_REALAWS_CERT_ENABLED=true`, so forks and credential-less runs never fail.
+- **Budgeted** — `AwsBatchRealCertificationTests` only *registers* a job definition (never submits
+  a job), so there is no compute and zero cost.
+- **Isolated + torn down** — `RealAwsCertificationFixture` mints a unique `honua-cert-*` prefix for
+  every resource; tests deregister in a `finally` block and assert no `ACTIVE` resource remains.
+
+Run locally against your own account (credentials via the default chain):
+
+```bash
+HONUA_REALAWS_CERT_ENABLED=true HONUA_REALAWS_CERT_REGION=us-west-2 \
+  dotnet test tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj \
+  --filter "Category=RealAwsCertification"
+```
+
+**Remainder (tracked under #2164):** the full submit-to-`SUCCEEDED` Batch lifecycle and the
+ECS/Lambda deploy + rollback certifications need an ephemeral Fargate compute environment + IAM
+execution role whose teardown is slower and must be supervised, so they are not performed
+automatically by this lane yet.
+
 ## Environment Requirements
 
 - Docker (for Testcontainers)

--- a/tests/dotnet/Honua.CloudIntegration.Tests/AwsBatchRealCertificationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/AwsBatchRealCertificationTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Amazon;
+using Amazon.Batch;
+using Amazon.Batch.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Real-AWS certification lane (#2164): the first live-account smoke proving the AWS Batch
+/// control-plane path Honua's <c>AwsBatchComputeBackend</c> depends on actually works against a
+/// REAL account (not LocalStack), and that the OIDC/credential wiring in
+/// <c>real-aws-certification.yml</c> is sound. It performs a register → describe → deregister
+/// round-trip on a uniquely-named job definition.
+///
+/// SAFETY: this lane is OFF unless <see cref="RealAwsCertificationFixture.Enabled"/> (it
+/// <c>[SkippableFact]</c>-skips otherwise, so it never costs money or fails on
+/// forks/PRs without credentials). The job definition is registered ONLY (never submitted), so
+/// there is NO compute, NO running job, and therefore ZERO cost. Every created resource carries
+/// the per-run <c>honua-cert-*</c> prefix, no pre-existing resource is ever read-modified, and
+/// teardown (deregister → status INACTIVE) is guaranteed in a <c>finally</c> block.
+///
+/// Remainder (tracked under #2164, requires a supervised, budgeted run): the full
+/// submit-to-SUCCEEDED Batch lifecycle and the ECS/Lambda deploy + rollback certifications need an
+/// ephemeral Fargate compute environment + IAM execution role whose teardown is slower and must be
+/// supervised, so they are intentionally NOT performed automatically here.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.RealAwsCertification)]
+public sealed class AwsBatchRealCertificationTests : IClassFixture<RealAwsCertificationFixture>
+{
+    private readonly RealAwsCertificationFixture _cert;
+
+    public AwsBatchRealCertificationTests(RealAwsCertificationFixture cert)
+    {
+        _cert = cert;
+    }
+
+    [SkippableFact]
+    public async Task RegisterThenDeregisterJobDefinition_RoundTripsAgainstLiveBatch()
+    {
+        Skip.IfNot(
+            _cert.Enabled,
+            "Real-AWS certification lane disabled (set HONUA_REALAWS_CERT_ENABLED=true with credentials present).");
+
+        using var batch = new AmazonBatchClient(RegionEndpoint.GetBySystemName(_cert.Region));
+
+        var jobDefinitionName = $"{_cert.ResourcePrefix}-jobdef";
+
+        // Register an EC2-type container job definition. It is never submitted, so it incurs no
+        // cost and needs no compute environment or execution role. The image string is not pulled
+        // at registration time, so a public reference suffices.
+        var register = new RegisterJobDefinitionRequest
+        {
+            JobDefinitionName = jobDefinitionName,
+            Type = JobDefinitionType.Container,
+            ContainerProperties = new ContainerProperties
+            {
+                Image = "public.ecr.aws/docker/library/busybox:latest",
+                Command = ["true"],
+                ResourceRequirements =
+                [
+                    new ResourceRequirement { Type = ResourceType.VCPU, Value = "1" },
+                    new ResourceRequirement { Type = ResourceType.MEMORY, Value = "512" }
+                ]
+            }
+        };
+
+        string? registeredArn = null;
+        try
+        {
+            var registered = await batch.RegisterJobDefinitionAsync(register);
+            registeredArn = registered.JobDefinitionArn;
+
+            registeredArn.Should().NotBeNullOrWhiteSpace("registering against live AWS Batch must return an ARN");
+            registered.JobDefinitionName.Should().Be(jobDefinitionName);
+            registeredArn.Should().Contain(
+                _cert.ResourcePrefix,
+                "the created resource must carry the unique honua-cert-* prefix so it is isolated and traceable");
+
+            // The freshly registered definition must be discoverable as ACTIVE.
+            var active = await DescribeActiveAsync(batch, jobDefinitionName);
+            active.Should().ContainSingle("the just-registered job definition must be ACTIVE")
+                .Which.JobDefinitionArn.Should().Be(registeredArn);
+
+            // Tear down: deregister flips the revision to INACTIVE so no ACTIVE resource remains.
+            await batch.DeregisterJobDefinitionAsync(new DeregisterJobDefinitionRequest
+            {
+                JobDefinition = registeredArn
+            });
+            registeredArn = null;
+
+            var afterDeregister = await DescribeActiveAsync(batch, jobDefinitionName);
+            afterDeregister.Should().BeEmpty(
+                "after deregistration no ACTIVE job definition must remain — the lane leaves zero standing resources");
+        }
+        finally
+        {
+            // Guaranteed teardown if any assertion above threw after registration.
+            if (registeredArn is not null)
+            {
+                try
+                {
+                    await batch.DeregisterJobDefinitionAsync(new DeregisterJobDefinitionRequest
+                    {
+                        JobDefinition = registeredArn
+                    });
+                }
+                catch
+                {
+                    // Best-effort: a deregister failure here would leave only an INACTIVE-able
+                    // revision under the unique honua-cert-* prefix, never live infrastructure.
+                }
+            }
+        }
+    }
+
+    private static async Task<IReadOnlyList<JobDefinition>> DescribeActiveAsync(
+        AmazonBatchClient batch,
+        string jobDefinitionName)
+    {
+        var response = await batch.DescribeJobDefinitionsAsync(new DescribeJobDefinitionsRequest
+        {
+            JobDefinitionName = jobDefinitionName,
+            Status = "ACTIVE"
+        });
+
+        return response.JobDefinitions ?? [];
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
@@ -24,4 +24,16 @@ internal static class CloudIntegrationTraits
     /// Trait value applied to every Docker-backed cloud-integration test.
     /// </summary>
     public const string CloudIntegration = "CloudIntegration";
+
+    /// <summary>
+    /// Trait value applied to the real-AWS certification lane (#2164). These tests target a
+    /// LIVE AWS account (not an emulator) and are kept in a distinct category so neither the
+    /// default PR run nor the emulated <c>cloud-integration-harness.yml</c>
+    /// (<c>--filter "Category=CloudIntegration"</c>) ever invokes them. They run only in the
+    /// dedicated, OIDC-gated <c>real-aws-certification.yml</c> workflow (or locally with
+    /// <c>HONUA_REALAWS_CERT_ENABLED=true</c> and credentials present); every test
+    /// <c>[SkippableFact]</c>-skips — never fails — when the lane is not enabled, so
+    /// the project still builds and runs (skipping) on forks and credential-less environments.
+    /// </summary>
+    public const string RealAwsCertification = "RealAwsCertification";
 }

--- a/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
@@ -7,10 +7,18 @@
     EXCLUDED from the default PR test run (which filters Category!=CloudIntegration) and only
     runs in the dedicated nightly / explicit cloud-integration workflow.
 
-    All lanes are FREE (no paid token required):
-      * kind / k3d           : real Kubernetes-in-Docker for KubernetesJobBatchComputeBackend.
-      * LocalStack Community  : S3 artifact round-trip (the free service set). Each test gates
-                                with [SkippableFact] and skips (never fails) when Docker is absent.
+    Emulated lanes are FREE (no paid token required) and tagged [Trait("Category","CloudIntegration")]:
+      * kind / k3d           : real Kubernetes-in-Docker for KubernetesJobBatchComputeBackend —
+                                success, failure, and cancellation lifecycle paths.
+      * LocalStack Community  : S3 artifact round-trip and versioned artifact rollback (the free
+                                service set). Each test gates with [SkippableFact] and skips (never
+                                fails) when Docker is absent.
+
+    A separate real-AWS certification lane (#2164) is tagged [Trait("Category","RealAwsCertification")].
+    Those tests target a LIVE AWS account, run only in the OIDC-gated real-aws-certification.yml
+    workflow (or locally with HONUA_REALAWS_CERT_ENABLED=true), and [SkippableFact]-skip otherwise —
+    so they never cost money or fail on forks/PRs without credentials. Every created resource uses a
+    unique honua-cert-* prefix and is torn down in a finally block.
 
     This project is a test project (never AOT-published) and is intentionally NOT registered in
     the Honua.Server.Tests ADR-0037 shard matrix, so it never runs on the per-PR server-test path.
@@ -43,6 +51,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="AWSSDK.S3" />
+    <PackageReference Include="AWSSDK.Batch" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesJobNegativePathCloudIntegrationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/KubernetesJobNegativePathCloudIntegrationTests.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Free-tier emulated scenarios (#2166) that broaden the cloud-integration matrix beyond the
+/// happy-path <see cref="KubernetesJobLifecycleCloudIntegrationTests"/> into the failure and
+/// cancellation paths of <c>KubernetesJobBatchComputeBackend</c> against a real kind cluster.
+/// These are the GP-job analogue of the deploy-safety "failure-of-failure" coverage: a worker
+/// that exits non-zero must surface terminally as <see cref="ExecutionJobStatus.Failed"/> (the
+/// backend pins <c>backoffLimit: 0</c> so a failed Pod is not silently retried in-cluster), and a
+/// cancellation of a still-running Job must surface <see cref="ExecutionJobStatus.Cancelled"/>.
+///
+/// Gated identically to the lifecycle test: when no kind cluster is wired (no
+/// <c>HONUA_TEST_K8S_*</c> env vars) every test skips rather than fails, so the project still
+/// builds and runs (skipping) on boxes without a cluster.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.CloudIntegration)]
+public sealed class KubernetesJobNegativePathCloudIntegrationTests : IClassFixture<KindClusterFixture>
+{
+    // A worker image whose entrypoint exits non-zero (/bin/false) — stands in for a GP worker
+    // that fails. The CI workflow builds this image and loads it into the kind node so it
+    // resolves with ImagePullPolicy=Never. Overridable so a local run can point at a different
+    // self-terminating, non-zero-exit image already present on the node.
+    private static readonly string FailingImage =
+        Environment.GetEnvironmentVariable("HONUA_TEST_K8S_FAIL_IMAGE") ?? "honua-ci/job-fail:latest";
+
+    // A long-running worker image (sleep) — stands in for a GP worker that is still running when
+    // a cancellation arrives. Loaded into the kind node by the workflow with ImagePullPolicy=Never.
+    private static readonly string SleepingImage =
+        Environment.GetEnvironmentVariable("HONUA_TEST_K8S_SLEEP_IMAGE") ?? "honua-ci/job-sleep:latest";
+
+    private readonly KindClusterFixture _kind;
+
+    public KubernetesJobNegativePathCloudIntegrationTests(KindClusterFixture kind)
+    {
+        _kind = kind;
+    }
+
+    [SkippableFact]
+    public async Task SubmitJob_ContainerExitsNonZero_ReportsFailed()
+    {
+        Skip.IfNot(_kind.Available, "kind cluster not configured (HONUA_TEST_K8S_* env vars absent).");
+
+        var (backend, provider) = KubernetesBackendFactory.Create(
+            _kind.ApiServerUrl!,
+            _kind.BearerToken!,
+            _kind.CaBundlePath!,
+            _kind.Namespace,
+            defaultImage: FailingImage);
+        await using var _ = provider;
+
+        var operationId = $"ci-k8s-fail-{Guid.NewGuid():N}"[..24];
+        var job = CreateJob(operationId, FailingImage);
+
+        try
+        {
+            // 1. Submit: the failing worker Job must be created like any other.
+            var submission = await backend.StartAsync(job);
+            submission.Status.Should().BeOneOf(ExecutionJobStatus.Provisioning, ExecutionJobStatus.Queued);
+            submission.ProviderOperationId.Should().NotBeNullOrWhiteSpace();
+
+            var observedJob = MergeResolvedParameters(job, submission);
+
+            // 2. Observe until terminal: the Pod exits 1, the Job reaches its backoffLimit (0),
+            //    and the backend must map the failed Job to Failed — not retry it in-cluster.
+            var terminal = await PollUntilTerminalAsync(backend, observedJob, TimeSpan.FromMinutes(4));
+            terminal.Status.Should().Be(
+                ExecutionJobStatus.Failed,
+                "a worker that exits non-zero must surface terminally as Failed, not be silently retried");
+        }
+        finally
+        {
+            await TryCancelAsync(backend, job);
+        }
+    }
+
+    [SkippableFact]
+    public async Task CancelJob_WhileRunning_ReportsCancelled()
+    {
+        Skip.IfNot(_kind.Available, "kind cluster not configured (HONUA_TEST_K8S_* env vars absent).");
+
+        var (backend, provider) = KubernetesBackendFactory.Create(
+            _kind.ApiServerUrl!,
+            _kind.BearerToken!,
+            _kind.CaBundlePath!,
+            _kind.Namespace,
+            defaultImage: SleepingImage);
+        await using var _ = provider;
+
+        var operationId = $"ci-k8s-cancel-{Guid.NewGuid():N}"[..24];
+        // An activeDeadlineSeconds safety net guarantees a leaked sleep Job self-terminates even
+        // if cancellation cleanup is interrupted; the test cancels well before this fires.
+        var job = CreateJob(operationId, SleepingImage, activeDeadlineSeconds: 240);
+
+        try
+        {
+            // 1. Submit the long-running worker and wait until it is actually Running on the cluster.
+            var submission = await backend.StartAsync(job);
+            submission.Status.Should().BeOneOf(ExecutionJobStatus.Provisioning, ExecutionJobStatus.Queued);
+
+            var observedJob = MergeResolvedParameters(job, submission);
+            var running = await PollUntilAsync(
+                backend,
+                observedJob,
+                static status => status == ExecutionJobStatus.Running,
+                TimeSpan.FromMinutes(3));
+            running.Status.Should().Be(ExecutionJobStatus.Running, "the sleep worker stays active until cancelled");
+
+            // 2. Cancel the running Job: the backend deletes the provider Job and reports Cancelled.
+            var cancelObservedJob = observedJob with { ProviderOperationId = running.ProviderOperationId };
+            var cancelResult = await backend.CancelAsync(cancelObservedJob);
+            cancelResult.Status.Should().Be(
+                ExecutionJobStatus.Cancelled,
+                "cancelling a still-running Kubernetes Job must surface Cancelled");
+        }
+        finally
+        {
+            await TryCancelAsync(backend, job);
+        }
+    }
+
+    private static async Task<BatchComputeObservation> PollUntilTerminalAsync(
+        KubernetesJobBatchComputeBackend backend,
+        ExecutionJobRecord job,
+        TimeSpan timeout)
+        => await PollUntilAsync(
+            backend,
+            job,
+            static status => status is ExecutionJobStatus.Succeeded
+                or ExecutionJobStatus.Failed
+                or ExecutionJobStatus.Cancelled,
+            timeout);
+
+    private static async Task<BatchComputeObservation> PollUntilAsync(
+        KubernetesJobBatchComputeBackend backend,
+        ExecutionJobRecord job,
+        Func<ExecutionJobStatus, bool> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        BatchComputeObservation last = new() { Status = ExecutionJobStatus.Queued };
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            last = await backend.ObserveAsync(job);
+            if (predicate(last.Status))
+            {
+                return last;
+            }
+
+            // Carry the provider id forward so observe keeps resolving the same Job.
+            if (!string.IsNullOrWhiteSpace(last.ProviderOperationId))
+            {
+                job = job with { ProviderOperationId = last.ProviderOperationId };
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+
+        throw new TimeoutException(
+            $"Kubernetes Job did not satisfy the expected condition within {timeout}. Last status: {last.Status}.");
+    }
+
+    private static async Task TryCancelAsync(KubernetesJobBatchComputeBackend backend, ExecutionJobRecord job)
+    {
+        try
+        {
+            await backend.CancelAsync(job);
+        }
+        catch
+        {
+            // Cleanup is best-effort; the cluster is ephemeral CI infrastructure and the Job
+            // carries an activeDeadlineSeconds/TTL safety net.
+        }
+    }
+
+    private static ExecutionJobRecord MergeResolvedParameters(
+        ExecutionJobRecord job,
+        BatchComputeSubmissionResult submission)
+    {
+        var parameters = new Dictionary<string, string>(job.Spec.Parameters, StringComparer.Ordinal);
+        if (submission.ResolvedParameters is { Count: > 0 })
+        {
+            foreach (var (key, value) in submission.ResolvedParameters)
+            {
+                parameters[key] = value;
+            }
+        }
+
+        return job with
+        {
+            ProviderOperationId = submission.ProviderOperationId,
+            Spec = job.Spec with { Parameters = parameters }
+        };
+    }
+
+    private static ExecutionJobRecord CreateJob(string operationId, string image, int? activeDeadlineSeconds = null)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [KubernetesJobParameterKeys.Image] = image,
+            // The image is preloaded into the kind node by the workflow, so never attempt a
+            // registry pull (which would fail for the local-only honua-ci/* tags).
+            [KubernetesJobParameterKeys.ImagePullPolicy] = "Never"
+        };
+        if (activeDeadlineSeconds is { } deadline)
+        {
+            parameters[KubernetesJobParameterKeys.ActiveDeadlineSeconds] =
+                deadline.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        var spec = new ExecutionJobSpec
+        {
+            Kind = ExecutionJobKind.Geoprocessing,
+            TargetKind = BatchComputeTargetKind.KubernetesJob,
+            Backend = KubernetesJobBatchComputeBackend.BackendId,
+            WorkloadId = "ci-harness-workload",
+            WorkloadName = "cloud-integration-gp",
+            Artifact = image,
+            Parameters = parameters
+        };
+
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = spec
+        };
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/RealAwsCertificationFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/RealAwsCertificationFixture.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Gate + configuration surface for the real-AWS certification lane (#2164). Unlike the emulated
+/// fixtures, this one targets a LIVE AWS account, so it is OFF by default and only reports
+/// <see cref="Enabled"/> = true when <c>HONUA_REALAWS_CERT_ENABLED</c> is explicitly set to
+/// <c>true</c>. The dedicated <c>real-aws-certification.yml</c> workflow sets that flag (and
+/// assumes an OIDC role) only when the maintainer AWS credentials are present; on forks, PRs
+/// without secrets, and ordinary local runs the flag is absent so every certification test
+/// <c>[SkippableFact]</c>-skips rather than failing or spending money.
+///
+/// Credentials are resolved by the AWS SDK default chain (OIDC web-identity in CI, the shared
+/// <c>~/.aws</c> profile locally) — this fixture deliberately does not handle secrets itself. It
+/// only surfaces the master switch, the target <see cref="Region"/>, and a per-run unique
+/// <see cref="ResourcePrefix"/> so every resource a certification test creates is namespaced
+/// <c>honua-cert-*</c> and can never collide with or clobber pre-existing account infrastructure.
+/// </summary>
+public sealed class RealAwsCertificationFixture : IAsyncLifetime
+{
+    /// <summary>Master switch. The lane runs only when this is set to <c>true</c>.</summary>
+    public const string EnabledEnvVar = "HONUA_REALAWS_CERT_ENABLED";
+
+    /// <summary>Optional region override for the certification lane.</summary>
+    public const string RegionEnvVar = "HONUA_REALAWS_CERT_REGION";
+
+    /// <summary>
+    /// True only when the lane is explicitly enabled. Defaults to false so the certification
+    /// tests skip everywhere except the gated workflow / an opted-in local run.
+    /// </summary>
+    public bool Enabled { get; private set; }
+
+    /// <summary>
+    /// Target AWS region. Resolves <c>HONUA_REALAWS_CERT_REGION</c> → <c>AWS_REGION</c> →
+    /// <c>AWS_DEFAULT_REGION</c> → <c>us-west-2</c> (the Honua substrate region).
+    /// </summary>
+    public string Region { get; private set; } = "us-west-2";
+
+    /// <summary>
+    /// Per-run unique prefix (<c>honua-cert-{8 hex}</c>) applied to every created resource so a
+    /// certification run is isolated and traceable, and can never be confused with existing infra.
+    /// </summary>
+    public string ResourcePrefix { get; private set; } = "honua-cert-unset";
+
+    /// <summary>Resolves the lane configuration from the environment.</summary>
+    public Task InitializeAsync()
+    {
+        var enabledRaw = Environment.GetEnvironmentVariable(EnabledEnvVar);
+        Enabled = string.Equals(enabledRaw?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+
+        Region =
+            FirstNonEmpty(
+                Environment.GetEnvironmentVariable(RegionEnvVar),
+                Environment.GetEnvironmentVariable("AWS_REGION"),
+                Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION"))
+            ?? "us-west-2";
+
+        ResourcePrefix = $"honua-cert-{Guid.NewGuid():N}"[..18];
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>No standing resources; certification tests own their own create/teardown.</summary>
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static string? FirstNonEmpty(params string?[] candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (!string.IsNullOrWhiteSpace(candidate))
+            {
+                return candidate.Trim();
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/S3ArtifactRollbackCloudIntegrationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/S3ArtifactRollbackCloudIntegrationTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Amazon.S3;
+using Amazon.S3.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Free-tier (LocalStack Community) emulated scenario (#2166) that broadens the matrix beyond the
+/// single-object round-trip in <see cref="S3ArtifactRoundTripCloudIntegrationTests"/> into a
+/// deploy-artifact ROLLBACK path: a versioned bucket publishes artifact v1, then v2 (so v2 is the
+/// live version), and a rollback then promotes v1 back to live by deleting the bad v2 version. This
+/// exercises the S3 versioning surface (enable versioning, list object versions, delete by
+/// version id) that an artifact-store rollback relies on, against a REAL emulated S3 endpoint via
+/// the <see cref="LocalStackFixture"/>'s edge ServiceURL.
+///
+/// Gated like the other emulated scenarios: when Docker is unavailable the fixture reports
+/// <see cref="LocalStackFixture.Available"/> = false and this test skips (never fails).
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.CloudIntegration)]
+public sealed class S3ArtifactRollbackCloudIntegrationTests : IClassFixture<LocalStackFixture>
+{
+    private readonly LocalStackFixture _localStack;
+
+    public S3ArtifactRollbackCloudIntegrationTests(LocalStackFixture localStack)
+    {
+        _localStack = localStack;
+    }
+
+    [SkippableFact]
+    public async Task RollbackToPreviousVersion_RestoresPriorArtifact_ThroughCommunityS3()
+    {
+        Skip.IfNot(_localStack.Available, "LocalStack Community not available (Docker daemon absent).");
+
+        using var client = CreateClient(_localStack.ServiceUrl);
+
+        var bucket = $"honua-ci-rollback-{Guid.NewGuid():N}";
+        const string key = "deploy/manifest.json";
+        var v1Payload = $"artifact-v1-{Guid.NewGuid():N}";
+        var v2Payload = $"artifact-v2-{Guid.NewGuid():N}";
+
+        await client.PutBucketAsync(new PutBucketRequest { BucketName = bucket });
+
+        try
+        {
+            // Enable versioning so each publish retains a recoverable prior version — the
+            // precondition every immutable-artifact rollback strategy depends on.
+            await client.PutBucketVersioningAsync(new PutBucketVersioningRequest
+            {
+                BucketName = bucket,
+                VersioningConfig = new S3BucketVersioningConfig { Status = VersionStatus.Enabled }
+            });
+
+            // 1. Publish v1, then v2 (the bad release) over the same key.
+            await PutAsync(client, bucket, key, v1Payload);
+            await PutAsync(client, bucket, key, v2Payload);
+
+            // The live (latest) version is now v2.
+            (await GetAsync(client, bucket, key)).Should().Be(
+                v2Payload, "the most recent publish is the live version before rollback");
+
+            // 2. Enumerate object versions; both publishes must be retained for rollback.
+            var versions = await client.ListVersionsAsync(new ListVersionsRequest
+            {
+                BucketName = bucket,
+                Prefix = key
+            });
+            var keyVersions = versions.Versions.Where(v => v.Key == key).ToList();
+            keyVersions.Should().HaveCount(2, "both the prior and current artifact versions must be retained");
+
+            var liveVersionId = keyVersions.Single(v => v.IsLatest == true).VersionId;
+
+            // 3. Roll back by deleting the live (bad) version; S3 promotes the prior version to live.
+            await client.DeleteObjectAsync(new DeleteObjectRequest
+            {
+                BucketName = bucket,
+                Key = key,
+                VersionId = liveVersionId
+            });
+
+            // 4. The live artifact is once again v1 — rollback succeeded.
+            (await GetAsync(client, bucket, key)).Should().Be(
+                v1Payload, "deleting the bad version must promote the prior artifact back to live");
+        }
+        finally
+        {
+            await PurgeBucketAsync(client, bucket);
+        }
+    }
+
+    private static async Task PutAsync(AmazonS3Client client, string bucket, string key, string payload)
+        => await client.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = bucket,
+            Key = key,
+            ContentBody = payload
+        });
+
+    private static async Task<string> GetAsync(AmazonS3Client client, string bucket, string key)
+    {
+        using var response = await client.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = bucket,
+            Key = key
+        });
+        using var reader = new StreamReader(response.ResponseStream, Encoding.UTF8);
+        return await reader.ReadToEndAsync();
+    }
+
+    private static async Task PurgeBucketAsync(AmazonS3Client client, string bucket)
+    {
+        // A versioned bucket can only be deleted once every version (and delete marker) is removed.
+        // Best-effort cleanup so the ephemeral emulator does not accumulate state.
+        try
+        {
+            var versions = await client.ListVersionsAsync(new ListVersionsRequest { BucketName = bucket });
+            foreach (var version in versions.Versions)
+            {
+                await client.DeleteObjectAsync(new DeleteObjectRequest
+                {
+                    BucketName = bucket,
+                    Key = version.Key,
+                    VersionId = version.VersionId
+                });
+            }
+
+            await client.DeleteBucketAsync(new DeleteBucketRequest { BucketName = bucket });
+        }
+        catch
+        {
+            // The LocalStack container is ephemeral CI infrastructure; cleanup is best-effort.
+        }
+    }
+
+    private static AmazonS3Client CreateClient(string serviceUrl)
+    {
+        // Mirror the AwsS3FileStorage seam: explicit ServiceURL targets the emulator edge endpoint
+        // while ForcePathStyle keeps virtual-host bucket addressing off (LocalStack serves
+        // path-style by default). Static "test"/"test" credentials satisfy SigV4 signing.
+        var config = new AmazonS3Config
+        {
+            ServiceURL = serviceUrl,
+            ForcePathStyle = true,
+            AuthenticationRegion = LocalStackFixture.Region,
+        };
+
+        return new AmazonS3Client(
+            LocalStackFixture.AccessKeyId,
+            LocalStackFixture.SecretAccessKey,
+            config);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2166
Related to #2164

## Summary
Builds on the #2163 emulated cloud-integration harness (kind + LocalStack Community + ServiceURL override). This delivers the genuine remainder of umbrella #2166: (a) broadens the emulated cloud-integration matrix beyond the single first scenario with additional compute and artifact deploy-safety paths, and (b) scaffolds the #2164 real-AWS certification lane as a gated, budgeted, teardown-guaranteed workflow that runs against a live account only when an OIDC role is configured and otherwise is an explicit no-op/skip.

All new tests reuse the existing harness abstractions (`KindClusterFixture`, `KubernetesBackendFactory`, `LocalStackFixture`) and follow the same `[SkippableFact]` gating, so they pass where Docker/kind is available and skip cleanly (never fail) where it is not.

## Changes Made
- Emulated `Category=CloudIntegration` (free; kind + LocalStack Community):
  - `KubernetesJobNegativePathCloudIntegrationTests` — failure path (non-zero exit -> `Failed`, `backoffLimit: 0` not silently retried) and cancellation path (cancel a running Job -> `Cancelled`).
  - `S3ArtifactRollbackCloudIntegrationTests` — versioned-artifact rollback: enable versioning, publish v1/v2, delete the bad version, assert the prior artifact is promoted back to live.
  - `cloud-integration-harness.yml` now builds/loads `job-fail` (`/bin/false`) and `job-sleep` (`/bin/sleep`) busybox worker images alongside the existing `job-succeed`, and exports their image env vars.
- Real-AWS certification `Category=RealAwsCertification` (#2164):
  - `RealAwsCertificationFixture` — master switch on `HONUA_REALAWS_CERT_ENABLED`, region resolution (defaults `us-west-2`), and a per-run unique `honua-cert-*` resource prefix.
  - `AwsBatchRealCertificationTests` — register -> describe -> deregister round-trip against live AWS Batch; job definition is registered only (never submitted), so no compute and zero cost; teardown guaranteed in a `finally` block.
  - `real-aws-certification.yml` — OIDC-gated, weekly + manual, never on `pull_request`; runs the live tests only when `vars.REALAWS_CERT_ROLE_ARN` is set, otherwise emits a "lane dormant" no-op.
  - `CloudIntegrationTraits.RealAwsCertification` trait value isolates this lane from both the default PR run and the emulated harness filter.
- Docs: added a "Cloud-integration harness" section to `docs/internal/contributor/testkit.md` covering both lanes, the local run command, and the #2164 remainder.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Local verification (Docker/kind absent on this box):
- `dotnet build` of the test project (Release, `TreatWarningsAsErrors=true`): succeeded, 0 warnings.
- `dotnet format --verify-no-changes` on the project: clean.
- Emulated `Category=CloudIntegration`: all 5 tests skip cleanly (no Docker/kind).
- Real-AWS lane executed once against the live account (us-west-2): `RegisterThenDeregisterJobDefinition_RoundTripsAgainstLiveBatch` PASSED. Pre/post `describe` confirmed zero ACTIVE job definitions, compute environments, and job queues both before and after; the created `honua-cert-*` job definition was deregistered (terminal INACTIVE, no cost, not standing infrastructure). No other resources created; no pre-existing resources touched.

## Gate Impact
- [ ] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

New workflows are nightly/weekly + manual only; the new tests are excluded from the default PR run by category and are not in the ADR-0037 server shard matrix.

## Docs or Contract Impact
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

To enable the live real-AWS lane a maintainer must set `vars.REALAWS_CERT_ROLE_ARN` (least-privilege OIDC role for Batch register/describe/deregister) and optionally `vars.REALAWS_CERT_REGION`. Until then the lane is a dormant no-op.

## Breaking Changes
None

## Remainder (left open under #2164 / #2166)
- Full submit-to-`SUCCEEDED` AWS Batch lifecycle + ECS/Lambda deploy + rollback certification against live AWS — needs an ephemeral Fargate compute environment + IAM execution role whose teardown is slower and must be supervised, so it is intentionally not performed automatically. Tracked under #2164.
- Emulated ECS/Batch coverage requires LocalStack Pro; kept in the real-AWS lane rather than the free emulated matrix.
- GitOps -> serverless Batch provisioning (#2165) is out of scope (handled separately).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
