### PR TITLE
fix(deps): pin Scriban.Signed 7.2.0 to clear NU1903 (nightly restore break)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,6 +113,8 @@
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <!-- Transitive of WireMock.Net (response templating); pinned directly to clear GHSA-24c8-4792-22hx (NU1903). Test-only. -->
+    <PackageVersion Include="Scriban.Signed" Version="7.2.0" />
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
     <PackageVersion Include="Snappier" Version="1.3.1" />

--- a/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="NBomber" />
     <PackageReference Include="Parquet.Net" />
     <PackageReference Include="Snappier" />
+    <!-- Direct pin of WireMock.Net's transitive Scriban.Signed to a patched version (GHSA-24c8-4792-22hx). -->
+    <PackageReference Include="Scriban.Signed" />
     <PackageReference Include="NBomber.Http" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="NSubstitute" />


### PR DESCRIPTION
## Problem
Nightly full-solution restores started failing 2026-06-30 (Slow Tier, Migration Evidence Pack, Cross-Server Consume) — all at the `Restore` step, not tests. Root cause: a freshly published high-severity advisory **GHSA-24c8-4792-22hx** (DoS in Scriban's `array.insert_at`) against **Scriban.Signed <= 7.1.0**. Under `TreatWarningsAsErrors`, NuGet audit turns NU1903 into a hard restore error across the whole solution.

`Scriban.Signed` 7.0.6 is a **test-only transitive** — it enters solely via `WireMock.Net` (response templating), referenced only by `Honua.TestKit`. No shipped `src/` project pulls it.

## Fix
Pin the transitive directly to the patched **7.2.0**, mirroring the existing MessagePack NU1903 pin:
- `Directory.Packages.props`: `PackageVersion Scriban.Signed 7.2.0`
- `Honua.TestKit.csproj`: direct `PackageReference Scriban.Signed` so the pin wins over WireMock.Net's 7.0.6

## Verification
- `dotnet restore Honua.sln` → clean (exit 0, no NU190x)
- `Scriban.Signed` resolves to 7.2.0 in project.assets.json

Patched-version bump rather than a suppression since 7.2.0 clears the advisory outright.