### PR TITLE
fix(nightly): unbreak Load/Soak and Real-Client Interop nightlies

### DIFF
--- a/.github/workflows/load-soak-nightly.yml
+++ b/.github/workflows/load-soak-nightly.yml
@@ -146,6 +146,13 @@ jobs:
           HONUA_ADMIN_PASSWORD: "Load-Soak-Admin-Pass1!"
           PUBLIC_BASE_URL: ${{ env.BASE_URL }}
           HostValidation__AllowedHosts__0: "localhost"
+          # The soak harness deliberately floods the server from a single host, so the
+          # opt-in app-level rate limiter (activated by #355 / appsettings.Security.json,
+          # GlobalRequestsPerMinute=1000 per tenant/identity/IP partition) would reject
+          # ~94% of requests as 429s and mask real latency/throughput signal. Production
+          # posture is edge rate limiting (ADR-0004); disable the app-level limiter here
+          # so the load/soak run measures the server, not the throttle.
+          RateLimiting__Enabled: "false"
           Security__DisableHttpsRedirection: "true"
           Security__ConnectionEncryption__MasterKey: "test-master-key-32-chars-long-000000"
           ConnectionStrings__redis: "localhost:6379"

--- a/docker/client-compat/cesium/Dockerfile
+++ b/docker/client-compat/cesium/Dockerfile
@@ -1,7 +1,12 @@
 # Cesium client interop lane. Uses the official Playwright image so headless
 # Chromium with WebGL works without further configuration.
-
-FROM mcr.microsoft.com/playwright:v1.59.1-noble
+#
+# IMPORTANT: keep this image tag in lockstep with the @playwright/test version
+# resolved in tests/js-browser/cesium/package-lock.json. The image bakes in the
+# matching browser build; a drift (e.g. the lockfile bumped to 1.61.0 while this
+# stayed at 1.59.1) makes `npx playwright test` fail with
+# "browserType.launch: Executable doesn't exist at .../chromium_headless_shell-<build>".
+FROM mcr.microsoft.com/playwright:v1.61.0-noble
 
 ENV DEBIAN_FRONTEND=noninteractive \
     NODE_OPTIONS="--max-old-space-size=4096" \


### PR DESCRIPTION
Two chronically-red nightly workflows, each caused by an environment/harness mismatch, not a product regression.

## Load/Soak Nightly (red since 2026-06-26)
- **Root cause:** batch-round2 (#2183) landed the opt-in app-level rate limiter (#355) on trunk. `appsettings.Security.json` ships `RateLimiting:Enabled=true` with `GlobalRequestsPerMinute=1000`. The soak harness floods the server from a single host, so all traffic past 1000/min got 429.
- **Evidence (run 28314480834, 06-28):** 15436 total NBomber scenario failures == 15437 `Rate limit exceeded` server warnings; reported failure rate 93.93% vs the 0.0001 gate. The last green run (06-25, `fdc0d3eb`) predated #355; auth-bypass warnings are benign (public read endpoints serve anonymously, only 6 unrelated 404s).
- **Fix:** set `RateLimiting__Enabled=false` on the load-soak server env. Production posture is edge rate limiting (ADR-0004); the app-level limiter isn't what the soak test measures. The `HONUA_LOAD_MAX_FAILURE_RATE` gate is left untouched.

## Real-Client Interop Matrix (red since 2026-06-21)
- **Root cause:** #1933 regenerated `tests/js-browser/cesium/package-lock.json`, bumping `@playwright/test` to 1.61.0, while `docker/client-compat/cesium/Dockerfile` stayed pinned to `playwright:v1.59.1-noble`. The image no longer contains the chromium build (`headless_shell-1228`) that 1.61.0 launches.
- **Evidence (run 28437885395):** the full matrix ran (all 5 lanes emitted envelopes — not an empty-lane false positive). The only baseline-diff regressions were the four `js-cesium` `CERT-RNDR-01` cases, all failing with `browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1228/...`. Every other lane was green.
- **Fix:** bump the cesium base image to `v1.61.0-noble` to match the lockfile, plus a lockstep comment to prevent future drift.