### PR TITLE
ci(security): risk-accept e_sqlite3 CVE-2025-6965 to clear Security Nightly

### DIFF
--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -69,14 +69,25 @@ jobs:
 
           cat vulnerability-report.txt
 
-          if grep -E "(High|Critical)" vulnerability-report.txt; then
+          # Advisories explicitly risk-accepted because there is NO upstream fix.
+          # Keep in sync with the NuGetAuditSuppress entries in Directory.Build.props
+          # and the .trivyignore file. `dotnet list package --vulnerable` does not
+          # honor NuGetAuditSuppress, so the accepted rows are filtered here before the
+          # gate. Only no-patched-version advisories belong here; anything with a fix
+          # must be bumped, not allowlisted.
+          #   GHSA-2m69-gcr7-jv3q — SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11 (no patched version)
+          ALLOWLISTED_ADVISORIES="GHSA-2m69-gcr7-jv3q"
+
+          grep -vE "${ALLOWLISTED_ADVISORIES}" vulnerability-report.txt > vulnerability-report.gated.txt || true
+
+          if grep -E "(High|Critical)" vulnerability-report.gated.txt; then
             echo "vulnerable_packages=true" >> "$GITHUB_OUTPUT"
-            echo "::error::High or Critical vulnerabilities found in NuGet packages"
+            echo "::error::High or Critical vulnerabilities found in NuGet packages (excluding risk-accepted advisories)"
             exit 1
           fi
 
           echo "vulnerable_packages=false" >> "$GITHUB_OUTPUT"
-          echo "No high or critical NuGet vulnerabilities found"
+          echo "No high or critical NuGet vulnerabilities found (excluding risk-accepted advisories)"
 
       - name: Upload vulnerability report
         uses: actions/upload-artifact@v7
@@ -251,6 +262,7 @@ jobs:
           format: sarif
           output: trivy-container-results.sarif
           severity: HIGH,CRITICAL
+          trivyignores: .trivyignore
 
       - name: Upload container Trivy SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v4
@@ -266,6 +278,7 @@ jobs:
           format: table
           severity: HIGH,CRITICAL
           exit-code: '1'
+          trivyignores: .trivyignore
 
       - name: Install container-structure-test
         run: |

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,14 @@
+# Trivy ignore file — risk-accepted vulnerabilities with no available upstream fix.
+#
+# Keep this in sync with the NuGetAuditSuppress entries in Directory.Build.props.
+# Only advisories that are genuinely unactionable (no patched version) belong here;
+# everything else must be remediated by a version bump, not ignored.
+#
+# CVE-2025-6965 — SQLitePCLRaw.lib.e_sqlite3 2.1.11 (HIGH): integer truncation in the
+#   bundled SQLite native lib. Pulled in transitively via Microsoft.Data.Sqlite. There
+#   is NO patched e_sqlite3 published (first_patched_version = none), so it cannot be
+#   cleared by a version bump. Same finding as GHSA-2m69-gcr7-jv3q suppressed for the
+#   NuGet audit in Directory.Build.props. e_sqlite3 is the bundled SQLite used by
+#   test/tooling paths; tracked for re-evaluation when a patched e_sqlite3 ships, at
+#   which point this entry is removed.
+CVE-2025-6965


### PR DESCRIPTION
## Problem
Security Nightly has been red on two steps, both reporting the same finding:
**SQLitePCLRaw.lib.e_sqlite3 2.1.11 — CVE-2025-6965 / GHSA-2m69-gcr7-jv3q (HIGH)**, integer truncation in the bundled SQLite native lib (transitive via Microsoft.Data.Sqlite). There is **no patched e_sqlite3 published**, so it cannot be cleared by a version bump. It is already risk-accepted for the main NuGet audit via `NuGetAuditSuppress` in `Directory.Build.props`, but neither the Trivy container scan nor `dotnet list package --vulnerable` honors that suppression.

The other finding, Scriban.Signed 7.0.6, is already fixed on trunk (pinned to 7.2.0 in #2318).

## Fix
- **Container Trivy scan**: add `.trivyignore` (CVE-2025-6965, documented) and wire `trivyignores: .trivyignore` into both container scan steps.
- **NuGet Vulnerability Scan**: filter the risk-accepted advisory (GHSA-2m69-gcr7-jv3q) out of the report before the High/Critical gate.

Kept in sync with the existing `Directory.Build.props` rationale. Only no-upstream-fix advisories are accepted; **a new/unrelated High still fails** both gates (verified).

## Verification
- Gate-logic test: with only e_sqlite3 present the NuGet gate passes; adding a synthetic new HIGH still fails it.
- After #2318 + this change, the nightly's remaining High/Critical set is empty.