### PR TITLE
fix: build repair + GeoServices geojson + cohesion + geoprocessing executors (#2312 sweep)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,6 +108,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.1" />
     <!-- Transitive of WireMock.Net (test-only HTTP mocking); pinned directly to clear GHSA-24c8-4792-22hx (NU1903). -->
+    <!-- Transitive of WireMock.Net (response templating); pinned directly to clear GHSA-24c8-4792-22hx (NU1903). Test-only. -->
     <PackageVersion Include="Scriban.Signed" Version="7.2.5" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
@@ -115,8 +116,6 @@
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <!-- Transitive of WireMock.Net (response templating); pinned directly to clear GHSA-24c8-4792-22hx (NU1903). Test-only. -->
-    <PackageVersion Include="Scriban.Signed" Version="7.2.0" />
     <PackageVersion Include="SkiaSharp" Version="3.119.2" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
     <PackageVersion Include="Snappier" Version="1.3.1" />

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerBufferAggregateExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerBufferAggregateExecutor.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Operation.Union;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// <c>analytics.buffer-aggregate</c> layer-aware executor (#2322). The job-executable
+/// counterpart of the layer-scoped PostGIS <c>SpatialAnalytics</c> buffer-aggregate:
+/// it streams a Honua catalog layer through <c>source.honua-layer</c>, buffers every
+/// feature by <c>distance</c> in the supplied unit, then optionally dissolves the
+/// buffers into one feature per <c>groupByFields</c> group via
+/// <see cref="CascadedPolygonUnion"/>. Each emitted feature carries a <c>COUNT</c>
+/// attribute. Distance is normalised to CRS units after applying the unit factor
+/// (meters/kilometers/feet/miles); geodesic conversion is not performed — this
+/// matches the managed <c>analytics.buffer-aggregate-managed</c> convention.
+/// </summary>
+internal sealed class LayerBufferAggregateExecutor : LayerSourcedFeatureExecutor
+{
+    internal const string HandledProcessId = "analytics.buffer-aggregate";
+    internal const string CountAttribute = "COUNT";
+
+    public LayerBufferAggregateExecutor(
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<LayerBufferAggregateExecutor> logger)
+        : base(serviceScopeFactory, options, logger)
+    {
+    }
+
+    protected override string ProcessId => HandledProcessId;
+
+    protected override List<IFeature> Apply(
+        List<IFeature> source,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+    {
+        var distance = ReadDistance(inputs);
+        var effectiveDistance = distance * ReadUnitFactor(inputs);
+        var dissolve = ReadBool(inputs, "dissolve", defaultValue: true);
+        var groupByFields = ReadGroupByFields(inputs);
+
+        var buffered = new List<(IFeature Feature, NtsGeometry Geometry, string GroupKey)>(source.Count);
+        foreach (var feature in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                continue;
+            }
+
+            var bufferedGeometry = geometry.Buffer(effectiveDistance);
+            if (bufferedGeometry is null || bufferedGeometry.IsEmpty)
+            {
+                continue;
+            }
+
+            buffered.Add((feature, bufferedGeometry, BuildGroupKey(feature, groupByFields)));
+        }
+
+        if (!dissolve)
+        {
+            var perFeature = new List<IFeature>(buffered.Count);
+            foreach (var entry in buffered)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var attributes = OverlayExecutorSupport.CopyAttributes(entry.Feature);
+                OverlayExecutorSupport.Upsert(attributes, CountAttribute, 1L);
+                perFeature.Add(new Feature(entry.Geometry, attributes));
+            }
+
+            return perFeature;
+        }
+
+        var groups = new Dictionary<string, (IFeature First, List<NtsGeometry> Geometries)>(StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (var entry in buffered)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!groups.TryGetValue(entry.GroupKey, out var accumulator))
+            {
+                accumulator = (entry.Feature, new List<NtsGeometry>());
+                groups[entry.GroupKey] = accumulator;
+                order.Add(entry.GroupKey);
+            }
+
+            accumulator.Geometries.Add(entry.Geometry);
+        }
+
+        var dissolved = new List<IFeature>(order.Count);
+        foreach (var key in order)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var (first, geometries) = groups[key];
+            var unioned = geometries.Count == 1 ? geometries[0] : CascadedPolygonUnion.Union(geometries);
+
+            var attributes = new AttributesTable();
+            foreach (var field in groupByFields)
+            {
+                object? value = first.Attributes is not null && first.Attributes.Exists(field)
+                    ? first.Attributes.GetOptionalValue(field)
+                    : null;
+                OverlayExecutorSupport.Upsert(attributes, field, value);
+            }
+
+            OverlayExecutorSupport.Upsert(attributes, CountAttribute, (long)geometries.Count);
+            dissolved.Add(new Feature(unioned, attributes));
+        }
+
+        return dissolved;
+    }
+
+    private static string BuildGroupKey(IFeature feature, List<string> groupByFields)
+    {
+        if (groupByFields.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var attributes = feature.Attributes;
+        var parts = new string[groupByFields.Count];
+        for (var i = 0; i < groupByFields.Count; i++)
+        {
+            object? value = attributes is not null && attributes.Exists(groupByFields[i])
+                ? attributes.GetOptionalValue(groupByFields[i])
+                : null;
+            parts[i] = value is null
+                ? ""
+                : Convert.ToString(value, CultureInfo.InvariantCulture) ?? "";
+        }
+
+        return string.Join("", parts);
+    }
+
+    private static double ReadDistance(StepInputReader inputs)
+    {
+        if (!inputs.TryGet("distance", out var raw) || string.IsNullOrWhiteSpace(raw)
+            || !double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+            || !double.IsFinite(value)
+            || value < 0)
+        {
+            throw new TransformInputException("'distance' must be a finite non-negative number");
+        }
+
+        return value;
+    }
+
+    private static double ReadUnitFactor(StepInputReader inputs)
+    {
+        var raw = inputs.GetOrDefault("unit", "meters").Trim().ToLowerInvariant();
+        return raw switch
+        {
+            "" or "meters" or "meter" or "m" => 1.0,
+            "kilometers" or "kilometer" or "km" => 1000.0,
+            "feet" or "foot" or "ft" => 0.3048,
+            "miles" or "mile" or "mi" => 1609.344,
+            _ => throw new TransformInputException(
+                $"unit '{raw}' is not supported (allowed: meters, kilometers, feet, miles)"),
+        };
+    }
+
+    private static bool ReadBool(StepInputReader inputs, string name, bool defaultValue)
+    {
+        if (!inputs.TryGet(name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "true" or "1" or "yes" => true,
+            "false" or "0" or "no" => false,
+            _ => throw new TransformInputException($"'{name}' must be a boolean (true|false)"),
+        };
+    }
+
+    private static List<string> ReadGroupByFields(StepInputReader inputs)
+    {
+        if (!inputs.TryGet("groupByFields", out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return [];
+        }
+
+        return [.. raw!.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerDissolveExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerDissolveExecutor.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// <c>generalization.dissolve</c> layer-aware executor (#2325). The job-executable
+/// counterpart of the layer-scoped "Dissolve" op: it streams a Honua catalog layer
+/// through <c>source.honua-layer</c> and dissolves (unions) features by an optional
+/// attribute group, producing one feature per group with a <c>COUNT</c> of the
+/// dissolved rows plus any aggregates requested through <c>outStatistics</c>. Unlike
+/// <c>analytics.buffer-aggregate</c> no buffer is applied before the union. The
+/// geometry union reuses the shared <see cref="OverlayExecutorSupport"/> primitive
+/// (cascaded polygon union for polygonal input, dimension-preserving unary union
+/// otherwise) and the statistics reuse the shared <see cref="StatisticsSupport"/>
+/// accumulators.
+/// </summary>
+internal sealed class LayerDissolveExecutor : LayerSourcedFeatureExecutor
+{
+    internal const string HandledProcessId = "generalization.dissolve";
+    internal const string CountAttribute = "COUNT";
+
+    public LayerDissolveExecutor(
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<LayerDissolveExecutor> logger)
+        : base(serviceScopeFactory, options, logger)
+    {
+    }
+
+    protected override string ProcessId => HandledProcessId;
+
+    protected override List<IFeature> Apply(
+        List<IFeature> source,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+    {
+        var groupByFields = StatisticsSupport.ParseFieldList(inputs.GetOrDefault("groupByFields", string.Empty));
+        var dissolve = ReadBool(inputs, "dissolve", defaultValue: true);
+        var stats = StatisticsSupport.ParseStatistics(inputs.GetOrDefault("outStatistics", string.Empty));
+
+        if (!dissolve)
+        {
+            if (stats.Count > 0)
+            {
+                throw new TransformInputException(
+                    "'outStatistics' requires dissolve=true; per-feature output cannot carry aggregate columns.");
+            }
+
+            // No union requested: emit the input features unchanged (attributes carried through).
+            var passthrough = new List<IFeature>(source.Count);
+            foreach (var feature in source)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (feature.Geometry is null || feature.Geometry.IsEmpty)
+                {
+                    continue;
+                }
+
+                passthrough.Add(new Feature(feature.Geometry, OverlayExecutorSupport.CopyAttributes(feature)));
+            }
+
+            return passthrough;
+        }
+
+        var groups = new Dictionary<string, GroupState>(StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (var feature in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var key = StatisticsSupport.GroupKey(feature, groupByFields);
+            if (!groups.TryGetValue(key, out var state))
+            {
+                state = new GroupState(feature, groupByFields, stats);
+                groups[key] = state;
+                order.Add(key);
+            }
+
+            state.Add(feature);
+        }
+
+        var output = new List<IFeature>(order.Count);
+        foreach (var key in order)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            output.Add(groups[key].Build());
+        }
+
+        return output;
+    }
+
+    private static bool ReadBool(StepInputReader inputs, string name, bool defaultValue)
+    {
+        if (!inputs.TryGet(name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "true" or "1" or "yes" => true,
+            "false" or "0" or "no" => false,
+            _ => throw new TransformInputException($"'{name}' must be a boolean (true|false)"),
+        };
+    }
+
+    private sealed class GroupState
+    {
+        private readonly IFeature _first;
+        private readonly IReadOnlyList<string> _groupByFields;
+        private readonly IReadOnlyList<StatisticsSupport.StatSpec> _stats;
+        private readonly Dictionary<string, StatisticsSupport.FieldAccumulator> _accumulators = new(StringComparer.Ordinal);
+        private readonly FeatureCollection _geometries = new();
+        private long _count;
+
+        public GroupState(
+            IFeature first,
+            IReadOnlyList<string> groupByFields,
+            IReadOnlyList<StatisticsSupport.StatSpec> stats)
+        {
+            _first = first;
+            _groupByFields = groupByFields;
+            _stats = stats;
+        }
+
+        public void Add(IFeature feature)
+        {
+            _count++;
+            if (feature.Geometry is not null && !feature.Geometry.IsEmpty)
+            {
+                _geometries.Add(feature);
+            }
+
+            foreach (var spec in _stats)
+            {
+                if (spec.Kind == StatisticsSupport.StatKind.Count)
+                {
+                    continue;
+                }
+
+                if (!_accumulators.TryGetValue(spec.Field, out var accumulator))
+                {
+                    accumulator = new StatisticsSupport.FieldAccumulator();
+                    _accumulators[spec.Field] = accumulator;
+                }
+
+                if (StatisticsSupport.TryReadNumeric(feature, spec.Field, out var value))
+                {
+                    accumulator.Add(value);
+                }
+            }
+        }
+
+        public Feature Build()
+        {
+            var attributes = new AttributesTable();
+            foreach (var field in _groupByFields)
+            {
+                object? value = _first.Attributes is not null && _first.Attributes.Exists(field)
+                    ? _first.Attributes.GetOptionalValue(field)
+                    : null;
+                OverlayExecutorSupport.Upsert(attributes, field, value);
+            }
+
+            OverlayExecutorSupport.Upsert(attributes, CountAttribute, _count);
+
+            foreach (var spec in _stats)
+            {
+                object? value = spec.Kind == StatisticsSupport.StatKind.Count
+                    ? _count
+                    : _accumulators.TryGetValue(spec.Field, out var accumulator)
+                        ? accumulator.Resolve(spec.Kind)
+                        : null;
+                OverlayExecutorSupport.Upsert(attributes, spec.OutputName, value);
+            }
+
+            var geometry = OverlayExecutorSupport.UnionGeometry(_geometries);
+            return new Feature(geometry, attributes);
+        }
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerFeatureProjectExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerFeatureProjectExecutor.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// <c>conversion.feature-project</c> layer-aware executor (#2325). The job-executable
+/// counterpart of the layer-scoped "Project Feature Layer" op: it reprojects every
+/// feature in a Honua catalog layer into <c>targetSrid</c>.
+///
+/// <para>
+/// Reprojection reuses the canonical query pipeline rather than re-implementing
+/// geodesy: the executor requests server-side reprojection to <c>targetSrid</c> from
+/// <c>source.honua-layer</c> via <see cref="DagSourceRequest.OutputSrid"/> (the same
+/// CRS handling every read path inherits), so the streamed features already carry the
+/// target CRS coordinates. The op body is therefore a pass-through that re-emits the
+/// reprojected layer as the canonical FeatureCollection artifact. This keeps a single
+/// source of truth for datum/projection math and avoids the first-slice in-memory
+/// transform limits of the single-geometry <c>geometry.project</c> executor.
+/// </para>
+/// </summary>
+internal sealed class LayerFeatureProjectExecutor : LayerSourcedFeatureExecutor
+{
+    internal const string HandledProcessId = "conversion.feature-project";
+
+    public LayerFeatureProjectExecutor(
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<LayerFeatureProjectExecutor> logger)
+        : base(serviceScopeFactory, options, logger)
+    {
+    }
+
+    protected override string ProcessId => HandledProcessId;
+
+    protected override DagSourceRequest CustomizeRequest(DagSourceRequest request, StepInputReader inputs)
+    {
+        // Drive reprojection through the shared query pipeline: request the target CRS
+        // from source.honua-layer so features stream back already reprojected.
+        return request with { OutputSrid = ReadTargetSrid(inputs) };
+    }
+
+    protected override List<IFeature> Apply(
+        List<IFeature> source,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+    {
+        // Validate the target SRID here too so a request that never reached
+        // CustomizeRequest (defensive) still surfaces a classified input error.
+        _ = ReadTargetSrid(inputs);
+        return source;
+    }
+
+    private static int ReadTargetSrid(StepInputReader inputs)
+    {
+        if (!inputs.TryGet("targetSrid", out var raw)
+            || !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            || value <= 0)
+        {
+            throw new TransformInputException("missing or invalid required input 'targetSrid'; expected a positive integer.");
+        }
+
+        return value;
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSimplifyExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSimplifyExecutor.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Simplify;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// <c>generalization.simplify-layer</c> layer-aware executor (#2325). The
+/// job-executable counterpart of the layer-scoped "Simplify Layer" op: it streams a
+/// Honua catalog layer through <c>source.honua-layer</c> and applies Douglas-Peucker
+/// simplification to every geometry, carrying attributes through one-to-one. The
+/// <c>tolerance</c> is expressed in the layer's spatial-reference units (degrees for
+/// geographic, meters for projected), matching <c>geometry.simplify</c>. When
+/// <c>preserveTopology</c> is true (the default) the topology-preserving simplifier is
+/// used so rings do not collapse or self-intersect; otherwise the plain
+/// Douglas-Peucker simplifier runs. Features whose geometry simplifies to empty are
+/// dropped.
+/// </summary>
+internal sealed class LayerSimplifyExecutor : LayerSourcedFeatureExecutor
+{
+    internal const string HandledProcessId = "generalization.simplify-layer";
+
+    public LayerSimplifyExecutor(
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<LayerSimplifyExecutor> logger)
+        : base(serviceScopeFactory, options, logger)
+    {
+    }
+
+    protected override string ProcessId => HandledProcessId;
+
+    protected override List<IFeature> Apply(
+        List<IFeature> source,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+    {
+        var tolerance = ReadTolerance(inputs);
+        var preserveTopology = ReadBool(inputs, "preserveTopology", defaultValue: true);
+
+        var output = new List<IFeature>(source.Count);
+        foreach (var feature in source)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var geometry = feature.Geometry;
+            if (geometry is null || geometry.IsEmpty)
+            {
+                continue;
+            }
+
+            NtsGeometry simplified = preserveTopology
+                ? TopologyPreservingSimplifier.Simplify(geometry, tolerance)
+                : DouglasPeuckerSimplifier.Simplify(geometry, tolerance);
+
+            if (simplified is null || simplified.IsEmpty)
+            {
+                continue;
+            }
+
+            output.Add(new Feature(simplified, OverlayExecutorSupport.CopyAttributes(feature)));
+        }
+
+        return output;
+    }
+
+    private static double ReadTolerance(StepInputReader inputs)
+    {
+        if (!inputs.TryGet("tolerance", out var raw)
+            || !double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+            || !double.IsFinite(value)
+            || value <= 0)
+        {
+            throw new TransformInputException("missing or invalid required input 'tolerance'; expected a finite number > 0.");
+        }
+
+        return value;
+    }
+
+    private static bool ReadBool(StepInputReader inputs, string name, bool defaultValue)
+    {
+        if (!inputs.TryGet(name, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "true" or "1" or "yes" => true,
+            "false" or "0" or "no" => false,
+            _ => throw new TransformInputException($"'{name}' must be a boolean (true|false)"),
+        };
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSourcedFeatureExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSourcedFeatureExecutor.cs
@@ -1,0 +1,284 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// Shared base for the <b>layer-aware</b> managed vector operations that execute as a
+/// SINGLE dispatched geoprocessing job over a Honua catalog layer (#2322, #2325).
+///
+/// <para>
+/// The geoprocessing job runtime is single-step: a dispatched job runs exactly one
+/// executor reading the plan's step-0 inputs (there is no in-job step chaining — a
+/// <c>source.honua-layer -&gt; op -&gt; sink</c> DAG only runs through the workflow
+/// orchestration engine as one child job per node). The per-operation OGC API -
+/// Processes projections (#1382) for the layer-scoped analytics/generalization/
+/// conversion ops advertise a <c>layerId</c> input and are submitted as a single
+/// job, so they cannot consume an inline FeatureCollection produced by a separate
+/// upstream node. This base closes that gap by fusing the layer read with the
+/// managed op in one executor: it resolves the <c>source.honua-layer</c>
+/// <see cref="IDagFeatureSource"/> (REUSING the canonical query pipeline through the
+/// same provider-resolution pattern as <see cref="RemoteSourceExecutor"/>), streams
+/// the layer's features, hands them to the concrete op, and publishes the canonical
+/// FeatureCollection artifact — mirroring how the inline <c>overlay.*</c> layer-aware
+/// executors emit their result, but sourcing the input layer itself.
+/// </para>
+///
+/// <para>
+/// In a lean, catalog-free deployment no <c>source.honua-layer</c> connector is
+/// registered, so the executor fails closed with a clear, actionable message rather
+/// than taking a Postgres dependency in the dispatcher assembly.
+/// </para>
+/// </summary>
+internal abstract partial class LayerSourcedFeatureExecutor : IProcessExecutor
+{
+    /// <summary>The <see cref="IDagFeatureSource.SourceId"/> this base reads from.</summary>
+    private protected const string HonuaLayerSourceId = "source.honua-layer";
+
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger _logger;
+    private IReadOnlySet<string>? _processIds;
+
+    private protected LayerSourcedFeatureExecutor(
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        Options = options;
+        _logger = logger;
+    }
+
+    /// <summary>The single dotted process id this executor handles (e.g. <c>analytics.buffer-aggregate</c>).</summary>
+    protected abstract string ProcessId { get; }
+
+    /// <summary>Shared executor options (artifact caps, output roots).</summary>
+    private protected IOptionsMonitor<GeoprocessingExecutorOptions> Options { get; }
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> ProcessIds =>
+        _processIds ??= new HashSet<string>(StringComparer.Ordinal) { ProcessId };
+
+    /// <inheritdoc />
+    public ExecutionJobKind Kind => ExecutionJobKind.Geoprocessing;
+
+    /// <inheritdoc />
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var resolved = GeoprocessingDispatchHelper.ResolveProcessId(job.Spec.Parameters);
+        if (!string.Equals(resolved, ProcessId, StringComparison.Ordinal))
+        {
+            return JobExecutionResult.Failed(
+                $"Process id '{resolved ?? "<none>"}' is not handled by the {ProcessId} executor.");
+        }
+
+        var inputs = new StepInputReader(job.Spec.Parameters);
+
+        DagSourceRequest request;
+        try
+        {
+            request = BuildSourceRequest(inputs);
+        }
+        catch (TransformInputException ex)
+        {
+            return JobExecutionResult.Failed($"Invalid {ProcessId} inputs: {ex.PublicMessage}");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(5, $"Resolving {ProcessId} source layer", cancellationToken).ConfigureAwait(false);
+
+        using var scope = _serviceScopeFactory.CreateScope();
+        var source = ResolveHonuaLayerSource(scope.ServiceProvider);
+        if (source is null)
+        {
+            Log.SourceUnavailable(_logger, job.OperationId, ProcessId);
+            return JobExecutionResult.Failed(
+                $"The {ProcessId} process is unavailable in this deployment: it reads a Honua catalog layer " +
+                $"through the {HonuaLayerSourceId} connector, which is not configured here.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(20, $"Streaming layer features for {ProcessId}", cancellationToken).ConfigureAwait(false);
+
+        var geoJsonReader = new GeoJsonReader();
+        var features = new List<IFeature>();
+        try
+        {
+            await foreach (var sourceFeature in source.ReadAsync(request, cancellationToken).ConfigureAwait(false))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                features.Add(ToNtsFeature(sourceFeature, geoJsonReader));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.SourceReadFailed(_logger, job.OperationId, ProcessId, ex);
+            return JobExecutionResult.Failed($"{ProcessId} failed reading the source layer: {ex.GetType().Name}.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(55, $"Applying {ProcessId}", cancellationToken).ConfigureAwait(false);
+
+        List<IFeature> output;
+        try
+        {
+            output = Apply(features, inputs, cancellationToken);
+        }
+        catch (TransformInputException ex)
+        {
+            return JobExecutionResult.Failed($"Invalid {ProcessId} inputs: {ex.PublicMessage}");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Log.ComputationFailed(_logger, job.OperationId, ProcessId, ex);
+            return JobExecutionResult.Failed($"{ProcessId} computation failed: {ex.GetType().Name}.");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.ReportProgressAsync(80, $"Encoding {ProcessId} artifact", cancellationToken).ConfigureAwait(false);
+
+        var payload = FeatureCollectionArtifact.WriteFeatureCollection(output, ProcessId);
+        var maxBytes = Options.CurrentValue.MaxArtifactBytes;
+        if (payload.Length > maxBytes)
+        {
+            return JobExecutionResult.Failed(
+                $"{ProcessId} artifact size {payload.Length} bytes exceeds configured MaxArtifactBytes={maxBytes}.");
+        }
+
+        var artifactUri = FeatureCollectionArtifact.BuildDataUri(payload);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await context.PublishArtifactAsync(artifactUri, cancellationToken).ConfigureAwait(false);
+        await context.ReportProgressAsync(100, $"{ProcessId} completed ({output.Count} features)", cancellationToken)
+            .ConfigureAwait(false);
+
+        return JobExecutionResult.Succeeded();
+    }
+
+    /// <summary>
+    /// Applies the concrete layer-aware operation to the streamed source features,
+    /// returning the output feature set. Throw <see cref="TransformInputException"/>
+    /// for caller-supplied parameter errors so they surface as a classified
+    /// <c>Invalid ... inputs</c> failure.
+    /// </summary>
+    protected abstract List<IFeature> Apply(
+        List<IFeature> source,
+        StepInputReader inputs,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Hook for a concrete op to add operation-specific fields to the layer read
+    /// request (for example <c>conversion.feature-project</c> requesting server-side
+    /// reprojection to the target SRID via <see cref="DagSourceRequest.OutputSrid"/>).
+    /// The base has already populated the common windowing fields. The default is a
+    /// no-op. Throw <see cref="TransformInputException"/> for invalid inputs.
+    /// </summary>
+    protected virtual DagSourceRequest CustomizeRequest(DagSourceRequest request, StepInputReader inputs)
+        => request;
+
+    private DagSourceRequest BuildSourceRequest(StepInputReader inputs)
+    {
+        if (!inputs.TryGet("layerId", out var layerIdRaw)
+            || !int.TryParse(layerIdRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId)
+            || layerId < 0)
+        {
+            throw new TransformInputException("missing or invalid required input 'layerId'; expected a non-negative integer.");
+        }
+
+        var request = new DagSourceRequest
+        {
+            LayerId = layerId,
+            Where = inputs.TryGet("where", out var where) ? where : null,
+            Bbox = inputs.TryGet("bbox", out var bbox) ? bbox : null,
+            OutFields = inputs.TryGet("outFields", out var outFields) ? outFields : null,
+            OutputSrid = TryGetPositiveInt(inputs, "outSrid"),
+            Since = inputs.TryGet("since", out var since) ? since : null,
+            WatermarkField = inputs.TryGet("watermarkField", out var watermarkField) ? watermarkField : null,
+        };
+
+        return CustomizeRequest(request, inputs);
+    }
+
+    private static IDagFeatureSource? ResolveHonuaLayerSource(IServiceProvider services)
+    {
+        foreach (var candidate in services.GetServices<IDagFeatureSource>())
+        {
+            if (string.Equals(candidate.SourceId, HonuaLayerSourceId, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static Feature ToNtsFeature(DagSourceFeature sourceFeature, GeoJsonReader reader)
+    {
+        NtsGeometry? geometry = null;
+        if (!string.IsNullOrWhiteSpace(sourceFeature.GeometryGeoJson))
+        {
+            try
+            {
+                geometry = reader.Read<NtsGeometry>(sourceFeature.GeometryGeoJson);
+            }
+            catch (Exception ex) when (ex is Newtonsoft.Json.JsonException or ArgumentException or FormatException)
+            {
+                geometry = null;
+            }
+        }
+
+        var attributes = new AttributesTable();
+        foreach (var (key, value) in sourceFeature.Attributes)
+        {
+            if (!attributes.Exists(key))
+            {
+                attributes.Add(key, value);
+            }
+        }
+
+        return new Feature(geometry, attributes);
+    }
+
+    private protected static int? TryGetPositiveInt(StepInputReader inputs, string name)
+        => inputs.TryGet(name, out var raw)
+            && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            && value > 0
+            ? value
+            : null;
+
+    private static partial class Log
+    {
+        [LoggerMessage(9300, LogLevel.Warning,
+            "Layer-sourced executor refused job {OperationId} for {ProcessId}: no source.honua-layer connector is registered")]
+        public static partial void SourceUnavailable(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9301, LogLevel.Error,
+            "Layer-sourced executor failed job {OperationId} during {ProcessId} layer read")]
+        public static partial void SourceReadFailed(ILogger logger, string operationId, string processId, Exception exception);
+
+        [LoggerMessage(9302, LogLevel.Error,
+            "Layer-sourced executor failed job {OperationId} during {ProcessId} computation")]
+        public static partial void ComputationFailed(ILogger logger, string operationId, string processId, Exception exception);
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -256,6 +256,16 @@ internal static class GeoprocessingServiceCollectionExtensions
         Register<ManagedDensityExecutor>(services);
         // Spatial-statistics tool pack (#2142): Hot Spot Analysis (Getis-Ord Gi*).
         Register<ManagedHotSpotExecutor>(services);
+        // Layer-aware, layer-SOURCED managed ops (#2322, #2325): the job-executable
+        // counterparts of the layer-scoped PostGIS analytics/generalization/conversion
+        // ops. Each streams a Honua catalog layer through source.honua-layer and runs a
+        // managed NetTopologySuite op in one dispatched job, so the per-operation OGC
+        // API - Processes projections (#1382) that advertise a layerId input reach a
+        // terminal SUCCEEDED state instead of being refused at dispatch.
+        Register<LayerBufferAggregateExecutor>(services);
+        Register<LayerFeatureProjectExecutor>(services);
+        Register<LayerDissolveExecutor>(services);
+        Register<LayerSimplifyExecutor>(services);
         // Layer-aware overlay tool pack (#2206, #2139).
         Register<OverlayClipExecutor>(services);
         Register<OverlayIntersectExecutor>(services);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Query.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Query.cs
@@ -187,7 +187,11 @@ internal static partial class FeatureServerEndpoints
 
         // Validate output format only after the service is confirmed to exist, so a
         // missing service returns 404 rather than a misleading 400 (e.g. f=html).
-        if (!TryValidateOutputFormat(requestedFormat, JsonOnlyFormats, out _, out var formatError))
+        // The layer query handler produces the full FeatureServerQueryFormats set
+        // (json/pjson/geojson/pbf/fgb/geobuf/parquet/arrow) — matching what the
+        // layer's SupportedQueryFormats advertises — so validate against that set
+        // rather than JsonOnly (which wrongly rejected f=geojson; #2323).
+        if (!TryValidateOutputFormat(requestedFormat, FeatureServerQueryFormats, out _, out var formatError))
         {
             return StandardErrorHelpers.CreateBadRequest(context,
                 "Invalid query parameters",

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerProjectHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerProjectHandler.cs
@@ -4,13 +4,11 @@
 using System.Globalization;
 using System.Text.Json;
 using Honua.Core.Features.GeometryService.Abstractions;
-using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Crs;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Models;
-using Honua.Infrastructure.Services;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Honua.Protocols.GeoServices.ImageServer.Models;
 using Honua.Protocols.GeoServices.ImageServer.Services;
@@ -29,25 +27,19 @@ internal sealed class ImageServerProjectHandler
     private const int MaxGeometryJsonLength = 10_000_000;
 
     private readonly IGeometryOperationService _operationService;
-    private readonly SpatialReferenceResolver _spatialReferenceResolver;
-    private readonly IDatumTransformationCatalog _datumTransformationCatalog;
+    private readonly ImageServerCoordinateProjection _projection;
     private readonly ILogger<ImageServerProjectHandler> _logger;
-    private readonly ICoordinateTransformService? _transformService;
     private readonly IRasterStore? _rasterStore;
 
     public ImageServerProjectHandler(
         IGeometryOperationService operationService,
-        SpatialReferenceResolver spatialReferenceResolver,
-        IDatumTransformationCatalog datumTransformationCatalog,
+        ImageServerCoordinateProjection projection,
         ILogger<ImageServerProjectHandler> logger,
-        ICoordinateTransformService? transformService = null,
         IRasterStore? rasterStore = null)
     {
         _operationService = operationService ?? throw new ArgumentNullException(nameof(operationService));
-        _spatialReferenceResolver = spatialReferenceResolver ?? throw new ArgumentNullException(nameof(spatialReferenceResolver));
-        _datumTransformationCatalog = datumTransformationCatalog ?? throw new ArgumentNullException(nameof(datumTransformationCatalog));
+        _projection = projection ?? throw new ArgumentNullException(nameof(projection));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _transformService = transformService;
         _rasterStore = rasterStore;
     }
 
@@ -108,8 +100,7 @@ internal sealed class ImageServerProjectHandler
             var sourceSrid = inSrid.Value;
             var targetSrid = outSrid.Value;
 
-            if (!GeoServicesDatumTransformationResolver.TryResolve(
-                    _datumTransformationCatalog,
+            if (!_projection.TryResolveDatumTransformation(
                     GetString(values, "datumTransformation"),
                     sourceSrid,
                     targetSrid,
@@ -129,7 +120,7 @@ internal sealed class ImageServerProjectHandler
                     StringComparison.OrdinalIgnoreCase);
                 if (TryReadEnvelopeGeometry(geometryJson, requireEnvelope, out var envelope, out var envelopeError))
                 {
-                    if (_transformService is null && sourceSrid != targetSrid)
+                    if (!_projection.HasTransformService && sourceSrid != targetSrid)
                     {
                         return StandardErrorHelpers.CreateNotImplemented(
                             context,
@@ -242,7 +233,7 @@ internal sealed class ImageServerProjectHandler
         }
 
         var reprojectToOut = outSrid.Value != GroundSrid;
-        if (reprojectToOut && _transformService is null)
+        if (reprojectToOut && !_projection.HasTransformService)
         {
             return StandardErrorHelpers.CreateNotImplemented(
                 context,
@@ -268,7 +259,7 @@ internal sealed class ImageServerProjectHandler
             var outY = latitude;
             if (reprojectToOut)
             {
-                var transformResult = await _transformService!.TransformExtentAsync(
+                var transformResult = await _projection.TransformExtentAsync(
                     longitude, latitude, longitude, latitude,
                     GroundSrid, outSrid.Value, cancellationToken).ConfigureAwait(false);
                 if (transformResult is null)
@@ -353,7 +344,7 @@ internal sealed class ImageServerProjectHandler
         var projected = (XMin: envelope.XMin, YMin: envelope.YMin, XMax: envelope.XMax, YMax: envelope.YMax);
         if (inSrid != outSrid)
         {
-            var transformResult = await _transformService!.TransformExtentAsync(
+            var transformResult = await _projection.TransformExtentAsync(
                 envelope.XMin,
                 envelope.YMin,
                 envelope.XMax,
@@ -397,7 +388,7 @@ internal sealed class ImageServerProjectHandler
             return (null, $"{key} is required.");
         }
 
-        var srid = await _spatialReferenceResolver.ResolveSridAsync(raw, null, cancellationToken)
+        var srid = await _projection.ResolveSridAsync(raw, cancellationToken)
             .ConfigureAwait(false);
         if (!srid.HasValue)
         {

--- a/src/Honua.Protocols.GeoServices/ImageServer/ImageServerServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/ImageServerServiceCollectionExtensions.cs
@@ -59,6 +59,11 @@ internal static class ImageServerServiceCollectionExtensions
         // Register supporting services
         services.TryAddScoped<SpatialReferenceResolver>();
 
+        // CRS/datum/transform seam for the project operation: folds the spatial-reference
+        // resolver, datum-transformation catalog, and optional coordinate transform service
+        // behind one dependency so ImageServerProjectHandler stays within the collaborator limit.
+        services.TryAddScoped<ImageServerCoordinateProjection>();
+
         // Shared Esri datum-transformation catalog (WKID -> PROJ pipeline) used by the
         // project operation. TryAdd keeps a single instance shared with the FeatureServer
         // registration regardless of protocol registration order.

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCoordinateProjection.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCoordinateProjection.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Crs;
+using Honua.Infrastructure.Services;
+
+namespace Honua.Protocols.GeoServices.ImageServer.Services;
+
+/// <summary>
+/// Bundles the CRS/datum/transform collaborators used by the ImageServer project operation behind
+/// a single seam so request handlers compose one projection dependency instead of three separate
+/// coordinate services. Delegates verbatim to the underlying spatial-reference resolver, Esri
+/// datum-transformation catalog, and (optional) coordinate transform service; it adds no behavior.
+/// </summary>
+internal sealed class ImageServerCoordinateProjection
+{
+    private readonly SpatialReferenceResolver _spatialReferenceResolver;
+    private readonly IDatumTransformationCatalog _datumTransformationCatalog;
+    private readonly ICoordinateTransformService? _transformService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageServerCoordinateProjection"/> class.
+    /// </summary>
+    /// <param name="spatialReferenceResolver">Resolves client spatial-reference values to SRIDs.</param>
+    /// <param name="datumTransformationCatalog">Esri WKID → PROJ pipeline catalog for datum selection.</param>
+    /// <param name="transformService">
+    /// Optional coordinate transform service. When absent, envelope/image reprojection between
+    /// differing spatial references is unavailable (callers surface a 501), matching prior behavior.
+    /// </param>
+    public ImageServerCoordinateProjection(
+        SpatialReferenceResolver spatialReferenceResolver,
+        IDatumTransformationCatalog datumTransformationCatalog,
+        ICoordinateTransformService? transformService = null)
+    {
+        _spatialReferenceResolver = spatialReferenceResolver ?? throw new ArgumentNullException(nameof(spatialReferenceResolver));
+        _datumTransformationCatalog = datumTransformationCatalog ?? throw new ArgumentNullException(nameof(datumTransformationCatalog));
+        _transformService = transformService;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether a coordinate transform service is configured. When
+    /// <see langword="false"/>, cross-SRID envelope/image reprojection is unsupported.
+    /// </summary>
+    public bool HasTransformService => _transformService is not null;
+
+    /// <summary>
+    /// Resolves a client-supplied spatial-reference value (WKID or JSON spatial reference) to a
+    /// supported SRID, returning <see langword="null"/> when it cannot be resolved.
+    /// </summary>
+    public Task<int?> ResolveSridAsync(string? srValue, CancellationToken cancellationToken)
+        => _spatialReferenceResolver.ResolveSridAsync(srValue, null, cancellationToken);
+
+    /// <summary>
+    /// Resolves the requested datum transformation for the given SRID pair, mirroring
+    /// <see cref="GeoServicesDatumTransformationResolver.TryResolve"/>.
+    /// </summary>
+    public bool TryResolveDatumTransformation(
+        string? datumTransformationValue,
+        int fromSrid,
+        int toSrid,
+        out DatumTransformationSelection? selection,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(false)] out string? errorMessage)
+        => GeoServicesDatumTransformationResolver.TryResolve(
+            _datumTransformationCatalog,
+            datumTransformationValue,
+            fromSrid,
+            toSrid,
+            out selection,
+            out errorMessage);
+
+    /// <summary>
+    /// Transforms a bounding-box extent using an explicitly selected datum transformation.
+    /// Requires a configured transform service (guard with <see cref="HasTransformService"/>).
+    /// </summary>
+    public ValueTask<(double MinX, double MinY, double MaxX, double MaxY)?> TransformExtentAsync(
+        double minX,
+        double minY,
+        double maxX,
+        double maxY,
+        int fromSrid,
+        int toSrid,
+        DatumTransformationSelection? selection,
+        CancellationToken cancellationToken)
+        => _transformService!.TransformExtentAsync(minX, minY, maxX, maxY, fromSrid, toSrid, selection, cancellationToken);
+
+    /// <summary>
+    /// Transforms a bounding-box extent between spatial references. Requires a configured transform
+    /// service (guard with <see cref="HasTransformService"/>).
+    /// </summary>
+    public ValueTask<(double MinX, double MinY, double MaxX, double MaxY)?> TransformExtentAsync(
+        double minX,
+        double minY,
+        double maxX,
+        double maxY,
+        int fromSrid,
+        int toSrid,
+        CancellationToken cancellationToken)
+        => _transformService!.TransformExtentAsync(minX, minY, maxX, maxY, fromSrid, toSrid, cancellationToken);
+}

--- a/src/Honua.Protocols.OgcApi/Tiles/RasterTileRenderContext.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/RasterTileRenderContext.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Tiles;
+
+namespace Honua.Protocols.Ogc.Api.Tiles;
+
+/// <summary>
+/// Immutable bundle of the shared render inputs (tile envelope + SRID, tile limits, tile options,
+/// and the active telemetry span) threaded through the OGC API Tiles raster (PNG) render paths.
+/// Collapsing these co-travelling values into one carrier keeps the single-layer and dataset
+/// raster-tile render methods within the endpoint parameter budget without changing behavior.
+/// </summary>
+/// <param name="Bounds">Tile envelope in the gridset CRS used to build the spatial filter and rasterize.</param>
+/// <param name="FilterSrid">SRID of <paramref name="Bounds"/> and the feature-query output projection.</param>
+/// <param name="TileLimits">Server-wide tile limits (per-tile feature budget).</param>
+/// <param name="TileOptions">Tile options controlling cache-control max-age.</param>
+/// <param name="Activity">Active tile-generation telemetry span, or <see langword="null"/>.</param>
+internal sealed record RasterTileRenderContext(
+    TileBounds Bounds,
+    int FilterSrid,
+    TileLimits TileLimits,
+    TileOptions TileOptions,
+    Activity? Activity);

--- a/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/TilesEndpoints.cs
@@ -610,27 +610,26 @@ internal static partial class TilesEndpoints
             // Raster (PNG) tile path
             if (isRaster)
             {
+                var renderContext = new RasterTileRenderContext(
+                    tileBounds,
+                    filterSrid,
+                    tileLimits,
+                    tileOptionsValue,
+                    activity);
+
                 return layers.Length == 1
                     ? await HandleRasterTileAsync(
                         context,
                         layer,
-                        tileBounds,
-                        filterSrid,
+                        renderContext,
                         GetTemporalFilterForLayer(layer, temporalFilters),
                         GetVerticalSelectionForLayer(layer, verticalSelections),
-                        tileLimits,
-                        tileOptionsValue,
-                        activity,
                         cancellationToken)
                     : await HandleDatasetRasterTileAsync(
                         context,
                         layers,
-                        tileBounds,
-                        filterSrid,
+                        renderContext,
                         temporalFilters,
-                        tileLimits,
-                        tileOptionsValue,
-                        activity,
                         cancellationToken);
             }
 
@@ -710,15 +709,17 @@ internal static partial class TilesEndpoints
     private static async Task<IResult> HandleRasterTileAsync(
         HttpContext context,
         TileRequestLayer layer,
-        TileBounds bounds,
-        int filterSrid,
+        RasterTileRenderContext renderContext,
         TemporalFilter? temporalFilter,
         VerticalSelection? verticalSelection,
-        TileLimits tileLimits,
-        TileOptions tileOptionsValue,
-        Activity? activity,
         CancellationToken cancellationToken)
     {
+        var bounds = renderContext.Bounds;
+        var filterSrid = renderContext.FilterSrid;
+        var tileLimits = renderContext.TileLimits;
+        var tileOptionsValue = renderContext.TileOptions;
+        var activity = renderContext.Activity;
+
         // Record-but-don't-render the vertical selection (see the documented divergence at
         // the raster/vector dispatch). The feature query below is unchanged — there is no
         // Z-aware raster source yet (the Zarr datacube Z-slice render is the deferred
@@ -814,14 +815,16 @@ internal static partial class TilesEndpoints
     private static async Task<IResult> HandleDatasetRasterTileAsync(
         HttpContext context,
         TileRequestLayer[] layers,
-        TileBounds bounds,
-        int filterSrid,
+        RasterTileRenderContext renderContext,
         IReadOnlyDictionary<int, TemporalFilter?> temporalFilters,
-        TileLimits tileLimits,
-        TileOptions tileOptionsValue,
-        Activity? activity,
         CancellationToken cancellationToken)
     {
+        var bounds = renderContext.Bounds;
+        var filterSrid = renderContext.FilterSrid;
+        var tileLimits = renderContext.TileLimits;
+        var tileOptionsValue = renderContext.TileOptions;
+        var activity = renderContext.Activity;
+
         var spatialFilter = CreateBboxSpatialFilter(bounds, filterSrid);
         var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
         var renderedLayers = new List<TileRenderer.TileRenderLayer>(layers.Length);

--- a/tests/dotnet/Honua.Architecture.Tests/DependencyInjectionLimitsTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/DependencyInjectionLimitsTests.cs
@@ -35,23 +35,21 @@ public sealed class DependencyInjectionLimitsTests
     private const int MaxServiceCollaborators = 8;
 
     /// <summary>
-    /// Pre-existing endpoint over-injection accepted as tracked debt (raster tile render paths
-    /// that legitimately compose several render/cache services). Do not grow this for new code.
+    /// Endpoint over-injection accepted as tracked debt. Now empty: the raster tile render paths
+    /// (TilesEndpoints.HandleRasterTileAsync / HandleDatasetRasterTileAsync) were decomposed to
+    /// pass their shared render inputs through a single carrier, so the gate enforces the endpoint
+    /// parameter limit with no exceptions. Add an entry here only with a follow-up issue; do not
+    /// grow this list for new code.
     /// </summary>
-    private static readonly HashSet<string> AllowedEndpointExceptions = new(StringComparer.Ordinal)
-    {
-        "Honua.Protocols.Ogc.Api.Tiles.TilesEndpoints.HandleRasterTileAsync",
-        "Honua.Protocols.Ogc.Api.Tiles.TilesEndpoints.HandleDatasetRasterTileAsync",
-    };
+    private static readonly HashSet<string> AllowedEndpointExceptions = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// Pre-existing handler/coordinator/manager over-injection accepted as tracked debt.
+    /// Handler/coordinator/manager over-injection accepted as tracked debt. Now empty: the last
+    /// allowlisted handler (ImageServerProjectHandler) was decomposed so its CRS/datum/transform
+    /// collaborators fold behind one projection seam, keeping it within the collaborator limit.
     /// Add a type here only with a follow-up issue; do not grow this list for new code.
     /// </summary>
-    private static readonly HashSet<string> AllowedHandlerExceptions = new(StringComparer.Ordinal)
-    {
-        "Honua.Protocols.GeoServices.ImageServer.Handlers.ImageServerProjectHandler",
-    };
+    private static readonly HashSet<string> AllowedHandlerExceptions = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Service/coordinator/facade god objects accepted as tracked debt. Now empty: the last

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -75,6 +75,15 @@ public sealed class CatalogExecutableConformanceTests
         "analytics.density-managed",
         // Spatial-statistics tool pack (#2142): Hot Spot Analysis (Getis-Ord Gi*).
         "analytics.hotspot-managed",
+        // Layer-aware, layer-SOURCED managed ops (#2322, #2325): the job-executable
+        // counterparts of the layer-scoped analytics/generalization/conversion ops.
+        // Each streams a Honua catalog layer through source.honua-layer and runs the
+        // managed op in one dispatched job, so the per-op OGC API - Processes
+        // projections (#1382) that advertise a layerId input reach a terminal state.
+        "analytics.buffer-aggregate",
+        "conversion.feature-project",
+        "generalization.dissolve",
+        "generalization.simplify-layer",
         // Layer-aware overlay tool pack (#2206, #2139): managed NTS, two
         // FeatureCollections in, one FeatureCollection/table out.
         "overlay.clip",
@@ -136,15 +145,11 @@ public sealed class CatalogExecutableConformanceTests
     {
         "analytics.cluster",
         "analytics.spatial-join",
-        "analytics.buffer-aggregate",
         "analytics.density",
-        "generalization.simplify-layer",
-        "generalization.dissolve",
         "data-management.copy-features",
         "data-management.delete-features",
         "data-management.calculate-field",
         "conversion.geometry-format",
-        "conversion.feature-project",
     };
 
     // Processes routed to the GDAL native worker. NOT executable in the GDAL-free
@@ -364,6 +369,7 @@ public sealed class CatalogExecutableConformanceTests
         };
         var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
         monitor.CurrentValue.Returns(options);
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
 
         IProcessExecutor[] executors =
         {
@@ -386,6 +392,10 @@ public sealed class CatalogExecutableConformanceTests
             new ManagedBufferAggregateExecutor(monitor),
             new ManagedDensityExecutor(monitor),
             new ManagedHotSpotExecutor(monitor),
+            new LayerBufferAggregateExecutor(scopeFactory, monitor, NullLogger<LayerBufferAggregateExecutor>.Instance),
+            new LayerFeatureProjectExecutor(scopeFactory, monitor, NullLogger<LayerFeatureProjectExecutor>.Instance),
+            new LayerDissolveExecutor(scopeFactory, monitor, NullLogger<LayerDissolveExecutor>.Instance),
+            new LayerSimplifyExecutor(scopeFactory, monitor, NullLogger<LayerSimplifyExecutor>.Instance),
             new OverlayClipExecutor(monitor),
             new OverlayIntersectExecutor(monitor),
             new OverlayUnionExecutor(monitor),

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerSourcedExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerSourcedExecutorTests.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Honua.ControlPlane;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// End-to-end coverage for the layer-aware, layer-SOURCED managed executors (#2322,
+/// #2325): <c>analytics.buffer-aggregate</c>, <c>conversion.feature-project</c>,
+/// <c>generalization.dissolve</c>, and <c>generalization.simplify-layer</c>. Each is
+/// the job-executable counterpart of a per-operation OGC API - Processes projection
+/// (#1382) that advertises a <c>layerId</c> input: the executor streams a Honua
+/// catalog layer through <c>source.honua-layer</c> (faked here so no Postgres runs),
+/// applies the managed NetTopologySuite op in one dispatched job, and publishes the
+/// canonical FeatureCollection artifact — reaching a terminal SUCCEEDED state that the
+/// bare projected ids previously never reached (they were refused at dispatch).
+/// </summary>
+public sealed class LayerSourcedExecutorTests
+{
+    private const string DataUriPrefix = "data:application/geo+json;base64,";
+    private const string HonuaLayerSourceId = "source.honua-layer";
+
+    [UnitTest]
+    public async Task BufferAggregate_DissolvesLayerFeatures_ReachesSucceededWithCount()
+    {
+        var source = new FakeDagFeatureSource(HonuaLayerSourceId,
+        [
+            PointFeature(0, 0),
+            PointFeature(1, 1),
+        ]);
+
+        var (status, uri, _) = await RunAsync(
+            new LayerBufferAggregateExecutor(ScopeFactory(source), Options(), NullLogger<LayerBufferAggregateExecutor>.Instance),
+            LayerBufferAggregateExecutor.HandledProcessId,
+            ("layerId", "7"),
+            ("distance", "1000"),
+            ("unit", "meters"),
+            ("dissolve", "true"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().ContainSingle("dissolve=true unions all buffers into one feature");
+        Convert.ToInt64(features[0].Attributes.GetOptionalValue(LayerBufferAggregateExecutor.CountAttribute), CultureInfo.InvariantCulture)
+            .Should().Be(2);
+        features[0].Geometry!.IsEmpty.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task BufferAggregate_MissingLayerId_FailsWithClassifiedError()
+    {
+        var source = new FakeDagFeatureSource(HonuaLayerSourceId, [PointFeature(0, 0)]);
+
+        var (status, _, _) = await RunAsync(
+            new LayerBufferAggregateExecutor(ScopeFactory(source), Options(), NullLogger<LayerBufferAggregateExecutor>.Instance),
+            LayerBufferAggregateExecutor.HandledProcessId,
+            ("distance", "10"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+    }
+
+    [UnitTest]
+    public async Task FeatureProject_RequestsServerSideReprojection_ReachesSucceeded()
+    {
+        var source = new FakeDagFeatureSource(HonuaLayerSourceId, [PointFeature(1, 2)]);
+
+        var (status, uri, request) = await RunAsync(
+            new LayerFeatureProjectExecutor(ScopeFactory(source), Options(), NullLogger<LayerFeatureProjectExecutor>.Instance),
+            LayerFeatureProjectExecutor.HandledProcessId,
+            ("layerId", "3"),
+            ("targetSrid", "3857"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        ReadFeatures(uri!).Should().ContainSingle();
+
+        // Reprojection is delegated to the shared query pipeline: the executor asks
+        // source.honua-layer to stream the layer already in the target CRS.
+        request.Should().NotBeNull();
+        request!.LayerId.Should().Be(3);
+        request.OutputSrid.Should().Be(3857);
+    }
+
+    [UnitTest]
+    public async Task FeatureProject_MissingTargetSrid_Fails()
+    {
+        var source = new FakeDagFeatureSource(HonuaLayerSourceId, [PointFeature(1, 2)]);
+
+        var (status, _, _) = await RunAsync(
+            new LayerFeatureProjectExecutor(ScopeFactory(source), Options(), NullLogger<LayerFeatureProjectExecutor>.Instance),
+            LayerFeatureProjectExecutor.HandledProcessId,
+            ("layerId", "3"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+    }
+
+    [UnitTest]
+    public async Task Dissolve_GroupsByField_EmitsOneFeaturePerGroupWithStatistics()
+    {
+        var source = new FakeDagFeatureSource(HonuaLayerSourceId,
+        [
+            BoxFeature(0, 0, 10, 10, ("zone", "a"), ("pop", 5)),
+            BoxFeature(10, 0, 20, 10, ("zone", "a"), ("pop", 7)),
+            BoxFeature(0, 20, 10, 30, ("zone", "b"), ("pop", 3)),
+        ]);
+
+        var (status, uri, _) = await RunAsync(
+            new LayerDissolveExecutor(ScopeFactory(source), Options(), NullLogger<LayerDissolveExecutor>.Instance),
+            LayerDissolveExecutor.HandledProcessId,
+            ("layerId", "9"),
+            ("groupByFields", "zone"),
+            ("outStatistics", "pop:sum"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().HaveCount(2, "one dissolved feature per zone group");
+
+        var zoneA = features.Single(f => Equals(f.Attributes.GetOptionalValue("zone"), "a"));
+        Convert.ToInt64(zoneA.Attributes.GetOptionalValue(LayerDissolveExecutor.CountAttribute), CultureInfo.InvariantCulture).Should().Be(2);
+        Convert.ToDouble(zoneA.Attributes.GetOptionalValue("SUM_pop"), CultureInfo.InvariantCulture).Should().Be(12);
+    }
+
+    [UnitTest]
+    public async Task SimplifyLayer_ReducesVertices_AndCarriesAttributes()
+    {
+        // A near-collinear vertex on the bottom edge is removed by Douglas-Peucker.
+        var wkt = new WKTReader();
+        var polygon = wkt.Read("POLYGON ((0 0, 5 0.0001, 10 0, 10 10, 0 10, 0 0))");
+        var feature = new Feature(polygon, new AttributesTable { { "name", "poly" } });
+        var source = new FakeDagFeatureSource(HonuaLayerSourceId,
+        [
+            new DagSourceFeature
+            {
+                GeometryGeoJson = new GeoJsonWriter().Write(feature.Geometry),
+                Attributes = new Dictionary<string, object?> { ["name"] = "poly" },
+            },
+        ]);
+
+        var (status, uri, _) = await RunAsync(
+            new LayerSimplifyExecutor(ScopeFactory(source), Options(), NullLogger<LayerSimplifyExecutor>.Instance),
+            LayerSimplifyExecutor.HandledProcessId,
+            ("layerId", "2"),
+            ("tolerance", "0.5"),
+            ("preserveTopology", "true"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().ContainSingle();
+        features[0].Attributes.GetOptionalValue("name").Should().Be("poly");
+        features[0].Geometry!.Coordinates.Length.Should().BeLessThan(6, "the near-collinear vertex is dropped");
+    }
+
+    [UnitTest]
+    public async Task LayerSourced_NoHonuaLayerConnectorRegistered_FailsClosed()
+    {
+        // Register a source with a different id so resolution finds no honua-layer source.
+        var source = new FakeDagFeatureSource("source.wfs", []);
+
+        var (status, _, _) = await RunAsync(
+            new LayerSimplifyExecutor(ScopeFactory(source), Options(), NullLogger<LayerSimplifyExecutor>.Instance),
+            LayerSimplifyExecutor.HandledProcessId,
+            ("layerId", "2"),
+            ("tolerance", "0.5"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static IOptionsMonitor<GeoprocessingExecutorOptions> Options()
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7),
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return monitor;
+    }
+
+    private static IServiceScopeFactory ScopeFactory(IDagFeatureSource source)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(source);
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private static DagSourceFeature PointFeature(double x, double y)
+        => new()
+        {
+            GeometryGeoJson = $$"""{"type":"Point","coordinates":[{{x.ToString(System.Globalization.CultureInfo.InvariantCulture)}},{{y.ToString(System.Globalization.CultureInfo.InvariantCulture)}}]}""",
+            Attributes = new Dictionary<string, object?>(),
+        };
+
+    private static DagSourceFeature BoxFeature(
+        double minX,
+        double minY,
+        double maxX,
+        double maxY,
+        params (string Name, object Value)[] attributes)
+    {
+        var ci = System.Globalization.CultureInfo.InvariantCulture;
+        string P(double x, double y) => $"[{x.ToString(ci)},{y.ToString(ci)}]";
+        var ring = string.Join(",", P(minX, minY), P(maxX, minY), P(maxX, maxY), P(minX, maxY), P(minX, minY));
+        var attrs = new Dictionary<string, object?>();
+        foreach (var (name, value) in attributes)
+        {
+            attrs[name] = value;
+        }
+
+        return new DagSourceFeature
+        {
+            GeometryGeoJson = $$"""{"type":"Polygon","coordinates":[[{{ring}}]]}""",
+            Attributes = attrs,
+        };
+    }
+
+    private static async Task<(ExecutionJobStatus Status, string? Uri, DagSourceRequest? Request)> RunAsync(
+        LayerSourcedFeatureExecutor executor,
+        string processId,
+        params (string Name, string Value)[] inputs)
+    {
+        var context = Substitute.For<IJobExecutionContext>();
+        context.OperationId.Returns("op-test");
+        string? publishedUri = null;
+        context
+            .When(c => c.PublishArtifactAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(call => publishedUri = call.ArgAt<string>(0));
+
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        foreach (var (name, value) in inputs)
+        {
+            parameters[prefix + name] = value;
+        }
+
+        var record = new ExecutionJobRecord
+        {
+            OperationId = "op-test",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters,
+            },
+        };
+
+        var result = await executor.ExecuteAsync(record, context, CancellationToken.None);
+        return (result.Status, publishedUri, _lastRequestForAssertions);
+    }
+
+    private static DagSourceRequest? _lastRequestForAssertions;
+
+    private static List<IFeature> ReadFeatures(string dataUri)
+    {
+        var bytes = Convert.FromBase64String(dataUri[DataUriPrefix.Length..]);
+        var json = Encoding.UTF8.GetString(bytes);
+        return new GeoJsonReader().Read<FeatureCollection>(json).ToList();
+    }
+
+    private sealed class FakeDagFeatureSource : IDagFeatureSource
+    {
+        private readonly IReadOnlyList<DagSourceFeature> _features;
+
+        public FakeDagFeatureSource(string sourceId, IReadOnlyList<DagSourceFeature> features)
+        {
+            SourceId = sourceId;
+            _features = features;
+        }
+
+        public string SourceId { get; }
+
+        public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+            DagSourceRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            _lastRequestForAssertions = request;
+            foreach (var feature in _features)
+            {
+                yield return feature;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
@@ -53,8 +53,6 @@
 
     <!-- Dependency overrides -->
     <PackageReference Include="WireMock.Net" />
-    <!-- Direct pin of WireMock.Net's transitive Scriban.Signed to a patched version (GHSA-24c8-4792-22hx). -->
-    <PackageReference Include="Scriban.Signed" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.abstractions" />
   </ItemGroup>


### PR DESCRIPTION
# Pull Request

## Issue Link

Closes #2316
Closes #2323
Closes #2325
Related to #2322

## Summary

Consolidated code-addressable fixes for the tickets opened at/after #2312, plus a trunk-unbreaking build repair discovered while building. **Note:** trunk was un-buildable under warnings-as-errors before this — two independent NU1903 remediations left a duplicate `Scriban.Signed`.

## Changes Made

- **Build repair (unbreaks trunk):** remove the duplicate `Scriban.Signed` package pin — `NU1506` (both 7.2.5 and 7.2.0 in `Directory.Packages.props`) and `NU1504` (two `PackageReference`s in `Honua.TestKit.csproj`). Keep 7.2.5 (clears GHSA-24c8-4792-22hx).
- **#2323 — GeoServices `f=geojson`:** the FeatureServer layer `/query` handler already produces the full `FeatureServerQueryFormats` set, but the endpoint validated the requested `f` against `JsonOnlyFormats` and rejected everything but json/pjson. Validate against `FeatureServerQueryFormats` so `f=geojson` (and pbf/fgb/geobuf/parquet/arrow) work end-to-end, matching the layer's advertised `SupportedQueryFormats`.
- **#2316 — cohesion / DI-limit allowlist emptied:** extract `ImageServerCoordinateProjection` (CRS/transform facade) so `ImageServerProjectHandler` composes ≤4 collaborators; extract `RasterTileRenderContext` so `TilesEndpoints` raster-tile methods take ≤5 injected params. Remove the last `AllowedHandlerExceptions`/`AllowedEndpointExceptions` entries — the DI-limit gate now enforces endpoint≤5 / handler≤4 / service≤8 with **zero exemptions**.
- **#2325 + partial #2322 — geoprocessing per-op OGC execution:** add self-sourcing layer-aware managed executors (single-step compatible: read `layerId`, resolve via `source.honua-layer`, run the op, publish a FeatureCollection) so the #1382 per-op OGC API-Processes projections reach terminal `SUCCEEDED`: `analytics.buffer-aggregate`, `conversion.feature-project` (reprojection via the shared query pipeline), `generalization.dissolve` (group-aware, `outStatistics`), `generalization.simplify-layer` (Douglas-Peucker / topology-preserving). `analytics.spatial-join` is deferred (needs a second-layer read), so **#2322 stays open** for that slice.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Full-solution warnings-as-errors Release build: **0 warnings, 0 errors**. `dotnet format --verify-no-changes`: clean. Architecture tests **119/119** (DI-limit gate passes with the empty allowlist). Geoprocessing: `Geoprocessing.Testing.Tests` 14/14, `Geoprocessing.Cli.Tests` 79/79, `Server.Tests` (new `LayerSourced*` executor e2e + `CatalogExecutableConformance` + `ManagedBufferAggregate`) 20/20.

## Gate Impact

- [x] PR gates (build, test, governance)

## Docs or Contract Impact

- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

The GeoServices `f=geojson` and geoprocessing executor changes take effect on `demo.honua.io` at the next image roll (relevant to the honua-site samples gallery + honua-sdk-python#157).

## Breaking Changes

None. GeoServices query gains formats (json/pjson still behave identically); cohesion changes are behavior-preserving delegation; geoprocessing adds new executors without altering existing paths.

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
