### PR TITLE
feat(geoprocessing): layer-aware analytics.spatial-join executor (#2322)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSourcedFeatureExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSourcedFeatureExecutor.cs
@@ -117,15 +117,10 @@ internal abstract partial class LayerSourcedFeatureExecutor : IProcessExecutor
         cancellationToken.ThrowIfCancellationRequested();
         await context.ReportProgressAsync(20, $"Streaming layer features for {ProcessId}", cancellationToken).ConfigureAwait(false);
 
-        var geoJsonReader = new GeoJsonReader();
-        var features = new List<IFeature>();
+        List<IFeature> features;
         try
         {
-            await foreach (var sourceFeature in source.ReadAsync(request, cancellationToken).ConfigureAwait(false))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                features.Add(ToNtsFeature(sourceFeature, geoJsonReader));
-            }
+            features = await ReadLayerAsync(source, request, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -143,7 +138,8 @@ internal abstract partial class LayerSourcedFeatureExecutor : IProcessExecutor
         List<IFeature> output;
         try
         {
-            output = Apply(features, inputs, cancellationToken);
+            output = await ApplyCoreAsync(new LayerOpContext(features, source), inputs, cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (TransformInputException ex)
         {
@@ -181,11 +177,97 @@ internal abstract partial class LayerSourcedFeatureExecutor : IProcessExecutor
     /// returning the output feature set. Throw <see cref="TransformInputException"/>
     /// for caller-supplied parameter errors so they surface as a classified
     /// <c>Invalid ... inputs</c> failure.
+    ///
+    /// <para>
+    /// Single-layer ops override this synchronous hook. A two-layer op (for example
+    /// <c>analytics.spatial-join</c>, which resolves a second catalog layer through
+    /// the same <c>source.honua-layer</c> connector) overrides
+    /// <see cref="ApplyCoreAsync"/> instead and leaves this default in place.
+    /// </para>
     /// </summary>
-    protected abstract List<IFeature> Apply(
+    protected virtual List<IFeature> Apply(
         List<IFeature> source,
         StepInputReader inputs,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken)
+        => throw new NotSupportedException(
+            $"{GetType().Name} must override {nameof(Apply)} or {nameof(ApplyCoreAsync)}.");
+
+    /// <summary>
+    /// Asynchronous apply seam. The default delegates to the synchronous
+    /// <see cref="Apply"/> over the already-streamed target layer. A two-layer op
+    /// overrides this to resolve and read an additional catalog layer (via
+    /// <see cref="LayerOpContext.LayerSource"/> and <see cref="ReadLayerAsync"/>)
+    /// before computing its output. Throw <see cref="TransformInputException"/> for
+    /// caller-supplied parameter errors so they surface as a classified
+    /// <c>Invalid ... inputs</c> failure.
+    /// </summary>
+    private protected virtual Task<List<IFeature>> ApplyCoreAsync(
+        LayerOpContext context,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+        => Task.FromResult(Apply(context.Features, inputs, cancellationToken));
+
+    /// <summary>
+    /// The resolved inputs a concrete layer-aware op computes over: the streamed
+    /// target-layer <see cref="Features"/> and the resolved <see cref="LayerSource"/>
+    /// connector, so a two-layer op can read a second catalog layer through the same
+    /// connector within the executor's service scope.
+    /// </summary>
+    private protected readonly struct LayerOpContext
+    {
+        /// <summary>Creates a context over the streamed target features and connector.</summary>
+        public LayerOpContext(List<IFeature> features, IDagFeatureSource layerSource)
+        {
+            Features = features;
+            LayerSource = layerSource;
+        }
+
+        /// <summary>The streamed features of the primary (target) layer.</summary>
+        public List<IFeature> Features { get; }
+
+        /// <summary>The resolved <c>source.honua-layer</c> connector for further layer reads.</summary>
+        public IDagFeatureSource LayerSource { get; }
+    }
+
+    /// <summary>
+    /// Streams every feature the resolved <paramref name="source"/> returns for
+    /// <paramref name="request"/> into an in-memory NetTopologySuite feature list.
+    /// Shared by the base's primary layer read and by two-layer ops that resolve a
+    /// second catalog layer through the same connector.
+    /// </summary>
+    private protected static async Task<List<IFeature>> ReadLayerAsync(
+        IDagFeatureSource source,
+        DagSourceRequest request,
+        CancellationToken cancellationToken)
+    {
+        var geoJsonReader = new GeoJsonReader();
+        var features = new List<IFeature>();
+        await foreach (var sourceFeature in source.ReadAsync(request, cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            features.Add(ToNtsFeature(sourceFeature, geoJsonReader));
+        }
+
+        return features;
+    }
+
+    /// <summary>
+    /// Reads and validates a non-negative catalog layer id from the input at
+    /// <paramref name="key"/> (for example <c>layerId</c> for the target layer or
+    /// <c>joinLayerId</c> for a spatial-join reference layer).
+    /// </summary>
+    private protected static int RequireLayerId(StepInputReader inputs, string key)
+    {
+        if (!inputs.TryGet(key, out var raw)
+            || !int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            || value < 0)
+        {
+            throw new TransformInputException(
+                $"missing or invalid required input '{key}'; expected a non-negative integer.");
+        }
+
+        return value;
+    }
 
     /// <summary>
     /// Hook for a concrete op to add operation-specific fields to the layer read
@@ -199,16 +281,9 @@ internal abstract partial class LayerSourcedFeatureExecutor : IProcessExecutor
 
     private DagSourceRequest BuildSourceRequest(StepInputReader inputs)
     {
-        if (!inputs.TryGet("layerId", out var layerIdRaw)
-            || !int.TryParse(layerIdRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var layerId)
-            || layerId < 0)
-        {
-            throw new TransformInputException("missing or invalid required input 'layerId'; expected a non-negative integer.");
-        }
-
         var request = new DagSourceRequest
         {
-            LayerId = layerId,
+            LayerId = RequireLayerId(inputs, "layerId"),
             Where = inputs.TryGet("where", out var where) ? where : null,
             Bbox = inputs.TryGet("bbox", out var bbox) ? bbox : null,
             OutFields = inputs.TryGet("outFields", out var outFields) ? outFields : null,

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSpatialJoinExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/LayerSpatialJoinExecutor.cs
@@ -1,0 +1,257 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Index.Strtree;
+using NtsEnvelope = NetTopologySuite.Geometries.Envelope;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Geoprocessing.Execution;
+
+/// <summary>
+/// <c>analytics.spatial-join</c> layer-aware executor (#2322). The job-executable
+/// counterpart of the layer-scoped PostGIS <c>SpatialAnalytics</c> spatial join, and
+/// the two-layer sibling of the single-layer <see cref="LayerSourcedFeatureExecutor"/>
+/// ops: it resolves BOTH the target layer (<c>layerId</c>) AND the reference/join
+/// layer (<c>joinLayerId</c>) through the same <c>source.honua-layer</c> connector,
+/// then enriches every target feature with attributes and aggregates drawn from the
+/// join features that satisfy a spatial predicate — all in one dispatched job.
+///
+/// <para>
+/// Predicates reuse NetTopologySuite's managed relational operators (no GEOS/GDAL
+/// native dependency): <c>intersects</c> (default), <c>contains</c> (the join
+/// geometry contains the target — the classic point-in-polygon case), <c>within</c>
+/// (the target contains the join geometry), and <c>dwithin</c> (the join geometry is
+/// within <c>distance</c> of the target). Distances are evaluated in the CRS units of
+/// the supplied geometries — geodesic conversion is not performed, matching the other
+/// managed layer-aware analytics executors. Candidate join features are pruned through
+/// an in-memory <see cref="STRtree{T}"/> index before the exact predicate test.
+/// </para>
+///
+/// <para>
+/// Each target feature carries its original attributes plus a <c>JOIN_COUNT</c> of the
+/// matched join rows. For every column named in <c>carryFields</c> the matched join
+/// values are emitted as an array attribute of the same name (empty array on zero
+/// matches), and any <c>outStatistics</c> <c>field:stat</c> aggregates are computed
+/// over the matched join rows through the shared <see cref="StatisticsSupport"/>
+/// accumulators. Targets with no match are preserved one-to-one with a
+/// <c>JOIN_COUNT</c> of 0.
+/// </para>
+/// </summary>
+internal sealed class LayerSpatialJoinExecutor : LayerSourcedFeatureExecutor
+{
+    /// <summary>The dotted process id this executor handles.</summary>
+    internal const string HandledProcessId = "analytics.spatial-join";
+
+    /// <summary>Attribute holding the count of matched join features on each target.</summary>
+    internal const string JoinCountAttribute = "JOIN_COUNT";
+
+    /// <summary>Initializes a new instance of the <see cref="LayerSpatialJoinExecutor"/> class.</summary>
+    public LayerSpatialJoinExecutor(
+        IServiceScopeFactory serviceScopeFactory,
+        IOptionsMonitor<GeoprocessingExecutorOptions> options,
+        ILogger<LayerSpatialJoinExecutor> logger)
+        : base(serviceScopeFactory, options, logger)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override string ProcessId => HandledProcessId;
+
+    /// <inheritdoc />
+    private protected override async Task<List<IFeature>> ApplyCoreAsync(
+        LayerOpContext context,
+        StepInputReader inputs,
+        CancellationToken cancellationToken)
+    {
+        var (predicate, distance) = ReadPredicate(inputs);
+        var carryFields = StatisticsSupport.ParseFieldList(inputs.GetOrDefault("carryFields", string.Empty));
+        var stats = StatisticsSupport.ParseStatistics(inputs.GetOrDefault("outStatistics", string.Empty));
+
+        // Resolve the second (join) layer through the same source.honua-layer connector
+        // that streamed the target layer. Only the join layer id windows this read; the
+        // shared analytics where/bbox filters apply to the target layer.
+        var joinLayerId = RequireLayerId(inputs, "joinLayerId");
+        var joinRequest = new DagSourceRequest { LayerId = joinLayerId };
+        var joinFeatures = await ReadLayerAsync(context.LayerSource, joinRequest, cancellationToken)
+            .ConfigureAwait(false);
+
+        var index = BuildIndex(joinFeatures, cancellationToken);
+
+        var output = new List<IFeature>(context.Features.Count);
+        foreach (var target in context.Features)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            output.Add(Join(target, index, predicate, distance, carryFields, stats));
+        }
+
+        return output;
+    }
+
+    private static Feature Join(
+        IFeature target,
+        STRtree<IFeature> index,
+        SpatialPredicate predicate,
+        double distance,
+        IReadOnlyList<string> carryFields,
+        IReadOnlyList<StatisticsSupport.StatSpec> stats)
+    {
+        var attributes = OverlayExecutorSupport.CopyAttributes(target);
+
+        var carried = new Dictionary<string, List<object?>>(StringComparer.Ordinal);
+        foreach (var field in carryFields)
+        {
+            carried[field] = [];
+        }
+
+        var accumulators = new Dictionary<string, StatisticsSupport.FieldAccumulator>(StringComparer.Ordinal);
+        foreach (var spec in stats)
+        {
+            if (spec.Kind != StatisticsSupport.StatKind.Count && !accumulators.ContainsKey(spec.Field))
+            {
+                accumulators[spec.Field] = new StatisticsSupport.FieldAccumulator();
+            }
+        }
+
+        long matchCount = 0;
+        var geometry = target.Geometry;
+        if (geometry is not null && !geometry.IsEmpty)
+        {
+            foreach (var candidate in index.Query(QueryEnvelope(geometry, predicate, distance)))
+            {
+                if (!Matches(candidate.Geometry, geometry, predicate, distance))
+                {
+                    continue;
+                }
+
+                matchCount++;
+                foreach (var field in carryFields)
+                {
+                    carried[field].Add(ReadValue(candidate, field));
+                }
+
+                foreach (var accumulator in accumulators)
+                {
+                    if (StatisticsSupport.TryReadNumeric(candidate, accumulator.Key, out var value))
+                    {
+                        accumulator.Value.Add(value);
+                    }
+                }
+            }
+        }
+
+        OverlayExecutorSupport.Upsert(attributes, JoinCountAttribute, matchCount);
+        foreach (var field in carryFields)
+        {
+            OverlayExecutorSupport.Upsert(attributes, field, carried[field].ToArray());
+        }
+
+        foreach (var spec in stats)
+        {
+            object? value = spec.Kind == StatisticsSupport.StatKind.Count
+                ? matchCount
+                : accumulators.TryGetValue(spec.Field, out var accumulator)
+                    ? accumulator.Resolve(spec.Kind)
+                    : null;
+            OverlayExecutorSupport.Upsert(attributes, spec.OutputName, value);
+        }
+
+        return new Feature(target.Geometry, attributes);
+    }
+
+    private static STRtree<IFeature> BuildIndex(List<IFeature> joinFeatures, CancellationToken cancellationToken)
+    {
+        var index = new STRtree<IFeature>();
+        foreach (var feature in joinFeatures)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var geometry = feature.Geometry;
+            if (geometry is not null && !geometry.IsEmpty)
+            {
+                index.Insert(geometry.EnvelopeInternal, feature);
+            }
+        }
+
+        index.Build();
+        return index;
+    }
+
+    private static NtsEnvelope QueryEnvelope(NtsGeometry targetGeometry, SpatialPredicate predicate, double distance)
+    {
+        var envelope = targetGeometry.EnvelopeInternal.Copy();
+        if (predicate == SpatialPredicate.Dwithin)
+        {
+            // Widen the candidate window by the distance threshold so join geometries
+            // whose envelopes fall just outside the target's are still tested exactly.
+            envelope.ExpandBy(distance);
+        }
+
+        return envelope;
+    }
+
+    private static bool Matches(
+        NtsGeometry? joinGeometry,
+        NtsGeometry targetGeometry,
+        SpatialPredicate predicate,
+        double distance)
+    {
+        if (joinGeometry is null || joinGeometry.IsEmpty)
+        {
+            return false;
+        }
+
+        return predicate switch
+        {
+            SpatialPredicate.Contains => joinGeometry.Contains(targetGeometry),
+            SpatialPredicate.Within => targetGeometry.Contains(joinGeometry),
+            SpatialPredicate.Dwithin => joinGeometry.IsWithinDistance(targetGeometry, distance),
+            _ => joinGeometry.Intersects(targetGeometry),
+        };
+    }
+
+    private static object? ReadValue(IFeature feature, string field)
+        => feature.Attributes is not null && feature.Attributes.Exists(field)
+            ? feature.Attributes.GetOptionalValue(field)
+            : null;
+
+    private static (SpatialPredicate Predicate, double Distance) ReadPredicate(StepInputReader inputs)
+    {
+        var raw = inputs.GetOrDefault("predicate", "intersects").Trim().ToLowerInvariant();
+        var predicate = raw switch
+        {
+            "" or "intersects" => SpatialPredicate.Intersects,
+            "contains" => SpatialPredicate.Contains,
+            "within" => SpatialPredicate.Within,
+            "dwithin" => SpatialPredicate.Dwithin,
+            _ => throw new TransformInputException(
+                $"predicate '{raw}' is not supported (allowed: intersects, contains, within, dwithin)"),
+        };
+
+        var distance = 0d;
+        if (predicate == SpatialPredicate.Dwithin)
+        {
+            if (!inputs.TryGet("distance", out var distanceRaw)
+                || !double.TryParse(distanceRaw, NumberStyles.Float, CultureInfo.InvariantCulture, out distance)
+                || !double.IsFinite(distance)
+                || distance <= 0)
+            {
+                throw new TransformInputException(
+                    "predicate 'dwithin' requires a finite positive 'distance' threshold");
+            }
+        }
+
+        return (predicate, distance);
+    }
+
+    private enum SpatialPredicate
+    {
+        Intersects,
+        Contains,
+        Within,
+        Dwithin,
+    }
+}

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingServiceCollectionExtensions.cs
@@ -266,6 +266,10 @@ internal static class GeoprocessingServiceCollectionExtensions
         Register<LayerFeatureProjectExecutor>(services);
         Register<LayerDissolveExecutor>(services);
         Register<LayerSimplifyExecutor>(services);
+        // Two-layer analytics.spatial-join (#2322): resolves BOTH the target layerId and
+        // the joinLayerId through source.honua-layer and enriches each target feature
+        // with matched join attributes/aggregates in one dispatched job.
+        Register<LayerSpatialJoinExecutor>(services);
         // Layer-aware overlay tool pack (#2206, #2139).
         Register<OverlayClipExecutor>(services);
         Register<OverlayIntersectExecutor>(services);

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -84,6 +84,9 @@ public sealed class CatalogExecutableConformanceTests
         "conversion.feature-project",
         "generalization.dissolve",
         "generalization.simplify-layer",
+        // Two-layer analytics.spatial-join (#2322): resolves both the target layerId and
+        // the joinLayerId through source.honua-layer and joins them in one dispatched job.
+        "analytics.spatial-join",
         // Layer-aware overlay tool pack (#2206, #2139): managed NTS, two
         // FeatureCollections in, one FeatureCollection/table out.
         "overlay.clip",
@@ -139,12 +142,12 @@ public sealed class CatalogExecutableConformanceTests
     // Processes that execute ONLY through the synchronous PostGIS SpatialAnalytics
     // protocol or another non-dispatcher surface (layer-scoped, Pro-gated, or
     // destructive edit paths). NOT job-dispatchable; MUST be absent from the
-    // dispatcher. analytics.spatial-join lives here — its job-executable managed
-    // counterpart is analytics.spatial-join-managed above.
+    // dispatcher. analytics.spatial-join is NO LONGER here: #2322 added a layer-aware
+    // job executor (LayerSpatialJoinExecutor) that resolves both the target and join
+    // layers through source.honua-layer, so it is now job-executable above.
     private static readonly string[] ProtocolOnlyProcessIds =
     {
         "analytics.cluster",
-        "analytics.spatial-join",
         "analytics.density",
         "data-management.copy-features",
         "data-management.delete-features",
@@ -396,6 +399,7 @@ public sealed class CatalogExecutableConformanceTests
             new LayerFeatureProjectExecutor(scopeFactory, monitor, NullLogger<LayerFeatureProjectExecutor>.Instance),
             new LayerDissolveExecutor(scopeFactory, monitor, NullLogger<LayerDissolveExecutor>.Instance),
             new LayerSimplifyExecutor(scopeFactory, monitor, NullLogger<LayerSimplifyExecutor>.Instance),
+            new LayerSpatialJoinExecutor(scopeFactory, monitor, NullLogger<LayerSpatialJoinExecutor>.Instance),
             new OverlayClipExecutor(monitor),
             new OverlayIntersectExecutor(monitor),
             new OverlayUnionExecutor(monitor),

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerSourcedExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/LayerSourcedExecutorTests.cs
@@ -181,9 +181,119 @@ public sealed class LayerSourcedExecutorTests
         status.Should().Be(ExecutionJobStatus.Failed);
     }
 
+    [UnitTest]
+    public async Task SpatialJoin_IntersectsCarriesJoinFields_ReachesSucceededWithJoinCount()
+    {
+        // Target layer 7: two disjoint zone polygons. Join layer 8: three named points,
+        // two inside zone A and one inside zone B.
+        var source = new FakeTwoLayerDagFeatureSource(HonuaLayerSourceId, new Dictionary<int, IReadOnlyList<DagSourceFeature>>
+        {
+            [7] =
+            [
+                BoxFeature(0, 0, 10, 10, ("zone", "a")),
+                BoxFeature(20, 20, 30, 30, ("zone", "b")),
+            ],
+            [8] =
+            [
+                NamedPoint(5, 5, "p1"),
+                NamedPoint(6, 6, "p2"),
+                NamedPoint(25, 25, "p3"),
+            ],
+        });
+
+        var (status, uri, _) = await RunAsync(
+            new LayerSpatialJoinExecutor(ScopeFactory(source), Options(), NullLogger<LayerSpatialJoinExecutor>.Instance),
+            LayerSpatialJoinExecutor.HandledProcessId,
+            ("layerId", "7"),
+            ("joinLayerId", "8"),
+            ("predicate", "intersects"),
+            ("carryFields", "name"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().HaveCount(2, "each target zone is preserved one-to-one");
+
+        var zoneA = features.Single(f => Equals(f.Attributes.GetOptionalValue("zone"), "a"));
+        Convert.ToInt64(zoneA.Attributes.GetOptionalValue(LayerSpatialJoinExecutor.JoinCountAttribute), CultureInfo.InvariantCulture)
+            .Should().Be(2);
+        CarriedValues(zoneA, "name").Should().BeEquivalentTo(new[] { "p1", "p2" });
+
+        var zoneB = features.Single(f => Equals(f.Attributes.GetOptionalValue("zone"), "b"));
+        Convert.ToInt64(zoneB.Attributes.GetOptionalValue(LayerSpatialJoinExecutor.JoinCountAttribute), CultureInfo.InvariantCulture)
+            .Should().Be(1);
+        CarriedValues(zoneB, "name").Should().BeEquivalentTo(new[] { "p3" });
+    }
+
+    [UnitTest]
+    public async Task SpatialJoin_Dwithin_MatchesNeighboursWithinDistance()
+    {
+        // Target point at origin; join layer has one point 3 units away and one 30 away.
+        var source = new FakeTwoLayerDagFeatureSource(HonuaLayerSourceId, new Dictionary<int, IReadOnlyList<DagSourceFeature>>
+        {
+            [1] = [NamedPoint(0, 0, "target")],
+            [2] =
+            [
+                NamedPoint(3, 0, "near"),
+                NamedPoint(30, 0, "far"),
+            ],
+        });
+
+        var (status, uri, _) = await RunAsync(
+            new LayerSpatialJoinExecutor(ScopeFactory(source), Options(), NullLogger<LayerSpatialJoinExecutor>.Instance),
+            LayerSpatialJoinExecutor.HandledProcessId,
+            ("layerId", "1"),
+            ("joinLayerId", "2"),
+            ("predicate", "dwithin"),
+            ("distance", "5"),
+            ("carryFields", "name"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().ContainSingle();
+        Convert.ToInt64(features[0].Attributes.GetOptionalValue(LayerSpatialJoinExecutor.JoinCountAttribute), CultureInfo.InvariantCulture)
+            .Should().Be(1, "only the point within 5 units matches");
+        CarriedValues(features[0], "name").Should().BeEquivalentTo(new[] { "near" });
+    }
+
+    [UnitTest]
+    public async Task SpatialJoin_MissingJoinLayerId_Fails()
+    {
+        var source = new FakeTwoLayerDagFeatureSource(HonuaLayerSourceId, new Dictionary<int, IReadOnlyList<DagSourceFeature>>
+        {
+            [7] = [BoxFeature(0, 0, 10, 10, ("zone", "a"))],
+        });
+
+        var (status, _, _) = await RunAsync(
+            new LayerSpatialJoinExecutor(ScopeFactory(source), Options(), NullLogger<LayerSpatialJoinExecutor>.Instance),
+            LayerSpatialJoinExecutor.HandledProcessId,
+            ("layerId", "7"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private static List<string?> CarriedValues(IFeature feature, string field)
+    {
+        var raw = feature.Attributes.GetOptionalValue(field);
+        raw.Should().BeAssignableTo<System.Collections.IEnumerable>("carried join fields are emitted as arrays");
+        var values = new List<string?>();
+        foreach (var item in (System.Collections.IEnumerable)raw!)
+        {
+            values.Add(item?.ToString());
+        }
+
+        return values;
+    }
+
+    private static DagSourceFeature NamedPoint(double x, double y, string name)
+        => new()
+        {
+            GeometryGeoJson = $$"""{"type":"Point","coordinates":[{{x.ToString(System.Globalization.CultureInfo.InvariantCulture)}},{{y.ToString(System.Globalization.CultureInfo.InvariantCulture)}}]}""",
+            Attributes = new Dictionary<string, object?> { ["name"] = name },
+        };
 
     private static IOptionsMonitor<GeoprocessingExecutorOptions> Options()
     {
@@ -307,6 +417,43 @@ public sealed class LayerSourcedExecutorTests
             foreach (var feature in _features)
             {
                 yield return feature;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Fake <see cref="IDagFeatureSource"/> that returns a distinct feature set per
+    /// catalog layer id, so a two-layer op such as <c>analytics.spatial-join</c> reads
+    /// its target (<c>layerId</c>) and join (<c>joinLayerId</c>) layers from the same
+    /// connector without a Postgres catalog.
+    /// </summary>
+    private sealed class FakeTwoLayerDagFeatureSource : IDagFeatureSource
+    {
+        private readonly IReadOnlyDictionary<int, IReadOnlyList<DagSourceFeature>> _byLayer;
+
+        public FakeTwoLayerDagFeatureSource(
+            string sourceId,
+            IReadOnlyDictionary<int, IReadOnlyList<DagSourceFeature>> byLayer)
+        {
+            SourceId = sourceId;
+            _byLayer = byLayer;
+        }
+
+        public string SourceId { get; }
+
+        public async IAsyncEnumerable<DagSourceFeature> ReadAsync(
+            DagSourceRequest request,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            _lastRequestForAssertions = request;
+            if (request.LayerId is int layerId && _byLayer.TryGetValue(layerId, out var features))
+            {
+                foreach (var feature in features)
+                {
+                    yield return feature;
+                }
             }
 
             await Task.CompletedTask;


### PR DESCRIPTION
# Pull Request

## Issue Link

Closes #2322

## Summary

Implements the last deferred slice of #2322: `analytics.spatial-join` as a layer-aware, two-layer managed job executor, so its per-op OGC API-Processes projection (#1382) reaches terminal `SUCCEEDED`. Builds on the single-layer self-sourcing executors landed in #2327; #2322's other ops (buffer/dissolve, plus the #2325 project/dissolve/simplify) already landed there.

## Changes Made

- **`LayerSpatialJoinExecutor`** (new, internal sealed): resolves both the target layer (`layerId`) and the join layer (`joinLayerId`) via the same `source.honua-layer` connector, prunes candidates with an in-memory `STRtree`, and enriches each target with `JOIN_COUNT`, `carryFields`-as-arrays, and optional `outStatistics`. Predicates reuse NTS managed operators (no geodesy reimplementation): `intersects` (default), `contains`, `within`, `dwithin` (requires positive `distance`). Zero-match targets preserved one-to-one.
- **`LayerSourcedFeatureExecutor`**: extracted `ReadLayerAsync` + added a `virtual ApplyCoreAsync` async seam so a two-layer executor can read a second layer in the same scope, **without changing the 4 existing single-layer executors** (default delegates to the existing synchronous `Apply`).
- Registered the executor; moved `analytics.spatial-join` from protocol-only to job-executable in `CatalogExecutableConformanceTests`.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

3 new e2e tests (intersects+carryFields → SUCCEEDED with per-zone `JOIN_COUNT` + carried arrays; `dwithin` distance filtering → SUCCEEDED; missing-`joinLayerId` failure). Build (Release, warnings-as-errors): `Honua.Geoprocessing` and `Honua.Server.Tests` both **0 warnings / 0 errors**. Tests: `LayerSourcedExecutorTests` + `CatalogExecutableConformanceTests` **17/17**; full `Features.Geoprocessing` folder **755/755**. `dotnet format` clean; no NUL/binary source files.

## Gate Impact

- [x] PR gates (build, test, governance)

## Docs or Contract Impact

- [x] None — no docs or contract impact

## Release/Deploy Impact

- [x] None — standard merge-and-release flow

## Breaking Changes

None. New executor + additive base-class seam; existing executors and paths unchanged.

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
