### PR TITLE
feat(mcp): generate geospatial-mcp reference manifest from the live /mcp surface (Track A)

### DIFF
--- a/scripts/conformance/mcp/manifest-gen/Honua.Mcp.ManifestGen.csproj
+++ b/scripts/conformance/mcp/manifest-gen/Honua.Mcp.ManifestGen.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Standalone generator for the geospatial-mcp reference conformance manifest.
+    It is intentionally NOT part of Honua.sln: it is a build-on-demand helper
+    that runs CapabilityManifestEmitter (in Honua.Ai) to emit the
+    honua.manifest.json the geospatial-mcp repo vendors under
+    conformance/manifests/. Regenerating and diffing against the checked-in
+    manifest keeps the published spec aligned to the live server grammar
+    (Decision A). See scripts/conformance/mcp/manifest-gen/Program.cs.
+
+    See Program.cs for the exact dotnet run invocation and output path.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <!-- Throwaway conformance helper, not shipped server code: keep it out of
+         the strict server analyzer / docs / warnings-as-errors gate. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Honua.Ai\Honua.Ai.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/conformance/mcp/manifest-gen/Program.cs
+++ b/scripts/conformance/mcp/manifest-gen/Program.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+// geospatial-mcp reference conformance-manifest generator.
+//
+// Runs CapabilityManifestEmitter (Honua.Ai) to project the live /mcp operator
+// surface into the geospatial-mcp honua.manifest.json shape and writes it to a
+// known path. The geospatial-mcp repo vendors the output as
+// conformance/manifests/honua.manifest.json and scores it with
+// conformance/check_manifest.py --strict.
+//
+// Usage: dotnet run --project scripts/conformance/mcp/manifest-gen -- <output-file>
+// Default output: ./honua.manifest.json
+
+using Honua.Ai.Protocols.Mcp.Discovery;
+
+var outPath = args.Length > 0 ? args[0] : "honua.manifest.json";
+var fullPath = Path.GetFullPath(outPath);
+
+var directory = Path.GetDirectoryName(fullPath);
+if (!string.IsNullOrEmpty(directory))
+{
+    Directory.CreateDirectory(directory);
+}
+
+var json = CapabilityManifestEmitter.EmitJson();
+File.WriteAllText(fullPath, json);
+
+Console.WriteLine($"geospatial-mcp manifest written to {fullPath}");
+Console.WriteLine(
+    $"  {CapabilityManifestEmitter.Tools.Count} tools, "
+    + $"{CapabilityManifestEmitter.ResourcesByLiveFamily.Count} resource families "
+    + $"(specDate {CapabilityManifestEmitter.SpecDate}).");
+return 0;

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/CapabilityManifestEmitter.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/CapabilityManifestEmitter.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Ai.Protocols.Mcp.Discovery;
+
+/// <summary>
+/// Identity block of an emitted geospatial-mcp conformance manifest.
+/// </summary>
+internal sealed class CapabilityManifestImplementation
+{
+    /// <summary>Human-readable implementation name (e.g. <c>Honua /mcp</c>).</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True only for the reference implementation named in the geospatial-mcp
+    /// <c>CONFORMANCE.md</c> (Honua). Always <c>true</c> for this emitter.
+    /// </summary>
+    [JsonPropertyName("isReferenceImplementation")]
+    public bool IsReferenceImplementation { get; set; }
+}
+
+/// <summary>
+/// One advertised tool entry in an emitted geospatial-mcp conformance manifest.
+/// Shape mirrors <c>spec/schemas/conformance/manifest.schema.json</c> — the
+/// <c>tools[]</c> item is <c>{standardName, advertisedName, workflowFamily}</c>.
+/// </summary>
+internal sealed class CapabilityManifestTool
+{
+    /// <summary>The bare geospatial-mcp taxonomy tool name this tool implements.</summary>
+    [JsonPropertyName("standardName")]
+    public string StandardName { get; set; } = string.Empty;
+
+    /// <summary>The name the live <c>/mcp</c> surface advertises on <c>tools/list</c>.</summary>
+    [JsonPropertyName("advertisedName")]
+    public string AdvertisedName { get; set; } = string.Empty;
+
+    /// <summary>The workflow-family tag the live surface attaches to the tool.</summary>
+    [JsonPropertyName("workflowFamily")]
+    public string WorkflowFamily { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// One advertised resource-family entry in an emitted geospatial-mcp conformance
+/// manifest. Shape mirrors the manifest schema's <c>resources[]</c> item
+/// <c>{family, uriForm}</c>.
+/// </summary>
+internal sealed class CapabilityManifestResource
+{
+    /// <summary>The geospatial-mcp standard resource-family label.</summary>
+    [JsonPropertyName("family")]
+    public string Family { get; set; } = string.Empty;
+
+    /// <summary>The <c>honua://</c> URI template the family is served under (Decision A grammar).</summary>
+    [JsonPropertyName("uriForm")]
+    public string UriForm { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// The full emitted geospatial-mcp conformance manifest document.
+/// </summary>
+internal sealed class CapabilityManifest
+{
+    /// <summary>
+    /// The <c>Date</c> header of the <c>spec/conformance.md</c> revision this
+    /// manifest is produced against.
+    /// </summary>
+    [JsonPropertyName("specDate")]
+    public string SpecDate { get; set; } = string.Empty;
+
+    /// <summary>Identity of the implementation under test.</summary>
+    [JsonPropertyName("implementation")]
+    public CapabilityManifestImplementation Implementation { get; set; } = new();
+
+    /// <summary>Advertised tools that map onto standard vocabulary.</summary>
+    [JsonPropertyName("tools")]
+    public IReadOnlyList<CapabilityManifestTool> Tools { get; set; } = [];
+
+    /// <summary>Advertised resource families that map onto standard vocabulary.</summary>
+    [JsonPropertyName("resources")]
+    public IReadOnlyList<CapabilityManifestResource> Resources { get; set; } = [];
+}
+
+/// <summary>
+/// AOT-compatible source-generated JSON context for the emitted geospatial-mcp
+/// conformance manifest. <c>WriteIndented</c> is on so the emitted file is a
+/// human-reviewable, diff-stable artifact.
+/// </summary>
+[JsonSerializable(typeof(CapabilityManifest))]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class CapabilityManifestJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Emits the geospatial-mcp <c>honua.manifest.json</c> conformance manifest from
+/// the live MCP operator surface (#2323, Track A). It is the single source of
+/// truth for the reference manifest the geospatial-mcp repo vendors: the manifest
+/// is <b>generated</b> from this projection rather than hand-maintained, so the
+/// server grammar (Decision A: <c>honua://map-packages/{id}</c>,
+/// <c>app-packages/{id}</c>, <c>published-services/{id}</c>) is always the
+/// contract the published spec aligns to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The projection is bound to the live catalog by the MCP taxonomy-alignment
+/// conformance tests: they assert every advertised tool in
+/// <see cref="Tools"/> is present in the live <c>tools/list</c> roster (and vice
+/// versa), that each entry's <see cref="CapabilityManifestTool.WorkflowFamily"/>
+/// matches the live handler's telemetry family, and that every emitted resource
+/// <see cref="CapabilityManifestResource.UriForm"/> structurally matches the
+/// live <c>resources/templates/list</c> URI template for that family. A tool or
+/// URI-grammar change that is not reflected here is therefore a build failure.
+/// </para>
+/// <para>
+/// The result families deliberately cover only what the live surface actually
+/// serves. The spec's stand-alone <c>honua://results/{result_package_id}</c>
+/// package/artifact/provenance sub-resources are NOT served (results are reached
+/// through the job at <c>honua://jobs/{jobId}/results</c>), so they are recorded
+/// as <c>known-gap</c> in the vendored index rather than invented here.
+/// </para>
+/// </remarks>
+internal static class CapabilityManifestEmitter
+{
+    /// <summary>
+    /// The <c>Date</c> header of the <c>spec/conformance.md</c> revision the
+    /// emitted manifest is produced against.
+    /// </summary>
+    public const string SpecDate = "2026-04-19";
+
+    /// <summary>The implementation name recorded in the emitted manifest.</summary>
+    public const string ImplementationName = "Honua /mcp";
+
+    /// <summary>
+    /// The advertised tool projection: <c>advertisedName -&gt; (standardName,
+    /// workflowFamily)</c>. Title-cased workflow families mirror the live
+    /// <see cref="McpTelemetry.WorkflowFamily"/> telemetry tags.
+    /// </summary>
+    public static IReadOnlyList<CapabilityManifestTool> Tools { get; } =
+    [
+        Tool("honua_plan_analysis", "plan_analysis", "Planning"),
+        Tool("honua_ground_candidates", "ground_candidates", "Planning"),
+        Tool("honua_clarify_intent", "clarify_intent", "Planning"),
+        Tool("honua_validate_plan", "validate_plan", "Planning"),
+        Tool("honua_dry_run_plan", "validate_plan", "Planning"),
+        Tool("honua_execute_plan", "execute_plan", "Execution"),
+        Tool("honua_cancel_job", "cancel_job", "Lifecycle"),
+        Tool("honua_propose_operation", "propose_operation", "Lifecycle"),
+        Tool("honua_publish_service", "publish_service", "Lifecycle"),
+        Tool("honua_create_map_package", "create_map_package", "Execution"),
+        Tool("honua_create_app_package", "create_app_package", "Execution"),
+        Tool("honua_validate_package", "validate_package", "Planning"),
+        Tool("honua_preview_package", "preview_package", "Planning"),
+        Tool("honua_geocode_address", "geocode_address", "Execution"),
+        Tool("honua_solve_route", "solve_route", "Execution"),
+        Tool("honua_list_layers", "list_layers", "Results"),
+        Tool("honua_query_features", "query_features", "Results"),
+        Tool("honua_render_map", "render_map", "Results"),
+        Tool("honua_resolve_entity", "resolve_entity", "Results"),
+        Tool("honua_list_capabilities", "list_capabilities", "Results"),
+    ];
+
+    /// <summary>
+    /// The served resource-family projection keyed by the live
+    /// <c>IMcpResource.Family</c> tag (<see cref="McpTelemetry.ResourceFamily"/>).
+    /// Only families the live surface actually serves are present; each carries
+    /// the standard family label and the Decision-A snake_case URI form the
+    /// vendored index pins.
+    /// </summary>
+    public static IReadOnlyDictionary<string, CapabilityManifestResource> ResourcesByLiveFamily { get; } =
+        new Dictionary<string, CapabilityManifestResource>(StringComparer.Ordinal)
+        {
+            [McpTelemetry.ResourceFamily.Workspaces] =
+                Resource("Workspace", "honua://workspaces/{workspace_id}"),
+            [McpTelemetry.ResourceFamily.MapPackages] =
+                Resource("Map package", "honua://map-packages/{map_package_id}"),
+            [McpTelemetry.ResourceFamily.AppPackages] =
+                Resource("App package", "honua://app-packages/{app_package_id}"),
+            [McpTelemetry.ResourceFamily.PublishedServices] =
+                Resource("Published service", "honua://published-services/{published_service_id}"),
+            [McpTelemetry.ResourceFamily.Deployments] =
+                Resource("Deployment", "honua://deployments/{deployment_id}"),
+        };
+
+    /// <summary>
+    /// Builds the emitted manifest document from the canonical projection, with
+    /// tools ordered by advertised name and resources by family for a diff-stable
+    /// artifact.
+    /// </summary>
+    public static CapabilityManifest EmitManifest() => new()
+    {
+        SpecDate = SpecDate,
+        Implementation = new CapabilityManifestImplementation
+        {
+            Name = ImplementationName,
+            IsReferenceImplementation = true,
+        },
+        Tools = Tools
+            .OrderBy(t => t.AdvertisedName, StringComparer.Ordinal)
+            .ToList(),
+        Resources = ResourcesByLiveFamily.Values
+            .OrderBy(r => r.Family, StringComparer.Ordinal)
+            .ToList(),
+    };
+
+    /// <summary>
+    /// Serializes <see cref="EmitManifest"/> to the newline-terminated,
+    /// indented JSON the geospatial-mcp repo vendors as
+    /// <c>conformance/manifests/honua.manifest.json</c>.
+    /// </summary>
+    public static string EmitJson()
+    {
+        var json = JsonSerializer.Serialize(
+            EmitManifest(),
+            CapabilityManifestJsonContext.Default.CapabilityManifest);
+        return json + "\n";
+    }
+
+    private static CapabilityManifestTool Tool(string advertisedName, string standardName, string workflowFamily) =>
+        new()
+        {
+            StandardName = standardName,
+            AdvertisedName = advertisedName,
+            WorkflowFamily = workflowFamily,
+        };
+
+    private static CapabilityManifestResource Resource(string family, string uriForm) =>
+        new() { Family = family, UriForm = uriForm };
+}

--- a/src/Honua.Ai/Honua.Ai.csproj
+++ b/src/Honua.Ai/Honua.Ai.csproj
@@ -97,6 +97,9 @@
     <InternalsVisibleTo Include="Honua.Server.Tests" />
     <InternalsVisibleTo Include="Honua.Architecture.Tests" />
     <InternalsVisibleTo Include="Honua.Ai.Tests" />
+    <!-- Standalone geospatial-mcp reference-manifest generator
+         (scripts/conformance/mcp/manifest-gen, not part of Honua.sln). -->
+    <InternalsVisibleTo Include="Honua.Mcp.ManifestGen" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "geospatial-mcp JSON Schema index",
-  "description": "Machine-readable map from standard MCP tool names and resource family URIs to their JSON Schema (draft 2020-12) files. 'standardName' is the bare taxonomy.md tool name; 'referenceToolName' is the name the reference implementation (Honua /mcp) advertises. 'implementationStatus' records whether the reference implementation ships the tool today (implemented) or whether it is a standard family not yet implemented as a discrete tool (known-gap).",
-  "date": "2026-06-21",
+  "description": "Machine-readable map from standard MCP tool names and resource family URIs to their JSON Schema (draft 2020-12) files. 'standardName' is the bare taxonomy.md tool name; 'referenceToolName' is the name the reference implementation (Honua /mcp) advertises. 'implementationStatus' records whether the reference implementation ships the tool/resource family today (implemented) or whether it is a standard family not yet served by the reference (known-gap). For resources, 'implementationStatus' gates the FULL conformance level the same way it does for tools: a manifest must advertise every 'implemented' resource family to reach FULL; 'known-gap' families are reported as informational notes only.",
+  "date": "2026-07-01",
   "dialect": "https://json-schema.org/draft/2020-12/schema",
   "tools": [
     {
@@ -43,16 +43,24 @@
     },
     {
       "standardName": "create_map_package",
-      "referenceToolName": null,
+      "referenceToolName": "honua_create_map_package",
       "family": "Map composition",
       "schema": "tools/create_map_package.schema.json",
-      "implementationStatus": "known-gap"
+      "implementationStatus": "implemented",
+      "notes": "Reference implementation (#1951): routes through the canonical IMapGenerationService pipeline."
     },
     {
       "standardName": "refine_map_package",
       "referenceToolName": null,
       "family": "Map composition",
       "schema": "tools/refine_map_package.schema.json",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "standardName": "get_style",
+      "referenceToolName": null,
+      "family": "Style inspection",
+      "schema": "tools/get_style.schema.json",
       "implementationStatus": "known-gap"
     },
     {
@@ -78,10 +86,11 @@
     },
     {
       "standardName": "create_app_package",
-      "referenceToolName": null,
+      "referenceToolName": "honua_create_app_package",
       "family": "App composition",
       "schema": "tools/create_app_package.schema.json",
-      "implementationStatus": "known-gap"
+      "implementationStatus": "implemented",
+      "notes": "Reference implementation (#1951): routes through the canonical IAppGenerationService pipeline."
     },
     {
       "standardName": "preview_app_package",
@@ -96,13 +105,6 @@
       "family": "Publishing",
       "schema": "tools/publish_result.schema.json",
       "implementationStatus": "known-gap"
-    },
-    {
-      "standardName": "publish_service",
-      "referenceToolName": "honua_publish_service",
-      "family": "Publishing",
-      "schema": "tools/publish_service.schema.json",
-      "implementationStatus": "implemented"
     },
     {
       "standardName": "list_layers",
@@ -155,12 +157,36 @@
       "implementationStatus": "implemented"
     },
     {
+      "standardName": "publish_service",
+      "referenceToolName": "honua_publish_service",
+      "family": "Publishing",
+      "schema": "tools/publish_service.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Native divergence from publish_result: honua_publish_service publishes a source table as a new hosted service (connectionId/schema/table/layerName), whereas the standard publish_result promotes an existing result/package (sourceId). publish_result stays a known-gap until the standard finalizes a service-publish contract (honua-server#730/#732)."
+    },
+    {
+      "standardName": "validate_package",
+      "referenceToolName": "honua_validate_package",
+      "family": "Composition review (reference shape)",
+      "schema": "tools/validate_package.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Reference-shape review tool: read-only inspection of a map/app package's requirement coverage."
+    },
+    {
+      "standardName": "preview_package",
+      "referenceToolName": "honua_preview_package",
+      "family": "Composition review (reference shape)",
+      "schema": "tools/preview_package.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Reference-shape review tool: read-only preview plan for a map/app package before publishing."
+    },
+    {
       "standardName": "resolve_entity",
       "referenceToolName": "honua_resolve_entity",
       "family": "Discovery and grounding (Honua extension)",
       "schema": "tools/resolve_entity.schema.json",
       "implementationStatus": "implemented",
-      "notes": "Honua extension (#1949): NL/text -> ranked service/layer references grounded in the live catalog. Pending formalization in the geospatial-mcp standard; schema marks x-honua-extension."
+      "notes": "Honua extension (#1949): NL/text -> ranked service/layer references grounded in the live catalog. Pending formalization in the standard; schema marks x-honua-extension."
     },
     {
       "standardName": "list_capabilities",
@@ -168,7 +194,7 @@
       "family": "Discovery and grounding (Honua extension)",
       "schema": "tools/list_capabilities.schema.json",
       "implementationStatus": "implemented",
-      "notes": "Honua extension (#1949): self-describing manifest of the live tool/resource surface for a cold client LLM. Pending formalization in the geospatial-mcp standard; schema marks x-honua-extension."
+      "notes": "Honua extension (#1949): self-describing manifest of the live tool/resource surface for a cold client LLM. Pending formalization in the standard; schema marks x-honua-extension."
     }
   ],
   "resources": [
@@ -176,73 +202,96 @@
       "family": "Result package",
       "uriForm": "honua://results/{result_package_id}",
       "schema": "resources/result-package.schema.json",
-      "shapeFidelity": "concrete"
+      "shapeFidelity": "concrete",
+      "implementationStatus": "known-gap",
+      "notes": "The reference implementation does not serve a stand-alone result-package URI keyed by result_package_id; result data is reached through the owning job at honua://jobs/{job_id}/results (job-keyed), which is outside the standard resource vocabulary. Known-gap until the standard reconciles the addressing model."
     },
     {
       "family": "Result artifact",
       "uriForm": "honua://results/{result_package_id}/artifacts/{artifact_id}",
       "schema": "resources/artifact.schema.json",
-      "shapeFidelity": "concrete"
+      "shapeFidelity": "concrete",
+      "implementationStatus": "known-gap",
+      "notes": "Per-artifact result sub-resource is not served by the reference implementation; artifacts are inspected inline on the job results view. Known-gap."
     },
     {
       "family": "Result provenance",
       "uriForm": "honua://results/{result_package_id}/provenance",
       "schema": "resources/provenance.schema.json",
-      "shapeFidelity": "concrete"
+      "shapeFidelity": "concrete",
+      "implementationStatus": "known-gap",
+      "notes": "Result-provenance sub-resource is not served as a stand-alone URI; provenance is inlined on the job results view. Known-gap."
     },
     {
       "family": "Workspace",
       "uriForm": "honua://workspaces/{workspace_id}",
       "schema": "resources/workspace.schema.json",
-      "shapeFidelity": "concrete-reference"
+      "shapeFidelity": "concrete-reference",
+      "implementationStatus": "implemented"
     },
     {
       "family": "Workspace artifact",
       "uriForm": "honua://workspaces/{workspace_id}/artifacts/{artifact_id}",
       "schema": "resources/artifact.schema.json",
-      "shapeFidelity": "concrete"
+      "shapeFidelity": "concrete",
+      "implementationStatus": "known-gap",
+      "notes": "Per-artifact workspace sub-resource is not served as a stand-alone URI by the reference implementation. Known-gap."
     },
     {
       "family": "Map package",
-      "uriForm": "honua://maps/{map_package_id}",
+      "uriForm": "honua://map-packages/{map_package_id}",
       "schema": "resources/map-package.schema.json",
-      "shapeFidelity": "responsibility-level"
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "implemented"
     },
     {
       "family": "App package",
-      "uriForm": "honua://apps/{app_package_id}",
+      "uriForm": "honua://app-packages/{app_package_id}",
       "schema": "resources/app-package.schema.json",
-      "shapeFidelity": "responsibility-level"
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "implemented"
     },
     {
       "family": "Style",
       "uriForm": "honua://styles/{style_id}",
       "schema": "resources/style.schema.json",
-      "shapeFidelity": "responsibility-level"
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "known-gap"
     },
     {
       "family": "Theme",
       "uriForm": "honua://themes/{theme_id}",
       "schema": "resources/theme.schema.json",
-      "shapeFidelity": "responsibility-level"
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "known-gap"
     },
     {
       "family": "Map template",
       "uriForm": "honua://templates/maps/{map_template_id}",
       "schema": "resources/map-template.schema.json",
-      "shapeFidelity": "responsibility-level"
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "known-gap"
+    },
+    {
+      "family": "App template",
+      "uriForm": "honua://templates/apps/{app_template_id}",
+      "schema": "resources/app-template.schema.json",
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "known-gap"
     },
     {
       "family": "Published service",
-      "uriForm": "honua://services/{published_service_id}",
+      "uriForm": "honua://published-services/{published_service_id}",
       "schema": "resources/published-service.schema.json",
-      "shapeFidelity": "responsibility-level"
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "implemented"
     },
     {
       "family": "Deployment",
       "uriForm": "honua://deployments/{deployment_id}",
       "schema": "resources/deployment.schema.json",
-      "shapeFidelity": "responsibility-level"
+      "shapeFidelity": "responsibility-level",
+      "implementationStatus": "implemented"
     }
   ],
   "common": [
@@ -250,6 +299,13 @@
       "name": "GeoprocessingError",
       "schema": "common/geoprocessing-error.schema.json",
       "role": "Canonical error envelope reused by all tool/resource failure paths."
+    }
+  ],
+  "conformance": [
+    {
+      "name": "ConformanceManifest",
+      "schema": "conformance/manifest.schema.json",
+      "role": "Static declaration of the MCP tool/resource surface an implementation advertises, checked against this index by conformance/check_manifest.py. See /CONFORMANCE.md."
     }
   ]
 }

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/get_style.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/get_style.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/get_style.schema.json",
+  "title": "get_style inputSchema",
+  "description": "Argument shape for get_style (Analyze, Publish Data, Build App). Read-only style inspection: with styleId, resolves a single canonical StyleRef (style_id/title/encodings) from the server OGC API – Styles surface; without styleId, lists the available styles (honua://styles). Like every MCP tool it is read-only and never mutates server-side styles. See taxonomy.md §Style inspection and resources.md §honua://styles/{style_id}.",
+  "type": "object",
+  "properties": {
+    "styleId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "StyleRef identifier (style_…) to resolve. When omitted, the tool lists the available styles (honua://styles)."
+    },
+    "encoding": {
+      "type": "string",
+      "description": "Optional StyleEncoding to select from StyleRef.encodings when resolving a single style.",
+      "enum": [
+        "mapbox-style",
+        "sld-1.0.0",
+        "sld-1.1.0",
+        "esri-drawing-info",
+        "esri-image-renderer",
+        "3d-tiles-styling"
+      ]
+    },
+    "includeStylesheet": {
+      "type": "boolean",
+      "description": "When true and styleId is set, include the resolved stylesheet body (inlineBody) for the selected encoding; otherwise the StyleRef projection advertises derived encodings by reference (storageRef)."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/preview_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/preview_package.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/preview_package.schema.json",
+  "title": "preview_package inputSchema",
+  "description": "Argument shape for the read-only composition-review tool (advertised name honua_preview_package). Computes a read-only preview plan for a map/app package before publishing, in addition to the requirement-coverage review; it never mutates server state. x-honua-reference-shape: tracks the reference implementation; the bare taxonomy models package preview as a CapabilityCatalog + resource read.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {
+    "contractVersion": {
+      "type": "string",
+      "description": "Package-review contract version. Current value is honua.package_review.v1."
+    },
+    "packageFamily": {
+      "type": "string",
+      "description": "Supported values are query, analysis_plan, map_package, dashboard_report, form, app_package, workflow, gp, and etl. Missing or unknown values are returned as canonical missing_package_family or unsupported_package_family findings rather than rejected by the schema."
+    },
+    "packageId": { "type": "string" },
+    "requestedAction": { "type": "string" },
+    "format": { "type": "string" },
+    "packagePayload": {
+      "type": ["object", "array", "string", "number", "boolean", "null"],
+      "description": "Opaque package payload inspected only by the matching package-family adapter."
+    },
+    "requirements": {
+      "type": ["object", "null"],
+      "description": "Shared data binding, permission, schema, CRS, capability, dependency, and approval requirements. An explicit null is normalized to an empty requirement set."
+    },
+    "estimate": {
+      "type": "object",
+      "description": "Optional upstream estimate echoed in the shared package-review response."
+    },
+    "includePreviewPlan": { "type": "boolean" },
+    "includePassFindings": { "type": "boolean" },
+    "resourceRefs": {
+      "type": ["object", "null"],
+      "additionalProperties": { "type": "string" },
+      "description": "Safe caller-visible resource references. An explicit null is normalized to an empty map."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/validate_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/validate_package.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/validate_package.schema.json",
+  "title": "validate_package inputSchema",
+  "description": "Argument shape for the read-only composition-review tool (advertised name honua_validate_package). Inspects a map/app package's requirement coverage (data bindings, permissions, schema, CRS, capabilities, dependencies, approvals) and returns canonical findings without mutating server state. x-honua-reference-shape: tracks the reference implementation; the bare taxonomy models package review as a CapabilityCatalog + resource read.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {
+    "contractVersion": {
+      "type": "string",
+      "description": "Package-review contract version. Current value is honua.package_review.v1."
+    },
+    "packageFamily": {
+      "type": "string",
+      "description": "Supported values are query, analysis_plan, map_package, dashboard_report, form, app_package, workflow, gp, and etl. Missing or unknown values are returned as canonical missing_package_family or unsupported_package_family findings rather than rejected by the schema."
+    },
+    "packageId": { "type": "string" },
+    "requestedAction": { "type": "string" },
+    "format": { "type": "string" },
+    "packagePayload": {
+      "type": ["object", "array", "string", "number", "boolean", "null"],
+      "description": "Opaque package payload inspected only by the matching package-family adapter."
+    },
+    "requirements": {
+      "type": ["object", "null"],
+      "description": "Shared data binding, permission, schema, CRS, capability, dependency, and approval requirements. An explicit null is normalized to an empty requirement set."
+    },
+    "includePassFindings": { "type": "boolean" },
+    "resourceRefs": {
+      "type": ["object", "null"],
+      "additionalProperties": { "type": "string" },
+      "description": "Safe caller-visible resource references. An explicit null is normalized to an empty map."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -2,11 +2,18 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using FluentAssertions;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Discovery;
 using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.Core.Features.PackageReview.Abstractions;
+using Honua.Geoprocessing;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
+using NSubstitute;
 using StandardSchema = Newtonsoft.Json.Schema.JSchema;
 
 namespace Honua.Server.Tests.Features.Protocols.Mcp;
@@ -373,6 +380,197 @@ public sealed partial class McpTaxonomyAlignmentTests
         // families; assert the roster is non-trivial so the wiring is real.
         BuildResources().Should().NotBeEmpty();
     }
+
+    // -------------------------------------------------------------------
+    // Resource-URI-TEMPLATE conformance (Track A, #2323): the live resource
+    // grammar IS the contract. Every live URI template that maps onto a
+    // standard resource family must match the vendored index.json uriForm
+    // (Decision A grammar), and every standard family the index marks
+    // 'implemented' must be served by a live template. This makes any URI
+    // drift — e.g. reverting honua://map-packages/{id} to honua://maps/{id} —
+    // a build failure rather than a silent spec/server divergence.
+    // -------------------------------------------------------------------
+
+    private static string VendoredIndexPath => Path.Combine(SchemaRoot, "index.json");
+
+    /// <summary>
+    /// Normalizes a URI template by collapsing every <c>{token}</c> placeholder
+    /// to <c>{}</c> so the server's domain token names
+    /// (<c>{packageId}</c>) compare equal to the standard's snake_case tokens
+    /// (<c>{map_package_id}</c>): Decision A pins the path grammar, not the
+    /// placeholder spelling.
+    /// </summary>
+    private static string NormalizeUriTemplate(string uri) =>
+        Regex.Replace(uri, "\\{[^}]*\\}", "{}");
+
+    private static Dictionary<string, (string UriForm, string Status)> ReadIndexResourceUriForms()
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(VendoredIndexPath));
+        var map = new Dictionary<string, (string, string)>(StringComparer.Ordinal);
+        foreach (var resource in doc.RootElement.GetProperty("resources").EnumerateArray())
+        {
+            var family = resource.GetProperty("family").GetString()!;
+            var uriForm = resource.GetProperty("uriForm").GetString()!;
+            var status = resource.TryGetProperty("implementationStatus", out var s)
+                ? s.GetString()!
+                : "implemented";
+            map[family] = (uriForm, status);
+        }
+
+        return map;
+    }
+
+    [UnitTest]
+    public void LiveResourceTemplates_MatchVendoredIndexUriForms_AndCoverEveryImplementedFamily()
+    {
+        var indexResources = ReadIndexResourceUriForms();
+
+        // live resource-family tag -> standard family label. Sourced from the
+        // emitter's canonical projection so the emitter, the live catalog, and
+        // the vendored index cannot drift apart independently.
+        var liveFamilyToStandard = CapabilityManifestEmitter.ResourcesByLiveFamily;
+
+        var coveredStandardFamilies = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var resource in BuildResources())
+        {
+            if (!liveFamilyToStandard.TryGetValue(resource.Family, out var projection))
+            {
+                // Honua-native families with no standard analog (jobs, proposals,
+                // process/feature catalog, job report) are outside the standard
+                // resource vocabulary and are intentionally not projected.
+                continue;
+            }
+
+            var standardFamily = projection.Family;
+            indexResources.TryGetValue(standardFamily, out var indexEntry).Should().BeTrue(
+                $"standard family '{standardFamily}' must exist in the vendored index.json");
+            indexEntry.Status.Should().Be("implemented",
+                $"family '{standardFamily}' is served by the live surface, so the index must mark it implemented");
+
+            var templates = resource.DescribeTemplates();
+            templates.Should().NotBeEmpty(
+                $"served family '{standardFamily}' must advertise a URI template");
+
+            foreach (var template in templates)
+            {
+                NormalizeUriTemplate(template.UriTemplate).Should().Be(
+                    NormalizeUriTemplate(indexEntry.UriForm),
+                    $"live URI template '{template.UriTemplate}' for family '{standardFamily}' must match "
+                    + $"the Decision A uriForm '{indexEntry.UriForm}' pinned in the vendored index.json");
+            }
+
+            coveredStandardFamilies.Add(standardFamily);
+        }
+
+        // Every standard family the index marks 'implemented' must be served by a
+        // live template — a spec family flipped to implemented without a backing
+        // live resource fails here.
+        var implementedIndexFamilies = indexResources
+            .Where(kvp => kvp.Value.Status == "implemented")
+            .Select(kvp => kvp.Key)
+            .ToArray();
+
+        coveredStandardFamilies.Should().BeEquivalentTo(implementedIndexFamilies,
+            "every index resource family marked 'implemented' must be served by a live URI template, "
+            + "and every served family must be marked implemented");
+    }
+
+    // -------------------------------------------------------------------
+    // Emitted-manifest conformance (Track A, #2323): the CapabilityManifestEmitter
+    // projection must stay bound to the live tool catalog and score FULL against
+    // the vendored index — the same coverage check conformance/check_manifest.py
+    // runs in geospatial-mcp CI.
+    // -------------------------------------------------------------------
+
+    private static IReadOnlyList<IMcpTool> BuildLiveToolRoster()
+    {
+        // BuildTools() omits the package-review tools because they take extra
+        // service dependencies; the live /mcp DI registration advertises them, so
+        // the full advertised roster includes them here.
+        var reviewService = Substitute.For<IPackageReviewService>();
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        return
+        [
+            .. BuildTools(),
+            new ValidatePackageTool(reviewService, jobService, NullLogger<ValidatePackageTool>.Instance),
+            new PreviewPackageTool(reviewService, jobService, NullLogger<PreviewPackageTool>.Instance),
+        ];
+    }
+
+    [UnitTest]
+    public void EmittedManifest_ToolRoster_MatchesLiveCatalog_AndTitleCasesLiveWorkflowFamily()
+    {
+        var manifest = CapabilityManifestEmitter.EmitManifest();
+        var liveTools = BuildLiveToolRoster();
+
+        // 1. The emitted advertised-name set is exactly the live advertised roster.
+        var emittedNames = manifest.Tools.Select(t => t.AdvertisedName).ToHashSet(StringComparer.Ordinal);
+        var liveNames = liveTools.Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
+        emittedNames.Should().BeEquivalentTo(liveNames,
+            "the emitter projection must advertise exactly the live /mcp tool roster — add or remove "
+            + "the tool in CapabilityManifestEmitter.Tools when the catalog changes");
+
+        // 2. Every emitted workflowFamily is the title-cased live telemetry family.
+        var liveFamilyByName = liveTools.ToDictionary(t => t.Name, t => t.WorkflowFamily, StringComparer.Ordinal);
+        foreach (var tool in manifest.Tools)
+        {
+            var expected = TitleCase(liveFamilyByName[tool.AdvertisedName]);
+            tool.WorkflowFamily.Should().Be(expected,
+                $"emitted workflowFamily for '{tool.AdvertisedName}' must be the title-cased live telemetry family");
+        }
+    }
+
+    [UnitTest]
+    public void EmittedManifest_ScoresFull_AgainstVendoredIndex()
+    {
+        // Mirrors conformance/check_manifest.py: every advertised standardName maps
+        // onto the index, every 'implemented' index tool/resource family is
+        // advertised, and every advertised resource uriForm equals the index.
+        var manifest = CapabilityManifestEmitter.EmitManifest();
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(VendoredIndexPath));
+        var indexTools = doc.RootElement.GetProperty("tools").EnumerateArray()
+            .ToDictionary(
+                t => t.GetProperty("standardName").GetString()!,
+                t => t.TryGetProperty("implementationStatus", out var s) ? s.GetString()! : "implemented",
+                StringComparer.Ordinal);
+        var indexResources = ReadIndexResourceUriForms();
+
+        // Every advertised tool maps onto a standard name.
+        var advertisedStd = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var tool in manifest.Tools)
+        {
+            indexTools.ContainsKey(tool.StandardName).Should().BeTrue(
+                $"advertised tool '{tool.AdvertisedName}' maps to standardName '{tool.StandardName}' "
+                + "which must exist in the vendored index.json");
+            advertisedStd.Add(tool.StandardName);
+        }
+
+        // Every 'implemented' index tool is advertised (FULL tool coverage).
+        var implementedIndexTools = indexTools.Where(kvp => kvp.Value == "implemented").Select(kvp => kvp.Key);
+        advertisedStd.Should().Contain(implementedIndexTools,
+            "every standard tool marked 'implemented' in the index must be advertised by the emitted manifest");
+
+        // Every advertised resource family maps onto the index with an equal uriForm.
+        var advertisedFamilies = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var resource in manifest.Resources)
+        {
+            indexResources.TryGetValue(resource.Family, out var indexEntry).Should().BeTrue(
+                $"advertised resource family '{resource.Family}' must exist in the vendored index.json");
+            resource.UriForm.Should().Be(indexEntry.UriForm,
+                $"advertised uriForm for '{resource.Family}' must equal the index-pinned uriForm");
+            advertisedFamilies.Add(resource.Family);
+        }
+
+        // Every 'implemented' index resource family is advertised (FULL resource coverage).
+        var implementedIndexFamilies = indexResources.Where(kvp => kvp.Value.Status == "implemented").Select(kvp => kvp.Key);
+        advertisedFamilies.Should().Contain(implementedIndexFamilies,
+            "every standard resource family marked 'implemented' in the index must be advertised by the emitted manifest");
+    }
+
+    private static string TitleCase(string value) =>
+        string.IsNullOrEmpty(value) ? value : char.ToUpperInvariant(value[0]) + value[1..];
 
     // -------------------------------------------------------------------
     // JSON-schema loading + fixture helpers


### PR DESCRIPTION
## Related Issue

Related to #2323

## Summary

Track A interop fix (release-gating): closes the spec-first-client 404 between the geospatial-mcp spec and the honua-server `/mcp` surface. Decision A — the **server** grammar is the contract; the published spec aligns to it. This PR makes honua-server the generator of the geospatial-mcp reference manifest so the spec can never drift from the live grammar again.

Coordinated pair with geospatial-mcp PR (align-spec-to-server-grammar); land together so `check_manifest.py` never sees a mismatched pair.

## Changes Made

- Add `CapabilityManifestEmitter` (leaf, beside `ListCapabilitiesTool`): projects the live catalog into the geospatial-mcp `honua.manifest.json` shape — 20 tools `{standardName, advertisedName, workflowFamily}` and 5 served resource families `{family, uriForm}` (Decision A URIs).
- Add `scripts/conformance/mcp/manifest-gen` (standalone `dotnet run` generator, not in `Honua.sln`, mirrors the CNG artifact-gen pattern) that writes the emitted manifest to a known path.
- Add a resource-URI-TEMPLATE conformance assertion: every live `DescribeTemplates()` URI template that maps to a standard family must match the vendored `index.json` Decision A `uriForm`, and every implemented family must be served — URI drift is now a build failure.
- Add emitter↔live-roster + emitter↔index FULL-coverage tests (mirror geospatial-mcp `check_manifest.py`).
- Sync vendored `ConformanceSchemas/geospatial-mcp/index.json` to Decision A (map/app/published-service uriForms; create_map/app_package implemented; add publish_service/validate_package/preview_package/resolve_entity/list_capabilities; mark unserved result/artifact/provenance/workspace-artifact families known-gap).

## Breaking Changes

None. Additive: new leaf emitter + standalone generator + conformance tests + vendored-schema sync. No runtime endpoint or DTO changes.

## Gate Impact

- [x] No gate impact / additive test + tooling only

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- Built the emitter + generator (Release, warnings-as-errors) and ran `dotnet run` on the generator to emit the manifest.
- `dotnet test Honua.Ai.Tests --filter McpTaxonomyAlignmentTests`: 38/38 pass, including the new URI-template and emitter conformance tests.
- `dotnet format --verify-no-changes` on the changed C# files: clean.
- Cross-repo: the emitted manifest scores FULL under geospatial-mcp `check_manifest.py --strict`.
