### PR TITLE
feat: add CapabilityDescriptor + ICapabilityRegistry foundation (#2333)

### DIFF
--- a/src/Honua.Core/Features/Capabilities/CapabilityDescriptor.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityDescriptor.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The single, frozen description of one platform capability — the row in the
+/// unified capability registry (ADR-0058, Decision B). Every capability-facing
+/// surface derives from this descriptor rather than keeping its own roster:
+/// the <c>/mcp</c> catalog, the <c>geospatial-mcp</c> conformance manifest, the
+/// <c>honua.capability_manifest.v1</c> wire (#1186), Studio AI, the SDK
+/// projections (Tracks C/D), and Console.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This shape is frozen before the SDK/Console fan-out.</b> Post-freeze
+/// changes must be additive and follow the normal contract-version discipline
+/// (ADR-0058 "Freeze discipline"). Add new <c>init</c> properties; do not
+/// reorder, rename, or remove existing ones.
+/// </para>
+/// <para>
+/// The record uses <c>init</c> properties (not positional parameters) so that
+/// adding a field is a source- and binary-additive change that does not disturb
+/// downstream projections.
+/// </para>
+/// </remarks>
+public sealed record CapabilityDescriptor
+{
+    /// <summary>
+    /// Stable, unique capability identifier (for example <c>temporal.filtering</c>,
+    /// <c>protocol.mcp.tool.plan_analysis</c>, or <c>format.geoparquet</c>). This is
+    /// the primary key downstream surfaces bind to and must never change once
+    /// frozen.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Grouping category for the capability. For <c>/mcp</c> tool descriptors this
+    /// is the MCP workflow family (<c>planning</c>/<c>execution</c>/<c>lifecycle</c>/
+    /// <c>results</c>); for manifest capabilities it is the #1186 category
+    /// (<c>temporal</c>, <c>packages</c>, …); for resources it is <c>resource</c>;
+    /// for data formats it is <c>format</c>.
+    /// </summary>
+    public required string Category { get; init; }
+
+    /// <summary>The broad kind of capability.</summary>
+    public required CapabilityKind Kind { get; init; }
+
+    /// <summary>The product-lifecycle maturity (shared enum; see <see cref="CapabilityMaturity"/>).</summary>
+    public required CapabilityMaturity Maturity { get; init; }
+
+    /// <summary>
+    /// The existing <see cref="FeatureCatalog"/> entitlement key that gates this
+    /// capability, or <c>null</c> when the capability is ungated. When set, this is
+    /// the same string used by license entitlement checks.
+    /// </summary>
+    public string? EntitlementKey { get; init; }
+
+    /// <summary>
+    /// The minimum edition required, derived from <see cref="FeatureCatalog"/> for
+    /// the <see cref="EntitlementKey"/>, or <c>null</c> when the capability is
+    /// ungated or has no catalog mapping.
+    /// </summary>
+    public HonuaEdition? MinimumEdition { get; init; }
+
+    /// <summary>
+    /// The bare <c>geospatial-mcp</c> taxonomy name this capability implements
+    /// (a tool's <c>standardName</c>, or a resource family's standard label), or
+    /// <c>null</c> when the capability has no standard-vocabulary name. Mirrors
+    /// the <c>standardName</c>/<c>family</c> fields the <c>CapabilityManifestEmitter</c>
+    /// (#2338) emits so the registry and the emitter cannot diverge.
+    /// </summary>
+    public string? StandardName { get; init; }
+
+    /// <summary>
+    /// The name the live <c>/mcp</c> surface advertises for this capability on
+    /// <c>tools/list</c> (for example <c>honua_plan_analysis</c>), or <c>null</c> for
+    /// non-tool capabilities. Mirrors the emitter's <c>advertisedName</c>.
+    /// </summary>
+    public string? McpToolName { get; init; }
+
+    /// <summary>
+    /// The <c>honua://</c> resource-URI templates this capability serves
+    /// (Decision A grammar), or empty for non-resource capabilities. Mirrors the
+    /// emitter's <c>uriForm</c> and the <c>McpResourceUris</c> seam.
+    /// </summary>
+    public IReadOnlyList<string> ResourceUriTemplates { get; init; } = [];
+
+    /// <summary>
+    /// The package/manifest schema version this capability is expressed under
+    /// (for example a package-family schema version), or <c>null</c>. Populated by
+    /// B3 (#2335) when the #1186 package families layer onto the registry.
+    /// </summary>
+    public string? PackageSchemaVersion { get; init; }
+
+    /// <summary>
+    /// Whether the live surface actually serves this capability today, or declares
+    /// it as an honest gap. See <see cref="CapabilityImplementationStatus"/>.
+    /// </summary>
+    public CapabilityImplementationStatus ImplementationStatus { get; init; }
+        = CapabilityImplementationStatus.Served;
+
+    /// <summary>
+    /// The <c>geospatial-mcp</c> conformance-manifest section this capability is
+    /// asserted under (<c>tools</c> or <c>resources</c>), or <c>null</c> when the
+    /// capability does not participate in <c>geospatial-mcp</c> conformance
+    /// (manifest capabilities, data formats). Lets a downstream surface tell which
+    /// capabilities the conformance harness pins.
+    /// </summary>
+    public string? ConformanceMapping { get; init; }
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityGateContext.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityGateContext.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The inputs a capability resolution is evaluated against — the seam that the
+/// config-driven experimental gate resolver (#2339 / T2) and the per-environment
+/// manifest resolver (#2335 / B3) fill in. In B1 the context is accepted by
+/// <see cref="ICapabilityRegistry.Resolve"/> but not yet consulted (resolution is
+/// a pass-through); it is defined now so its shape is frozen alongside
+/// <see cref="CapabilityDescriptor"/>.
+/// </summary>
+/// <remarks>
+/// New gate inputs (experimental flag overrides, tenant scope, config snapshot)
+/// are added here as additive <c>init</c> properties by the follow-up tickets.
+/// </remarks>
+public sealed record CapabilityGateContext
+{
+    /// <summary>The active platform edition the capability is evaluated for.</summary>
+    public HonuaEdition Edition { get; init; } = HonuaEdition.Community;
+
+    /// <summary>
+    /// The deployment environment name (for example <c>production</c>), or
+    /// <c>null</c> when the evaluation is not environment-scoped.
+    /// </summary>
+    public string? DeploymentEnvironment { get; init; }
+
+    /// <summary>
+    /// A default context (Community edition, no environment scope) for callers
+    /// that have no richer context — primarily the B1 pass-through and tests.
+    /// </summary>
+    public static CapabilityGateContext Default { get; } = new();
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityImplementationStatus.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityImplementationStatus.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// Whether the live surface actually serves a capability, or declares it as an
+/// honest gap. This mirrors the <c>known-gap</c> concept the
+/// <c>CapabilityManifestEmitter</c> (#2338 / ADR-0058 "Derive, don't fork")
+/// records in the vendored <c>geospatial-mcp</c> index rather than silently
+/// advertising unserved sub-families.
+/// </summary>
+public enum CapabilityImplementationStatus
+{
+    /// <summary>The capability is served by the live surface today.</summary>
+    Served = 0,
+
+    /// <summary>
+    /// A declared but not-served gap — advertised as <c>known-gap</c> in the
+    /// conformance manifest so "what the platform claims" stays equal to "what it
+    /// serves". No descriptor in B1 uses this value (B1 mirrors only what exists).
+    /// </summary>
+    KnownGap = 1,
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityKind.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityKind.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The broad kind of a <see cref="CapabilityDescriptor"/>. This is the top-level
+/// axis every downstream surface (SDK projections, Console binding) groups
+/// capabilities by, so it is part of the frozen contract (ADR-0058).
+/// </summary>
+public enum CapabilityKind
+{
+    /// <summary>
+    /// A platform feature capability — an edition-gated or manifest-advertised
+    /// behaviour (for example <c>temporal.filtering</c> or <c>edit.features</c>).
+    /// </summary>
+    Feature = 0,
+
+    /// <summary>
+    /// A protocol operation — an operation or resource exposed on a protocol
+    /// surface (for example an <c>/mcp</c> tool/resource or
+    /// <c>protocol.odata.batch</c>).
+    /// </summary>
+    ProtocolOperation = 1,
+
+    /// <summary>
+    /// A data format the platform can read and/or write (for example
+    /// <c>format.geoparquet</c>).
+    /// </summary>
+    DataFormat = 2,
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityMaturity.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityMaturity.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The product-lifecycle maturity of a capability. This is the <b>shared</b>
+/// maturity enum for the platform: the unified capability registry (ADR-0058)
+/// and the evidence-based feature-catalog generator (ADR-0054, consumed in T9)
+/// both project from it, so it lives in <c>Honua.Core</c> where both can
+/// reference it. The ordering is deliberately least-to-most mature so callers
+/// can compare with <c>&gt;=</c>.
+/// </summary>
+public enum CapabilityMaturity
+{
+    /// <summary>Planned but not yet built; declared for roadmap visibility only.</summary>
+    Planned = 0,
+
+    /// <summary>
+    /// Deferred out of the current release scope; present on trunk but not
+    /// advertised/served (ADR-0058 defers temporal, disconnected-sync, and others).
+    /// </summary>
+    Deferred = 1,
+
+    /// <summary>
+    /// Experimental — implemented but off by default and config-gated; the
+    /// experimental flag precedence lands in #2339 (T2) and the flips in T10 (#2346).
+    /// </summary>
+    Experimental = 2,
+
+    /// <summary>Partially implemented — a subset of the capability is served.</summary>
+    Partial = 3,
+
+    /// <summary>Fully implemented and shipped in the current live surface.</summary>
+    Implemented = 4,
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -1,0 +1,281 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Licensing.Domain;
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The default <see cref="ICapabilityRegistry"/> — the single source of truth
+/// for the platform capability roster (ADR-0058, Decision B). B1 populates it to
+/// <b>faithfully mirror the live roster that exists today</b>: the <c>/mcp</c>
+/// tools and resources (from <c>McpOperatorSurface</c> /
+/// <c>McpServiceCollectionExtensions</c>), the #1186 capability-manifest
+/// capabilities (from <c>CapabilityManifestService</c>), and the platform data
+/// formats (from <c>SupportedFileFormat</c> and the shared format readers/writers).
+/// It is a description-layer projection only — B1 disables nothing and changes no
+/// behaviour. B2 (#2334) composes <c>/mcp</c> from this registry and B3 (#2335)
+/// layers the #1186 per-environment resolver onto it.
+/// </summary>
+/// <remarks>
+/// A runtime registry↔catalog conformance check pins this roster to the live
+/// surface so it cannot silently drift (see the conformance test that mirrors the
+/// <c>McpTaxonomyAlignmentTests</c> / <c>FeatureCatalogDriftTests</c> style).
+/// </remarks>
+public sealed class CapabilityRegistry : ICapabilityRegistry
+{
+    /// <summary>Id prefix for <c>/mcp</c> tool capability descriptors.</summary>
+    public const string McpToolIdPrefix = "protocol.mcp.tool.";
+
+    /// <summary>Id prefix for <c>/mcp</c> resource-family capability descriptors.</summary>
+    public const string McpResourceIdPrefix = "protocol.mcp.resource.";
+
+    /// <summary>Id prefix for data-format capability descriptors.</summary>
+    public const string DataFormatIdPrefix = "format.";
+
+    /// <summary>Reason code returned by <see cref="Resolve"/> for an unregistered id.</summary>
+    public const string NotRegisteredReasonCode = "capability-not-registered";
+
+    private static readonly Dictionary<string, HonuaEdition> EditionByEntitlementKey =
+        FeatureCatalog.All.ToDictionary(
+            static f => f.Key,
+            static f => f.MinimumEdition,
+            StringComparer.Ordinal);
+
+    private static readonly IReadOnlyList<CapabilityDescriptor> AllDescriptors = BuildAll();
+
+    private static readonly Dictionary<string, CapabilityDescriptor> ById =
+        AllDescriptors.ToDictionary(static d => d.Id, StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public IReadOnlyList<CapabilityDescriptor> All => AllDescriptors;
+
+    /// <inheritdoc />
+    public CapabilityDescriptor? Find(string id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return ById.GetValueOrDefault(id);
+    }
+
+    /// <inheritdoc />
+    public CapabilityResolution Resolve(string id, CapabilityGateContext context)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(context);
+
+        // B1 pass-through seam: every registered capability resolves enabled (no
+        // capability is disabled in this PR), and an unknown id resolves disabled.
+        // #2339 (T2) replaces this with CapabilityGateContext-driven precedence
+        // (edition + environment + config) that can disable Experimental
+        // capabilities with a specific ReasonCode.
+        return ById.ContainsKey(id)
+            ? new CapabilityResolution(true, null)
+            : new CapabilityResolution(false, NotRegisteredReasonCode);
+    }
+
+    private static List<CapabilityDescriptor> BuildAll()
+    {
+        var descriptors = new List<CapabilityDescriptor>();
+        descriptors.AddRange(BuildMcpToolDescriptors());
+        descriptors.AddRange(BuildMcpResourceDescriptors());
+        descriptors.AddRange(BuildManifestCapabilityDescriptors());
+        descriptors.AddRange(BuildDataFormatDescriptors());
+        return descriptors;
+    }
+
+    // -----------------------------------------------------------------------
+    // /mcp tools — the live tools/list roster (McpServiceCollectionExtensions).
+    // (advertisedName, geospatial-mcp standardName, workflow family)
+    // -----------------------------------------------------------------------
+    private static IEnumerable<CapabilityDescriptor> BuildMcpToolDescriptors()
+    {
+        (string Advertised, string Standard, string Family)[] tools =
+        [
+            ("honua_plan_analysis", "plan_analysis", "planning"),
+            ("honua_ground_candidates", "ground_candidates", "planning"),
+            ("honua_clarify_intent", "clarify_intent", "planning"),
+            ("honua_validate_plan", "validate_plan", "planning"),
+            ("honua_dry_run_plan", "validate_plan", "planning"),
+            ("honua_validate_package", "validate_package", "planning"),
+            ("honua_preview_package", "preview_package", "planning"),
+            ("honua_execute_plan", "execute_plan", "execution"),
+            ("honua_create_map_package", "create_map_package", "execution"),
+            ("honua_create_app_package", "create_app_package", "execution"),
+            ("honua_geocode_address", "geocode_address", "execution"),
+            ("honua_solve_route", "solve_route", "execution"),
+            ("honua_cancel_job", "cancel_job", "lifecycle"),
+            ("honua_propose_operation", "propose_operation", "lifecycle"),
+            ("honua_publish_service", "publish_service", "lifecycle"),
+            ("honua_list_layers", "list_layers", "results"),
+            ("honua_query_features", "query_features", "results"),
+            ("honua_render_map", "render_map", "results"),
+            ("honua_resolve_entity", "resolve_entity", "results"),
+            ("honua_list_capabilities", "list_capabilities", "results"),
+        ];
+
+        foreach (var (advertised, standard, family) in tools)
+        {
+            yield return new CapabilityDescriptor
+            {
+                Id = McpToolIdPrefix + advertised[McpToolNamePrefixLength..],
+                Category = family,
+                Kind = CapabilityKind.ProtocolOperation,
+                Maturity = CapabilityMaturity.Implemented,
+                StandardName = standard,
+                McpToolName = advertised,
+                ConformanceMapping = "tools",
+            };
+        }
+    }
+
+    private const int McpToolNamePrefixLength = 6; // "honua_".Length
+
+    // -----------------------------------------------------------------------
+    // /mcp resource families — the live resources/list + resources/templates/list
+    // roster (default composition + opt-in promotion surface).
+    // (family, standard label, honua:// URI templates)
+    // -----------------------------------------------------------------------
+    private static IEnumerable<CapabilityDescriptor> BuildMcpResourceDescriptors()
+    {
+        (string Family, string StandardLabel, string[] Uris)[] resources =
+        [
+            ("jobs", "Job", ["honua://jobs/{jobId}"]),
+            ("job-results", "Job results", ["honua://jobs/{jobId}/results"]),
+            ("job-reports", "Job report", ["honua://jobs/{jobId}/report"]),
+            ("proposals", "Proposal", ["honua://proposals/{proposalId}"]),
+            ("workspaces", "Workspace", ["honua://workspaces/{workspaceId}"]),
+            ("catalog", "Catalog", ["honua://catalog/processes", "honua://catalog/features"]),
+            ("published-services", "Published service", ["honua://published-services/{serviceId}"]),
+            ("deployments", "Deployment", ["honua://deployments/{deploymentId}"]),
+            ("map-packages", "Map package", ["honua://map-packages/{packageId}"]),
+            ("app-packages", "App package", ["honua://app-packages/{packageId}"]),
+            (
+                "promotion-index",
+                "Promotion index",
+                [
+                    "honua://published-services",
+                    "honua://deployments",
+                    "honua://map-packages",
+                    "honua://app-packages",
+                ]),
+        ];
+
+        foreach (var (family, standardLabel, uris) in resources)
+        {
+            yield return new CapabilityDescriptor
+            {
+                Id = McpResourceIdPrefix + family,
+                Category = "resource",
+                Kind = CapabilityKind.ProtocolOperation,
+                Maturity = CapabilityMaturity.Implemented,
+                StandardName = standardLabel,
+                ResourceUriTemplates = uris,
+                ConformanceMapping = "resources",
+            };
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // #1186 capability-manifest capabilities — mirrors
+    // CapabilityManifestService.BuildCapabilities (honua.capability_manifest.v1).
+    // (id, category, entitlement key, kind)
+    // -----------------------------------------------------------------------
+    private static IEnumerable<CapabilityDescriptor> BuildManifestCapabilityDescriptors()
+    {
+        (string Id, string Category, string? EntitlementKey, CapabilityKind Kind)[] capabilities =
+        [
+            ("package.metadata-v2", "packages", null, CapabilityKind.Feature),
+            ("package.release-package", "packages", null, CapabilityKind.Feature),
+            ("package.gitops-manifest", "packages", null, CapabilityKind.Feature),
+            ("package.map", "packages", null, CapabilityKind.Feature),
+            ("package.app", "packages", null, CapabilityKind.Feature),
+
+            ("temporal.filtering", "temporal", "temporal.filtering", CapabilityKind.Feature),
+            ("temporal.extent-discovery", "temporal", "temporal.extent-discovery", CapabilityKind.Feature),
+            ("temporal.histogram", "temporal", "temporal.histogram", CapabilityKind.Feature),
+            ("temporal.time-series-tiles", "temporal", "temporal.time-series-tiles", CapabilityKind.Feature),
+
+            ("sync.offline", "sync", FeatureCatalog.FieldOpsOfflineSyncKey, CapabilityKind.Feature),
+            ("realtime.feature-streams", "realtime", "streaming.feature-subscriptions", CapabilityKind.Feature),
+            ("alerts.geofence", "alerts", "alerts.enter-exit", CapabilityKind.Feature),
+            ("jobs.runner", "jobs", null, CapabilityKind.Feature),
+            ("ai.spec-apply", "ai", FeatureCatalog.AiSpecApplyKey, CapabilityKind.Feature),
+            ("ai.grounding", "ai", FeatureCatalog.AiGroundingKey, CapabilityKind.Feature),
+            ("ai.workflow-generation", "ai", FeatureCatalog.AiWorkflowGenerationKey, CapabilityKind.Feature),
+            ("gitops.release-manifest", "gitops", null, CapabilityKind.Feature),
+
+            ("transport.grpc", "transports", null, CapabilityKind.ProtocolOperation),
+            ("transport.grpc-web", "transports", null, CapabilityKind.ProtocolOperation),
+            ("transport.native-grpc", "transports", null, CapabilityKind.ProtocolOperation),
+            ("transport.mcp", "transports", null, CapabilityKind.ProtocolOperation),
+            ("transport.qgis", "transports", null, CapabilityKind.ProtocolOperation),
+
+            ("security.mtls", "security", null, CapabilityKind.Feature),
+            ("preview.file-import", "preview", "import.file", CapabilityKind.Feature),
+            ("query.features", "query", null, CapabilityKind.Feature),
+            // analysis.spatial is gated by a composite of four analytics keys; the
+            // single-key EntitlementKey field cannot represent it, so it is left
+            // null (the manifest projection keeps the composite key set in B3).
+            ("analysis.spatial", "analysis", null, CapabilityKind.Feature),
+            ("publication.metadata-release", "publication", null, CapabilityKind.Feature),
+            ("upload.file", "upload", "import.file", CapabilityKind.Feature),
+            ("edit.features", "edit", FeatureCatalog.FeatureServerEditsKey, CapabilityKind.Feature),
+        ];
+
+        foreach (var (id, category, entitlementKey, kind) in capabilities)
+        {
+            yield return new CapabilityDescriptor
+            {
+                Id = id,
+                Category = category,
+                Kind = kind,
+                Maturity = CapabilityMaturity.Implemented,
+                EntitlementKey = entitlementKey,
+                MinimumEdition = ResolveMinimumEdition(entitlementKey),
+            };
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Data formats — the shared format readers/writers. The import formats mirror
+    // Honua.Core's SupportedFileFormat enum; esrijson/wkb are additional writer/
+    // codec-backed formats that are not import enum members.
+    // (canonical name, minimum edition or null)
+    // -----------------------------------------------------------------------
+    private static IEnumerable<CapabilityDescriptor> BuildDataFormatDescriptors()
+    {
+        string[] formats =
+        [
+            "geojson",
+            "shapefile",
+            "geopackage",
+            "gpx",
+            "kml",
+            "gml",
+            "wkt",
+            "csv",
+            "filegdb",
+            "flatgeobuf",
+            "geoparquet",
+            "esrijson",
+            "wkb",
+        ];
+
+        foreach (var name in formats)
+        {
+            yield return new CapabilityDescriptor
+            {
+                Id = DataFormatIdPrefix + name,
+                Category = "format",
+                Kind = CapabilityKind.DataFormat,
+                Maturity = CapabilityMaturity.Implemented,
+                StandardName = name,
+            };
+        }
+    }
+
+    private static HonuaEdition? ResolveMinimumEdition(string? entitlementKey)
+        => entitlementKey is not null && EditionByEntitlementKey.TryGetValue(entitlementKey, out var edition)
+            ? edition
+            : null;
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistryServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistryServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// Dependency-injection registration for the unified capability registry
+/// (ADR-0058). This is the composition seam B2 (#2334) uses to bind the
+/// <c>/mcp</c> surface to the registry; B1 provides the registration without
+/// wiring any surface to it (no behaviour change).
+/// </summary>
+public static class CapabilityRegistryServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="ICapabilityRegistry"/> as a singleton
+    /// <see cref="CapabilityRegistry"/>. Safe to call more than once.
+    /// </summary>
+    /// <param name="services">The service collection to add the registry to.</param>
+    /// <returns>The same service collection, for chaining.</returns>
+    public static IServiceCollection AddCapabilityRegistry(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.TryAddSingleton<ICapabilityRegistry, CapabilityRegistry>();
+        return services;
+    }
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityResolution.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityResolution.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The outcome of resolving a capability against a
+/// <see cref="CapabilityGateContext"/>. It is the single evaluation result the
+/// gate resolver (#2339 / T2), manifest enforcement (T4), and the per-surface
+/// gates (T5–T7) consume.
+/// </summary>
+/// <param name="Enabled">Whether the capability is enabled for the given context.</param>
+/// <param name="ReasonCode">
+/// A stable machine-readable reason when <paramref name="Enabled"/> is
+/// <c>false</c> (for example <c>capability-not-registered</c>), or <c>null</c>
+/// when enabled.
+/// </param>
+public readonly record struct CapabilityResolution(bool Enabled, string? ReasonCode);

--- a/src/Honua.Core/Features/Capabilities/ICapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/ICapabilityRegistry.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The single source of truth for the platform's capability roster (ADR-0058,
+/// Decision B). Both the <c>/mcp</c> surface and Studio AI bind to it, and every
+/// other surface becomes a projection derived from it. B1 populates it to mirror
+/// the live roster; B2 (#2334) composes <c>/mcp</c> from it and B3 (#2335) layers
+/// the #1186 per-environment resolver onto it.
+/// </summary>
+public interface ICapabilityRegistry
+{
+    /// <summary>All registered capability descriptors, in a stable order.</summary>
+    IReadOnlyList<CapabilityDescriptor> All { get; }
+
+    /// <summary>
+    /// Finds a descriptor by its <see cref="CapabilityDescriptor.Id"/>, or returns
+    /// <c>null</c> when no capability with that id is registered.
+    /// </summary>
+    /// <param name="id">The stable capability identifier.</param>
+    CapabilityDescriptor? Find(string id);
+
+    /// <summary>
+    /// Resolves whether a capability is enabled for the given context. This is the
+    /// single evaluation entry point the gate resolver (#2339 / T2) and downstream
+    /// gates call.
+    /// </summary>
+    /// <remarks>
+    /// In B1 this is a pass-through: every registered capability resolves
+    /// <c>Enabled = true</c> (no capability is disabled in this PR) and an unknown
+    /// id resolves <c>Enabled = false</c>. The config-driven experimental gating and
+    /// its reason codes land in #2339 (T2), which replaces the pass-through with
+    /// <see cref="CapabilityGateContext"/>-driven precedence.
+    /// </remarks>
+    /// <param name="id">The stable capability identifier.</param>
+    /// <param name="context">The edition/environment/config inputs to evaluate against.</param>
+    CapabilityResolution Resolve(string id, CapabilityGateContext context);
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
@@ -1,0 +1,313 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Resources;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.Core.Features.Capabilities;
+using Honua.Core.Features.Deployment.Abstractions;
+using Honua.Core.Features.FileImport.Domain;
+using Honua.Core.Features.Grounding.Abstractions;
+using Honua.Core.Features.PackageReview.Abstractions;
+using Honua.Core.Features.Publishing.Abstractions;
+using Honua.Core.Features.Reporting.Abstractions;
+using Honua.Geoprocessing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Ai.Tests.Capabilities;
+
+/// <summary>
+/// Runtime registry↔catalog conformance check for the unified capability registry
+/// (ADR-0058, honua-server B1 / #2333). It fails if the <see cref="CapabilityRegistry"/>
+/// drifts from the live surface it mirrors: a live <c>/mcp</c> tool/resource or a
+/// #1186 capability-manifest capability with no registry descriptor, or a registry
+/// descriptor that resolves to nothing real. Modelled on
+/// <c>McpTaxonomyAlignmentTests</c> and <c>FeatureCatalogDriftTests</c>.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class CapabilityRegistryConformanceTests
+{
+    private static readonly CapabilityRegistry Registry = new();
+
+    // The #1186 capability roster, sourced from
+    // CapabilityManifestService.BuildCapabilities (honua.capability_manifest.v1).
+    // The #1186 service cannot be constructed from a unit test (its options
+    // snapshot bundles internal option types in Honua.Hosting/Honua.Import that
+    // are not visible here), so this roster is pinned here like the taxonomy
+    // roster in McpTaxonomyAlignmentTests. Adding a capability to
+    // BuildCapabilities requires adding a registry descriptor AND updating this
+    // list — that is the intended freeze discipline, not incidental duplication.
+    private static readonly string[] ManifestCapabilityIds =
+    [
+        "package.metadata-v2",
+        "package.release-package",
+        "package.gitops-manifest",
+        "package.map",
+        "package.app",
+        "temporal.filtering",
+        "temporal.extent-discovery",
+        "temporal.histogram",
+        "temporal.time-series-tiles",
+        "sync.offline",
+        "realtime.feature-streams",
+        "alerts.geofence",
+        "jobs.runner",
+        "ai.spec-apply",
+        "ai.grounding",
+        "ai.workflow-generation",
+        "gitops.release-manifest",
+        "transport.grpc",
+        "transport.grpc-web",
+        "transport.native-grpc",
+        "transport.mcp",
+        "transport.qgis",
+        "security.mtls",
+        "preview.file-import",
+        "query.features",
+        "analysis.spatial",
+        "publication.metadata-release",
+        "upload.file",
+        "edit.features",
+    ];
+
+    // Format descriptors that intentionally exist beyond the SupportedFileFormat
+    // import enum: writer/codec-backed formats (EsriJsonWkbWriter, WKT/WKB codecs).
+    private static readonly HashSet<string> NonImportFormatNames =
+        new(StringComparer.Ordinal) { "esrijson", "wkb" };
+
+    [UnitTest]
+    public void Registry_IsNotEmpty()
+    {
+        Registry.All.Should().NotBeEmpty();
+        Registry.All.Should().OnlyContain(d =>
+            !string.IsNullOrWhiteSpace(d.Id) && !string.IsNullOrWhiteSpace(d.Category));
+    }
+
+    [UnitTest]
+    public void EveryDescriptor_ResolvesToItself_AndHasUniqueId()
+    {
+        var ids = Registry.All.Select(d => d.Id).ToArray();
+        ids.Should().OnlyHaveUniqueItems("capability ids are the frozen primary key");
+
+        foreach (var descriptor in Registry.All)
+        {
+            Registry.Find(descriptor.Id).Should().BeSameAs(descriptor,
+                $"Find must round-trip the descriptor for '{descriptor.Id}'");
+        }
+    }
+
+    [UnitTest]
+    public void Resolve_EnablesEveryRegisteredCapability_AndRejectsUnknown()
+    {
+        var context = CapabilityGateContext.Default;
+
+        foreach (var descriptor in Registry.All)
+        {
+            var resolution = Registry.Resolve(descriptor.Id, context);
+            resolution.Enabled.Should().BeTrue(
+                $"B1 is a pass-through — every registered capability ('{descriptor.Id}') resolves enabled");
+            resolution.ReasonCode.Should().BeNull();
+        }
+
+        var unknown = Registry.Resolve("does.not.exist", context);
+        unknown.Enabled.Should().BeFalse();
+        unknown.ReasonCode.Should().Be(CapabilityRegistry.NotRegisteredReasonCode);
+    }
+
+    [UnitTest]
+    public void LiveMcpTools_MatchRegistryToolDescriptors()
+    {
+        var liveToolNames = BuildLiveTools()
+            .Select(t => t.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var registryToolNames = Registry.All
+            .Where(d => d.Id.StartsWith(CapabilityRegistry.McpToolIdPrefix, StringComparison.Ordinal))
+            .Select(d => d.McpToolName!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        registryToolNames.Should().BeEquivalentTo(liveToolNames,
+            "every live /mcp tool must have exactly one registry descriptor and vice versa");
+    }
+
+    [UnitTest]
+    public void RegistryToolDescriptors_MirrorLiveWorkflowFamilies()
+    {
+        var liveFamilyByName = BuildLiveTools()
+            .ToDictionary(t => t.Name, t => t.WorkflowFamily, StringComparer.Ordinal);
+
+        foreach (var descriptor in Registry.All
+                     .Where(d => d.Id.StartsWith(CapabilityRegistry.McpToolIdPrefix, StringComparison.Ordinal)))
+        {
+            descriptor.McpToolName.Should().NotBeNull();
+            liveFamilyByName.TryGetValue(descriptor.McpToolName!, out var liveFamily).Should().BeTrue();
+            descriptor.Category.Should().Be(liveFamily,
+                $"tool '{descriptor.McpToolName}' Category must mirror the live workflow family");
+        }
+    }
+
+    [UnitTest]
+    public void LiveMcpResources_MatchRegistryResourceDescriptors()
+    {
+        var liveFamilies = BuildLiveResources()
+            .Select(r => r.Family)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var registryFamilies = Registry.All
+            .Where(d => d.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal))
+            .Select(d => d.Id[CapabilityRegistry.McpResourceIdPrefix.Length..])
+            .ToHashSet(StringComparer.Ordinal);
+
+        registryFamilies.Should().BeEquivalentTo(liveFamilies,
+            "every live /mcp resource family must have exactly one registry descriptor and vice versa");
+    }
+
+    [UnitTest]
+    public void RegistryResourceUris_MatchLiveResourceUris()
+    {
+        var resources = BuildLiveResources();
+        var liveUris = resources.SelectMany(r => r.Describe()).Select(d => d.Uri)
+            .Concat(resources.SelectMany(r => r.DescribeTemplates()).Select(d => d.UriTemplate))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var registryUris = Registry.All
+            .Where(d => d.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal))
+            .SelectMany(d => d.ResourceUriTemplates)
+            .ToHashSet(StringComparer.Ordinal);
+
+        registryUris.Should().BeEquivalentTo(liveUris,
+            "the registry resource-URI templates must mirror the live resources/list + templates surface");
+    }
+
+    [UnitTest]
+    public void ManifestCapabilities_AllHaveRegistryDescriptor()
+    {
+        var registryManifestIds = Registry.All
+            .Where(d =>
+                !d.Id.StartsWith(CapabilityRegistry.McpToolIdPrefix, StringComparison.Ordinal) &&
+                !d.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal) &&
+                !d.Id.StartsWith(CapabilityRegistry.DataFormatIdPrefix, StringComparison.Ordinal))
+            .Select(d => d.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+        registryManifestIds.Should().BeEquivalentTo(ManifestCapabilityIds,
+            "every #1186 capability-manifest capability must have exactly one registry descriptor and vice versa");
+    }
+
+    [UnitTest]
+    public void EntitlementBackedDescriptors_DeriveMinimumEditionFromFeatureCatalog()
+    {
+        foreach (var descriptor in Registry.All.Where(d => d.EntitlementKey is not null))
+        {
+            Honua.Core.Features.Licensing.Domain.FeatureCatalog.All
+                .Select(f => f.Key)
+                .Should().Contain(descriptor.EntitlementKey!,
+                    $"'{descriptor.Id}' entitlement key must exist in the FeatureCatalog");
+
+            var expectedEdition = Honua.Core.Features.Licensing.Domain.FeatureCatalog.All
+                .First(f => f.Key == descriptor.EntitlementKey).MinimumEdition;
+            descriptor.MinimumEdition.Should().Be(expectedEdition,
+                $"'{descriptor.Id}' MinimumEdition must be derived from the FeatureCatalog");
+        }
+    }
+
+    [UnitTest]
+    public void SupportedFileFormats_AllHaveRegistryDescriptor()
+    {
+        foreach (var format in Enum.GetValues<SupportedFileFormat>())
+        {
+            var expectedId = CapabilityRegistry.DataFormatIdPrefix
+                + format.ToString().ToLowerInvariant();
+            Registry.Find(expectedId).Should().NotBeNull(
+                $"import format '{format}' must have registry descriptor '{expectedId}'");
+        }
+    }
+
+    [UnitTest]
+    public void FormatDescriptors_MapToRealFormat()
+    {
+        var importFormatNames = Enum.GetValues<SupportedFileFormat>()
+            .Select(f => f.ToString().ToLowerInvariant())
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var descriptor in Registry.All
+                     .Where(d => d.Id.StartsWith(CapabilityRegistry.DataFormatIdPrefix, StringComparison.Ordinal)))
+        {
+            var name = descriptor.Id[CapabilityRegistry.DataFormatIdPrefix.Length..];
+            (importFormatNames.Contains(name) || NonImportFormatNames.Contains(name)).Should().BeTrue(
+                $"format descriptor '{descriptor.Id}' must map to a SupportedFileFormat member or a known writer/codec format");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Live-surface construction — mirrors McpTaxonomyAlignmentTests.BuildTools /
+    // BuildResources, extended with the two package-review tools those tests
+    // construct separately, so this enumerates the full advertised 20-tool roster.
+    // -----------------------------------------------------------------------
+    private static IMcpTool[] BuildLiveTools()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        var groundingService = Substitute.For<IGroundingService>();
+        var reviewService = Substitute.For<IPackageReviewService>();
+        return
+        [
+            new ValidatePlanTool(jobService, NullLogger<ValidatePlanTool>.Instance),
+            new DryRunPlanTool(jobService, NullLogger<DryRunPlanTool>.Instance),
+            new ExecutePlanTool(jobService, NullLogger<ExecutePlanTool>.Instance),
+            new CancelJobTool(jobService, NullLogger<CancelJobTool>.Instance),
+            new ProposeOperationTool(NullLogger<ProposeOperationTool>.Instance),
+            new PublishServiceTool(NullLogger<PublishServiceTool>.Instance),
+            new CreateMapPackageTool(jobService, NullLogger<CreateMapPackageTool>.Instance),
+            new CreateAppPackageTool(jobService, NullLogger<CreateAppPackageTool>.Instance),
+            new PlanAnalysisTool(
+                Substitute.For<Honua.Ai.AiBuilder.Planning.IPlanAnalysisService>(),
+                jobService,
+                NullLogger<PlanAnalysisTool>.Instance),
+            new GroundCandidatesTool(groundingService, jobService, NullLogger<GroundCandidatesTool>.Instance),
+            new ClarifyIntentTool(groundingService, jobService, NullLogger<ClarifyIntentTool>.Instance),
+            new GeocodeTool(jobService, NullLogger<GeocodeTool>.Instance),
+            new RouteTool(jobService, NullLogger<RouteTool>.Instance),
+            new ValidatePackageTool(reviewService, jobService, NullLogger<ValidatePackageTool>.Instance),
+            new PreviewPackageTool(reviewService, jobService, NullLogger<PreviewPackageTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.Discovery.ResolveEntityTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.Discovery.ResolveEntityTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.Discovery.ListCapabilitiesTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.Discovery.ListCapabilitiesTool>.Instance),
+        ];
+    }
+
+    private static IMcpResource[] BuildLiveResources()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        var reportService = Substitute.For<IAnalysisReportService>();
+        var services = Substitute.For<IPublishedServiceStore>();
+        var deployments = Substitute.For<IDeploymentStore>();
+        return
+        [
+            new JobStatusResource(jobService, NullLogger<JobStatusResource>.Instance),
+            new JobResultsResource(jobService, NullLogger<JobResultsResource>.Instance),
+            new ProposalStatusResource(NullLogger<ProposalStatusResource>.Instance),
+            new AnalysisReportResource(reportService, NullLogger<AnalysisReportResource>.Instance),
+            new WorkspaceResource(jobService, NullLogger<WorkspaceResource>.Instance),
+            new ProcessCatalogResource(jobService, NullLogger<ProcessCatalogResource>.Instance),
+            new FeatureCatalogResource(jobService, NullLogger<FeatureCatalogResource>.Instance),
+            new PublishedServiceResource(
+                services, deployments, jobService, NullLogger<PublishedServiceResource>.Instance),
+            new DeploymentResource(deployments, jobService, NullLogger<DeploymentResource>.Instance),
+            new MapPackageResource(deployments, jobService, NullLogger<MapPackageResource>.Instance),
+            new AppPackageResource(deployments, jobService, NullLogger<AppPackageResource>.Instance),
+            new PromotionSurfaceIndexResource(
+                services, deployments, jobService, NullLogger<PromotionSurfaceIndexResource>.Instance),
+        ];
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2333

## Summary
Introduces the pre-freeze foundation of the unified capability registry (ADR-0058, Decision B): `CapabilityDescriptor` + `ICapabilityRegistry` in `Honua.Core`, populated to faithfully mirror today's live roster, plus a runtime registry↔catalog conformance check. This is the frozen contract the SDK/Console fan-out (Tracks C/D) will project from, so the record shape is the deliverable. No behaviour change — this is the description/discovery layer only; nothing is disabled and no capability is gated in this PR.

Placed in `Honua.Core` so both `Honua.Ai`'s `/mcp` surface and `Honua.Server`'s `/api/v1/capabilities` can depend on it without a layering inversion.

## Changes Made
- Add `CapabilityDescriptor` (frozen `record` with `init` properties): `Id`, `Category`, `Kind`, `Maturity`, `EntitlementKey`, `MinimumEdition`, `StandardName`, `McpToolName`, `ResourceUriTemplates`, `PackageSchemaVersion`, `ImplementationStatus`, `ConformanceMapping`.
- Add shared enums: `CapabilityMaturity { Planned, Deferred, Experimental, Partial, Implemented }` (the shared enum ADR-0054's T9 catalog generator consumes), `CapabilityKind { Feature, ProtocolOperation, DataFormat }`, `CapabilityImplementationStatus { Served, KnownGap }`.
- Add `ICapabilityRegistry` (`All`, `Find`, `Resolve`) with `CapabilityGateContext` + `readonly record struct CapabilityResolution(bool Enabled, string? ReasonCode)`. `Resolve` is a B1 pass-through/registration seam (every registered capability resolves enabled; unknown id → disabled); config-driven experimental gating lands in #2339 (T2).
- Add `CapabilityRegistry` populated to mirror the live roster: 20 `/mcp` tools, 11 `/mcp` resource families, 29 #1186 capability-manifest capabilities, 13 data formats. `Maturity = Implemented` for the shipped set.
- Add `AddCapabilityRegistry` DI seam (registered, not yet wired to any surface — that is B2/#2334).
- Add `CapabilityRegistryConformanceTests` (Honua.Ai.Tests) mirroring `McpTaxonomyAlignmentTests`/`FeatureCatalogDriftTests`: fails if a live `/mcp` tool/resource, a #1186 capability, or a `SupportedFileFormat` has no descriptor, or a descriptor resolves to nothing real.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [ ] None — no docs or contract impact

Note: this defines a new internal contract (`CapabilityDescriptor`) intended to be frozen before the SDK/Console fan-out; no existing wire/OpenAPI/proto contract changes.

## Release/Deploy Impact
- [x] Requires coordinated release across repos

Downstream (post-freeze): Track C SDK projections (sdk-dotnet#169 / sdk-js#230) and Track D Console binding project from this descriptor.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
