### PR TITLE
feat: config-driven experimental capability flag resolver (#2339)

### DIFF
--- a/src/Honua.Core/Features/Capabilities/CapabilityFlagOptions.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityFlagOptions.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// Config-bound experimental feature-flag switches for the capability registry
+/// (#2339 / T2). Experimental capabilities (<see cref="CapabilityMaturity.Experimental"/>)
+/// are off by default; these flags are the only lever that turns one on — either
+/// globally or per-capability, per-environment — without re-forking (ADR-0058
+/// feature-flag system). Bound from the <c>Capabilities:Experimental</c> section:
+/// <list type="bullet">
+///   <item><description>
+///     <c>Capabilities:Experimental:Enabled</c> — the global master switch
+///     (default <c>false</c>). When <c>true</c>, every experimental capability is on.
+///   </description></item>
+///   <item><description>
+///     <c>Capabilities:Experimental:{descriptorId}:Enabled</c> — a per-capability
+///     override (default <c>false</c>), for example
+///     <c>Capabilities:Experimental:temporal.filtering:Enabled</c>.
+///   </description></item>
+/// </list>
+/// The environment-variable form uses the double-underscore separator, for example
+/// <c>Capabilities__Experimental__temporal.filtering__Enabled=true</c>.
+/// </summary>
+public sealed class CapabilityFlagOptions
+{
+    /// <summary>The configuration section these options bind from.</summary>
+    public const string SectionName = "Capabilities:Experimental";
+
+    /// <summary>The config key of the global master switch within the section.</summary>
+    public const string GlobalEnabledKey = "Enabled";
+
+    /// <summary>The config key of a per-capability override within its subsection.</summary>
+    public const string PerCapabilityEnabledKey = "Enabled";
+
+    /// <summary>
+    /// The global master switch (<c>Capabilities:Experimental:Enabled</c>). Defaults
+    /// to <c>false</c>: with no configuration, no experimental capability is enabled.
+    /// When <c>true</c>, it enables every experimental capability regardless of the
+    /// per-capability overrides.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Per-capability overrides keyed by <see cref="CapabilityDescriptor.Id"/>. A
+    /// missing entry is treated as disabled (default <c>false</c>).
+    /// </summary>
+    public IDictionary<string, ExperimentalCapabilityFlag> Capabilities { get; } =
+        new Dictionary<string, ExperimentalCapabilityFlag>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Whether the experimental capability with the given id is enabled: <c>true</c>
+    /// when the global master switch is on, or when the capability has a per-capability
+    /// override set to enabled. Non-experimental capabilities never consult this.
+    /// </summary>
+    /// <param name="capabilityId">The capability descriptor id to test.</param>
+    public bool IsExperimentalEnabled(string capabilityId)
+    {
+        ArgumentNullException.ThrowIfNull(capabilityId);
+
+        if (Enabled)
+        {
+            return true;
+        }
+
+        return Capabilities.TryGetValue(capabilityId, out var flag) && flag.Enabled;
+    }
+
+    /// <summary>
+    /// Binds the flag values from a <c>Capabilities:Experimental</c> configuration
+    /// section. Handled explicitly (rather than via <c>Bind</c>) because the global
+    /// <c>Enabled</c> scalar and the per-capability subsections are siblings under
+    /// the same section, which the default binder cannot separate into a dictionary.
+    /// </summary>
+    /// <param name="options">The options instance to populate.</param>
+    /// <param name="section">The <c>Capabilities:Experimental</c> section.</param>
+    public static void Bind(CapabilityFlagOptions options, IConfigurationSection section)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(section);
+
+        options.Enabled = section.GetValue(GlobalEnabledKey, false);
+
+        foreach (var child in section.GetChildren())
+        {
+            // Skip the global master scalar; every other child is a per-capability
+            // subsection keyed by the descriptor id.
+            if (string.Equals(child.Key, GlobalEnabledKey, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            options.Capabilities[child.Key] = new ExperimentalCapabilityFlag
+            {
+                Enabled = child.GetValue(PerCapabilityEnabledKey, false),
+            };
+        }
+    }
+}
+
+/// <summary>A single per-capability experimental override.</summary>
+public sealed class ExperimentalCapabilityFlag
+{
+    /// <summary>Whether this experimental capability is enabled. Defaults to <c>false</c>.</summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityGateContext.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityGateContext.cs
@@ -29,8 +29,16 @@ public sealed record CapabilityGateContext
     public string? DeploymentEnvironment { get; init; }
 
     /// <summary>
-    /// A default context (Community edition, no environment scope) for callers
-    /// that have no richer context — primarily the B1 pass-through and tests.
+    /// The config-bound experimental feature-flag switches evaluated against
+    /// <see cref="CapabilityMaturity.Experimental"/> capabilities (#2339 / T2).
+    /// Defaults to all-off (no experimental capability enabled), so a default
+    /// context leaves the B1 non-experimental roster unchanged.
+    /// </summary>
+    public CapabilityFlagOptions ExperimentalFlags { get; init; } = new();
+
+    /// <summary>
+    /// A default context (Community edition, no environment scope, experimental
+    /// flags off) for callers that have no richer context — primarily tests.
     /// </summary>
     public static CapabilityGateContext Default { get; } = new();
 }

--- a/src/Honua.Core/Features/Capabilities/CapabilityGateResolver.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityGateResolver.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The config-driven gate resolver that fills the <see cref="ICapabilityRegistry.Resolve"/>
+/// seam B1 (#2333) left as a pass-through (#2339 / T2). It applies the ADR-0058
+/// experimental feature-flag precedence to a single capability descriptor.
+/// </summary>
+/// <remarks>
+/// <para>Resolution precedence:</para>
+/// <list type="number">
+///   <item><description>
+///     Unknown id (null descriptor) → disabled with
+///     <see cref="CapabilityReasonCodes.NotRegistered"/> (B1 behaviour, preserved).
+///   </description></item>
+///   <item><description>
+///     <see cref="CapabilityMaturity.Experimental"/> maturity → enabled only when the
+///     per-capability or global experimental flag is on; otherwise disabled with
+///     <see cref="CapabilityReasonCodes.ExperimentalDisabled"/> (default-off).
+///   </description></item>
+///   <item><description>
+///     Entitlement/edition still applies <b>on top</b>: a flag-on experimental
+///     capability whose <see cref="CapabilityDescriptor.MinimumEdition"/> exceeds the
+///     context edition fails on edition with
+///     <see cref="CapabilityReasonCodes.LicenseRequired"/> — not on the flag.
+///   </description></item>
+///   <item><description>
+///     Non-experimental capabilities → enabled (the B1 pass-through behaviour;
+///     entitlement is enforced by the operation surfaces, not this description layer).
+///   </description></item>
+/// </list>
+/// </remarks>
+public static class CapabilityGateResolver
+{
+    /// <summary>
+    /// Resolves whether the given descriptor is enabled for the context, applying the
+    /// experimental feature-flag precedence.
+    /// </summary>
+    /// <param name="descriptor">
+    /// The capability descriptor, or <c>null</c> when no capability with the requested
+    /// id is registered.
+    /// </param>
+    /// <param name="context">The edition/environment/flag inputs to evaluate against.</param>
+    public static CapabilityResolution Resolve(CapabilityDescriptor? descriptor, CapabilityGateContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (descriptor is null)
+        {
+            return new CapabilityResolution(false, CapabilityReasonCodes.NotRegistered);
+        }
+
+        if (descriptor.Maturity == CapabilityMaturity.Experimental)
+        {
+            if (!context.ExperimentalFlags.IsExperimentalEnabled(descriptor.Id))
+            {
+                return new CapabilityResolution(false, CapabilityReasonCodes.ExperimentalDisabled);
+            }
+
+            // Flag-on experimental capability: entitlement/edition still applies on top,
+            // so an unlicensed edition fails on edition rather than being masked by the flag.
+            if (descriptor.MinimumEdition is { } minimumEdition && context.Edition < minimumEdition)
+            {
+                return new CapabilityResolution(false, CapabilityReasonCodes.LicenseRequired);
+            }
+        }
+
+        // Non-experimental (or flag-on experimental with a satisfied edition): enabled.
+        return new CapabilityResolution(true, null);
+    }
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityReasonCodes.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityReasonCodes.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// Stable, machine-readable reason codes returned by
+/// <see cref="ICapabilityRegistry.Resolve"/> / <see cref="CapabilityGateResolver"/>
+/// when a capability resolves <c>Enabled = false</c>. These are the registry-layer
+/// codes shared by every downstream gate (#2339 / T2 onward); the <c>/capabilities</c>
+/// manifest surface keeps its own richer availability codes and reuses the same
+/// string values where they overlap (for example <see cref="LicenseRequired"/>).
+/// </summary>
+public static class CapabilityReasonCodes
+{
+    /// <summary>No capability with the requested id is registered.</summary>
+    public const string NotRegistered = "capability-not-registered";
+
+    /// <summary>
+    /// The capability is <see cref="CapabilityMaturity.Experimental"/> and neither the
+    /// per-capability nor the global experimental flag is enabled, so it is off by
+    /// default (#2339 / T2).
+    /// </summary>
+    public const string ExperimentalDisabled = "experimental-disabled";
+
+    /// <summary>
+    /// The active edition does not meet the capability's
+    /// <see cref="CapabilityDescriptor.MinimumEdition"/>. Mirrors the existing
+    /// license/entitlement reason the <c>/capabilities</c> manifest emits for a
+    /// wrong-edition capability, so an entitlement failure is never masked by the
+    /// experimental flag.
+    /// </summary>
+    public const string LicenseRequired = "license-required";
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -34,7 +34,7 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
     public const string DataFormatIdPrefix = "format.";
 
     /// <summary>Reason code returned by <see cref="Resolve"/> for an unregistered id.</summary>
-    public const string NotRegisteredReasonCode = "capability-not-registered";
+    public const string NotRegisteredReasonCode = CapabilityReasonCodes.NotRegistered;
 
     private static readonly Dictionary<string, HonuaEdition> EditionByEntitlementKey =
         FeatureCatalog.All.ToDictionary(
@@ -63,14 +63,10 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
         ArgumentNullException.ThrowIfNull(id);
         ArgumentNullException.ThrowIfNull(context);
 
-        // B1 pass-through seam: every registered capability resolves enabled (no
-        // capability is disabled in this PR), and an unknown id resolves disabled.
-        // #2339 (T2) replaces this with CapabilityGateContext-driven precedence
-        // (edition + environment + config) that can disable Experimental
-        // capabilities with a specific ReasonCode.
-        return ById.ContainsKey(id)
-            ? new CapabilityResolution(true, null)
-            : new CapabilityResolution(false, NotRegisteredReasonCode);
+        // #2339 (T2): the config-driven experimental feature-flag precedence. The
+        // registry supplies the descriptor (or null for an unknown id) and defers the
+        // maturity/flag/edition precedence to CapabilityGateResolver.
+        return CapabilityGateResolver.Resolve(Find(id), context);
     }
 
     private static List<CapabilityDescriptor> BuildAll()

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistryServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistryServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -24,6 +25,29 @@ public static class CapabilityRegistryServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         services.TryAddSingleton<ICapabilityRegistry, CapabilityRegistry>();
+        return services;
+    }
+
+    /// <summary>
+    /// Binds <see cref="CapabilityFlagOptions"/> from the
+    /// <c>Capabilities:Experimental</c> configuration section (#2339 / T2). The global
+    /// master switch and the per-capability overrides are siblings under one section,
+    /// so binding is done explicitly via <see cref="CapabilityFlagOptions.Bind"/>
+    /// rather than the default binder. Safe to call more than once.
+    /// </summary>
+    /// <param name="services">The service collection to add the options to.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The same service collection, for chaining.</returns>
+    public static IServiceCollection AddCapabilityFlagOptions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<CapabilityFlagOptions>()
+            .Configure(options =>
+                CapabilityFlagOptions.Bind(options, configuration.GetSection(CapabilityFlagOptions.SectionName)));
         return services;
     }
 }

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestOptionsSnapshot.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestOptionsSnapshot.cs
@@ -3,6 +3,7 @@
 
 using Honua.Core.Configuration;
 using Honua.Core.Features.Alerts.Domain;
+using Honua.Core.Features.Capabilities;
 using Honua.ControlPlane;
 using Honua.Import.FileImport;
 using Honua.Infrastructure.Authentication;
@@ -33,7 +34,8 @@ internal sealed class CapabilityManifestOptionsSnapshot
         IOptions<FileUploadSecurityOptions> fileUploadSecurityOptions,
         IOptions<GrpcOptions> grpcOptions,
         IOptions<AlertOptions> alertOptions,
-        IOptions<RbacOptions> rbacOptions)
+        IOptions<RbacOptions> rbacOptions,
+        IOptions<CapabilityFlagOptions> capabilityFlagOptions)
     {
         ArgumentNullException.ThrowIfNull(limitsOptions);
         ArgumentNullException.ThrowIfNull(streamOptions);
@@ -45,6 +47,7 @@ internal sealed class CapabilityManifestOptionsSnapshot
         ArgumentNullException.ThrowIfNull(grpcOptions);
         ArgumentNullException.ThrowIfNull(alertOptions);
         ArgumentNullException.ThrowIfNull(rbacOptions);
+        ArgumentNullException.ThrowIfNull(capabilityFlagOptions);
 
         Limits = limitsOptions.Value;
         Streaming = streamOptions.Value;
@@ -56,6 +59,7 @@ internal sealed class CapabilityManifestOptionsSnapshot
         Grpc = grpcOptions.Value;
         Alerts = alertOptions.Value;
         Rbac = rbacOptions.Value;
+        ExperimentalCapabilityFlags = capabilityFlagOptions.Value;
     }
 
     public LimitsOptions Limits { get; }
@@ -77,4 +81,11 @@ internal sealed class CapabilityManifestOptionsSnapshot
     public AlertOptions Alerts { get; }
 
     public RbacOptions Rbac { get; }
+
+    /// <summary>
+    /// The config-bound experimental feature-flag switches (#2339 / T2). Carried on the
+    /// snapshot so the per-environment manifest honours the flags; the manifest begins
+    /// acting on them in T4 (#2340).
+    /// </summary>
+    public CapabilityFlagOptions ExperimentalCapabilityFlags { get; }
 }

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
@@ -1,13 +1,20 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Capabilities;
+using Microsoft.Extensions.Configuration;
+
 namespace Honua.Server.Features.Capabilities;
 
 internal static class CapabilityManifestServiceCollectionExtensions
 {
-    public static IServiceCollection AddCapabilityManifest(this IServiceCollection services)
+    public static IServiceCollection AddCapabilityManifest(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        // #2339 (T2): bind the experimental feature-flag options so the manifest
+        // snapshot can carry them. T4 (#2340) is where the manifest acts on them.
+        services.AddCapabilityFlagOptions(configuration);
         services.AddSingleton<CapabilityManifestOptionsSnapshot>();
         services.AddScoped<ICapabilityManifestService, CapabilityManifestService>();
         return services;

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -155,7 +155,7 @@ internal static class FeatureRegistrationExtensions
         services.AddAnalysisContent(configuration);
         services.AddTemporalHistory();
         services.AddAnalysisReporting(configuration);
-        services.AddCapabilityManifest();
+        services.AddCapabilityManifest(configuration);
         services.AddPackageReview();
         services.AddMcpOperatorSurface(configuration);
         services.AddSpecGrounding();

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityGateResolverTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityGateResolverTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Honua.Core.Features.Capabilities;
+using Honua.Core.Features.Licensing.Domain;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Tests.Features.Capabilities;
+
+/// <summary>
+/// Unit coverage for the config-driven experimental feature-flag resolver
+/// (#2339 / T2): the maturity/flag/edition precedence in
+/// <see cref="CapabilityGateResolver"/>, plus the <see cref="CapabilityFlagOptions"/>
+/// config binding for the <c>Capabilities:Experimental</c> schema.
+/// </summary>
+public sealed class CapabilityGateResolverTests
+{
+    private const string ExperimentalId = "temporal.filtering";
+
+    private static CapabilityDescriptor Experimental(HonuaEdition? minimumEdition = null) => new()
+    {
+        Id = ExperimentalId,
+        Category = "temporal",
+        Kind = CapabilityKind.Feature,
+        Maturity = CapabilityMaturity.Experimental,
+        MinimumEdition = minimumEdition,
+    };
+
+    private static CapabilityDescriptor NonExperimental(HonuaEdition? minimumEdition = null) => new()
+    {
+        Id = "query.features",
+        Category = "query",
+        Kind = CapabilityKind.Feature,
+        Maturity = CapabilityMaturity.Implemented,
+        MinimumEdition = minimumEdition,
+    };
+
+    private static CapabilityGateContext Context(
+        CapabilityFlagOptions? flags = null,
+        HonuaEdition edition = HonuaEdition.Community) => new()
+        {
+            Edition = edition,
+            ExperimentalFlags = flags ?? new CapabilityFlagOptions(),
+        };
+
+    private static CapabilityFlagOptions GlobalOn() => new() { Enabled = true };
+
+    private static CapabilityFlagOptions PerCapabilityOn(string id, bool enabled = true)
+    {
+        var options = new CapabilityFlagOptions();
+        options.Capabilities[id] = new ExperimentalCapabilityFlag { Enabled = enabled };
+        return options;
+    }
+
+    [Fact]
+    public void Experimental_WithFlagsOff_IsDisabledWithExperimentalReason()
+    {
+        var resolution = CapabilityGateResolver.Resolve(Experimental(), Context());
+
+        resolution.Enabled.Should().BeFalse();
+        resolution.ReasonCode.Should().Be(CapabilityReasonCodes.ExperimentalDisabled);
+    }
+
+    [Fact]
+    public void Experimental_WithGlobalFlagOn_IsEnabled()
+    {
+        var resolution = CapabilityGateResolver.Resolve(Experimental(), Context(GlobalOn()));
+
+        resolution.Enabled.Should().BeTrue();
+        resolution.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void Experimental_WithPerCapabilityFlagOn_IsEnabled()
+    {
+        var resolution = CapabilityGateResolver.Resolve(
+            Experimental(),
+            Context(PerCapabilityOn(ExperimentalId)));
+
+        resolution.Enabled.Should().BeTrue();
+        resolution.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void Experimental_WithPerCapabilityFlagExplicitlyOff_IsDisabled()
+    {
+        var resolution = CapabilityGateResolver.Resolve(
+            Experimental(),
+            Context(PerCapabilityOn(ExperimentalId, enabled: false)));
+
+        resolution.Enabled.Should().BeFalse();
+        resolution.ReasonCode.Should().Be(CapabilityReasonCodes.ExperimentalDisabled);
+    }
+
+    [Fact]
+    public void Experimental_WithPerCapabilityFlagForDifferentId_IsDisabled()
+    {
+        var resolution = CapabilityGateResolver.Resolve(
+            Experimental(),
+            Context(PerCapabilityOn("some.other.capability")));
+
+        resolution.Enabled.Should().BeFalse();
+        resolution.ReasonCode.Should().Be(CapabilityReasonCodes.ExperimentalDisabled);
+    }
+
+    [Fact]
+    public void Experimental_WithGlobalFlagOn_ButWrongEdition_FailsOnEditionNotFlag()
+    {
+        var resolution = CapabilityGateResolver.Resolve(
+            Experimental(HonuaEdition.Enterprise),
+            Context(GlobalOn(), edition: HonuaEdition.Community));
+
+        resolution.Enabled.Should().BeFalse();
+        resolution.ReasonCode.Should().Be(CapabilityReasonCodes.LicenseRequired);
+        resolution.ReasonCode.Should().NotBe(CapabilityReasonCodes.ExperimentalDisabled);
+    }
+
+    [Fact]
+    public void Experimental_WithPerCapabilityFlagOn_ButWrongEdition_FailsOnEdition()
+    {
+        var resolution = CapabilityGateResolver.Resolve(
+            Experimental(HonuaEdition.Pro),
+            Context(PerCapabilityOn(ExperimentalId), edition: HonuaEdition.Community));
+
+        resolution.Enabled.Should().BeFalse();
+        resolution.ReasonCode.Should().Be(CapabilityReasonCodes.LicenseRequired);
+    }
+
+    [Fact]
+    public void Experimental_WithFlagOn_AndSatisfiedEdition_IsEnabled()
+    {
+        var resolution = CapabilityGateResolver.Resolve(
+            Experimental(HonuaEdition.Pro),
+            Context(GlobalOn(), edition: HonuaEdition.Enterprise));
+
+        resolution.Enabled.Should().BeTrue();
+        resolution.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void NonExperimental_IsEnabled_EvenWithFlagsOff()
+    {
+        var resolution = CapabilityGateResolver.Resolve(NonExperimental(), Context());
+
+        resolution.Enabled.Should().BeTrue();
+        resolution.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void NonExperimental_IsEnabled_EvenWhenEditionBelowMinimum()
+    {
+        // The registry description layer does not entitlement-gate non-experimental
+        // capabilities (B1 pass-through); operation surfaces enforce edition/entitlement.
+        var resolution = CapabilityGateResolver.Resolve(
+            NonExperimental(HonuaEdition.Enterprise),
+            Context(edition: HonuaEdition.Community));
+
+        resolution.Enabled.Should().BeTrue();
+        resolution.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void UnknownDescriptor_IsNotRegistered()
+    {
+        var resolution = CapabilityGateResolver.Resolve(null, Context());
+
+        resolution.Enabled.Should().BeFalse();
+        resolution.ReasonCode.Should().Be(CapabilityReasonCodes.NotRegistered);
+    }
+
+    [Fact]
+    public void Registry_UnknownId_IsNotRegistered()
+    {
+        var registry = new CapabilityRegistry();
+
+        var resolution = registry.Resolve("does.not.exist", CapabilityGateContext.Default);
+
+        resolution.Enabled.Should().BeFalse();
+        resolution.ReasonCode.Should().Be(CapabilityRegistry.NotRegisteredReasonCode);
+    }
+
+    [Fact]
+    public void Registry_RegisteredImplementedCapability_ResolvesEnabledUnderDefaultContext()
+    {
+        var registry = new CapabilityRegistry();
+        var descriptor = registry.All[0];
+
+        var resolution = registry.Resolve(descriptor.Id, CapabilityGateContext.Default);
+
+        resolution.Enabled.Should().BeTrue();
+        resolution.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void IsExperimentalEnabled_GlobalSwitch_OverridesMissingPerCapability()
+    {
+        var options = new CapabilityFlagOptions { Enabled = true };
+
+        options.IsExperimentalEnabled("anything.at.all").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsExperimentalEnabled_DefaultOptions_AreAllOff()
+    {
+        var options = new CapabilityFlagOptions();
+
+        options.Enabled.Should().BeFalse();
+        options.IsExperimentalEnabled(ExperimentalId).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Bind_ReadsGlobalSwitchAndPerCapabilityOverrides()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Capabilities:Experimental:Enabled"] = "true",
+                ["Capabilities:Experimental:temporal.filtering:Enabled"] = "true",
+                ["Capabilities:Experimental:format.geoparquet:Enabled"] = "false",
+            })
+            .Build();
+
+        var options = new CapabilityFlagOptions();
+        CapabilityFlagOptions.Bind(options, configuration.GetSection(CapabilityFlagOptions.SectionName));
+
+        options.Enabled.Should().BeTrue();
+        options.Capabilities.Should().ContainKey("temporal.filtering");
+        options.Capabilities["temporal.filtering"].Enabled.Should().BeTrue();
+        options.Capabilities.Should().ContainKey("format.geoparquet");
+        options.Capabilities["format.geoparquet"].Enabled.Should().BeFalse();
+        // The global "Enabled" scalar is not misread as a per-capability entry.
+        options.Capabilities.Should().NotContainKey("Enabled");
+    }
+
+    [Fact]
+    public void Bind_DefaultsToAllOff_WhenSectionAbsent()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var options = new CapabilityFlagOptions();
+        CapabilityFlagOptions.Bind(options, configuration.GetSection(CapabilityFlagOptions.SectionName));
+
+        options.Enabled.Should().BeFalse();
+        options.Capabilities.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddCapabilityFlagOptions_BindsFromConfigurationIntoOptions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Capabilities:Experimental:temporal.filtering:Enabled"] = "true",
+            })
+            .Build();
+
+        using var provider = new ServiceCollection()
+            .AddCapabilityFlagOptions(configuration)
+            .BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<CapabilityFlagOptions>>().Value;
+
+        options.Enabled.Should().BeFalse();
+        options.IsExperimentalEnabled("temporal.filtering").Should().BeTrue();
+        options.IsExperimentalEnabled("format.geoparquet").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #2339

> **STACKED ON #2356** (branch `feat/capability-registry-b1`, B1/#2333). This PR's base is `feat/capability-registry-b1`, not `trunk`, because it fills the `ICapabilityRegistry.Resolve` seam B1 introduced as a pass-through. **Once #2356 lands, rebase this branch onto `trunk` and retarget the base to `trunk`.** Review the incremental diff against the B1 branch.

## Summary
Track B extension (feature-flag system), **T2**. B1 (#2333) added `CapabilityDescriptor` (with `Maturity`/`Kind`/`EntitlementKey`/`MinimumEdition`) and an `ICapabilityRegistry.Resolve(id, context)` seam that currently returns `Enabled = true` for every registered capability. This PR replaces that pass-through with the ADR-0058 config-driven experimental feature-flag precedence, so experimental capabilities are **off by default** and can be turned on globally or per-capability, per-environment, without re-forking.

Scope is the **resolver + config + reason code only**. It does not change the manifest/endpoints/formats to *act* on the resolution (T4/T5/T6) and does not flip any capability to `Experimental` (T10) — every B1 capability is `Implemented`, so the served surface is unchanged (default-off, no behavior change unless configured).

## Changes Made
- **`CapabilityFlagOptions`** (Core) bound from the `Capabilities:Experimental` section: a global master switch `Capabilities:Experimental:Enabled` (default `false`) plus per-capability overrides `Capabilities:Experimental:{descriptorId}:Enabled` (default `false`). Env-var form `Capabilities__Experimental__{id}__Enabled`. Bound explicitly (the global scalar and per-cap subsections are siblings under one section) via `AddCapabilityFlagOptions(configuration)`.
- **`CapabilityReasonCodes`** (Core) — new `experimental-disabled` const, plus the shared `capability-not-registered` and the wrong-edition `license-required` codes.
- **`CapabilityGateResolver`** (Core) — implements the precedence (see below); `CapabilityRegistry.Resolve` now delegates to it.
- **`CapabilityGateContext`** extended with `ExperimentalFlags` (additive, defaults to all-off); B1 field set intact.
- **Wiring** — `CapabilityFlagOptions` bound in DI and carried on `CapabilityManifestOptionsSnapshot` (per-env snapshot honors the flags; the manifest begins acting on them in T4).

### Config-key schema
- `Capabilities:Experimental:Enabled` = `true|false` — global master switch (default `false`).
- `Capabilities:Experimental:{descriptorId}:Enabled` = `true|false` — per-capability override (default `false`), e.g. `Capabilities:Experimental:temporal.filtering:Enabled`.
- Env-var form: `Capabilities__Experimental__temporal.filtering__Enabled=true`.

### Reason-code precedence
1. Unknown id → `capability-not-registered` (B1 behavior, preserved).
2. `Maturity == Experimental` and neither the per-capability nor the global flag is on → `experimental-disabled`.
3. Flag-on experimental capability whose `MinimumEdition` exceeds the context edition → `license-required` (entitlement/edition still applies **on top**, not masked by the flag).
4. Non-experimental (or flag-on experimental with a satisfied edition) → enabled (B1 pass-through preserved; edition/entitlement is enforced by the operation surfaces, not this description layer).

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass

`CapabilityGateResolverTests` (18 tests, all green): experimental+flag-off → `experimental-disabled`; experimental+global-on and per-id-on → enabled; per-id-off / per-id-for-different-id → disabled; experimental+flag-on+wrong-edition → `license-required` (not experimental); non-experimental → enabled (even below min edition); unknown id → `capability-not-registered`; config binding of the `Capabilities:Experimental` schema (global + per-cap) and DI `AddCapabilityFlagOptions`. B1 `CapabilityRegistryConformanceTests` still pass (11/11). Release build (warnings-as-errors) clean for Core + Server; `dotnet format --verify-no-changes` clean.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes (new `Capabilities:Experimental:*` keys; default-off means no behavior change unless set)

## Breaking Changes
None.