### PR TITLE
fix: FileImport shard SASL no-password + stale staging-table seed

### DIFF
--- a/src/Honua.Postgres.Shared/Features/Infrastructure/PostgresDataSourceFactory.cs
+++ b/src/Honua.Postgres.Shared/Features/Infrastructure/PostgresDataSourceFactory.cs
@@ -64,6 +64,18 @@ internal static class PostgresDataSourceFactory
 
         connectionStringBuilder.Pooling = true;
 
+        // Retain the password in the string exposed by NpgsqlDataSource.ConnectionString
+        // (surfaced through IDatabaseConnectionProvider.GetConnectionString()). The post-import
+        // canonical-snapshot refresh and layer-publish materialize paths take that string and
+        // open a *fresh* NpgsqlConnection from it. Npgsql strips the password by default
+        // (Persist Security Info=false), so those fresh connections failed SCRAM auth with
+        // "No password has been provided but the backend requires one (in SASL/SCRAM-SHA-256)"
+        // — swallowed as a warning in TryRefreshPublishedSnapshotAsync, leaving published MVT
+        // tiles silently stale after an import (honua-server#1628). This does NOT weaken auth:
+        // the backend still requires the password; it only stops Npgsql from redacting it from
+        // the string handed back to code that must reconnect.
+        connectionStringBuilder.PersistSecurityInfo = true;
+
         if (limits.MaxConnectionPoolSize > 0)
         {
             connectionStringBuilder.MaxPoolSize = limits.MaxConnectionPoolSize;

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/PostgresDataSourceFactoryTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/PostgresDataSourceFactoryTests.cs
@@ -89,6 +89,28 @@ public sealed class PostgresDataSourceFactoryTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
+    public void Create_ExposedConnectionString_RetainsPasswordForReconnectPaths()
+    {
+        // Regression guard for the FileImport-shard SASL failure (honua-server#1628 follow-up):
+        // the post-import canonical-snapshot refresh and layer-publish materialize paths call
+        // IDatabaseConnectionProvider.GetConnectionString() (which returns
+        // NpgsqlDataSource.ConnectionString) and open a *fresh* NpgsqlConnection from it. Npgsql
+        // strips the password by default (Persist Security Info=false), which made those fresh
+        // connections fail SCRAM authentication with "No password has been provided but the
+        // backend requires one (in SASL/SCRAM-SHA-256)". The factory sets PersistSecurityInfo so
+        // the exposed string stays usable — the backend still requires the password (auth is not
+        // weakened), it is simply no longer redacted from the string handed back to reconnect.
+        const string withPassword = "Host=localhost;Database=honua;Username=honua;Password=s3cr3t";
+
+        using var dataSource = PostgresDataSourceFactory.Create(
+            withPassword, schemaHeadersEnabled: false, new ConnectionLimits());
+
+        dataSource.ConnectionString.Should().Contain("Password=s3cr3t",
+            "GetConnectionString() must return a connection string that can open a fresh connection under SCRAM auth");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
     public void Configure_MultiplexingEnabled_KeepsOptionsStartupParameter()
     {
         // Deliberate: with multiplexing, startup options are the only per-session-default

--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
@@ -215,6 +215,13 @@ internal static class WebAppFixturePostgresWiringMixin
         {
             var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
             dataSourceBuilder.ConnectionStringBuilder.Multiplexing = false;
+            // Mirror production (PostgresDataSourceFactory): keep the password in the string
+            // exposed by NpgsqlDataSource.ConnectionString so IDatabaseConnectionProvider
+            // .GetConnectionString() returns a value that can open a fresh connection. Without
+            // this, the import snapshot-refresh / publish-materialize paths reconnect with a
+            // passwordless string and fail SCRAM auth ("No password has been provided but the
+            // backend requires one (in SASL/SCRAM-SHA-256)") in the FileImport integration shard.
+            dataSourceBuilder.ConnectionStringBuilder.PersistSecurityInfo = true;
             return dataSourceBuilder.Build();
         });
     }

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -769,6 +769,31 @@ sql:
       END;
       $$;
   - |
+      -- Mirrors migration 071_FixImportStagingTableNameLength.sql so the
+      -- migration-skipping integration fixture derives the staging-table name the
+      -- same length-safe way the runtime schema does. Without this, long-but-valid
+      -- physical names (e.g. imported_<requested> >= 55 chars, which the default
+      -- Replace load mode always uses) RAISEd 'Staging table name exceeds
+      -- PostgreSQL identifier limit of 63 characters' (P0001) and failed the
+      -- FileImport shard's ad-hoc/operational-schema import tests.
+      CREATE OR REPLACE FUNCTION honua.import_staging_table_name(table_name text)
+      RETURNS text
+      LANGUAGE plpgsql
+      IMMUTABLE
+      AS $$
+      DECLARE
+          staging_name text;
+      BEGIN
+          staging_name := table_name || '__staging';
+
+          IF length(staging_name) > 63 THEN
+              staging_name := 'stg_' || md5(table_name);
+          END IF;
+
+          RETURN staging_name;
+      END;
+      $$;
+  - |
       CREATE OR REPLACE FUNCTION honua.create_import_staging_table(
           schema_name text,
           table_name text,
@@ -786,10 +811,7 @@ sql:
               RAISE EXCEPTION 'Target SRID must be a positive integer';
           END IF;
 
-          staging_name := table_name || '__staging';
-          IF length(staging_name) > 63 THEN
-              RAISE EXCEPTION 'Staging table name exceeds PostgreSQL identifier limit of 63 characters';
-          END IF;
+          staging_name := honua.import_staging_table_name(table_name);
 
           EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
           EXECUTE format('DROP TABLE IF EXISTS %I.%I', schema_name, staging_name);
@@ -815,7 +837,7 @@ sql:
           PERFORM honua.assert_import_identifier(schema_name, 'Schema name');
           PERFORM honua.assert_import_identifier(table_name, 'Table name');
 
-          staging_name := table_name || '__staging';
+          staging_name := honua.import_staging_table_name(table_name);
 
           EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', schema_name, table_name);
           EXECUTE format('ALTER TABLE %I.%I RENAME TO %I', schema_name, staging_name, table_name);


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes  #1628 follow-up (FileImport shard SASL)

## Summary
Fixes the persistent `Server Tests (FileImport)` integration-shard failure that was re-escalating the honua-server release merge-train batch. The shard exhibited two distinct, reproducible problems that this PR resolves at the harness/config level without weakening authentication:

1. **`Npgsql: No password has been provided but the backend requires one (SASL/SCRAM-SHA-256)`** — the post-import canonical-snapshot refresh (`ImportEndpoints.TryRefreshPublishedSnapshotAsync` -> `PostgreSqlLayerPublishingService.RefreshMaterializedFeaturesForSourceTableAsync`) opens a *fresh* `NpgsqlConnection` from `IDatabaseConnectionProvider.GetConnectionString()`. That method returns `NpgsqlDataSource.ConnectionString`, which Npgsql redacts the password from by default (`Persist Security Info=false`), so the reconnect failed SCRAM auth. This is a **real product bug**, not test-only: in production the same path silently swallows the failure as a warning, leaving published MVT tiles stale after an import (defeating honua-server#1628). Fixed by setting `PersistSecurityInfo=true` at the single datasource-build site so the exposed string stays usable — the backend still requires the password, so auth is not weakened.

2. **`P0001: Staging table name exceeds PostgreSQL identifier limit of 63 characters`** (the assertions that actually turned the shard red — `ImportFile_CustomTargetSchema_CanDiscoverAdHocImportSchema` and `ImportFile_DefaultOperationalSchema_CanDiscoverPublishAndQueryFeatureServer`). The migration-skipping integration fixture seeds its `honua.*` import functions from `tests/seed/server.yaml`, whose copy of `honua.create_import_staging_table` had drifted: it still RAISEd on long `<table>__staging` names — the exact behavior migration `071_FixImportStagingTableNameLength.sql` replaced with a length-safe md5 fallback. The seed was never updated when 071 landed. Fixed by mirroring migration 071 in the seed.

## Changes Made
- `PostgresDataSourceFactory.Configure`: set `PersistSecurityInfo=true` so `NpgsqlDataSource.ConnectionString` (surfaced via `IDatabaseConnectionProvider.GetConnectionString()`) retains the password for reconnect-from-string paths (snapshot refresh, layer-publish materialize).
- `WebAppFixturePostgresWiringMixin.OverrideNonMultiplexingDataSource`: mirror the same `PersistSecurityInfo=true` on the test-overridden datasource so the integration host reproduces production behavior.
- `tests/seed/server.yaml`: add the `honua.import_staging_table_name` helper and switch `honua.create_import_staging_table` / `honua.swap_import_table` to the length-safe md5 fallback, mirroring migration 071 (removes the P0001 RAISE).
- Add `PostgresDataSourceFactoryTests.Create_ExposedConnectionString_RetainsPasswordForReconnectPaths` regression test.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Verified locally (Release, Testcontainers PostGIS):
- `PostgresDataSourceFactoryTests`: 31/31 passed (incl. the new password-retention test).
- The two previously-failing FileImport tests + the snapshot-refresh (`GeoParquetImportTests.Upload_WithNestedColumn_...`) test: 3/3 passed, with zero `No password`/`SASL`/`P0001`/`SnapshotRefreshFailed` signatures in the run log.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
