### PR TITLE
fix(formats): auto-detect EsriJSON & WKB imports, fix GPX extensions parse (#2352 #2353 #2354)

### DIFF
--- a/src/Honua.Core/Features/FileImport/Domain/SupportedFileFormat.cs
+++ b/src/Honua.Core/Features/FileImport/Domain/SupportedFileFormat.cs
@@ -72,5 +72,16 @@ public enum SupportedFileFormat
     /// <summary>
     /// GeoParquet format (.parquet, .geoparquet)
     /// </summary>
-    GeoParquet = 11
+    GeoParquet = 11,
+
+    /// <summary>
+    /// Esri JSON feature set (.esrijson) — features with an <c>attributes</c> object and an
+    /// Esri geometry (<c>x</c>/<c>y</c>, <c>points</c>, <c>paths</c>, or <c>rings</c>).
+    /// </summary>
+    EsriJson = 12,
+
+    /// <summary>
+    /// Well-Known Binary geometry (.wkb) — one or more concatenated WKB/EWKB geometries.
+    /// </summary>
+    Wkb = 13
 }

--- a/src/Honua.Core/Features/FileImport/Services/FileFormatDetectionService.cs
+++ b/src/Honua.Core/Features/FileImport/Services/FileFormatDetectionService.cs
@@ -32,6 +32,8 @@ internal sealed class FileFormatDetectionService : IFileFormatDetectionService
         {
             [".geojson"] = SupportedFileFormat.GeoJson,
             [".json"] = SupportedFileFormat.GeoJson,
+            [".esrijson"] = SupportedFileFormat.EsriJson,
+            [".wkb"] = SupportedFileFormat.Wkb,
             [".kml"] = SupportedFileFormat.Kml,
             [".kmz"] = SupportedFileFormat.Kml,
             [".gml"] = SupportedFileFormat.Gml,
@@ -167,6 +169,16 @@ internal sealed class FileFormatDetectionService : IFileFormatDetectionService
     {
         var trimmed = textContent.TrimStart();
 
+        // Esri JSON detection MUST run before GeoJSON: an Esri feature set is a JSON object
+        // whose features carry an "attributes" object and an Esri geometry ("rings"/"paths"/
+        // "points"/"x","y"), plus Esri markers such as "geometryType":"esriGeometry..." or
+        // "spatialReference". These payloads must never fall through to the GeoJSON branch and
+        // be silently misinterpreted (honua-server#2352).
+        if (trimmed.StartsWith('{') && LooksLikeEsriJson(trimmed))
+        {
+            return SupportedFileFormat.EsriJson;
+        }
+
         // GeoJSON detection
         if (trimmed.StartsWith('{') &&
             (trimmed.Contains("\"type\"") &&
@@ -231,5 +243,35 @@ internal sealed class FileFormatDetectionService : IFileFormatDetectionService
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Heuristically decide whether a JSON document is an Esri feature set rather than GeoJSON.
+    /// Esri payloads use <c>attributes</c> (not GeoJSON <c>properties</c>) and Esri geometry
+    /// shapes (<c>x</c>/<c>y</c>, <c>points</c>, <c>paths</c>, <c>rings</c>), and never carry a
+    /// GeoJSON <c>"type":"Feature"</c>/<c>"FeatureCollection"</c> discriminator.
+    /// </summary>
+    private static bool LooksLikeEsriJson(string trimmed)
+    {
+        // A GeoJSON document is unambiguously identified by its "type" discriminator; if present,
+        // this is not Esri JSON.
+        if (trimmed.Contains("\"type\"", StringComparison.Ordinal) &&
+            (trimmed.Contains("\"FeatureCollection\"", StringComparison.Ordinal) ||
+             trimmed.Contains("\"Feature\"", StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        var hasEsriMarker =
+            trimmed.Contains("esriGeometry", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.Contains("\"geometryType\"", StringComparison.Ordinal) ||
+            trimmed.Contains("\"spatialReference\"", StringComparison.Ordinal);
+
+        var hasEsriGeometry =
+            trimmed.Contains("\"rings\"", StringComparison.Ordinal) ||
+            trimmed.Contains("\"paths\"", StringComparison.Ordinal) ||
+            trimmed.Contains("\"attributes\"", StringComparison.Ordinal);
+
+        return hasEsriMarker && hasEsriGeometry;
     }
 }

--- a/src/Honua.Geometry/Features/FileImport/Services/EsriJsonFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/EsriJsonFormatReader.cs
@@ -1,0 +1,289 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using NetTopologySuite.Algorithm;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+using Honua.Core.Features.FileImport.Services;
+
+namespace Honua.Core.Features.FileImport.Services;
+
+/// <summary>
+/// Reader for Esri JSON feature sets (the ArcGIS <c>FeatureSet</c> shape). Each feature carries an
+/// <c>attributes</c> object and an Esri geometry (<c>x</c>/<c>y</c>, <c>points</c>, <c>paths</c>, or
+/// <c>rings</c>). This lets Esri-shaped payloads import correctly instead of being silently
+/// misinterpreted as GeoJSON (honua-server#2352).
+/// </summary>
+internal static class EsriJsonFormatReader
+{
+    /// <summary>
+    /// Streams features parsed from an Esri JSON feature set.
+    /// </summary>
+    internal static async IAsyncEnumerable<IFeature> ReadStreamingAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        var root = document.RootElement;
+
+        var srid = TryReadWkid(root) ?? 4326;
+        var factory = new GeometryFactory(new PrecisionModel(), srid);
+
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("features", out var features) ||
+            features.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var recordIndex = 0;
+        foreach (var element in features.EnumerateArray())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            NtsGeometry? geometry = null;
+            if (element.TryGetProperty("geometry", out var geometryElement) &&
+                geometryElement.ValueKind == JsonValueKind.Object)
+            {
+                geometry = ParseGeometry(geometryElement, factory);
+            }
+
+            var attributes = new AttributesTable();
+            if (element.TryGetProperty("attributes", out var attributesElement) &&
+                attributesElement.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var attribute in attributesElement.EnumerateObject())
+                {
+                    if (!attributes.Exists(attribute.Name))
+                    {
+                        attributes.Add(attribute.Name, GetAttributeValue(attribute.Value));
+                    }
+                }
+            }
+
+            yield return new Feature(geometry, attributes);
+
+            if (++recordIndex % 256 == 0)
+            {
+                await Task.Yield();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the feature set's spatial reference well-known id (<c>spatialReference.wkid</c> or
+    /// <c>latestWkid</c>) so the import pipeline can assign the source CRS. Returns
+    /// <see langword="null"/> when the document has no usable spatial reference.
+    /// </summary>
+    internal static async Task<int?> TryDetectSridAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            return TryReadWkid(document.RootElement);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static int? TryReadWkid(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("spatialReference", out var spatialReference) ||
+            spatialReference.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (spatialReference.TryGetProperty("latestWkid", out var latestWkid) &&
+            latestWkid.ValueKind == JsonValueKind.Number &&
+            latestWkid.TryGetInt32(out var latest))
+        {
+            return latest;
+        }
+
+        if (spatialReference.TryGetProperty("wkid", out var wkid) &&
+            wkid.ValueKind == JsonValueKind.Number &&
+            wkid.TryGetInt32(out var value))
+        {
+            return value;
+        }
+
+        return null;
+    }
+
+    private static NtsGeometry? ParseGeometry(JsonElement geometry, GeometryFactory factory)
+    {
+        // Point: {"x": .., "y": ..}
+        if (geometry.TryGetProperty("x", out var x) && geometry.TryGetProperty("y", out var y) &&
+            TryGetDouble(x, out var px) && TryGetDouble(y, out var py))
+        {
+            return factory.CreatePoint(new Coordinate(px, py));
+        }
+
+        // Multipoint: {"points": [[x, y], ...]}
+        if (geometry.TryGetProperty("points", out var points) && points.ValueKind == JsonValueKind.Array)
+        {
+            var coordinates = ReadCoordinates(points);
+            return coordinates.Length == 0 ? null : factory.CreateMultiPointFromCoords(coordinates);
+        }
+
+        // Polyline: {"paths": [[[x, y], ...], ...]}
+        if (geometry.TryGetProperty("paths", out var paths) && paths.ValueKind == JsonValueKind.Array)
+        {
+            var lines = ReadPartsAsLineStrings(paths, factory);
+            return lines.Length switch
+            {
+                0 => null,
+                1 => lines[0],
+                _ => factory.CreateMultiLineString(lines)
+            };
+        }
+
+        // Polygon: {"rings": [[[x, y], ...], ...]}
+        if (geometry.TryGetProperty("rings", out var rings) && rings.ValueKind == JsonValueKind.Array)
+        {
+            return ParsePolygon(rings, factory);
+        }
+
+        return null;
+    }
+
+    private static NtsGeometry? ParsePolygon(JsonElement rings, GeometryFactory factory)
+    {
+        // Esri polygons list exterior rings clockwise and interior rings (holes) counter-clockwise,
+        // with holes following their containing exterior ring. Group accordingly into one or more
+        // NTS polygons.
+        var polygons = new List<Polygon>();
+        LinearRing? shell = null;
+        var holes = new List<LinearRing>();
+
+        void FlushShell()
+        {
+            if (shell != null)
+            {
+                polygons.Add(factory.CreatePolygon(shell, holes.ToArray()));
+                holes.Clear();
+                shell = null;
+            }
+        }
+
+        foreach (var ringElement in rings.EnumerateArray())
+        {
+            var coordinates = ReadCoordinates(ringElement);
+            if (coordinates.Length < 4)
+            {
+                continue;
+            }
+
+            var closed = EnsureClosed(coordinates);
+            var ring = factory.CreateLinearRing(closed);
+
+            // Signed area > 0 is counter-clockwise (an Esri hole); <= 0 is clockwise (an exterior).
+            if (Area.OfRingSigned(closed) > 0 && shell != null)
+            {
+                holes.Add(ring);
+            }
+            else
+            {
+                FlushShell();
+                shell = ring;
+            }
+        }
+
+        FlushShell();
+
+        return polygons.Count switch
+        {
+            0 => null,
+            1 => polygons[0],
+            _ => factory.CreateMultiPolygon(polygons.ToArray())
+        };
+    }
+
+    private static LineString[] ReadPartsAsLineStrings(JsonElement parts, GeometryFactory factory)
+    {
+        var lines = new List<LineString>();
+        foreach (var part in parts.EnumerateArray())
+        {
+            var coordinates = ReadCoordinates(part);
+            if (coordinates.Length >= 2)
+            {
+                lines.Add(factory.CreateLineString(coordinates));
+            }
+        }
+
+        return lines.ToArray();
+    }
+
+    private static Coordinate[] ReadCoordinates(JsonElement coordinateArray)
+    {
+        var coordinates = new List<Coordinate>();
+        foreach (var pair in coordinateArray.EnumerateArray())
+        {
+            if (pair.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            var ordinates = pair.EnumerateArray();
+            if (!ordinates.MoveNext() || !TryGetDouble(ordinates.Current, out var cx))
+            {
+                continue;
+            }
+
+            if (!ordinates.MoveNext() || !TryGetDouble(ordinates.Current, out var cy))
+            {
+                continue;
+            }
+
+            coordinates.Add(new Coordinate(cx, cy));
+        }
+
+        return coordinates.ToArray();
+    }
+
+    private static Coordinate[] EnsureClosed(Coordinate[] coordinates)
+    {
+        if (coordinates.Length > 0 && !coordinates[0].Equals2D(coordinates[^1]))
+        {
+            var closed = new Coordinate[coordinates.Length + 1];
+            Array.Copy(coordinates, closed, coordinates.Length);
+            closed[^1] = coordinates[0].Copy();
+            return closed;
+        }
+
+        return coordinates;
+    }
+
+    private static bool TryGetDouble(JsonElement element, out double value)
+    {
+        if (element.ValueKind == JsonValueKind.Number && element.TryGetDouble(out value))
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static object? GetAttributeValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.TryGetInt64(out var longValue)
+                ? longValue
+                : element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => element.GetRawText()
+        };
+    }
+}

--- a/src/Honua.Geometry/Features/FileImport/Services/GpxFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/GpxFormatReader.cs
@@ -87,29 +87,74 @@ internal static class GpxFormatReader
         using (var subtree = reader.ReadSubtree())
         {
             await subtree.ReadAsync();
-            while (await subtree.ReadAsync())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (subtree.NodeType != XmlNodeType.Element)
-                {
-                    continue;
-                }
-
-                var name = subtree.LocalName;
-                if (subtree.IsEmptyElement)
-                {
-                    attributes.Add(name, string.Empty);
-                    continue;
-                }
-
-                var value = await subtree.ReadElementContentAsStringAsync();
-                attributes.Add(name, value);
-            }
+            await ReadLeafAttributesAsync(subtree, attributes, cancellationToken);
         }
 
         return new Feature(geometry, attributes);
     }
+
+    /// <summary>
+    /// Walks the already-opened element subtree and records leaf (simple-text) descendants as
+    /// attributes keyed by their local name. Container elements such as GPX <c>&lt;extensions&gt;</c>
+    /// (which GDAL uses to carry source fields, e.g. <c>&lt;ogr:zone_code&gt;030&lt;/ogr:zone_code&gt;</c>)
+    /// are descended into rather than read as text. This avoids the
+    /// <see cref="System.Xml.XmlException"/> that <c>ReadElementContentAsString</c> throws on an
+    /// element that has child elements (honua-server#2354).
+    /// </summary>
+    private static async Task ReadLeafAttributesAsync(
+        XmlReader reader,
+        AttributesTable attributes,
+        CancellationToken cancellationToken)
+    {
+        string? pendingName = null;
+
+        while (await reader.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            switch (reader.NodeType)
+            {
+                case XmlNodeType.Element:
+                    if (reader.IsEmptyElement)
+                    {
+                        // A self-closing leaf (e.g. <name/>). The <extensions> wrapper carries no
+                        // value of its own, so it is never recorded as an attribute.
+                        if (!IsContainerElement(reader.LocalName) && !attributes.Exists(reader.LocalName))
+                        {
+                            attributes.Add(reader.LocalName, string.Empty);
+                        }
+
+                        pendingName = null;
+                    }
+                    else
+                    {
+                        // Candidate leaf. If this turns out to be a container, the next Element
+                        // read overwrites pendingName before any Text arrives, so container
+                        // wrappers never produce a spurious attribute.
+                        pendingName = reader.LocalName;
+                    }
+
+                    break;
+
+                case XmlNodeType.Text:
+                case XmlNodeType.CDATA:
+                    if (pendingName != null && !attributes.Exists(pendingName))
+                    {
+                        attributes.Add(pendingName, reader.Value);
+                    }
+
+                    pendingName = null;
+                    break;
+
+                case XmlNodeType.EndElement:
+                    pendingName = null;
+                    break;
+            }
+        }
+    }
+
+    private static bool IsContainerElement(string localName) =>
+        string.Equals(localName, "extensions", StringComparison.OrdinalIgnoreCase);
 
     private static async Task<IFeature?> ParseTrackAsync(
         XmlReader reader,

--- a/src/Honua.Geometry/Features/FileImport/Services/WkbFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/WkbFormatReader.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using NetTopologySuite.Features;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+using Honua.Core.Features.FileImport.Services;
+
+namespace Honua.Core.Features.FileImport.Services;
+
+/// <summary>
+/// Reader for Well-Known Binary (WKB/EWKB) geometry payloads. A <c>.wkb</c> upload is one or more
+/// concatenated WKB geometries; each is read into a geometry-only feature (WKB carries no
+/// attributes). This lets WKB auto-detect and import instead of failing with a generic
+/// "Multipart import request is invalid." message (honua-server#2353).
+/// </summary>
+internal static class WkbFormatReader
+{
+    /// <summary>
+    /// Streams geometry-only features parsed from a stream of concatenated WKB/EWKB geometries.
+    /// </summary>
+    internal static async IAsyncEnumerable<IFeature> ReadStreamingAsync(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // NTS WKBReader.Read(Stream) reads exactly one geometry and leaves the stream positioned
+        // immediately after it. Buffer to a seekable MemoryStream so we can loop by byte position
+        // (import sources are size-capped upstream) and reliably detect end-of-input.
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken);
+        if (buffer.Length == 0)
+        {
+            yield break;
+        }
+
+        buffer.Position = 0;
+        var reader = new WKBReader { HandleSRID = true };
+        var recordIndex = 0;
+
+        while (buffer.Position < buffer.Length)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            NtsGeometry geometry;
+            var positionBefore = buffer.Position;
+            try
+            {
+                geometry = reader.Read(buffer);
+            }
+            catch (Exception ex) when (ex is FormatException or ArgumentException or EndOfStreamException or System.IO.IOException)
+            {
+                throw new InvalidDataException(
+                    "WKB payload could not be parsed. Expected one or more concatenated WKB/EWKB geometries.",
+                    ex);
+            }
+
+            // Guard against a reader that makes no progress (defensive; avoids an infinite loop
+            // on a malformed trailer).
+            if (buffer.Position <= positionBefore)
+            {
+                break;
+            }
+
+            if (geometry != null)
+            {
+                yield return new Feature(geometry, new AttributesTable());
+            }
+
+            if (++recordIndex % 256 == 0)
+            {
+                await Task.Yield();
+            }
+        }
+    }
+}

--- a/src/Honua.Import/Features/FileImport/ImportEndpoints.cs
+++ b/src/Honua.Import/Features/FileImport/ImportEndpoints.cs
@@ -198,6 +198,8 @@ internal static partial class ImportEndpoints
         {
             [".geojson"] = "GeoJSON - Web-standard JSON format",
             [".json"] = "JSON - May contain GeoJSON data",
+            [".esrijson"] = "Esri JSON - ArcGIS feature set (attributes + Esri geometry)",
+            [".wkb"] = "WKB - Well-Known Binary geometry (one or more concatenated geometries)",
             [".zip"] = "Zipped Shapefile - contains .shp/.dbf/.shx/.prj components",
             [".gpkg"] = "GeoPackage - OGC SQLite-based format",
             [".gpx"] = "GPX - GPS Exchange format",

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.CrsDetection.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.CrsDetection.cs
@@ -31,6 +31,7 @@ internal sealed partial class StreamingFileImportService
             return format switch
             {
                 SupportedFileFormat.GeoJson => await DetectGeoJsonSridAsync(stream, cancellationToken),
+                SupportedFileFormat.EsriJson => await EsriJsonFormatReader.TryDetectSridAsync(stream, cancellationToken) ?? 4326,
                 SupportedFileFormat.Kml => 4326,
                 SupportedFileFormat.Gpx => 4326,
                 SupportedFileFormat.Csv => 4326,
@@ -102,6 +103,7 @@ internal sealed partial class StreamingFileImportService
         return format switch
         {
             SupportedFileFormat.GeoJson => await DetectGeoJsonSridAsync(headerStream, cancellationToken),
+            SupportedFileFormat.EsriJson => await EsriJsonFormatReader.TryDetectSridAsync(headerStream, cancellationToken) ?? 4326,
             SupportedFileFormat.Kml => 4326,
             SupportedFileFormat.Gpx => 4326,
             SupportedFileFormat.Csv => 4326,

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Preview.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Preview.cs
@@ -181,6 +181,8 @@ internal sealed partial class StreamingFileImportService
             var featureStream = format.Value switch
             {
                 SupportedFileFormat.GeoJson => _geoJsonReader.ReadFeaturesAsync(fileStream, cancellationToken),
+                SupportedFileFormat.EsriJson => EsriJsonFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
+                SupportedFileFormat.Wkb => WkbFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.Wkt => WktFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.Kml => KmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
                 SupportedFileFormat.Gpx => GpxFormatReader.ReadStreamingAsync(fileStream, cancellationToken),

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
@@ -101,6 +101,8 @@ internal sealed partial class StreamingFileImportService
         var featureStream = format switch
         {
             SupportedFileFormat.GeoJson => _geoJsonReader.ReadFeaturesAsync(fileStream, cancellationToken),
+            SupportedFileFormat.EsriJson => EsriJsonFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
+            SupportedFileFormat.Wkb => WkbFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Wkt => WktFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Kml => KmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Gpx => GpxFormatReader.ReadStreamingAsync(fileStream, cancellationToken),

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/EsriJsonFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/EsriJsonFormatReaderTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.FileImport.Services;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.Import;
+
+// Regression coverage for honua-server#2352: Esri JSON feature sets must parse into features with
+// their geometry and attributes rather than being mis-read as GeoJSON.
+public sealed class EsriJsonFormatReaderTests
+{
+    private static async Task<List<NetTopologySuite.Features.IFeature>> ReadAsync(string json)
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        var features = new List<NetTopologySuite.Features.IFeature>();
+        await foreach (var feature in EsriJsonFormatReader.ReadStreamingAsync(stream, CancellationToken.None))
+        {
+            features.Add(feature);
+        }
+
+        return features;
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_PointFeatureSet_ReturnsPointsWithAttributes()
+    {
+        const string json = """
+            {"geometryType":"esriGeometryPoint","spatialReference":{"wkid":4326},"features":[
+            {"attributes":{"zone_code":"030","zone_name":"Residential"},"geometry":{"x":-156.30,"y":20.80}},
+            {"attributes":{"zone_code":"500","zone_name":"Commercial"},"geometry":{"x":-156.40,"y":20.90}}]}
+            """;
+
+        var features = await ReadAsync(json);
+
+        features.Should().HaveCount(2);
+        var first = features[0];
+        first.Geometry.Should().BeOfType<Point>();
+        first.Geometry!.Coordinate.X.Should().Be(-156.30);
+        first.Geometry!.Coordinate.Y.Should().Be(20.80);
+        first.Geometry!.SRID.Should().Be(4326);
+        first.Attributes["zone_code"].Should().Be("030");
+        first.Attributes["zone_name"].Should().Be("Residential");
+
+        features[1].Attributes["zone_code"].Should().Be("500");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_PolygonRings_ReturnsPolygon()
+    {
+        const string json = """
+            {"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":4326},"features":[
+            {"attributes":{"id":1},"geometry":{"rings":[[[0,0],[0,10],[10,10],[10,0],[0,0]]]}}]}
+            """;
+
+        var features = await ReadAsync(json);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeAssignableTo<Polygon>();
+        features[0].Geometry!.Area.Should().BeApproximately(100, 0.001);
+        features[0].Attributes["id"].Should().Be(1L);
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_PolylinePaths_ReturnsLineString()
+    {
+        const string json = """
+            {"geometryType":"esriGeometryPolyline","spatialReference":{"wkid":4326},"features":[
+            {"attributes":{"id":2},"geometry":{"paths":[[[0,0],[1,1],[2,2]]]}}]}
+            """;
+
+        var features = await ReadAsync(json);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeOfType<LineString>();
+        features[0].Geometry!.NumPoints.Should().Be(3);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/EsriJsonWkbFormatDetectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/EsriJsonWkbFormatDetectionTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.FileImport.Domain;
+using Honua.Core.Features.FileImport.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.Import;
+
+// Regression coverage for honua-server#2352 (EsriJSON) and #2353 (WKB): both must be recognised
+// on the import path instead of falling through to null (WKB -> generic multipart error) or being
+// silently treated as GeoJSON (EsriJSON).
+public sealed class EsriJsonWkbFormatDetectionTests
+{
+    private readonly FileFormatDetectionService _service =
+        new(NullLogger<FileFormatDetectionService>.Instance);
+
+    [Theory]
+    [InlineData("sample.esrijson")]
+    [InlineData("SAMPLE.EsriJson")]
+    public void DetectFormat_EsriJsonExtension_ReturnsEsriJson(string fileName)
+    {
+        _service.DetectFormat(fileName).Should().Be(SupportedFileFormat.EsriJson);
+    }
+
+    [Theory]
+    [InlineData("sample.wkb")]
+    [InlineData("SAMPLE.WKB")]
+    public void DetectFormat_WkbExtension_ReturnsWkb(string fileName)
+    {
+        _service.DetectFormat(fileName).Should().Be(SupportedFileFormat.Wkb);
+    }
+
+    [Fact]
+    public void GetSupportedExtensions_IncludesEsriJsonAndWkb()
+    {
+        var extensions = _service.GetSupportedExtensions();
+        extensions.Should().Contain(".esrijson");
+        extensions.Should().Contain(".wkb");
+    }
+
+    [Fact]
+    public void DetectFormatFromContent_EsriFeatureSet_ReturnsEsriJson_NotGeoJson()
+    {
+        const string esriJson = """
+            {"geometryType":"esriGeometryPoint","spatialReference":{"wkid":4326},"features":[
+            {"attributes":{"zone_code":"030"},"geometry":{"x":-156.30,"y":20.80}}]}
+            """;
+        var bytes = Encoding.UTF8.GetBytes(esriJson);
+
+        _service.DetectFormatFromContent(bytes, "payload.json")
+            .Should().Be(SupportedFileFormat.EsriJson);
+    }
+
+    [Fact]
+    public void DetectFormatFromContent_EsriPolygonRings_ReturnsEsriJson()
+    {
+        const string esriJson = """
+            {"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":4326},"features":[
+            {"attributes":{"id":1},"geometry":{"rings":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]}}]}
+            """;
+        var bytes = Encoding.UTF8.GetBytes(esriJson);
+
+        _service.DetectFormatFromContent(bytes, "payload.json")
+            .Should().Be(SupportedFileFormat.EsriJson);
+    }
+
+    [Fact]
+    public void DetectFormatFromContent_GeoJsonFeatureCollection_StillReturnsGeoJson()
+    {
+        const string geoJson = """
+            {"type":"FeatureCollection","features":[
+            {"type":"Feature","properties":{"zone_code":"030"},"geometry":{"type":"Point","coordinates":[-156.30,20.80]}}]}
+            """;
+        var bytes = Encoding.UTF8.GetBytes(geoJson);
+
+        _service.DetectFormatFromContent(bytes, "payload.json")
+            .Should().Be(SupportedFileFormat.GeoJson);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/GpxFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/GpxFormatReaderTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.FileImport.Services;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Core.Tests.Features.Import;
+
+// Regression coverage for honua-server#2354: GPX produced by GDAL (ogr2ogr -f GPX
+// -dsco GPX_USE_EXTENSIONS=YES) stores source attributes under <extensions> with child
+// elements. The reader previously threw XmlException ("ReadElementContentAs() methods cannot
+// be called on an element that has child elements") and yielded no features.
+public sealed class GpxFormatReaderTests
+{
+    private static async Task<List<NetTopologySuite.Features.IFeature>> ReadAsync(string gpx)
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(gpx));
+        var features = new List<NetTopologySuite.Features.IFeature>();
+        await foreach (var feature in GpxFormatReader.ReadStreamingAsync(stream, CancellationToken.None))
+        {
+            features.Add(feature);
+        }
+
+        return features;
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_GdalWaypointsWithExtensions_ReturnsFeaturesWithAttributes()
+    {
+        const string gpx = """
+            <?xml version="1.0"?>
+            <gpx version="1.1" creator="GDAL" xmlns:ogr="http://osgeo.org/gdal" xmlns="http://www.topografix.com/GPX/1/1">
+            <metadata><bounds minlat="20.8" minlon="-156.4" maxlat="20.9" maxlon="-156.3"/></metadata>
+            <wpt lat="20.8" lon="-156.3">
+              <extensions>
+                <ogr:zone_code>030</ogr:zone_code>
+                <ogr:zone_name>Residential</ogr:zone_name>
+              </extensions>
+            </wpt>
+            <wpt lat="20.9" lon="-156.4">
+              <extensions>
+                <ogr:zone_code>500</ogr:zone_code>
+                <ogr:zone_name>Commercial</ogr:zone_name>
+              </extensions>
+            </wpt>
+            </gpx>
+            """;
+
+        var features = await ReadAsync(gpx);
+
+        features.Should().HaveCount(2);
+
+        var first = features[0];
+        first.Geometry.Should().BeOfType<Point>();
+        first.Geometry!.Coordinate.X.Should().Be(-156.3);
+        first.Geometry!.Coordinate.Y.Should().Be(20.8);
+        first.Attributes["zone_code"].Should().Be("030");
+        first.Attributes["zone_name"].Should().Be("Residential");
+
+        features[1].Attributes["zone_code"].Should().Be("500");
+        features[1].Attributes["zone_name"].Should().Be("Commercial");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_SimpleWaypointChildren_ReturnsAttributes()
+    {
+        const string gpx = """
+            <?xml version="1.0"?>
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+            <wpt lat="10.0" lon="20.0">
+              <name>Summit</name>
+              <ele>1234</ele>
+            </wpt>
+            </gpx>
+            """;
+
+        var features = await ReadAsync(gpx);
+
+        features.Should().ContainSingle();
+        features[0].Attributes["name"].Should().Be("Summit");
+        features[0].Attributes["ele"].Should().Be("1234");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/WkbFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/WkbFormatReaderTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FileImport.Services;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Core.Tests.Features.Import;
+
+// Regression coverage for honua-server#2353: a WKB payload (one or more concatenated WKB
+// geometries) must import instead of failing with a generic "Multipart import request is invalid."
+public sealed class WkbFormatReaderTests
+{
+    private static async Task<List<NetTopologySuite.Features.IFeature>> ReadAsync(byte[] bytes)
+    {
+        await using var stream = new MemoryStream(bytes);
+        var features = new List<NetTopologySuite.Features.IFeature>();
+        await foreach (var feature in WkbFormatReader.ReadStreamingAsync(stream, CancellationToken.None))
+        {
+            features.Add(feature);
+        }
+
+        return features;
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_ConcatenatedWkbPoints_ReturnsGeometryFeatures()
+    {
+        var factory = new GeometryFactory();
+        var writer = new WKBWriter();
+        using var buffer = new MemoryStream();
+        buffer.Write(writer.Write(factory.CreatePoint(new Coordinate(-156.30, 20.80))));
+        buffer.Write(writer.Write(factory.CreatePoint(new Coordinate(-156.40, 20.90))));
+
+        var features = await ReadAsync(buffer.ToArray());
+
+        features.Should().HaveCount(2);
+        features[0].Geometry.Should().BeOfType<Point>();
+        features[0].Geometry!.Coordinate.X.Should().Be(-156.30);
+        features[1].Geometry!.Coordinate.Y.Should().Be(20.90);
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_SingleWkbPolygon_ReturnsPolygon()
+    {
+        var factory = new GeometryFactory();
+        var polygon = factory.CreatePolygon(new[]
+        {
+            new Coordinate(0, 0),
+            new Coordinate(0, 10),
+            new Coordinate(10, 10),
+            new Coordinate(10, 0),
+            new Coordinate(0, 0)
+        });
+        var bytes = new WKBWriter().Write(polygon);
+
+        var features = await ReadAsync(bytes);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeAssignableTo<Polygon>();
+        features[0].Geometry!.Area.Should().BeApproximately(100, 0.001);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/StreamingImportTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/StreamingImportTests.cs
@@ -231,6 +231,110 @@ public class StreamingImportTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_EsriJsonFeatureSet_AutoDetectsAndImports()
+    {
+        // Regression: honua-server#2352 — Esri JSON must auto-detect and import (not be silently
+        // parsed as GeoJSON). Mirrors the e2e format-harness sample.esrijson feature set.
+        const string esriJson = """
+            {"geometryType":"esriGeometryPoint","spatialReference":{"wkid":4326},"features":[
+            {"attributes":{"zone_code":"030","zone_name":"Residential"},"geometry":{"x":-156.30,"y":20.80}},
+            {"attributes":{"zone_code":"500","zone_name":"Commercial"},"geometry":{"x":-156.40,"y":20.90}}]}
+            """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(esriJson, Encoding.UTF8, "application/json");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "sample.esrijson"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("esrijson_import_table"), "TableName");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.BeSuccessful();
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("EsriJson");
+        responseContent.Should().Contain("\"featureCount\":2");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_WkbPayload_AutoDetectsAndImports()
+    {
+        // Regression: honua-server#2353 — a WKB payload (concatenated WKB points) must auto-detect
+        // and import rather than failing with "Multipart import request is invalid."
+        using var buffer = new MemoryStream();
+        WriteWkbPoint(buffer, -156.30, 20.80);
+        WriteWkbPoint(buffer, -156.40, 20.90);
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(buffer.ToArray());
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "sample.wkb"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("wkb_import_table"), "TableName");
+        content.Add(new StringContent("4326"), "SourceSrid");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.BeSuccessful();
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("Wkb");
+        responseContent.Should().Contain("\"featureCount\":2");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
+    public async Task Import_GpxWithGdalExtensions_ImportsWaypoints()
+    {
+        // Regression: honua-server#2354 — GPX waypoints whose attributes live under <extensions>
+        // (GDAL GPX_USE_EXTENSIONS output) must import instead of yielding zero features.
+        const string gpx = """
+            <?xml version="1.0"?>
+            <gpx version="1.1" creator="GDAL" xmlns:ogr="http://osgeo.org/gdal" xmlns="http://www.topografix.com/GPX/1/1">
+            <wpt lat="20.8" lon="-156.3"><extensions><ogr:zone_code>030</ogr:zone_code></extensions></wpt>
+            <wpt lat="20.9" lon="-156.4"><extensions><ogr:zone_code>500</ogr:zone_code></extensions></wpt>
+            </gpx>
+            """;
+
+        var content = new MultipartFormDataContent();
+        var fileContent = new StringContent(gpx, Encoding.UTF8, "application/gpx+xml");
+        fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+        {
+            Name = "File",
+            FileName = "sample.gpx"
+        };
+        content.Add(fileContent);
+        content.Add(new StringContent("gpx_import_table"), "TableName");
+        content.Add(new StringContent("true"), "OverwriteExisting");
+
+        var response = await _client.PostAsync("/api/v1/admin/import/upload", content);
+
+        response.BeSuccessful();
+        var responseContent = await response.Content.ReadAsStringAsync();
+        responseContent.Should().Contain("Gpx");
+        responseContent.Should().Contain("\"featureCount\":2");
+    }
+
+    private static void WriteWkbPoint(Stream stream, double x, double y)
+    {
+        // Little-endian WKB Point: byteOrder(1) + geometryType(uint32=1) + x(double) + y(double).
+        stream.WriteByte(0x01);
+        stream.Write(BitConverter.GetBytes((uint)1));
+        stream.Write(BitConverter.GetBytes(x));
+        stream.Write(BitConverter.GetBytes(y));
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/import/upload")]
     public async Task Import_CsvFile_WithLongitudeLatitudeColumns_StreamsRows()
     {
         var csvContent = """


### PR DESCRIPTION
## Issue Link
Closes #2352 #2353 #2354

## Summary
Fixes three format-import bugs surfaced by the Slice-1 e2e format harness, which share the
import format-detection path (`FileFormatDetectionService` + the readers under
`Honua.Geometry` FileImport). All three were reproduced on `origin/trunk` before fixing.

## Changes Made
- **#2352 — EsriJSON now auto-detected + imported (never silently GeoJSON).** Added
  `SupportedFileFormat.EsriJson`, mapped the `.esrijson` extension, and added Esri-JSON
  **content** detection (Esri markers `geometryType`/`spatialReference`/`rings`/`paths` +
  `attributes`) ordered *before* GeoJSON and guarded so real GeoJSON still wins. New
  `EsriJsonFormatReader` parses Esri feature sets (point / multipoint / polyline / polygon,
  attributes, and `spatialReference.wkid` for source CRS).
- **#2353 — WKB now auto-detected + imported.** Added `SupportedFileFormat.Wkb`, mapped the
  `.wkb` extension, and a new `WkbFormatReader` that reads one or more concatenated WKB/EWKB
  geometries into geometry-only features. Malformed input now raises a clear
  `InvalidDataException` instead of the generic "Multipart import request is invalid."
- **#2354 — GPX read returns its features (real reader bug, not just detection).** GPX was
  correctly detected as `Gpx` but the waypoint parser called `ReadElementContentAsString` on
  GDAL's `<extensions>` container (which has child elements), throwing
  `XmlException: ReadElementContentAs() methods cannot be called on an element that has child
  elements` and yielding zero features. The parser now walks the waypoint subtree, descending
  into `<extensions>` and recording leaf elements as attributes.
- Wired both new formats into the import + preview reader switches and CRS detection; added
  `.esrijson`/`.wkb` entries to the `/import/formats` descriptions.

## Deeper-than-detection finding
#2354 is a genuine **reader** bug, not a detection gap: detection already returned `Gpx`, but
the reader threw on GDAL's `<extensions>` block. Confirmed on trunk via an XmlException repro.

## Testing
- [x] Unit tests added/updated — reader tests (GPX extensions, EsriJSON point/polygon/polyline,
  WKB points/polygon) + detection tests (extension + content, incl. GeoJSON-still-wins) in
  `Honua.Core.Tests`.
- [x] Integration tests added/updated — round-trip import via `/api/v1/admin/import/upload`
  asserting format + `featureCount` for EsriJSON, WKB, and GPX-with-extensions in
  `Honua.Server.Tests`.

_Reproduction was confirmed on trunk before the fix. Local full build/test was skipped due to a
saturated shared build lock; this rides the merge train (currently being unjammed by the
FileImport-SASL fix) and is verified by CI + the train._

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact (adds two enum members + extensions to an existing API response)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None
