### PR TITLE
fix(geoservices): accept Web Mercator alias 102100 on edits against 3857 layers

### DIFF
--- a/src/Honua.Core/Features/Shared/Models/SpatialReferenceExtensions.cs
+++ b/src/Honua.Core/Features/Shared/Models/SpatialReferenceExtensions.cs
@@ -126,6 +126,28 @@ public static class SpatialReferenceExtensions
         => from.Wkid != to.Wkid;
 
     /// <summary>
+    /// Normalizes well-known WGS 84 / Web Mercator SRID aliases
+    /// (<c>102100</c>, <c>102113</c>, <c>900913</c>, <c>3785</c>) to the canonical
+    /// EPSG code <c>3857</c>. All other SRIDs are returned unchanged.
+    /// </summary>
+    /// <remarks>
+    /// ArcGIS Pro and the ArcGIS JS API send <c>{wkid:102100, latestWkid:3857}</c> for
+    /// content Honua stores and advertises as EPSG:3857. These identifiers denote the
+    /// same coordinate system with identical coordinate values, so callers comparing an
+    /// incoming SRID against a stored/layer SRID must normalize both sides through this
+    /// method to treat them as equivalent. This is the shared canonical mapping used by
+    /// the query, import, and edit paths.
+    /// </remarks>
+    /// <param name="srid">SRID to normalize.</param>
+    /// <returns>EPSG:3857 for any Web Mercator alias; otherwise the input SRID.</returns>
+    public static int NormalizeWebMercatorSrid(int srid)
+        => srid switch
+        {
+            102100 or 102113 or 900913 or 3785 => 3857,
+            _ => srid
+        };
+
+    /// <summary>
     /// Creates a minimal spatial reference with just the WKID
     /// </summary>
     /// <param name="wkid">Well-known ID (EPSG code)</param>

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Helpers.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.Helpers.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
 using Honua.Core.Features.Migration.Services;
+using Honua.Core.Features.Shared.Models;
 using Honua.Core.Features.FileImport.Abstractions;
 using Honua.Core.Features.FileImport.Domain;
 using Honua.Core.Features.FileImport.Services;
@@ -104,11 +105,9 @@ internal sealed partial class GeoservicesImportService
     }
 
     private static int? NormalizeArcGisWkid(int? wkid)
-        => wkid switch
-        {
-            102100 or 102113 or 900913 or 3785 => 3857,
-            _ => wkid
-        };
+        => wkid.HasValue
+            ? SpatialReferenceExtensions.NormalizeWebMercatorSrid(wkid.Value)
+            : null;
 
     private static bool IsKnownArcGisAlias(int? wkid)
         => wkid is 102100 or 102113 or 900913 or 3785;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -1239,7 +1239,15 @@ internal sealed class FeatureServerEditsHandler(
             var layerSrid = resource.ReadSrid() ?? SpatialReference.WGS84.Wkid;
             var geometrySrid = feature.Geometry.SpatialReference?.Wkid
                 ?? feature.Geometry.SpatialReference?.LatestWkid;
-            if (geometrySrid.HasValue && geometrySrid.Value != layerSrid)
+            // Treat Web Mercator aliases as equivalent. ArcGIS Pro / the ArcGIS JS API send
+            // {wkid:102100, latestWkid:3857} against a layer stored as 3857; these are the same
+            // CRS with identical coordinate values. Normalize both sides through the shared
+            // Web Mercator alias table (the same normalization the query and import paths use)
+            // before comparing so the edit is accepted. A genuinely different CRS still fails
+            // here because the edit path does not reproject geometry.
+            if (geometrySrid.HasValue &&
+                SpatialReferenceExtensions.NormalizeWebMercatorSrid(geometrySrid.Value)
+                    != SpatialReferenceExtensions.NormalizeWebMercatorSrid(layerSrid))
             {
                 var safeError = SanitizeEditErrorMessage(
                     $"Geometry spatial reference {geometrySrid.Value} does not match layer SRID {layerSrid}.",
@@ -1247,10 +1255,11 @@ internal sealed class FeatureServerEditsHandler(
                 throw new ArgumentException(safeError);
             }
 
-            geometrySrid ??= layerSrid;
+            // The incoming spatial reference either matches the layer or is a Web Mercator
+            // alias of it, so store the geometry tagged with the layer's canonical SRID.
             try
             {
-                geometry = GeoServicesGeometryConverter.ConvertGeoServicesGeometryToWkb(feature.Geometry, geometrySrid);
+                geometry = GeoServicesGeometryConverter.ConvertGeoServicesGeometryToWkb(feature.Geometry, layerSrid);
             }
             catch (ArgumentException ex)
             {

--- a/tests/dotnet/Honua.Core.Tests/Features/SharedModels/SpatialReferenceExtensionsTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/SharedModels/SpatialReferenceExtensionsTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Shared.Models;
+using Xunit;
+
+namespace Honua.Core.Tests.Features.SharedModels;
+
+/// <summary>
+/// Unit coverage for <see cref="SpatialReferenceExtensions"/> SRID normalization.
+/// The Web Mercator alias table (#2360) must stay in sync across the query, import,
+/// and edit paths so an incoming 102100 spatial reference is treated as EPSG:3857.
+/// </summary>
+public sealed class SpatialReferenceExtensionsTests
+{
+    [Theory]
+    [InlineData(102100)]
+    [InlineData(102113)]
+    [InlineData(900913)]
+    [InlineData(3785)]
+    [InlineData(3857)]
+    public void NormalizeWebMercatorSrid_WebMercatorAliases_MapTo3857(int srid)
+    {
+        SpatialReferenceExtensions.NormalizeWebMercatorSrid(srid).Should().Be(3857);
+    }
+
+    [Theory]
+    [InlineData(4326)]
+    [InlineData(4269)]
+    [InlineData(2154)]
+    [InlineData(32633)]
+    public void NormalizeWebMercatorSrid_OtherSrids_PassThroughUnchanged(int srid)
+    {
+        SpatialReferenceExtensions.NormalizeWebMercatorSrid(srid).Should().Be(srid);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
@@ -355,6 +355,99 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
         applyResponse.AddResults[0].Error!.Description.Should().Contain("does not match layer SRID");
     }
 
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_WithWebMercatorAliasSrid_AgainstWebMercatorLayer_Succeeds()
+    {
+        // Regression for #2360: ArcGIS Pro / the ArcGIS JS API send the Web Mercator
+        // spatial reference as {wkid:102100, latestWkid:3857}. The srid-test point layer is
+        // stored as 3857, so this edit must be accepted (102100 is an alias of 3857) rather
+        // than rejected as a SRID mismatch (which, with rollbackOnFailure, failed the batch).
+        var request = new ApplyEditsRequest
+        {
+            Adds =
+            [
+                new GeoServicesFeature
+                {
+                    Attributes = new Dictionary<string, object?>
+                    {
+                        ["name"] = "Web Mercator Alias Point"
+                    },
+                    Geometry = new GeoServicesGeometry
+                    {
+                        // San Francisco expressed in EPSG:3857 metres.
+                        X = -13627361.0,
+                        Y = 4547675.0,
+                        SpatialReference = new GeoServicesSpatialReference { Wkid = 102100, LatestWkid = 3857 }
+                    }
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(request, FeatureServerJsonContext.Default.ApplyEditsRequest);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{SpatialReferenceTestLayerCatalog.ServiceId}/FeatureServer/{SpatialReferenceTestLayerCatalog.PointLayerId}/applyEdits",
+            content);
+
+        response.Be200Ok();
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var applyResponse = JsonSerializer.Deserialize(responseContent, FeatureServerJsonContext.Default.ApplyEditsResponse);
+
+        applyResponse.Should().NotBeNull();
+        applyResponse!.Success.Should().BeTrue();
+        applyResponse.AddResults.Should().NotBeNull();
+        applyResponse.AddResults![0].Success.Should().BeTrue();
+        applyResponse.AddResults[0].ObjectId.Should().BePositive();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_WithGenuinelyDifferentSrid_AgainstWebMercatorLayer_ReturnsError()
+    {
+        // Guard for #2360: normalizing Web Mercator aliases must not weaken genuine
+        // SRID-mismatch rejection. A truly different CRS (EPSG:4326) against the 3857 layer
+        // is still rejected because the edit path does not reproject geometry.
+        var request = new ApplyEditsRequest
+        {
+            Adds =
+            [
+                new GeoServicesFeature
+                {
+                    Attributes = new Dictionary<string, object?>
+                    {
+                        ["name"] = "Mismatched SRID Point"
+                    },
+                    Geometry = new GeoServicesGeometry
+                    {
+                        X = -122.4194,
+                        Y = 37.7749,
+                        SpatialReference = new GeoServicesSpatialReference { Wkid = 4326 }
+                    }
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(request, FeatureServerJsonContext.Default.ApplyEditsRequest);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{SpatialReferenceTestLayerCatalog.ServiceId}/FeatureServer/{SpatialReferenceTestLayerCatalog.PointLayerId}/applyEdits",
+            content);
+
+        response.Be200Ok();
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var applyResponse = JsonSerializer.Deserialize(responseContent, FeatureServerJsonContext.Default.ApplyEditsResponse);
+
+        applyResponse.Should().NotBeNull();
+        applyResponse!.Success.Should().BeFalse();
+        applyResponse.AddResults.Should().NotBeNull();
+        applyResponse.AddResults![0].Success.Should().BeFalse();
+        applyResponse.AddResults[0].Error.Should().NotBeNull();
+        applyResponse.AddResults[0].Error!.Description.Should().Contain("does not match layer SRID");
+    }
+
     private static bool IsClockwise(double[][] ring)
     {
         var area = 0.0;


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2360

## Summary
FeatureServer `applyEdits` rejected geometry whose `spatialReference` was `{wkid:102100, latestWkid:3857}` against a layer stored as `3857` — the exact payload ArcGIS Pro and the ArcGIS JS API send. The edit-path SRID guard did a raw `!=` comparison with no Web Mercator alias normalization and preferred `Wkid` (102100) over `LatestWkid` (3857), so a matching CRS looked like a mismatch. With `rollbackOnFailure` (default true) the whole edit batch failed, breaking ArcGIS Pro / JS-API editing.

Read/query and import already treat `102100 ≡ 3857`. This normalizes both sides of the edit-path comparison through a shared canonical Web Mercator alias helper so the alias is accepted, and stores the geometry tagged with the layer's canonical SRID. A genuinely different CRS (e.g. `4326` against a `3857` layer) is still rejected, because the edit path does not reproject geometry.

## Changes Made
- Add `SpatialReferenceExtensions.NormalizeWebMercatorSrid` in `Honua.Core` as the single source of truth for the Web Mercator alias table (`3857`/`900913`/`102100`/`102113`/`3785` → `3857`).
- Normalize both the incoming geometry SRID and the layer SRID through that helper in `FeatureServerEditsHandler`'s SRID guard; store WKB tagged with the layer's canonical SRID.
- Delegate the import path's `NormalizeArcGisWkid` to the shared helper so query/import/edit stay in sync.
- Add `applyEdits` regression tests (alias `{wkid:102100, latestWkid:3857}` accepted against a 3857 layer; genuine `4326` mismatch still rejected) plus unit coverage for the normalization helper.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
