### PR TITLE
fix(formats): parse EWKT/EWKB in CSV and WKT importers, warn on unparseable CSV geometry

### DIFF
--- a/src/Honua.Geometry/Features/FileImport/Services/CsvFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/CsvFormatReader.cs
@@ -70,14 +70,29 @@ internal static class CsvFormatReader
     internal static IAsyncEnumerable<IFeature> ReadStreamingAsync(
         Stream stream,
         CancellationToken cancellationToken)
-        => ReadStreamingAsync(stream, delimiterOverride: null, cancellationToken);
+        => ReadStreamingAsync(stream, delimiterOverride: null, diagnostics: null, cancellationToken);
 
     /// <summary>
     /// Stream features from a CSV file with an optional explicit delimiter override.
     /// </summary>
+    internal static IAsyncEnumerable<IFeature> ReadStreamingAsync(
+        Stream stream,
+        char? delimiterOverride,
+        CancellationToken cancellationToken)
+        => ReadStreamingAsync(stream, delimiterOverride, diagnostics: null, cancellationToken);
+
+    /// <summary>
+    /// Stream features from a CSV file with an optional explicit delimiter override and an
+    /// optional <see cref="CsvGeometryDiagnostics"/> sink. When a row has a mapped geometry
+    /// column whose value is present but cannot be parsed as WKT/EWKT/WKB, the raw value is
+    /// preserved as an attribute (so the data is never discarded) and the occurrence is
+    /// recorded on <paramref name="diagnostics"/> so the caller can surface a warning rather
+    /// than silently importing a null geometry.
+    /// </summary>
     internal static async IAsyncEnumerable<IFeature> ReadStreamingAsync(
         Stream stream,
         char? delimiterOverride,
+        CsvGeometryDiagnostics? diagnostics,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
@@ -86,6 +101,7 @@ internal static class CsvFormatReader
         CsvColumnMapping mapping = default;
         var geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
         var wktReader = new WKTReader();
+        var wkbReader = GeometryValueParser.CreateWkbReader();
         var sampleRecords = await ReadSampleRecordsAsync(reader, cancellationToken);
         var delimiter = delimiterOverride ?? DetectDelimiter(sampleRecords);
 
@@ -104,7 +120,7 @@ internal static class CsvFormatReader
                 return null;
             }
 
-            return BuildFeature(headers, fields, mapping, geometryFactory, wktReader);
+            return BuildFeature(headers, fields, mapping, geometryFactory, wktReader, wkbReader, diagnostics);
         }
 
         foreach (var sampleRecord in sampleRecords)
@@ -144,7 +160,9 @@ internal static class CsvFormatReader
         IReadOnlyList<string> fields,
         CsvColumnMapping mapping,
         GeometryFactory geometryFactory,
-        WKTReader wktReader)
+        WKTReader wktReader,
+        WKBReader wkbReader,
+        CsvGeometryDiagnostics? diagnostics)
     {
         var attributes = new AttributesTable();
 
@@ -164,7 +182,23 @@ internal static class CsvFormatReader
             attributes.Add(headers[i], value);
         }
 
-        var geometry = ParseGeometry(fields, mapping, geometryFactory, wktReader);
+        var geometry = ParseGeometry(
+            fields, mapping, geometryFactory, wktReader, wkbReader, out var unparseableGeometryValue);
+
+        // A geometry column was mapped and carried a value, but none of the supported
+        // encodings (WKT/EWKT/WKB hex) could parse it. Rather than silently dropping the
+        // geometry to NULL and reporting success (data loss), preserve the raw value as an
+        // attribute so it is never discarded and record the occurrence so the import surfaces
+        // a warning. Mirrors GeoParquet's skip/warn behaviour for null geometry.
+        if (geometry == null && unparseableGeometryValue != null)
+        {
+            diagnostics?.RecordUnparseableGeometry();
+            if (mapping.WktIndex.HasValue)
+            {
+                attributes.Add(headers[mapping.WktIndex.Value], unparseableGeometryValue);
+            }
+        }
+
         if (geometry == null && attributes.GetNames().Length == 0)
         {
             return null;
@@ -177,21 +211,29 @@ internal static class CsvFormatReader
         IReadOnlyList<string> fields,
         CsvColumnMapping mapping,
         GeometryFactory geometryFactory,
-        WKTReader wktReader)
+        WKTReader wktReader,
+        WKBReader wkbReader,
+        out string? unparseableGeometryValue)
     {
+        unparseableGeometryValue = null;
+
         if (mapping.WktIndex.HasValue)
         {
             var wktValue = GetField(fields, mapping.WktIndex.Value);
             if (!string.IsNullOrWhiteSpace(wktValue))
             {
-                try
+                // Handles plain WKT, EWKT (SRID=<n>; prefix — the standard PostGIS export
+                // form) and WKB/EWKB hex. This is what previously fell into a bare catch{}
+                // and silently produced a NULL geometry.
+                var geometry = GeometryValueParser.TryParse(wktValue, wktReader, wkbReader);
+                if (geometry != null)
                 {
-                    return wktReader.Read(wktValue.Trim());
+                    return geometry;
                 }
-                catch
-                {
-                    // Ignore malformed WKT and try other geometry encodings.
-                }
+
+                // Remember the raw value so the caller can preserve it and warn; fall through
+                // to the lon/lat encoding in case the file also carries coordinate columns.
+                unparseableGeometryValue = wktValue.Trim();
             }
         }
 
@@ -203,6 +245,8 @@ internal static class CsvFormatReader
             if (double.TryParse(longitudeValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var longitude) &&
                 double.TryParse(latitudeValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var latitude))
             {
+                // A parseable coordinate pair supersedes an unparseable WKT column.
+                unparseableGeometryValue = null;
                 return geometryFactory.CreatePoint(new Coordinate(longitude, latitude));
             }
         }
@@ -525,4 +569,22 @@ internal static class CsvFormatReader
         int? WktIndex,
         int? LongitudeIndex,
         int? LatitudeIndex);
+}
+
+/// <summary>
+/// Collects diagnostics emitted while streaming a CSV so the import pipeline can surface
+/// warnings instead of silently importing rows with dropped geometry. A single instance is
+/// passed to <see cref="CsvFormatReader"/> and read after enumeration completes.
+/// </summary>
+internal sealed class CsvGeometryDiagnostics
+{
+    /// <summary>
+    /// Number of rows whose mapped geometry column held a value that could not be parsed as
+    /// WKT, EWKT, or WKB/EWKB hex. Such rows are imported without geometry but with the raw
+    /// value preserved as an attribute.
+    /// </summary>
+    public int UnparseableGeometryRows { get; private set; }
+
+    /// <summary>Records that a row had an unparseable geometry value.</summary>
+    public void RecordUnparseableGeometry() => UnparseableGeometryRows++;
 }

--- a/src/Honua.Geometry/Features/FileImport/Services/GeometryValueParser.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/GeometryValueParser.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using NetTopologySuite.IO;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Core.Features.FileImport.Services;
+
+/// <summary>
+/// Shared parser for text geometry values that appear in CSV geometry columns and
+/// <c>.wkt</c> files. Understands three encodings that geospatial exports (notably
+/// standard PostGIS <c>COPY</c> / <c>ST_AsEWKB</c> output) emit, which the bare
+/// <see cref="WKTReader"/> cannot read on its own:
+/// <list type="bullet">
+///   <item>plain OGC WKT — <c>POINT(1 2)</c>;</item>
+///   <item>EWKT with a leading <c>SRID=&lt;n&gt;;</c> prefix — <c>SRID=4326;POINT(1 2)</c>
+///     (the SRID is honoured on the returned geometry);</item>
+///   <item>WKB / EWKB hex — <c>0101000020E6100000...</c>.</item>
+/// </list>
+/// Centralising this keeps the CSV and WKT readers from diverging on which encodings
+/// they accept.
+/// </summary>
+internal static class GeometryValueParser
+{
+    /// <summary>
+    /// Attempts to parse <paramref name="value"/> as plain WKT, EWKT (<c>SRID=n;</c> prefix),
+    /// or WKB/EWKB hex. Returns <see langword="null"/> when the value is blank or cannot be
+    /// parsed by any of the supported encodings. The supplied readers are reused across calls
+    /// because <see cref="WKTReader"/>/<see cref="WKBReader"/> are not cheap to allocate and
+    /// are not thread-safe; callers must not share them across threads.
+    /// </summary>
+    internal static NtsGeometry? TryParse(string? value, WKTReader wktReader, WKBReader wkbReader)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+
+        // EWKT: SRID=<n>;<wkt>. The CRS-detector strips this exact prefix; mirror that here
+        // and honour the declared SRID on the parsed geometry.
+        if (TryStripSridPrefix(trimmed, out var srid, out var wktBody))
+        {
+            var geometry = TryReadWkt(wktBody, wktReader);
+            if (geometry != null && srid.HasValue)
+            {
+                geometry.SRID = srid.Value;
+            }
+
+            return geometry;
+        }
+
+        // WKB / EWKB hex. A hex payload contains only hex digits (no whitespace, parentheses,
+        // commas, or WKT keywords), so this never collides with WKT text. WKBReader.HandleSRID
+        // reads the EWKB SRID flag when present.
+        if (LooksLikeHex(trimmed))
+        {
+            var geometry = TryReadWkbHex(trimmed, wkbReader);
+            if (geometry != null)
+            {
+                return geometry;
+            }
+        }
+
+        // Plain WKT.
+        return TryReadWkt(trimmed, wktReader);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="WKBReader"/> configured to honour the SRID/Z/M flags that PostGIS
+    /// EWKB carries. Callers should cache one per reader instance.
+    /// </summary>
+    internal static WKBReader CreateWkbReader() => new() { HandleSRID = true };
+
+    private static bool TryStripSridPrefix(string value, out int? srid, out string wktBody)
+    {
+        srid = null;
+        wktBody = value;
+
+        if (!value.StartsWith("SRID=", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var semicolon = value.IndexOf(';');
+        if (semicolon <= 5)
+        {
+            return false;
+        }
+
+        var sridText = value.Substring(5, semicolon - 5).Trim();
+        if (int.TryParse(sridText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedSrid) &&
+            parsedSrid > 0)
+        {
+            srid = parsedSrid;
+        }
+
+        wktBody = value[(semicolon + 1)..].Trim();
+        return true;
+    }
+
+    private static bool LooksLikeHex(string value)
+    {
+        // A WKB point serialises to 21 bytes (42 hex chars); require an even length and a
+        // sensible minimum so short attribute tokens are not misread as geometry.
+        if (value.Length < 10 || (value.Length & 1) != 0)
+        {
+            return false;
+        }
+
+        foreach (var ch in value)
+        {
+            var isHex = ch is (>= '0' and <= '9') or (>= 'a' and <= 'f') or (>= 'A' and <= 'F');
+            if (!isHex)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static NtsGeometry? TryReadWkbHex(string hex, WKBReader wkbReader)
+    {
+        try
+        {
+            var bytes = Convert.FromHexString(hex);
+            return wkbReader.Read(bytes);
+        }
+        catch (Exception ex) when (ex is FormatException or NetTopologySuite.IO.ParseException or ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static NtsGeometry? TryReadWkt(string wkt, WKTReader wktReader)
+    {
+        if (string.IsNullOrWhiteSpace(wkt))
+        {
+            return null;
+        }
+
+        try
+        {
+            return wktReader.Read(wkt);
+        }
+        catch (Exception ex) when (ex is NetTopologySuite.IO.ParseException or ArgumentException or FormatException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Honua.Geometry/Features/FileImport/Services/WktFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/WktFormatReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 using NetTopologySuite.Features;
 using NetTopologySuite.IO;
 using Honua.Core.Features.Import.Abstractions;
@@ -16,45 +17,88 @@ using Honua.Core.Features.FileImport.Services;
 namespace Honua.Core.Features.FileImport.Services;
 
 /// <summary>
-/// Streaming WKT (Well-Known Text) format reader. Parses WKT geometry lines into features
-/// using line-by-line streaming for memory-efficient processing.
+/// Streaming WKT (Well-Known Text) format reader. Parses geometry records into features
+/// using streaming for memory-efficient processing. Understands plain WKT, EWKT
+/// (<c>SRID=&lt;n&gt;;</c> prefix), and WKB/EWKB hex via <see cref="GeometryValueParser"/>,
+/// and accumulates records that span multiple physical lines (a single geometry whose
+/// coordinate list is pretty-printed across several lines).
 /// </summary>
 internal static class WktFormatReader
 {
     /// <summary>
-    /// Streams features from a WKT file, reading one geometry per line.
+    /// Streams features from a WKT file. A record is a single geometry; it may occupy one
+    /// line or span several lines. Records are delimited by parenthesis balance so that a
+    /// multi-line geometry is accumulated before it is parsed, and hex/EMPTY geometries
+    /// (which have no parentheses) are parsed as soon as they are read.
     /// </summary>
     internal static async IAsyncEnumerable<IFeature> ReadStreamingAsync(
         Stream stream,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var wktReader = new WKTReader();
+        var wkbReader = GeometryValueParser.CreateWkbReader();
         using var reader = new StreamReader(stream, leaveOpen: true);
+
+        var buffer = new StringBuilder();
+        var depth = 0;
 
         string? line;
         while ((line = await reader.ReadLineAsync(cancellationToken)) != null)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (string.IsNullOrWhiteSpace(line))
+            // Skip leading blank lines between records; do not break an in-progress record.
+            if (buffer.Length == 0 && string.IsNullOrWhiteSpace(line))
                 continue;
 
-            IFeature? feature = null;
-            try
-            {
-                var geometry = wktReader.Read(line.Trim());
-                if (geometry != null)
-                {
-                    feature = new Feature(geometry, new AttributesTable());
-                }
-            }
-            catch
-            {
-                // Skip invalid WKT lines
-            }
+            if (buffer.Length > 0)
+                buffer.Append('\n');
+            buffer.Append(line);
+            depth += ParenDelta(line);
 
+            // The record's parentheses are balanced (or it has none, e.g. WKB hex or
+            // "POINT EMPTY"): it is a complete geometry, so parse and reset.
+            if (depth <= 0)
+            {
+                var feature = BuildFeature(buffer, wktReader, wkbReader);
+                buffer.Clear();
+                depth = 0;
+                if (feature != null)
+                    yield return feature;
+            }
+        }
+
+        // Flush any trailing content (last record without a trailing newline, or an
+        // unbalanced tail we still attempt to parse rather than silently drop).
+        if (buffer.Length > 0)
+        {
+            var feature = BuildFeature(buffer, wktReader, wkbReader);
             if (feature != null)
                 yield return feature;
         }
+    }
+
+    private static Feature? BuildFeature(StringBuilder buffer, WKTReader wktReader, WKBReader wkbReader)
+    {
+        var text = buffer.ToString().Trim();
+        if (text.Length == 0)
+            return null;
+
+        var geometry = GeometryValueParser.TryParse(text, wktReader, wkbReader);
+        return geometry != null ? new Feature(geometry, new AttributesTable()) : null;
+    }
+
+    private static int ParenDelta(string line)
+    {
+        var delta = 0;
+        foreach (var ch in line)
+        {
+            if (ch == '(')
+                delta++;
+            else if (ch == ')')
+                delta--;
+        }
+
+        return delta;
     }
 }

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
@@ -98,6 +98,10 @@ internal sealed partial class StreamingFileImportService
             throw new InvalidOperationException("Shapefile scratch directory was not prepared.");
         }
 
+        // Collects CSV rows whose mapped geometry column held a value that could not be parsed
+        // (e.g. malformed WKT). Surfaced as a completion warning so the loss is never silent.
+        var csvGeometryDiagnostics = format == SupportedFileFormat.Csv ? new CsvGeometryDiagnostics() : null;
+
         var featureStream = format switch
         {
             SupportedFileFormat.GeoJson => _geoJsonReader.ReadFeaturesAsync(fileStream, cancellationToken),
@@ -105,7 +109,7 @@ internal sealed partial class StreamingFileImportService
             SupportedFileFormat.Kml => KmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Gpx => GpxFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Gml => GmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
-            SupportedFileFormat.Csv => CsvFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
+            SupportedFileFormat.Csv => CsvFormatReader.ReadStreamingAsync(fileStream, delimiterOverride: null, csvGeometryDiagnostics, cancellationToken),
             SupportedFileFormat.FlatGeobuf => FlatGeobufFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Shapefile => ReadShapefileStreamingAsync(shapefileScratch!.ShpPath, cancellationToken),
             SupportedFileFormat.GeoPackage => ReadGeoPackageStreamingAsync(fileStream, cancellationToken),
@@ -216,6 +220,12 @@ internal sealed partial class StreamingFileImportService
         if (format == SupportedFileFormat.GeoParquet && nullGeometrySkipped > 0)
         {
             completionWarningsBuilder.Add(string.Format(null, _nullGeometryWarningFormat, nullGeometrySkipped));
+        }
+
+        if (csvGeometryDiagnostics is { UnparseableGeometryRows: > 0 })
+        {
+            completionWarningsBuilder.Add(string.Format(
+                null, _csvUnparseableGeometryWarningFormat, csvGeometryDiagnostics.UnparseableGeometryRows));
         }
 
         if (_limits.ContinueOnError && totalFailed > 0)

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -71,6 +71,8 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         CompositeFormat.Parse("{0} row(s) were skipped because geometry was null.");
     private static readonly CompositeFormat _partialImportWarningFormat =
         CompositeFormat.Parse("{0} row(s) failed while continue-on-error was enabled; previously imported rows were retained.");
+    private static readonly CompositeFormat _csvUnparseableGeometryWarningFormat =
+        CompositeFormat.Parse("{0} row(s) had a geometry value that could not be parsed as WKT, EWKT, or WKB; each raw value was preserved as an attribute and the row was imported without geometry.");
     private static readonly Regex _wktSridRegex = new(
         @"SRID\s*=\s*(\d+)\s*;",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/CsvFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/CsvFormatReaderTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.FileImport.Services;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class CsvFormatReaderTests
+{
+    [Fact]
+    public async Task ReadStreamingAsync_PostgisEwktExport_ImportsWithGeometry()
+    {
+        // #2361: a standard PostGIS CSV export encodes the geometry column as EWKT
+        // ("SRID=<n>;WKT"). Previously a bare catch{} silently dropped it to NULL.
+        var csv = """
+            id,name,geom
+            1,San Francisco,SRID=4326;POINT(-122.4194 37.7749)
+            """;
+
+        var (features, _) = await ReadAllAsync(csv);
+
+        features.Should().ContainSingle();
+        var point = features[0].Geometry.Should().BeOfType<Point>().Subject;
+        point.X.Should().BeApproximately(-122.4194, 1e-6);
+        point.SRID.Should().Be(4326);
+        features[0].Attributes["name"].Should().Be("San Francisco");
+        // The geometry column must be excluded from attributes on success.
+        features[0].Attributes.Exists("geom").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_PostgisEwkbHexExport_ImportsWithGeometry()
+    {
+        // #2361: PostGIS also exports geometry as WKB/EWKB hex. This must parse too.
+        var writer = new WKBWriter { HandleSRID = true };
+        var hex = Convert.ToHexString(writer.Write(new Point(-122.4194, 37.7749) { SRID = 4326 }));
+        var csv = $"""
+            id,name,geom
+            1,San Francisco,{hex}
+            """;
+
+        var (features, _) = await ReadAllAsync(csv);
+
+        features.Should().ContainSingle();
+        var point = features[0].Geometry.Should().BeOfType<Point>().Subject;
+        point.X.Should().BeApproximately(-122.4194, 1e-6);
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_UnparseableGeometry_WarnsAndPreservesRawValueInsteadOfSilentNull()
+    {
+        // #2361: a claimed geometry value that cannot be parsed must NOT silently import as a
+        // successful null-geometry row with the raw value discarded. It is recorded on the
+        // diagnostics sink (surfaced as an import warning) and the raw value is preserved.
+        var csv = """
+            id,name,wkt
+            1,Broken,not-a-geometry
+            """;
+
+        var (features, diagnostics) = await ReadAllAsync(csv);
+
+        diagnostics.UnparseableGeometryRows.Should().Be(1);
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeNull();
+        features[0].Attributes["wkt"].Should().Be("not-a-geometry");
+        features[0].Attributes["name"].Should().Be("Broken");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_ValidWkt_DoesNotReportUnparseableGeometry()
+    {
+        var csv = """
+            id,name,wkt
+            1,Test,POINT(1 2)
+            """;
+
+        var (features, diagnostics) = await ReadAllAsync(csv);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeOfType<Point>();
+        diagnostics.UnparseableGeometryRows.Should().Be(0);
+    }
+
+    private static async Task<(List<IFeature> Features, CsvGeometryDiagnostics Diagnostics)> ReadAllAsync(string csv)
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+        var diagnostics = new CsvGeometryDiagnostics();
+        var features = new List<IFeature>();
+        await foreach (var feature in CsvFormatReader.ReadStreamingAsync(
+            stream, delimiterOverride: null, diagnostics, CancellationToken.None))
+        {
+            features.Add(feature);
+        }
+
+        return (features, diagnostics);
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/WktFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/WktFormatReaderTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Core.Features.FileImport.Services;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.Core.Tests.Features.Import;
+
+public sealed class WktFormatReaderTests
+{
+    [Fact]
+    public async Task ReadStreamingAsync_PlainWkt_ParsesFeatures()
+    {
+        var features = await ReadAllAsync("""
+            POINT(-122.4194 37.7749)
+            LINESTRING(0 0, 1 1)
+            """);
+
+        features.Should().HaveCount(2);
+        features[0].Geometry.Should().BeOfType<Point>();
+        features[1].Geometry.Should().BeOfType<LineString>();
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_EwktWithSridPrefix_ParsesFeatureAndHonoursSrid()
+    {
+        // #2363: a .wkt file exported with the standard PostGIS "SRID=<n>;" prefix previously
+        // yielded zero features because the bare WKTReader cannot parse EWKT.
+        var features = await ReadAllAsync("SRID=4326;POINT(-122.4194 37.7749)");
+
+        features.Should().ContainSingle();
+        var point = features[0].Geometry.Should().BeOfType<Point>().Subject;
+        point.SRID.Should().Be(4326);
+        point.X.Should().BeApproximately(-122.4194, 1e-6);
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_MultiLineGeometry_ParsesSingleFeature()
+    {
+        // #2363: a single geometry pretty-printed across several lines must be accumulated
+        // before parsing rather than parsed (and dropped) line-by-line.
+        var features = await ReadAllAsync("""
+            POLYGON((
+                0 0,
+                0 1,
+                1 1,
+                1 0,
+                0 0
+            ))
+            """);
+
+        features.Should().ContainSingle();
+        features[0].Geometry.Should().BeOfType<Polygon>();
+        features[0].Geometry!.Coordinates.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_WkbHexLine_ParsesFeature()
+    {
+        var expected = new Point(-122.4194, 37.7749) { SRID = 4326 };
+        var writer = new WKBWriter { HandleSRID = true };
+        var hex = Convert.ToHexString(writer.Write(expected));
+
+        var features = await ReadAllAsync(hex);
+
+        features.Should().ContainSingle();
+        var point = features[0].Geometry.Should().BeOfType<Point>().Subject;
+        point.X.Should().BeApproximately(-122.4194, 1e-6);
+        point.SRID.Should().Be(4326);
+    }
+
+    private static async Task<List<IFeature>> ReadAllAsync(string content)
+    {
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        var features = new List<IFeature>();
+        await foreach (var feature in WktFormatReader.ReadStreamingAsync(stream, CancellationToken.None))
+        {
+            features.Add(feature);
+        }
+
+        return features;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2361 #2363

## Summary
Standard PostGIS CSV/`.wkt` exports encode geometry as EWKT (`SRID=<n>;WKT`) or WKB/EWKB hex, but the CSV and WKT format readers only understood plain OGC WKT. As a result:

- **#2361 (S1):** a CSV column named `wkt`/`geom`/`geometry`/`shape` was claimed as the geometry source, but if its value was EWKT or EWKB-hex a bare `catch{}` produced a NULL geometry, discarded the raw value, and imported the row as `Completed` with zero warnings — silent, total geometry loss on the standard export form.
- **#2363 (S2, shared root cause):** `.wkt` import could not parse EWKT (despite the WKT CRS-detector being built around the `SRID=` prefix) or multi-line geometries, yielding 0 features.

This PR fixes both via a shared geometry-text parser and makes CSV geometry-parse failures non-silent.

## Changes Made
- Add `GeometryValueParser` (Honua.Geometry) — a shared helper that parses plain WKT, EWKT (stripping and honouring the `SRID=` prefix), and WKB/EWKB hex, so the CSV and WKT readers cannot diverge on accepted encodings.
- `WktFormatReader`: accumulate parenthesis-balanced records so multi-line geometries are parsed as one unit, and parse EWKT/EWKB via the shared helper (#2363).
- `CsvFormatReader`: parse the geometry column via the shared helper; when a mapped geometry column holds a value that cannot be parsed by any encoding, preserve the raw value as an attribute (never discarded) and record it on a `CsvGeometryDiagnostics` sink instead of silently dropping to NULL (#2361).
- `StreamingFileImportService`: surface an import warning when a CSV had unparseable-geometry rows, mirroring the existing GeoParquet null-geometry skip/warn path.
- Add regression tests: PostGIS-export CSVs (EWKT and EWKB-hex) import with geometry + featureCount>0; an unparseable CSV geometry value produces a diagnostic (not silent null-success) with the raw value preserved; `.wkt` files with `SRID=4326;POINT(...)`, WKB hex, and multi-line WKT import features.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
