### PR TITLE
fix: make Operate observability fixture host self-sufficient in Test env (#2350)

### DIFF
--- a/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureHostDefaults.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureHostDefaults.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Admin.OperateFixtures;
+
+/// <summary>
+/// Supplies the deterministic Development/Test-only configuration defaults a standalone Operate
+/// observability fixture host needs to be self-sufficient. The honua-console live lane boots the
+/// server image via Testcontainers with only a database connection string and the fixture flags;
+/// it does not supply the connection-encryption master key that the Postgres secure-connection
+/// provider (and therefore the audit-log/connection-provider request path) requires. Without a
+/// key every request — including <c>/healthz/live</c> and the fixture seed endpoint — fails with
+/// "Master key not configured." (honua-server#2350).
+/// </summary>
+/// <remarks>
+/// These defaults are applied only when the fixture is enabled in the Development or Test
+/// environment (the fixture validator forbids Production), and only for keys that are not already
+/// configured, so an explicit operator/WebAppFixture value always wins. They protect throwaway
+/// fixture connection strings in an ephemeral test container, never production secrets.
+/// </remarks>
+internal static class OperateObservabilityFixtureHostDefaults
+{
+    internal const string MasterKeyConfigurationPath = "Security:ConnectionEncryption:MasterKey";
+    internal const string SaltConfigurationPath = "Security:ConnectionEncryption:Salt";
+
+    // 49 characters, satisfying the 32-character minimum enforced by ConnectionEncryptionService.
+    internal const string DefaultConnectionEncryptionMasterKey =
+        "honua-operate-fixture-development-master-key-0001";
+
+    // Base64 of "honua-operate-fixture-development-salt"; any valid base64 salt round-trips
+    // within a single process, which is all the ephemeral fixture host needs.
+    internal const string DefaultConnectionEncryptionSalt =
+        "aG9udWEtb3BlcmF0ZS1maXh0dXJlLWRldmVsb3BtZW50LXNhbHQ=";
+
+    /// <summary>
+    /// Returns the fixture host defaults that are not already present in <paramref name="configuration"/>.
+    /// </summary>
+    /// <param name="configuration">The current host configuration.</param>
+    /// <returns>
+    /// A map of configuration keys to default values for every default not already configured. The
+    /// map is empty when the operator (or WebAppFixture) has supplied all of them.
+    /// </returns>
+    public static IReadOnlyDictionary<string, string?> CreateMissingDefaults(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var defaults = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        AddIfMissing(configuration, defaults, MasterKeyConfigurationPath, DefaultConnectionEncryptionMasterKey);
+        AddIfMissing(configuration, defaults, SaltConfigurationPath, DefaultConnectionEncryptionSalt);
+        return defaults;
+    }
+
+    private static void AddIfMissing(
+        IConfiguration configuration,
+        Dictionary<string, string?> defaults,
+        string key,
+        string value)
+    {
+        if (string.IsNullOrWhiteSpace(configuration[key]))
+        {
+            defaults[key] = value;
+        }
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -109,6 +109,33 @@ var registerInfrastructureInTestEnvironment =
         Environment.GetEnvironmentVariable("HONUA_REGISTER_TEST_INFRASTRUCTURE"),
         "true",
         StringComparison.OrdinalIgnoreCase);
+// Standalone Test images (e.g. the honua-console live lane's Testcontainers image) expose the
+// Operate observability fixture seed endpoint and must register the real data providers the
+// seeder resolves. They run their own migrations, unlike in-process WebAppFixture hosts which
+// set HONUA_SKIP_MIGRATIONS and wire isolated providers themselves (honua-server#2350).
+var operateObservabilityFixtureEnabled =
+    Honua.Server.Features.Admin.OperateFixtures.OperateObservabilityFixtureOptions.ResolveEnabled(
+        builder.Configuration,
+        builder.Configuration.GetValue<bool>(
+            $"{Honua.Server.Features.Admin.OperateFixtures.OperateObservabilityFixtureOptions.SectionName}:Enabled"));
+var hostManagesOwnMigrations = !builder.Configuration.GetValue<bool>("HONUA_SKIP_MIGRATIONS");
+
+// A standalone fixture host (Development/Test only) needs the connection-encryption master key
+// the Postgres secure-connection provider requires; the honua-console Testcontainers harness does
+// not supply it. Fill deterministic dev defaults for any keys not already configured so the seed
+// endpoint — and the audit-log/connection-provider path every request hits — works out of the box
+// (honua-server#2350). Skipped in Production because the fixture validator forbids it there.
+if (operateObservabilityFixtureEnabled &&
+    (builder.Environment.IsDevelopment() || isTestEnvironment))
+{
+    var operateFixtureHostDefaults =
+        Honua.Server.Features.Admin.OperateFixtures.OperateObservabilityFixtureHostDefaults
+            .CreateMissingDefaults(builder.Configuration);
+    if (operateFixtureHostDefaults.Count > 0)
+    {
+        builder.Configuration.AddInMemoryCollection(operateFixtureHostDefaults);
+    }
+}
 var serveStacOpsDemo = builder.Configuration.GetValue(
     "ServeStacOpsDemo",
     builder.Configuration.GetValue(
@@ -287,8 +314,14 @@ builder.Host.UseSerilog((context, services, config) =>
 // This is the only place where Server directly references Infrastructure
 // Rest of Server code uses only Core abstractions (IFeatureReader/Writer, ITileProvider, IRelationshipStore, IDatabaseHealthChecker)
 // Skip infrastructure registration in test environment by default - WebAppFixture handles it.
-// Standalone Python/JS harnesses can opt back in with HONUA_REGISTER_TEST_INFRASTRUCTURE=true.
-if (!isTestEnvironment || registerInfrastructureInTestEnvironment)
+// Standalone Python/JS harnesses can opt back in with HONUA_REGISTER_TEST_INFRASTRUCTURE=true;
+// a self-migrating standalone Test image that enables the Operate observability fixture also
+// opts in automatically so the seed endpoint's providers resolve (honua-server#2350).
+if (Honua.Server.Startup.TestInfrastructureRegistrationPolicy.ShouldRegisterInfrastructure(
+        isTestEnvironment,
+        registerInfrastructureInTestEnvironment,
+        operateObservabilityFixtureEnabled,
+        hostManagesOwnMigrations))
 {
     InfrastructureCompositionRoot.RegisterInfrastructureServices(builder.Services, builder.Configuration);
 }

--- a/src/Honua.Server/Startup/TestInfrastructureRegistrationPolicy.cs
+++ b/src/Honua.Server/Startup/TestInfrastructureRegistrationPolicy.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Startup;
+
+/// <summary>
+/// Decides whether the data-provider infrastructure composition root
+/// (<see cref="InfrastructureCompositionRoot.RegisterInfrastructureServices"/>) should run in
+/// the Test environment. Production and Development always register it; in Test it is skipped
+/// by default so in-process <c>WebAppFixture</c> hosts can substitute their own isolated
+/// providers without double-registration.
+/// </summary>
+/// <remarks>
+/// Standalone Test images (for example the Docker image the honua-console live lane boots via
+/// Testcontainers) run in the Test environment only to satisfy the Operate observability
+/// fixture validator, but they have no in-process fixture to supply providers. When such an
+/// image exposes the fixture seed endpoint it must register the real providers the seeder
+/// resolves (<c>IAlertAdminStore</c>, <c>IAlertEventStore</c>, <c>IAlertLifecycleStore</c>,
+/// <c>IDatabaseConnectionProvider</c>, and the investigation/audit stores); otherwise
+/// <c>POST /api/v1/admin/dev/fixtures/operate-observability/{profile}</c> throws
+/// "No service for type 'IAlertAdminStore' has been registered." and returns 500
+/// (honua-server#2350).
+/// </remarks>
+internal static class TestInfrastructureRegistrationPolicy
+{
+    /// <summary>
+    /// Determines whether the infrastructure composition root should register the configured
+    /// data provider for the current host.
+    /// </summary>
+    /// <param name="isTestEnvironment">Whether the host runs in the Test environment.</param>
+    /// <param name="explicitTestOptIn">
+    /// Whether <c>HONUA_REGISTER_TEST_INFRASTRUCTURE</c> opted the Test host back in.
+    /// </param>
+    /// <param name="operateObservabilityFixtureEnabled">
+    /// Whether the Operate observability seed fixture endpoint is enabled.
+    /// </param>
+    /// <param name="hostManagesOwnMigrations">
+    /// Whether this host runs its own database migrations. Standalone deployments manage their
+    /// own migrations; in-process WebAppFixture hosts set <c>HONUA_SKIP_MIGRATIONS=true</c> and
+    /// wire their own isolated providers, so they must not trigger this opt-in.
+    /// </param>
+    /// <returns><see langword="true"/> when infrastructure services should be registered.</returns>
+    public static bool ShouldRegisterInfrastructure(
+        bool isTestEnvironment,
+        bool explicitTestOptIn,
+        bool operateObservabilityFixtureEnabled,
+        bool hostManagesOwnMigrations)
+    {
+        if (!isTestEnvironment)
+        {
+            return true;
+        }
+
+        if (explicitTestOptIn)
+        {
+            return true;
+        }
+
+        // A self-migrating standalone Test image that exposes the Operate observability fixture
+        // endpoint needs the real providers the seeder resolves. WebAppFixture hosts skip
+        // migrations and register their own providers, so they are intentionally excluded to
+        // avoid double-registration.
+        return operateObservabilityFixtureEnabled && hostManagesOwnMigrations;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Startup/OperateObservabilityFixtureHostDefaultsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Startup/OperateObservabilityFixtureHostDefaultsTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Honua.Server.Features.Admin.OperateFixtures;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Startup;
+
+/// <summary>
+/// Regression guard for honua-server#2350: a standalone Operate observability fixture host that
+/// supplies no connection-encryption key must receive deterministic Development/Test defaults so
+/// the Postgres secure-connection provider (and therefore the seed endpoint) works. Explicitly
+/// configured values must always win.
+/// </summary>
+public sealed class OperateObservabilityFixtureHostDefaultsTests
+{
+    [Fact]
+    public void CreateMissingDefaults_WhenUnset_SuppliesMasterKeyAndSalt()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var defaults = OperateObservabilityFixtureHostDefaults.CreateMissingDefaults(configuration);
+
+        defaults.Should().ContainKey(OperateObservabilityFixtureHostDefaults.MasterKeyConfigurationPath);
+        defaults.Should().ContainKey(OperateObservabilityFixtureHostDefaults.SaltConfigurationPath);
+        defaults[OperateObservabilityFixtureHostDefaults.MasterKeyConfigurationPath]
+            .Should().NotBeNullOrWhiteSpace();
+        // ConnectionEncryptionService enforces a 32-character minimum on the master key.
+        defaults[OperateObservabilityFixtureHostDefaults.MasterKeyConfigurationPath]!
+            .Length.Should().BeGreaterThanOrEqualTo(32);
+    }
+
+    [Fact]
+    public void CreateMissingDefaults_WhenConfigured_DoesNotOverrideOperatorValues()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [OperateObservabilityFixtureHostDefaults.MasterKeyConfigurationPath] =
+                    "operator-supplied-master-key-value-0001",
+                [OperateObservabilityFixtureHostDefaults.SaltConfigurationPath] =
+                    "b3BlcmF0b3Itc3VwcGxpZWQtc2FsdA==",
+            })
+            .Build();
+
+        var defaults = OperateObservabilityFixtureHostDefaults.CreateMissingDefaults(configuration);
+
+        defaults.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateMissingDefaults_WhenOnlySaltConfigured_SuppliesOnlyMasterKey()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [OperateObservabilityFixtureHostDefaults.SaltConfigurationPath] =
+                    "b3BlcmF0b3Itc3VwcGxpZWQtc2FsdA==",
+            })
+            .Build();
+
+        var defaults = OperateObservabilityFixtureHostDefaults.CreateMissingDefaults(configuration);
+
+        defaults.Should().ContainKey(OperateObservabilityFixtureHostDefaults.MasterKeyConfigurationPath);
+        defaults.Should().NotContainKey(OperateObservabilityFixtureHostDefaults.SaltConfigurationPath);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Startup/TestInfrastructureRegistrationPolicyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Startup/TestInfrastructureRegistrationPolicyTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Startup;
+
+namespace Honua.Server.Tests.Startup;
+
+/// <summary>
+/// Regression guard for honua-server#2350: a standalone Test image (e.g. the honua-console
+/// live lane's Testcontainers server) that enables the Operate observability fixture must
+/// register the real data-provider infrastructure the seeder resolves, otherwise
+/// <c>POST /api/v1/admin/dev/fixtures/operate-observability/{profile}</c> 500s with
+/// "No service for type 'IAlertAdminStore' has been registered.". In-process WebAppFixture
+/// hosts (which skip migrations and wire their own providers) must stay excluded.
+/// </summary>
+public sealed class TestInfrastructureRegistrationPolicyTests
+{
+    [Fact]
+    public void ShouldRegisterInfrastructure_OutsideTestEnvironment_AlwaysRegisters()
+    {
+        TestInfrastructureRegistrationPolicy.ShouldRegisterInfrastructure(
+                isTestEnvironment: false,
+                explicitTestOptIn: false,
+                operateObservabilityFixtureEnabled: false,
+                hostManagesOwnMigrations: false)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ShouldRegisterInfrastructure_TestEnvironmentWithoutOptIn_SkipsForWebAppFixture()
+    {
+        // WebAppFixture host: skips migrations (hostManagesOwnMigrations = false) and wires its
+        // own isolated providers, so the composition root must stay skipped even when the
+        // fixture endpoint is enabled (OperateObservabilityFixtureEndpointsTests scenario).
+        TestInfrastructureRegistrationPolicy.ShouldRegisterInfrastructure(
+                isTestEnvironment: true,
+                explicitTestOptIn: false,
+                operateObservabilityFixtureEnabled: true,
+                hostManagesOwnMigrations: false)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void ShouldRegisterInfrastructure_TestEnvironmentWithExplicitOptIn_Registers()
+    {
+        TestInfrastructureRegistrationPolicy.ShouldRegisterInfrastructure(
+                isTestEnvironment: true,
+                explicitTestOptIn: true,
+                operateObservabilityFixtureEnabled: false,
+                hostManagesOwnMigrations: false)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ShouldRegisterInfrastructure_StandaloneTestImageWithFixtureEnabled_Registers()
+    {
+        // honua-server#2350: standalone Test image that runs its own migrations and enables the
+        // Operate observability fixture must register the providers the seeder depends on.
+        TestInfrastructureRegistrationPolicy.ShouldRegisterInfrastructure(
+                isTestEnvironment: true,
+                explicitTestOptIn: false,
+                operateObservabilityFixtureEnabled: true,
+                hostManagesOwnMigrations: true)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void ShouldRegisterInfrastructure_TestImageWithoutFixture_Skips()
+    {
+        TestInfrastructureRegistrationPolicy.ShouldRegisterInfrastructure(
+                isTestEnvironment: true,
+                explicitTestOptIn: false,
+                operateObservabilityFixtureEnabled: false,
+                hostManagesOwnMigrations: true)
+            .Should()
+            .BeFalse();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2350

## Summary
`POST /api/v1/admin/dev/fixtures/operate-observability/{profile}` returned **500** on the
nightly image, failing `Native.Core OperateObservabilityTestcontainersTests` and blocking the
honua-console nightly **live** lane before the Studio suite could run (preventing promotion to a
required check).

Root cause: the honua-console live lane boots the server image in the **Test** environment
(required so the fixture validator permits enabling it) with only a database connection string
and the fixture flags. In Test, the infrastructure composition root is skipped by default so
in-process `WebAppFixture` hosts can substitute their own providers — which left the seeder's
`IAlertAdminStore` / `IAlertEventStore` / `IDatabaseConnectionProvider` unregistered, so
`GetRequiredService<IAlertAdminStore>()` threw → 500. Once infrastructure is registered, the
Postgres secure-connection provider additionally needs a connection-encryption master key the
harness never supplies (the same one `WebAppFixture` injects).

The fix makes a standalone, self-migrating fixture host self-sufficient in Development/Test only
(never Production — the fixture validator forbids it there).

## Changes Made
- Register the data-provider infrastructure in the Test environment when the Operate observability
  fixture is enabled on a self-migrating standalone host; in-process `WebAppFixture` hosts skip
  migrations and wire their own providers, so they stay excluded (no double registration). Decision
  extracted to `TestInfrastructureRegistrationPolicy` (unit-tested).
- Supply deterministic Development/Test-only connection-encryption master key + salt defaults when
  the fixture is enabled and they are not already configured (`OperateObservabilityFixtureHostDefaults`);
  any explicit operator / `WebAppFixture` value always wins.
- Add unit regression tests for the registration policy and the host defaults.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Manual: reproduced the 500 on `ghcr.io/honua-io/honua-server:nightly` with the exact console-lane
env, then confirmed the fix's resulting state seeds cleanly — `POST .../operate-observability/console-testcontainers-v1`
returns **200** with `sourceHydrated:true`, and every Console-asserted surface (observability alerts,
jobs, events, alert zones, investigation) returns 200 with the seeded data. Existing
`OperateObservabilityFixtureEndpointsTests` (WebAppFixture path) still pass (7/7); new unit tests 8/8.
Release build with `TreatWarningsAsErrors=true` and `dotnet format --verify-no-changes` are clean.

## Gate Impact
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

<sub>Note: rides the merge train.</sub>
