### PR TITLE
feat: shared capability gate endpoint filter (#2341)

### DIFF
--- a/src/Honua.Hosting/Features/Capabilities/CapabilityGateEndpointFilter.cs
+++ b/src/Honua.Hosting/Features/Capabilities/CapabilityGateEndpointFilter.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Capabilities;
+using Honua.Infrastructure.Models;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Capabilities;
+
+/// <summary>
+/// Shared endpoint filter that gates a route (or route group) on a single
+/// capability descriptor from the unified capability registry (ADR-0058,
+/// Track T5 / #2341). It reads the gated descriptor id from the
+/// <see cref="CapabilityGateMetadata"/> attached by <c>WithCapabilityGate</c>,
+/// resolves it through <see cref="ICapabilityRegistry"/> with the config-driven
+/// experimental precedence (#2339 / T2), and short-circuits the request when the
+/// capability resolves <b>experimental-disabled</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The filter only short-circuits the <see cref="CapabilityReasonCodes.ExperimentalDisabled"/>
+/// outcome — an off-by-default experimental capability whose flag is not set. In
+/// that case it returns <c>404 Not Found</c> as <c>application/problem+json</c>
+/// with <c>type: honua:capability-experimental-disabled</c> and a hint to enable
+/// the capability via <c>Capabilities:Experimental:{id}</c>, so a disabled
+/// experimental surface is indistinguishable from an unmapped route.
+/// </para>
+/// <para>
+/// Every other resolution passes through to the endpoint: an enabled capability,
+/// an unregistered id, and — deliberately — the flag-on-but-wrong-edition
+/// (<see cref="CapabilityReasonCodes.LicenseRequired"/>) outcome, which the
+/// existing entitlement gate continues to surface as <c>402 Payment Required</c>.
+/// This filter does not change that path.
+/// </para>
+/// <para>
+/// It mirrors the <c>ETagEndpointFilter</c> registration shape — added via
+/// <c>AddEndpointFilter&lt;T&gt;</c> and activated from DI — so it is applied at
+/// the group level exactly like the other endpoint filters.
+/// </para>
+/// </remarks>
+internal sealed partial class CapabilityGateEndpointFilter : IEndpointFilter
+{
+    /// <summary>The problem <c>type</c> emitted for an experimental-disabled capability.</summary>
+    internal const string ExperimentalDisabledProblemType = "honua:capability-experimental-disabled";
+
+    private readonly ICapabilityRegistry _registry;
+    private readonly IOptions<CapabilityFlagOptions> _flags;
+    private readonly ILogger<CapabilityGateEndpointFilter> _logger;
+
+    /// <summary>
+    /// Creates the capability gate filter.
+    /// </summary>
+    /// <param name="registry">The unified capability registry to resolve against.</param>
+    /// <param name="flags">The config-bound experimental feature-flag switches.</param>
+    /// <param name="logger">The logger instance.</param>
+    public CapabilityGateEndpointFilter(
+        ICapabilityRegistry registry,
+        IOptions<CapabilityFlagOptions> flags,
+        ILogger<CapabilityGateEndpointFilter> logger)
+    {
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        _flags = flags ?? throw new ArgumentNullException(nameof(flags));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var httpContext = context.HttpContext;
+
+        // The gated descriptor id travels on endpoint metadata (added alongside the
+        // filter by WithCapabilityGate). With no marker the filter is inert.
+        var gate = httpContext.GetEndpoint()?.Metadata.GetMetadata<CapabilityGateMetadata>();
+        if (gate is null)
+        {
+            return next(context);
+        }
+
+        var gateContext = new CapabilityGateContext
+        {
+            ExperimentalFlags = _flags.Value,
+        };
+
+        var resolution = _registry.Resolve(gate.DescriptorId, gateContext);
+
+        // Only the experimental-disabled outcome is a short-circuit here. Enabled and
+        // unregistered fall through; the wrong-edition (license-required) outcome is
+        // intentionally left to the existing 402 entitlement path.
+        if (!resolution.Enabled &&
+            string.Equals(resolution.ReasonCode, CapabilityReasonCodes.ExperimentalDisabled, StringComparison.Ordinal))
+        {
+            Log.ExperimentalDisabled(_logger, gate.DescriptorId, httpContext.Request.Path);
+            return ValueTask.FromResult<object?>(CreateExperimentalDisabledProblem(httpContext, gate.DescriptorId));
+        }
+
+        return next(context);
+    }
+
+    private static IResult CreateExperimentalDisabledProblem(HttpContext httpContext, string descriptorId)
+    {
+        var detail =
+            $"The '{descriptorId}' capability is experimental and disabled. " +
+            $"Enable it via the configuration key 'Capabilities:Experimental:{descriptorId}:Enabled=true' " +
+            "(or the global switch 'Capabilities:Experimental:Enabled=true').";
+
+        return ProblemDetailsHelpers.CreateProblem(
+            httpContext,
+            ExperimentalDisabledProblemType,
+            StatusCodes.Status404NotFound,
+            ProblemDetailsHelpers.GetTitle(StatusCodes.Status404NotFound),
+            detail);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 4110, Level = LogLevel.Debug,
+            Message = "Capability gate short-circuited {DescriptorId} at {Path}: experimental-disabled")]
+        public static partial void ExperimentalDisabled(ILogger logger, string descriptorId, string path);
+    }
+}

--- a/src/Honua.Hosting/Features/Capabilities/CapabilityGateExtensions.cs
+++ b/src/Honua.Hosting/Features/Capabilities/CapabilityGateExtensions.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Capabilities;
+
+/// <summary>
+/// Extension methods for gating endpoints on a capability descriptor from the
+/// unified capability registry (ADR-0058, Track T5 / #2341). They attach the
+/// <see cref="CapabilityGateMetadata"/> marker plus the shared
+/// <see cref="CapabilityGateEndpointFilter"/>, mirroring the <c>WithETag</c>
+/// pattern in <c>ETagExtensions</c>.
+/// </summary>
+/// <remarks>
+/// Apply the gate at the <b>group</b> level so every endpoint in the group is
+/// covered by one filter registration:
+/// <code>
+/// var group = app.MapGroup("/some/feature").WithCapabilityGate("some.capability");
+/// </code>
+/// When the gated capability resolves experimental-disabled, the filter
+/// short-circuits with <c>404</c>; every other outcome (enabled, unregistered,
+/// or wrong-edition) passes through to the endpoint and its existing gates.
+/// </remarks>
+internal static class CapabilityGateExtensions
+{
+    /// <summary>
+    /// Gates every endpoint in a route group on the given capability descriptor.
+    /// </summary>
+    /// <param name="builder">The route group builder.</param>
+    /// <param name="descriptorId">
+    /// The stable <c>CapabilityDescriptor.Id</c> to gate on (for example
+    /// <c>temporal.filtering</c>).
+    /// </param>
+    /// <returns>The route group builder for chaining.</returns>
+    internal static RouteGroupBuilder WithCapabilityGate(this RouteGroupBuilder builder, string descriptorId)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(descriptorId);
+
+        builder.WithMetadata(new CapabilityGateMetadata(descriptorId));
+        builder.AddEndpointFilter<CapabilityGateEndpointFilter>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Gates a single endpoint on the given capability descriptor.
+    /// </summary>
+    /// <param name="builder">The route handler builder.</param>
+    /// <param name="descriptorId">
+    /// The stable <c>CapabilityDescriptor.Id</c> to gate on (for example
+    /// <c>temporal.filtering</c>).
+    /// </param>
+    /// <returns>The route handler builder for chaining.</returns>
+    internal static RouteHandlerBuilder WithCapabilityGate(this RouteHandlerBuilder builder, string descriptorId)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(descriptorId);
+
+        builder.WithMetadata(new CapabilityGateMetadata(descriptorId));
+        builder.AddEndpointFilter<CapabilityGateEndpointFilter>();
+        return builder;
+    }
+}

--- a/src/Honua.Hosting/Features/Capabilities/CapabilityGateMetadata.cs
+++ b/src/Honua.Hosting/Features/Capabilities/CapabilityGateMetadata.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Capabilities;
+
+/// <summary>
+/// Endpoint metadata that marks a route (or route group) as gated by a single
+/// capability descriptor from the unified capability registry (ADR-0058). It
+/// carries the <see cref="DescriptorId"/> the <see cref="CapabilityGateEndpointFilter"/>
+/// resolves at request time, and is attached by the
+/// <c>WithCapabilityGate(descriptorId)</c> extension (Track T5, #2341).
+/// </summary>
+/// <remarks>
+/// The marker is added as endpoint metadata (in addition to the filter) so the
+/// gated descriptor is discoverable by other conventions — OpenAPI/description
+/// surfaces and diagnostics can see which capability guards an endpoint without
+/// reaching into the filter. It mirrors the way the ETag filter is attached to
+/// endpoints in <c>ETagExtensions</c>.
+/// </remarks>
+internal sealed class CapabilityGateMetadata
+{
+    /// <summary>
+    /// Creates metadata gating an endpoint on the given capability descriptor.
+    /// </summary>
+    /// <param name="descriptorId">
+    /// The stable <c>CapabilityDescriptor.Id</c> this endpoint is gated on (for
+    /// example <c>temporal.filtering</c>).
+    /// </param>
+    public CapabilityGateMetadata(string descriptorId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(descriptorId);
+        DescriptorId = descriptorId;
+    }
+
+    /// <summary>
+    /// The stable capability-descriptor id the endpoint is gated on. The filter
+    /// resolves this id against the <c>ICapabilityRegistry</c> and short-circuits
+    /// the request when the capability resolves experimental-disabled.
+    /// </summary>
+    public string DescriptorId { get; }
+}

--- a/src/Honua.Server/Features/Admin/MetadataReleaseOperationEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/MetadataReleaseOperationEndpoints.cs
@@ -5,6 +5,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Server.Features.Admin.Models;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.ControlPlane;
 using Honua.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -21,6 +22,12 @@ internal static class MetadataReleaseOperationEndpoints
     public static void MapMetadataReleaseOperationEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/metadata/releases")
+            // T5 (#2341): representative group-level capability gate wiring. The
+            // shared CapabilityGateEndpointFilter short-circuits with 404 when the
+            // gated descriptor resolves experimental-disabled; publication.metadata-release
+            // is Implemented today, so this is behaviour-neutral. Attaching the gate to
+            // the deferred-feature groups is deferred to T10 (#2346).
+            .WithCapabilityGate("publication.metadata-release")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Metadata")

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
@@ -15,6 +15,10 @@ internal static class CapabilityManifestServiceCollectionExtensions
         // #2339 (T2): bind the experimental feature-flag options so the manifest
         // snapshot can carry them. T4 (#2340) is where the manifest acts on them.
         services.AddCapabilityFlagOptions(configuration);
+        // #2341 (T5): the unified capability registry (ADR-0058) is the single
+        // source of truth the shared CapabilityGateEndpointFilter resolves against.
+        // Register it here so the gate filter can resolve ICapabilityRegistry from DI.
+        services.AddCapabilityRegistry();
         services.AddSingleton<CapabilityManifestOptionsSnapshot>();
         services.AddScoped<ICapabilityManifestService, CapabilityManifestService>();
         return services;

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityGateEndpointFilterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityGateEndpointFilterTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Capabilities;
+using Honua.Infrastructure.Capabilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Server.Tests.Features.Capabilities;
+
+/// <summary>
+/// Component coverage for the shared <see cref="CapabilityGateEndpointFilter"/>
+/// (Track T5 / #2341): a group-level gate that short-circuits with 404
+/// <c>application/problem+json</c> when its capability descriptor resolves
+/// experimental-disabled, and passes through when the experimental flag is on.
+/// </summary>
+public sealed class CapabilityGateEndpointFilterTests
+{
+    private const string GatedDescriptorId = "test.experimental.capability";
+
+    private static readonly CapabilityDescriptor ExperimentalDescriptor = new()
+    {
+        Id = GatedDescriptorId,
+        Category = "test",
+        Kind = CapabilityKind.Feature,
+        Maturity = CapabilityMaturity.Experimental,
+    };
+
+    [Fact]
+    public async Task GatedEndpoint_WhenExperimentalDisabled_Returns404ProblemJson()
+    {
+        using var server = BuildServer(experimentalEnabled: false);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(new Uri("/gated/ping", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var problem = JsonSerializer.Deserialize<JsonElement>(content);
+
+        problem.GetProperty("type").GetString()
+            .Should().Be(CapabilityGateEndpointFilter.ExperimentalDisabledProblemType);
+        problem.GetProperty("status").GetInt32().Should().Be(StatusCodes.Status404NotFound);
+        problem.GetProperty("detail").GetString()
+            .Should().Contain($"Capabilities:Experimental:{GatedDescriptorId}");
+    }
+
+    [Fact]
+    public async Task GatedEndpoint_WhenExperimentalEnabled_Returns200()
+    {
+        using var server = BuildServer(experimentalEnabled: true);
+        using var client = server.CreateClient();
+
+        var response = await client.GetAsync(new Uri("/gated/ping", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("pong");
+    }
+
+    private static TestServer BuildServer(bool experimentalEnabled)
+    {
+        var builder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddLogging();
+                        services.AddRouting();
+                        services.AddSingleton<ICapabilityRegistry>(
+                            new StubCapabilityRegistry(ExperimentalDescriptor));
+                        services.AddOptions<CapabilityFlagOptions>()
+                            .Configure(options => options.Enabled = experimentalEnabled);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            var group = endpoints.MapGroup("/gated")
+                                .WithCapabilityGate(GatedDescriptorId);
+                            group.MapGet("/ping", () => Results.Ok("pong"));
+                        });
+                    });
+            });
+
+        var host = builder.Build();
+        host.Start();
+        return host.GetTestServer();
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ICapabilityRegistry"/> that exposes a single experimental
+    /// descriptor and defers resolution to the shared
+    /// <see cref="CapabilityGateResolver"/>, mirroring the production registry.
+    /// </summary>
+    private sealed class StubCapabilityRegistry : ICapabilityRegistry
+    {
+        private readonly CapabilityDescriptor _descriptor;
+
+        public StubCapabilityRegistry(CapabilityDescriptor descriptor) => _descriptor = descriptor;
+
+        public IReadOnlyList<CapabilityDescriptor> All => [_descriptor];
+
+        public CapabilityDescriptor? Find(string id)
+            => string.Equals(id, _descriptor.Id, StringComparison.Ordinal) ? _descriptor : null;
+
+        public CapabilityResolution Resolve(string id, CapabilityGateContext context)
+            => CapabilityGateResolver.Resolve(Find(id), context);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2341

## Summary
Delivers Track T5: a shared, reusable group-level capability gate that builds on the T2 config-driven experimental resolver (#2357). When a gated capability descriptor resolves experimental-disabled, the filter short-circuits the request with `404 application/problem+json` (`type: honua:capability-experimental-disabled`) so a disabled experimental surface is indistinguishable from an unmapped route. The licensed-but-wrong-edition path is intentionally left to the existing `402` entitlement gate — this PR does not change it. Per T5's scope, the reusable filter/metadata/extension plus one representative wiring land here; attaching the gate to the deferred-feature groups is T10's (#2346) flip concern.

## Changes Made
- Add `CapabilityGateEndpointFilter` (Honua.Hosting) that reads the gated descriptor id from endpoint metadata, resolves it via `ICapabilityRegistry` with the experimental precedence, and returns 404 problem+json (with a hint to enable via `Capabilities:Experimental:{id}`) only for the experimental-disabled outcome; enabled/unregistered/wrong-edition all pass through.
- Add `CapabilityGateMetadata` marker and `WithCapabilityGate(descriptorId)` extensions for `RouteGroupBuilder` and `RouteHandlerBuilder`, mirroring the `WithETag`/`AddEndpointFilter` pattern in `ETagExtensions`.
- Register `ICapabilityRegistry` in DI at the capability composition point so the gate filter can resolve it.
- Add one representative group-level wiring on the admin metadata-releases group (behaviour-neutral: the `publication.metadata-release` descriptor is Implemented today).
- Add TestServer-based tests: gated endpoint returns 404 when experimental-disabled and 200 when the experimental flag is enabled.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

> Note: the shared build/test lock was saturated, so the full Release build and test suite were not run locally; `dotnet format` was run on the changed files and reports no changes. CI validates the build/tests.
