### PR TITLE
feat: bind /mcp catalog to the capability registry (#2334)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/CapabilityRegistryBindingOptions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/CapabilityRegistryBindingOptions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Options that bind the served <c>/mcp</c> catalog to the unified capability
+/// registry (ADR-0058, Decision B / honua-server B2 #2334). Bound from the
+/// <c>Capabilities</c> configuration section.
+/// </summary>
+public sealed class CapabilityRegistryBindingOptions
+{
+    /// <summary>The configuration section these options bind from.</summary>
+    public const string SectionName = "Capabilities";
+
+    /// <summary>
+    /// When <c>true</c> (the default, and on in CI), the host runs a startup
+    /// composition conformance check that fails fast if the served <c>/mcp</c>
+    /// tool/resource catalog contains an entry the
+    /// <see cref="Honua.Core.Features.Capabilities.ICapabilityRegistry"/> does not
+    /// describe. Set <c>Capabilities:RegistryBinding=false</c> to disable the gate,
+    /// for example a bespoke host that intentionally serves a surface the shared
+    /// registry does not yet mirror.
+    /// </summary>
+    public bool RegistryBinding { get; set; } = true;
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/CapabilityManifestEmitter.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/CapabilityManifestEmitter.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Honua.Core.Features.Capabilities;
 
 namespace Honua.Ai.Protocols.Mcp.Discovery;
 
@@ -135,33 +136,22 @@ internal static class CapabilityManifestEmitter
     public const string ImplementationName = "Honua /mcp";
 
     /// <summary>
-    /// The advertised tool projection: <c>advertisedName -&gt; (standardName,
-    /// workflowFamily)</c>. Title-cased workflow families mirror the live
-    /// <see cref="McpTelemetry.WorkflowFamily"/> telemetry tags.
+    /// The unified capability registry (ADR-0058, Decision B) is the single source
+    /// of truth for the <c>/mcp</c> tool roster. B2 (#2334) re-points this emitter
+    /// to project its advertised tools from the registry rather than a
+    /// hand-maintained list, so the emitted manifest cannot drift from the registry
+    /// the live surface is bound to.
     /// </summary>
-    public static IReadOnlyList<CapabilityManifestTool> Tools { get; } =
-    [
-        Tool("honua_plan_analysis", "plan_analysis", "Planning"),
-        Tool("honua_ground_candidates", "ground_candidates", "Planning"),
-        Tool("honua_clarify_intent", "clarify_intent", "Planning"),
-        Tool("honua_validate_plan", "validate_plan", "Planning"),
-        Tool("honua_dry_run_plan", "validate_plan", "Planning"),
-        Tool("honua_execute_plan", "execute_plan", "Execution"),
-        Tool("honua_cancel_job", "cancel_job", "Lifecycle"),
-        Tool("honua_propose_operation", "propose_operation", "Lifecycle"),
-        Tool("honua_publish_service", "publish_service", "Lifecycle"),
-        Tool("honua_create_map_package", "create_map_package", "Execution"),
-        Tool("honua_create_app_package", "create_app_package", "Execution"),
-        Tool("honua_validate_package", "validate_package", "Planning"),
-        Tool("honua_preview_package", "preview_package", "Planning"),
-        Tool("honua_geocode_address", "geocode_address", "Execution"),
-        Tool("honua_solve_route", "solve_route", "Execution"),
-        Tool("honua_list_layers", "list_layers", "Results"),
-        Tool("honua_query_features", "query_features", "Results"),
-        Tool("honua_render_map", "render_map", "Results"),
-        Tool("honua_resolve_entity", "resolve_entity", "Results"),
-        Tool("honua_list_capabilities", "list_capabilities", "Results"),
-    ];
+    private static readonly ICapabilityRegistry Registry = new CapabilityRegistry();
+
+    /// <summary>
+    /// The advertised tool projection: <c>advertisedName -&gt; (standardName,
+    /// workflowFamily)</c>, projected from the capability registry's <c>/mcp</c>
+    /// tool descriptors. Title-cased workflow families mirror the live
+    /// <see cref="McpTelemetry.WorkflowFamily"/> telemetry tags (the registry stores
+    /// the lower-cased family in <see cref="CapabilityDescriptor.Category"/>).
+    /// </summary>
+    public static IReadOnlyList<CapabilityManifestTool> Tools { get; } = BuildTools(Registry);
 
     /// <summary>
     /// The served resource-family projection keyed by the live
@@ -218,6 +208,25 @@ internal static class CapabilityManifestEmitter
             CapabilityManifestJsonContext.Default.CapabilityManifest);
         return json + "\n";
     }
+
+    /// <summary>
+    /// Projects the advertised-tool manifest entries from the capability registry's
+    /// <c>/mcp</c> tool descriptors (those that carry an
+    /// <see cref="CapabilityDescriptor.McpToolName"/>). This is the provenance move
+    /// in ADR-0058 B2 (#2334): the tool roster is the registry's, not a local list.
+    /// </summary>
+    /// <param name="registry">The capability registry to project the roster from.</param>
+    internal static IReadOnlyList<CapabilityManifestTool> BuildTools(ICapabilityRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        return registry.All
+            .Where(d => d.McpToolName is not null)
+            .Select(d => Tool(d.McpToolName!, d.StandardName ?? d.McpToolName!, TitleCase(d.Category)))
+            .ToList();
+    }
+
+    private static string TitleCase(string value) =>
+        string.IsNullOrEmpty(value) ? value : char.ToUpperInvariant(value[0]) + value[1..];
 
     private static CapabilityManifestTool Tool(string advertisedName, string standardName, string workflowFamily) =>
         new()

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ListCapabilitiesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ListCapabilitiesTool.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Capabilities;
 using Honua.Geoprocessing;
 using Honua.Ai.Protocols.Mcp.Models;
 using Honua.Ai.Protocols.Mcp.Tools;
@@ -92,12 +93,19 @@ internal sealed class ListCapabilitiesTool : IMcpTool
         var surface = httpContext.RequestServices.GetService<McpOperatorSurface>();
         if (surface is not null)
         {
-            output.Tools = BuildToolManifest(surface);
+            // The unified capability registry (ADR-0058 B2, #2334) is the source of
+            // truth for the /mcp catalog roster: when present it governs which
+            // tools/resources are advertised, while the live handlers still supply
+            // the LLM-grade descriptions and read/write hints the wire carries. A
+            // lightweight host that did not register the registry falls back to the
+            // live surface unchanged.
+            var registry = httpContext.RequestServices.GetService<ICapabilityRegistry>();
+            output.Tools = BuildToolManifest(surface, registry);
             output.ToolCount = output.Tools.Count;
 
             if (includeResources || includeGroundingResources)
             {
-                var resources = BuildResourceManifest(surface);
+                var resources = BuildResourceManifest(surface, registry);
 
                 if (includeResources)
                 {
@@ -118,11 +126,29 @@ internal sealed class ListCapabilitiesTool : IMcpTool
         return McpToolHelpers.SuccessResult(output, DiscoveryJsonContext.Default.McpListCapabilitiesOutput);
     }
 
-    private static List<McpCapabilityTool> BuildToolManifest(McpOperatorSurface surface)
+    private static List<McpCapabilityTool> BuildToolManifest(
+        McpOperatorSurface surface,
+        ICapabilityRegistry? registry)
     {
+        var registryToolNames = registry is null
+            ? null
+            : registry.All
+                .Where(d => d.McpToolName is not null)
+                .Select(d => d.McpToolName!)
+                .ToHashSet(StringComparer.Ordinal);
+
         var tools = new List<McpCapabilityTool>();
         foreach (var tool in surface.ToolHandlers)
         {
+            // Only advertise tools with capability-registry provenance. The startup
+            // composition check (Capabilities:RegistryBinding) fails fast if the
+            // served surface ever contains a tool the registry does not describe,
+            // so in a conformant host this filter drops nothing.
+            if (registryToolNames is not null && !registryToolNames.Contains(tool.Name))
+            {
+                continue;
+            }
+
             var descriptor = tool.Describe();
             tools.Add(new McpCapabilityTool
             {
@@ -138,11 +164,28 @@ internal sealed class ListCapabilitiesTool : IMcpTool
         return tools;
     }
 
-    private static List<McpCapabilityResource> BuildResourceManifest(McpOperatorSurface surface)
+    private static List<McpCapabilityResource> BuildResourceManifest(
+        McpOperatorSurface surface,
+        ICapabilityRegistry? registry)
     {
+        var registryFamilies = registry is null
+            ? null
+            : registry.All
+                .Where(d => d.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal))
+                .Select(d => d.Id[CapabilityRegistry.McpResourceIdPrefix.Length..])
+                .ToHashSet(StringComparer.Ordinal);
+
         var resources = new List<McpCapabilityResource>();
         foreach (var resource in surface.Resources)
         {
+            // Only advertise resource families with capability-registry provenance
+            // (see BuildToolManifest); the registry-binding startup check guarantees
+            // the served families are a subset of the registry roster.
+            if (registryFamilies is not null && !registryFamilies.Contains(resource.Family))
+            {
+                continue;
+            }
+
             foreach (var descriptor in resource.Describe())
             {
                 resources.Add(new McpCapabilityResource

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryBindingStartupCheck.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryBindingStartupCheck.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Capabilities;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Startup composition conformance check (ADR-0058 B2, honua-server#2334): when
+/// <see cref="CapabilityRegistryBindingOptions.RegistryBinding"/> is enabled
+/// (the default, and on in CI), it asserts at host start that the served
+/// <c>/mcp</c> catalog is bound to the <see cref="ICapabilityRegistry"/> — no tool
+/// or resource is served without a registry descriptor — and fails fast otherwise
+/// so drift surfaces in CI rather than as a silent contract divergence.
+/// </summary>
+internal sealed class McpRegistryBindingStartupCheck : IHostedService
+{
+    private readonly McpOperatorSurface _surface;
+    private readonly ICapabilityRegistry _registry;
+    private readonly CapabilityRegistryBindingOptions _options;
+
+    public McpRegistryBindingStartupCheck(
+        McpOperatorSurface surface,
+        ICapabilityRegistry registry,
+        IOptions<CapabilityRegistryBindingOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _surface = surface;
+        _registry = registry;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.RegistryBinding)
+        {
+            return Task.CompletedTask;
+        }
+
+        var drift = McpRegistryCompositionValidator.FindDrift(_surface, _registry);
+        if (drift.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "The served /mcp catalog is not bound to the capability registry "
+                + "(ADR-0058 B2, honua-server#2334). Reconcile the roster, or disable "
+                + "the gate with Capabilities:RegistryBinding=false: "
+                + string.Join("; ", drift) + ".");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryCompositionValidator.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryCompositionValidator.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Capabilities;
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Composition conformance check for the unified capability registry
+/// (ADR-0058, Decision B / honua-server B2 #2334). It verifies the served
+/// <c>/mcp</c> catalog is bound to the registry: every advertised tool name and
+/// every advertised resource URI (concrete or template) must be described by a
+/// <see cref="CapabilityDescriptor"/> in the <see cref="ICapabilityRegistry"/> —
+/// no tool or resource is served without registry provenance.
+/// </summary>
+/// <remarks>
+/// This is the "nothing served without a registry descriptor" direction, which
+/// holds for any host regardless of which optional tools it wired. The reverse —
+/// every registry descriptor is served — is environment dependent (geocoding,
+/// routing, Metadata v2, and the promotion resources are conditionally composed),
+/// so it is asserted against the full roster in the unit tests
+/// (<c>CapabilityRegistryConformanceTests</c>) rather than at runtime.
+/// </remarks>
+internal static class McpRegistryCompositionValidator
+{
+    /// <summary>
+    /// Returns the drift between the served <paramref name="surface"/> catalog and
+    /// the <paramref name="registry"/> roster: one human-readable message per
+    /// served tool/resource that has no registry descriptor. An empty list means
+    /// the served catalog is fully bound to the registry.
+    /// </summary>
+    /// <param name="surface">The live MCP operator surface (the served catalog).</param>
+    /// <param name="registry">The unified capability registry (source of truth).</param>
+    public static IReadOnlyList<string> FindDrift(McpOperatorSurface surface, ICapabilityRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentNullException.ThrowIfNull(registry);
+
+        var problems = new List<string>();
+
+        var registryToolNames = registry.All
+            .Where(d => d.McpToolName is not null)
+            .Select(d => d.McpToolName!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var tool in surface.ToolHandlers)
+        {
+            if (!registryToolNames.Contains(tool.Name))
+            {
+                problems.Add(
+                    $"served /mcp tool '{tool.Name}' has no capability-registry descriptor");
+            }
+        }
+
+        var registryResourceUris = registry.All
+            .Where(d => d.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal))
+            .SelectMany(d => d.ResourceUriTemplates)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var resource in surface.Resources)
+        {
+            foreach (var descriptor in resource.Describe())
+            {
+                if (!registryResourceUris.Contains(descriptor.Uri))
+                {
+                    problems.Add(
+                        $"served /mcp resource '{descriptor.Uri}' (family '{resource.Family}') "
+                        + "has no capability-registry descriptor");
+                }
+            }
+
+            foreach (var template in resource.DescribeTemplates())
+            {
+                if (!registryResourceUris.Contains(template.UriTemplate))
+                {
+                    problems.Add(
+                        $"served /mcp resource template '{template.UriTemplate}' "
+                        + $"(family '{resource.Family}') has no capability-registry descriptor");
+                }
+            }
+        }
+
+        return problems;
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -7,6 +7,8 @@ using Honua.Ai.Grounding;
 using Honua.Ai.Protocols.Mcp.Resources;
 using Honua.Ai.Protocols.Mcp.Tools;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Honua.Core.Features.Capabilities;
 using Honua.Core.Features.Reporting.Abstractions;
 
 namespace Honua.Ai.Protocols.Mcp;
@@ -174,6 +176,18 @@ internal static class McpServiceCollectionExtensions
         // the job. Both are process-wide singletons.
         services.TryAddSingleton<IMcpNotificationPublisher, McpNotificationPublisher>();
         services.TryAddSingleton<McpJobProgressBridge>();
+
+        // ADR-0058 B2 (#2334): bind the served /mcp catalog to the unified
+        // capability registry as its single source of truth. The registry is the
+        // provenance the honua_list_capabilities projection and the geospatial-mcp
+        // manifest emitter read; the startup composition check
+        // (Capabilities:RegistryBinding, default on) fails fast if the served
+        // surface ever diverges from the registry roster.
+        services.AddCapabilityRegistry();
+        services.AddOptions<CapabilityRegistryBindingOptions>()
+            .Bind(configuration.GetSection(CapabilityRegistryBindingOptions.SectionName));
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, McpRegistryBindingStartupCheck>());
 
         return services;
     }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpRegistryCompositionTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpRegistryCompositionTests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Discovery;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Resources;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.Core.Features.Capabilities;
+using Honua.Geoprocessing;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Ai.Tests.Capabilities;
+
+/// <summary>
+/// Composition conformance for ADR-0058 B2 (#2334): the served <c>/mcp</c> catalog
+/// must be bound to the unified capability registry — no tool or resource is served
+/// without a registry descriptor — and the geospatial-mcp manifest emitter must
+/// project its tool roster from the registry rather than a hand-maintained list.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class McpRegistryCompositionTests
+{
+    private static readonly CapabilityRegistry Registry = new();
+
+    [UnitTest]
+    public void ConformantServedSurface_IsBoundToRegistry_NoDrift()
+    {
+        // A real (registry-backed) served surface: every advertised tool name and
+        // resource URI has a registry descriptor, so the composition check is clean.
+        var surface = BuildConformantSurface();
+
+        McpRegistryCompositionValidator.FindDrift(surface, Registry).Should().BeEmpty(
+            "every served /mcp tool and resource URI must have a capability-registry descriptor");
+    }
+
+    [UnitTest]
+    public void ServedToolsAndResourceFamilies_AreASubsetOfTheRegistryRoster()
+    {
+        var surface = BuildConformantSurface();
+
+        var registryToolNames = Registry.All
+            .Where(d => d.McpToolName is not null)
+            .Select(d => d.McpToolName!)
+            .ToHashSet(StringComparer.Ordinal);
+        surface.ToolHandlers.Select(t => t.Name)
+            .Should().OnlyContain(n => registryToolNames.Contains(n),
+                "no served /mcp tool may exist without a registry descriptor");
+
+        var registryFamilies = Registry.All
+            .Where(d => d.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal))
+            .Select(d => d.Id[CapabilityRegistry.McpResourceIdPrefix.Length..])
+            .ToHashSet(StringComparer.Ordinal);
+        surface.Resources.Select(r => r.Family)
+            .Should().OnlyContain(f => registryFamilies.Contains(f),
+                "no served /mcp resource family may exist without a registry descriptor");
+    }
+
+    [UnitTest]
+    public void OrphanTool_WithoutRegistryDescriptor_IsDetectedAsDrift()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        var surface = new McpOperatorSurface(
+            [
+                new ListCapabilitiesTool(jobService, NullLogger<ListCapabilitiesTool>.Instance),
+                new StubOrphanTool(),
+            ],
+            [],
+            NullLogger<McpOperatorSurface>.Instance);
+
+        McpRegistryCompositionValidator.FindDrift(surface, Registry)
+            .Should().ContainSingle()
+            .Which.Should().Contain(StubOrphanTool.OrphanName);
+    }
+
+    [UnitTest]
+    public void OrphanResource_WithoutRegistryDescriptor_IsDetectedAsDrift()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        var surface = new McpOperatorSurface(
+            [new ListCapabilitiesTool(jobService, NullLogger<ListCapabilitiesTool>.Instance)],
+            [new StubOrphanResource()],
+            NullLogger<McpOperatorSurface>.Instance);
+
+        McpRegistryCompositionValidator.FindDrift(surface, Registry)
+            .Should().ContainSingle()
+            .Which.Should().Contain(StubOrphanResource.OrphanUriTemplate);
+    }
+
+    [UnitTest]
+    public async Task StartupCheck_Throws_OnDrift_WhenRegistryBindingEnabled()
+    {
+        var check = new McpRegistryBindingStartupCheck(
+            new McpOperatorSurface([new StubOrphanTool()], [], NullLogger<McpOperatorSurface>.Instance),
+            Registry,
+            Options.Create(new CapabilityRegistryBindingOptions { RegistryBinding = true }));
+
+        var act = () => check.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not bound to the capability registry*");
+    }
+
+    [UnitTest]
+    public async Task StartupCheck_Skips_WhenRegistryBindingDisabled()
+    {
+        var check = new McpRegistryBindingStartupCheck(
+            new McpOperatorSurface([new StubOrphanTool()], [], NullLogger<McpOperatorSurface>.Instance),
+            Registry,
+            Options.Create(new CapabilityRegistryBindingOptions { RegistryBinding = false }));
+
+        // With the gate off, the drifted surface must not fail startup.
+        await check.StartAsync(CancellationToken.None);
+    }
+
+    [UnitTest]
+    public void EmitterTools_AreProjectedFromRegistry_AndTitleCaseTheWorkflowFamily()
+    {
+        // The emitter's advertised-tool roster is exactly the registry's /mcp tool
+        // set (both directions), with the workflow family title-cased from the
+        // registry Category — proving the manifest catalog cannot drift from the
+        // registry.
+        var registryTools = Registry.All
+            .Where(d => d.McpToolName is not null)
+            .ToDictionary(d => d.McpToolName!, StringComparer.Ordinal);
+
+        var emitted = CapabilityManifestEmitter.Tools;
+        emitted.Select(t => t.AdvertisedName).Should().BeEquivalentTo(registryTools.Keys,
+            "the emitted manifest must advertise exactly the registry's /mcp tool roster");
+
+        foreach (var tool in emitted)
+        {
+            var descriptor = registryTools[tool.AdvertisedName];
+            tool.StandardName.Should().Be(descriptor.StandardName);
+            tool.WorkflowFamily.Should().Be(TitleCase(descriptor.Category),
+                $"emitted workflowFamily for '{tool.AdvertisedName}' must be the title-cased registry Category");
+        }
+    }
+
+    private static string TitleCase(string value) =>
+        string.IsNullOrEmpty(value) ? value : char.ToUpperInvariant(value[0]) + value[1..];
+
+    private static McpOperatorSurface BuildConformantSurface()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        return new McpOperatorSurface(
+            [
+                new ValidatePlanTool(jobService, NullLogger<ValidatePlanTool>.Instance),
+                new ExecutePlanTool(jobService, NullLogger<ExecutePlanTool>.Instance),
+                new CancelJobTool(jobService, NullLogger<CancelJobTool>.Instance),
+                new ResolveEntityTool(jobService, NullLogger<ResolveEntityTool>.Instance),
+                new ListCapabilitiesTool(jobService, NullLogger<ListCapabilitiesTool>.Instance),
+            ],
+            [
+                new JobStatusResource(jobService, NullLogger<JobStatusResource>.Instance),
+                new WorkspaceResource(jobService, NullLogger<WorkspaceResource>.Instance),
+                new FeatureCatalogResource(jobService, NullLogger<FeatureCatalogResource>.Instance),
+            ],
+            NullLogger<McpOperatorSurface>.Instance);
+    }
+
+    /// <summary>A tool with a name no capability-registry descriptor advertises.</summary>
+    private sealed class StubOrphanTool : IMcpTool
+    {
+        public const string OrphanName = "honua_not_in_registry";
+
+        public string Name => OrphanName;
+
+        public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+        public McpToolDescriptor Describe() => new() { Name = OrphanName };
+
+        public Task<McpToolsCallResult> InvokeAsync(
+            HttpContext httpContext, JsonElement? arguments, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+    }
+
+    /// <summary>A resource template no capability-registry descriptor advertises.</summary>
+    private sealed class StubOrphanResource : IMcpResource
+    {
+        public const string OrphanUriTemplate = "honua://mystery/{mysteryId}";
+
+        public string Family => "mystery";
+
+        public IReadOnlyList<McpResourceDescriptor> Describe() => [];
+
+        public IReadOnlyList<McpResourceTemplateDescriptor> DescribeTemplates() =>
+            [new McpResourceTemplateDescriptor { UriTemplate = OrphanUriTemplate, Name = "Mystery" }];
+
+        public bool CanHandle(string uri) => false;
+
+        public Task<McpResourcesReadResult> ReadAsync(
+            HttpContext httpContext, string uri, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2334

## Summary
Track B2 of ADR-0058 (unified capability registry). Now that B1 (`CapabilityDescriptor` + `ICapabilityRegistry`, #2356) and the `CapabilityManifestEmitter` (#2338) are on trunk, this re-points the `/mcp` tool/resource catalog to read the registry as its single source of truth, and adds a composition conformance check that binds the served surface to the registry. The `/mcp` wire contract is preserved exactly — only provenance moves to the registry.

## Changes Made
- `CapabilityManifestEmitter.Tools` is now projected from `ICapabilityRegistry` (`McpToolName` / `StandardName` / `Category`) instead of a hand-maintained list. The emitted geospatial-mcp manifest is byte-identical (workflow families title-cased from the registry `Category`); the resource projection stays pinned to the vendored Decision-A index, which is a separate spec contract.
- `honua_list_capabilities` now filters its live-surface projection to the registry roster (tools by `McpToolName`, resources by family). The live handlers still supply the LLM-grade descriptions and read/write hints, so the wire output is unchanged. Falls back to the live surface when no registry is registered (lightweight hosts).
- New `McpRegistryCompositionValidator` + `McpRegistryBindingStartupCheck` (`IHostedService`) assert at host start that every served `/mcp` tool/resource has a registry descriptor — no tool/resource served without provenance — behind flag `Capabilities:RegistryBinding` (default on). `AddMcpOperatorSurface` now binds `CapabilityRegistryBindingOptions`, wires the check, and idempotently ensures the registry is registered (`TryAddSingleton`, reconciled with T5's #2341 registration).
- Tests: composition validator (conformant surface has no drift, orphan tool/resource detected, subset is allowed), startup-check throw-on-drift / skip-when-disabled, and emitter-from-registry projection (bidirectional roster + title-cased families).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — the `/mcp` wire contract (tool names, schemas, resource URIs) and the emitted geospatial-mcp manifest are unchanged; only the provenance of the catalog moves to the capability registry.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

> Note: the shared build/test lock was saturated, so the full Release build and test suite were not run locally; `dotnet format` was run on the changed files and reports no changes. CI validates the build/tests.
