### PR TITLE
feat(capabilities): gate format-negotiation seams via unified registry (#2342)

### DIFF
--- a/src/Honua.Core/Features/Capabilities/FormatCapabilityGate.cs
+++ b/src/Honua.Core/Features/Capabilities/FormatCapabilityGate.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Capabilities;
+
+/// <summary>
+/// The shared format-negotiation gate (#2342 / T6). Every format-negotiation seam
+/// — the GeoServices query output formatter, the OGC/OData converters, and the
+/// file-import reader dispatch — consults this gate <b>before</b> dispatching to a
+/// reader or writer, so a data format the unified capability registry (ADR-0058)
+/// reports as gated off (an <see cref="CapabilityMaturity.Experimental"/> format
+/// whose flag is unset, or a format the active edition is not entitled to) is
+/// rejected with a clear reason instead of being silently served or silently
+/// coerced to another format.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The gate is a thin projection over <see cref="ICapabilityRegistry.Resolve"/>
+/// (the T2 <see cref="CapabilityGateResolver"/> precedence): it maps a data-format
+/// name (the segment after <see cref="CapabilityRegistry.DataFormatIdPrefix"/>, for
+/// example <c>geoparquet</c>) to its <c>format.*</c> descriptor, resolves it against
+/// the supplied <see cref="CapabilityGateContext"/>, and translates the registry
+/// reason code into a format-scoped one (<see cref="FormatCapabilityReasonCodes"/>).
+/// </para>
+/// <para>
+/// In T6 every registered format is still <see cref="CapabilityMaturity.Implemented"/>,
+/// so the gate reports <see cref="FormatGateStatus.Enabled"/> for every registered
+/// format — no format is disabled in this ticket. The experimental flips land in T10
+/// (#2346) and flow through this seam unchanged: a flipped-and-flag-off format then
+/// resolves <see cref="FormatGateStatus.ExperimentalDisabled"/> here.
+/// </para>
+/// <para>
+/// A format the registry does not manage resolves <see cref="FormatGateStatus.Unknown"/>
+/// (it is not a <c>format.*</c> descriptor). The gate does not itself reject an
+/// unknown format — the seam owns whether an unrecognised token is a hard error
+/// (see <see cref="FormatGateDecision.IsBlocked"/>): a seam that already validates
+/// its wire tokens against a fixed supported set keeps that behaviour, while the
+/// gate only adds the <see cref="FormatGateStatus.ExperimentalDisabled"/> /
+/// <see cref="FormatGateStatus.LicenseRequired"/> rejection on top.
+/// </para>
+/// </remarks>
+public static class FormatCapabilityGate
+{
+    // A default registry backed by the same static roster CapabilityRegistry.All
+    // exposes, so seams that have no registry in scope (the deep formatter/import
+    // dispatch paths) can still consult the gate without new DI plumbing. Tests and
+    // future DI callers can pass an explicit registry.
+    private static readonly CapabilityRegistry SharedRegistry = new();
+
+    /// <summary>
+    /// Evaluates a single data-format name (the segment after
+    /// <see cref="CapabilityRegistry.DataFormatIdPrefix"/>, for example
+    /// <c>geoparquet</c> or <c>esrijson</c>) against the capability registry.
+    /// </summary>
+    /// <param name="formatName">
+    /// The registry data-format name (case-insensitive), <b>not</b> a protocol wire
+    /// token — the seam is responsible for mapping its wire token (for example the
+    /// GeoServices <c>f=json</c>) to the registry name (<c>esrijson</c>) first.
+    /// </param>
+    /// <param name="context">
+    /// The edition/environment/experimental-flag inputs, or <c>null</c> for
+    /// <see cref="CapabilityGateContext.Default"/> (Community edition, flags off).
+    /// </param>
+    /// <param name="registry">
+    /// The capability registry to resolve against, or <c>null</c> for the shared
+    /// default registry.
+    /// </param>
+    public static FormatGateDecision Evaluate(
+        string formatName,
+        CapabilityGateContext? context = null,
+        ICapabilityRegistry? registry = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(formatName);
+
+        var effectiveRegistry = registry ?? SharedRegistry;
+        var effectiveContext = context ?? CapabilityGateContext.Default;
+        var capabilityId = CapabilityRegistry.DataFormatIdPrefix + formatName.Trim().ToLowerInvariant();
+
+        return FormatGateDecision.FromResolution(effectiveRegistry.Resolve(capabilityId, effectiveContext));
+    }
+
+    /// <summary>
+    /// Filters an advertised list of data-format names down to those that are not
+    /// gated off, preserving order and dropping only registry-managed formats the
+    /// gate <see cref="FormatGateDecision.IsBlocked"/> reports as blocked. Names the
+    /// registry does not manage (<see cref="FormatGateStatus.Unknown"/>) are kept —
+    /// the advertising seam owns those.
+    /// </summary>
+    /// <param name="formatNames">The candidate registry data-format names.</param>
+    /// <param name="context">The gate context, or <c>null</c> for the default.</param>
+    /// <param name="registry">The registry, or <c>null</c> for the shared default.</param>
+    public static IReadOnlyList<string> FilterAdvertised(
+        IEnumerable<string> formatNames,
+        CapabilityGateContext? context = null,
+        ICapabilityRegistry? registry = null)
+    {
+        ArgumentNullException.ThrowIfNull(formatNames);
+
+        var kept = new List<string>();
+        foreach (var name in formatNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            if (!Evaluate(name, context, registry).IsBlocked)
+            {
+                kept.Add(name);
+            }
+        }
+
+        return kept;
+    }
+}
+
+/// <summary>
+/// The outcome of a <see cref="FormatCapabilityGate"/> evaluation.
+/// </summary>
+public enum FormatGateStatus
+{
+    /// <summary>The format is registered and enabled for the context.</summary>
+    Enabled = 0,
+
+    /// <summary>
+    /// The format is not managed by the capability registry (no <c>format.*</c>
+    /// descriptor). Not a rejection on its own — the seam decides.
+    /// </summary>
+    Unknown = 1,
+
+    /// <summary>
+    /// The format is an <see cref="CapabilityMaturity.Experimental"/> format whose
+    /// per-capability/global flag is unset, so it is off by default and must be
+    /// rejected.
+    /// </summary>
+    ExperimentalDisabled = 2,
+
+    /// <summary>
+    /// The format's <see cref="CapabilityDescriptor.MinimumEdition"/> exceeds the
+    /// active edition, so it must be rejected on entitlement.
+    /// </summary>
+    LicenseRequired = 3,
+}
+
+/// <summary>
+/// A <see cref="FormatCapabilityGate"/> decision: the <see cref="Status"/> plus a
+/// stable, format-scoped <see cref="ReasonCode"/> when the format is not enabled.
+/// </summary>
+/// <param name="Status">The gate status.</param>
+/// <param name="ReasonCode">
+/// The <see cref="FormatCapabilityReasonCodes"/> value when <see cref="Status"/> is
+/// not <see cref="FormatGateStatus.Enabled"/>, or <c>null</c> when enabled.
+/// </param>
+public readonly record struct FormatGateDecision(FormatGateStatus Status, string? ReasonCode)
+{
+    /// <summary>Whether the format is registered and enabled for the context.</summary>
+    public bool IsEnabled => Status == FormatGateStatus.Enabled;
+
+    /// <summary>
+    /// Whether the format is registry-managed <b>and</b> gated off, so the seam must
+    /// reject it (return a 400). An <see cref="FormatGateStatus.Unknown"/> format is
+    /// <b>not</b> blocked — it is simply not registry-managed.
+    /// </summary>
+    public bool IsBlocked => Status is FormatGateStatus.ExperimentalDisabled or FormatGateStatus.LicenseRequired;
+
+    internal static FormatGateDecision FromResolution(CapabilityResolution resolution)
+        => resolution.Enabled
+            ? new FormatGateDecision(FormatGateStatus.Enabled, null)
+            : resolution.ReasonCode switch
+            {
+                CapabilityReasonCodes.ExperimentalDisabled =>
+                    new FormatGateDecision(FormatGateStatus.ExperimentalDisabled, FormatCapabilityReasonCodes.ExperimentalDisabled),
+                CapabilityReasonCodes.LicenseRequired =>
+                    new FormatGateDecision(FormatGateStatus.LicenseRequired, FormatCapabilityReasonCodes.LicenseRequired),
+                _ => new FormatGateDecision(FormatGateStatus.Unknown, FormatCapabilityReasonCodes.Unknown),
+            };
+}
+
+/// <summary>
+/// Stable, machine-readable reason codes a format-negotiation seam returns on a 400
+/// when <see cref="FormatCapabilityGate"/> rejects a format. Format-scoped mirrors of
+/// the registry-layer <see cref="CapabilityReasonCodes"/> so the wire contract names
+/// the <c>format</c> axis explicitly.
+/// </summary>
+public static class FormatCapabilityReasonCodes
+{
+    /// <summary>The requested format is not a recognised/registered data format.</summary>
+    public const string Unknown = "format-unknown";
+
+    /// <summary>
+    /// The requested format is experimental and off by default (its experimental flag
+    /// is unset). Returned on the <c>f</c>/<c>outputFormat</c> value.
+    /// </summary>
+    public const string ExperimentalDisabled = "format-experimental-disabled";
+
+    /// <summary>The active edition is not entitled to the requested format.</summary>
+    public const string LicenseRequired = "format-license-required";
+}

--- a/src/Honua.Core/Features/FileImport/Services/InMemoryImportJobService.cs
+++ b/src/Honua.Core/Features/FileImport/Services/InMemoryImportJobService.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Honua.Core.Features.Capabilities;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -18,6 +19,47 @@ using Honua.Core.Features.FileImport.Domain;
 using Honua.Core.Features.FileImport.Services;
 
 namespace Honua.Core.Features.FileImport.Services;
+
+/// <summary>
+/// Guards the import reader dispatch behind the unified capability registry (T6 /
+/// #2342). The import job services detect a file's format and then dispatch to the
+/// matching reader; this guard is consulted at that seam <b>before</b> dispatch so an
+/// unrecognised file — which previously silently fell back to
+/// <see cref="SupportedFileFormat.GeoJson"/> and was mis-read — is rejected, as is a
+/// format the registry reports as gated off (an experimental format with its flag
+/// unset, or one the active edition is not entitled to). The thrown
+/// <see cref="NotSupportedException"/> is mapped to an HTTP 400 by the import endpoints.
+/// </summary>
+internal static class ImportFormatDispatchGuard
+{
+    /// <summary>
+    /// Requires a supported, enabled import format: returns the detected format when it
+    /// is recognised and not gated off, otherwise throws <see cref="NotSupportedException"/>.
+    /// </summary>
+    /// <param name="detectedFormat">
+    /// The format detected from the filename, or <c>null</c> when the extension matched no
+    /// supported import format (previously silently coerced to GeoJSON).
+    /// </param>
+    /// <param name="fileName">The source filename, for the error message.</param>
+    public static SupportedFileFormat RequireGatedFormat(SupportedFileFormat? detectedFormat, string fileName)
+    {
+        if (detectedFormat is not { } format)
+        {
+            throw new NotSupportedException(
+                $"Unsupported file format for '{fileName}': the file does not match a supported import format " +
+                $"({FormatCapabilityReasonCodes.Unknown}).");
+        }
+
+        var decision = FormatCapabilityGate.Evaluate(format.ToString().ToLowerInvariant());
+        if (decision.IsBlocked)
+        {
+            throw new NotSupportedException(
+                $"Import format '{format}' is disabled ({decision.ReasonCode}).");
+        }
+
+        return format;
+    }
+}
 
 /// <summary>
 /// In-memory implementation of import job service for background processing.
@@ -57,7 +99,8 @@ internal sealed partial class InMemoryImportJobService : IImportJobService, IDis
         CleanupCompletedJobsIfNeeded();
         request.Validate();
 
-        var format = _importService.DetectFormat(request.FileName) ?? SupportedFileFormat.GeoJson;
+        var format = ImportFormatDispatchGuard.RequireGatedFormat(
+            _importService.DetectFormat(request.FileName), request.FileName);
         var formatName = format.ToString();
 
         ImportJobState state;
@@ -568,7 +611,8 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
         using (var scope = _scopeFactory.CreateScope())
         {
             var importService = scope.ServiceProvider.GetRequiredService<IFileImportService>();
-            format = importService.DetectFormat(request.FileName) ?? SupportedFileFormat.GeoJson;
+            format = ImportFormatDispatchGuard.RequireGatedFormat(
+                importService.DetectFormat(request.FileName), request.FileName);
         }
         var formatName = format.ToString();
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerUtilities.cs
@@ -4,6 +4,7 @@
 using System.Collections.Frozen;
 using System.Globalization;
 using Honua.Core.Features.Attachments.Abstractions;
+using Honua.Core.Features.Capabilities;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Protocols.GeoServices;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
@@ -347,6 +348,16 @@ internal static partial class FeatureServerEndpoints
             return;
         }
 
+        // T6 (#2342): do not advertise a format the capability registry reports as gated
+        // off (an experimental format with its flag unset, or one the edition is not
+        // entitled to), so the advertised supportedQueryFormats stays consistent with what
+        // the query seam will actually serve. No-op while every format is Implemented.
+        if (RegistryFormatByWireToken.TryGetValue(format, out var registryFormatName) &&
+            FormatCapabilityGate.Evaluate(registryFormatName).IsBlocked)
+        {
+            return;
+        }
+
         formats.Add(format.ToUpperInvariant());
     }
 
@@ -458,6 +469,23 @@ internal static partial class FeatureServerEndpoints
         return true;
     }
 
+    // Maps a GeoServices query output wire token to its unified-registry data-format
+    // name (the segment after CapabilityRegistry.DataFormatIdPrefix). Tokens without a
+    // format.* descriptor (pbf/geobuf/arrow are encoded exports with no import-format
+    // descriptor) are absent and stay ungated. Used only to consult the capability
+    // gate (T6 / #2342) after the static supported-set check; it does not change which
+    // tokens are accepted while every format is still Implemented.
+    private static readonly FrozenDictionary<string, string> RegistryFormatByWireToken =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["json"] = "esrijson",
+            ["pjson"] = "esrijson",
+            ["geojson"] = "geojson",
+            ["parquet"] = "geoparquet",
+            ["fgb"] = "flatgeobuf",
+        }
+        .ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
     internal static bool TryValidateOutputFormat(
         string? format,
         FrozenSet<string> supportedFormats,
@@ -477,6 +505,23 @@ internal static partial class FeatureServerEndpoints
         {
             error = $"Output format '{trimmed}' is not supported. Supported formats: {string.Join(", ", supportedFormats)}.";
             return false;
+        }
+
+        // T6 (#2342): consult the unified capability registry BEFORE dispatch, so a
+        // format that is flipped experimental (T10 / #2346) with its flag unset — or one
+        // the active edition is not entitled to — returns a clear 400 on the `f` value
+        // rather than being served. In T6 every format is still Implemented, so this is a
+        // no-op today; it wires the seam. Tokens without a format.* descriptor stay ungated.
+        if (RegistryFormatByWireToken.TryGetValue(trimmed, out var registryFormatName))
+        {
+            var decision = FormatCapabilityGate.Evaluate(registryFormatName);
+            if (decision.IsBlocked)
+            {
+                error = decision.Status == FormatGateStatus.LicenseRequired
+                    ? $"Output format '{trimmed}' is not available for the active edition ({FormatCapabilityReasonCodes.LicenseRequired})."
+                    : $"Output format '{trimmed}' is experimental and disabled ({FormatCapabilityReasonCodes.ExperimentalDisabled}).";
+                return false;
+            }
         }
 
         normalizedFormat = string.Equals(trimmed, "pjson", StringComparison.OrdinalIgnoreCase)

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
@@ -102,8 +102,14 @@ internal sealed class QueryFormatter : IQueryFormatter
                     returnM,
                     effectiveLimits,
                     outFields)),
-            _ => ValueTask.FromResult<(object response, string contentType)>(
-                FormatAsGeoServicesJson(result, resource, returnGeometry, outputSrid, returnZ, returnM, effectiveLimits, outFields, suppressObjectId, returnCentroid))
+            // T6 (#2342): do NOT silently fall back to GeoServices JSON for an unknown or
+            // gated-off output format. The `f`/output-format value is validated (and
+            // capability-gated) at the endpoint seam (TryValidateOutputFormat) before dispatch,
+            // so only a supported format reaches here; an unrecognised token is a programming
+            // error, not a request to coerce to JSON. Fail loudly instead of returning a
+            // wrong-format 200.
+            _ => throw new NotSupportedException(
+                $"Output format '{format}' is not a supported GeoServices query output format.")
         };
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/FormatCapabilityGateTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/FormatCapabilityGateTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Honua.Core.Features.Capabilities;
+
+namespace Honua.Core.Tests.Features.Capabilities;
+
+/// <summary>
+/// Unit coverage for the shared format-negotiation gate (#2342 / T6): mapping a
+/// data-format name to its <c>format.*</c> descriptor, consulting the T2 resolver,
+/// and translating the outcome into a format-scoped <see cref="FormatGateDecision"/>.
+/// Enabled formats stay enabled; a disabled-experimental format and an unknown
+/// format resolve to a non-enabled decision so a seam returns a 400 rather than
+/// silently serving or coercing the format.
+/// </summary>
+public sealed class FormatCapabilityGateTests
+{
+    // A registry that reports a single format id as experimental, so the
+    // experimental-disabled path is exercised without flipping the real (all-Implemented)
+    // roster — that flip is T10 (#2346). Every other id resolves via the real
+    // CapabilityGateResolver precedence against the supplied descriptor.
+    private sealed class ExperimentalFormatRegistry : ICapabilityRegistry
+    {
+        private readonly string _experimentalId;
+
+        public ExperimentalFormatRegistry(string experimentalId) => _experimentalId = experimentalId;
+
+        public IReadOnlyList<CapabilityDescriptor> All => [];
+
+        public CapabilityDescriptor? Find(string id) => string.Equals(id, _experimentalId, System.StringComparison.Ordinal)
+            ? new CapabilityDescriptor
+            {
+                Id = _experimentalId,
+                Category = "format",
+                Kind = CapabilityKind.DataFormat,
+                Maturity = CapabilityMaturity.Experimental,
+            }
+            : null;
+
+        public CapabilityResolution Resolve(string id, CapabilityGateContext context)
+            => CapabilityGateResolver.Resolve(Find(id), context);
+    }
+
+    [Fact]
+    public void Evaluate_RegisteredImplementedFormat_IsEnabled()
+    {
+        // geojson is a real, Implemented format.* descriptor in the default registry.
+        var decision = FormatCapabilityGate.Evaluate("geojson");
+
+        decision.IsEnabled.Should().BeTrue();
+        decision.IsBlocked.Should().BeFalse();
+        decision.Status.Should().Be(FormatGateStatus.Enabled);
+        decision.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_IsCaseInsensitiveOnFormatName()
+    {
+        FormatCapabilityGate.Evaluate("GeoParquet").IsEnabled.Should().BeTrue();
+        FormatCapabilityGate.Evaluate("ESRIJSON").IsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_UnknownFormat_IsUnknown_AndNotBlocked()
+    {
+        // A wire token with no format.* descriptor (for example the GeoServices
+        // f=pbf / f=arrow output tokens) is not registry-managed: Unknown, not blocked.
+        var decision = FormatCapabilityGate.Evaluate("pbf");
+
+        decision.IsEnabled.Should().BeFalse();
+        decision.IsBlocked.Should().BeFalse();
+        decision.Status.Should().Be(FormatGateStatus.Unknown);
+        decision.ReasonCode.Should().Be(FormatCapabilityReasonCodes.Unknown);
+    }
+
+    [Fact]
+    public void Evaluate_ExperimentalFormatWithFlagsOff_IsExperimentalDisabled_AndBlocked()
+    {
+        var registry = new ExperimentalFormatRegistry(CapabilityRegistry.DataFormatIdPrefix + "geoparquet");
+
+        var decision = FormatCapabilityGate.Evaluate("geoparquet", context: null, registry: registry);
+
+        decision.IsEnabled.Should().BeFalse();
+        decision.IsBlocked.Should().BeTrue();
+        decision.Status.Should().Be(FormatGateStatus.ExperimentalDisabled);
+        decision.ReasonCode.Should().Be(FormatCapabilityReasonCodes.ExperimentalDisabled);
+    }
+
+    [Fact]
+    public void Evaluate_ExperimentalFormatWithGlobalFlagOn_IsEnabled()
+    {
+        var registry = new ExperimentalFormatRegistry(CapabilityRegistry.DataFormatIdPrefix + "geoparquet");
+        var context = new CapabilityGateContext
+        {
+            ExperimentalFlags = new CapabilityFlagOptions { Enabled = true },
+        };
+
+        var decision = FormatCapabilityGate.Evaluate("geoparquet", context, registry);
+
+        decision.IsEnabled.Should().BeTrue();
+        decision.IsBlocked.Should().BeFalse();
+        decision.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_ExperimentalFormatWithPerCapabilityFlagOn_IsEnabled()
+    {
+        var id = CapabilityRegistry.DataFormatIdPrefix + "geoparquet";
+        var registry = new ExperimentalFormatRegistry(id);
+        var flags = new CapabilityFlagOptions();
+        flags.Capabilities[id] = new ExperimentalCapabilityFlag { Enabled = true };
+        var context = new CapabilityGateContext { ExperimentalFlags = flags };
+
+        FormatCapabilityGate.Evaluate("geoparquet", context, registry).IsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Evaluate_NullOrWhitespaceFormat_Throws()
+    {
+        var evaluateNull = () => FormatCapabilityGate.Evaluate(null!);
+        var evaluateBlank = () => FormatCapabilityGate.Evaluate("   ");
+
+        evaluateNull.Should().Throw<System.ArgumentException>();
+        evaluateBlank.Should().Throw<System.ArgumentException>();
+    }
+
+    [Fact]
+    public void FilterAdvertised_KeepsEnabledAndUnknown_DropsBlocked()
+    {
+        var id = CapabilityRegistry.DataFormatIdPrefix + "geoparquet";
+        var registry = new ExperimentalFormatRegistry(id);
+
+        // geoparquet is experimental-disabled in this registry; geojson resolves via the
+        // registry (unknown here -> kept); pbf is not registry-managed (kept). Only the
+        // blocked geoparquet is dropped.
+        var kept = FormatCapabilityGate.FilterAdvertised(
+            ["geojson", "geoparquet", "pbf"],
+            context: null,
+            registry: registry);
+
+        kept.Should().Equal("geojson", "pbf");
+    }
+
+    [Fact]
+    public void FilterAdvertised_DefaultRegistry_KeepsAllRealFormats()
+    {
+        // Every format is Implemented in T6, so nothing is filtered from the real roster.
+        var kept = FormatCapabilityGate.FilterAdvertised(["geojson", "geoparquet", "esrijson", "flatgeobuf"]);
+
+        kept.Should().Equal("geojson", "geoparquet", "esrijson", "flatgeobuf");
+    }
+}


### PR DESCRIPTION
## Summary

T6 (#2342) adds the **format-gate seams**: it registers a shared gate over the
T2 `CapabilityGateResolver` (#2357) and consults it at every data-format
negotiation seam **before** dispatch, and it fixes the current silent
fall-back-to-JSON for unknown/gated-off formats.

No format is flipped to experimental in this PR (that is T10/#2346) — every
format stays enabled, so the gate is a no-op today and only wires the seam.
Data formats are already registered as `format.*` `CapabilityDescriptor`s
(Kind=DataFormat) in the B1 registry.

## Changes Made

- Add `FormatCapabilityGate` (Honua.Core.Features.Capabilities): a thin,
  DI-free projection over `ICapabilityRegistry.Resolve` that maps a data-format
  name to its `format.*` descriptor, applies the T2 experimental/edition
  precedence, and returns a `FormatGateDecision` with format-scoped reason codes
  (`format-experimental-disabled`, `format-unknown`, `format-license-required`).
- **GeoServices query seam** (`FeatureServerUtilities.TryValidateOutputFormat`):
  after the static supported-set check, consult the gate for the mapped registry
  format; a gated-off format returns a clear **400** on the `f` value with reason
  `format-experimental-disabled` (or `format-license-required`). The advertised
  `supportedQueryFormats` are filtered through the gate too.
- **Silent-fallback fix** (`QueryFormatters.FormatQueryResultAsync`): the `_ =>`
  arm no longer silently returns GeoServices JSON for an unknown/gated-off format
  — it throws instead of emitting a wrong-format 200.
- **File-import reader dispatch** (`InMemoryImportJobService` /
  `UniversalImportJobService`): replace the silent
  `DetectFormat(...) ?? SupportedFileFormat.GeoJson` coercion with a gated guard
  (`ImportFormatDispatchGuard`) that throws `NotSupportedException` — mapped to
  **400** by the import endpoints — for an unknown or gated-off format.
- Tests: `FormatCapabilityGateTests` — enabled format stays enabled; a
  disabled-experimental format is blocked (reason `format-experimental-disabled`);
  an unknown format is not registry-managed; advertised-list filtering.

Note: the OData `$format` value is captured but never consumed (OData is
JSON-only) and the WFS `Wfs20FeatureFormatConverter` is GML type-translation, not
an output-format negotiation seam — neither has a silent fallback to fix. The
shared gate is available to them if a real negotiation seam is added later.

## Breaking Changes

None. Every format stays enabled; behaviour changes only for previously-silent
error paths (unknown/gated-off format now returns 400 instead of a wrong-format
200 or a mis-read import).

## Gate Impact

- [x] No gate-tier impact (wires the seam; no format flipped experimental)

## Testing

- [x] Added unit tests (`FormatCapabilityGateTests`)
- [ ] Ran scripts/ci/pre-pr-check.sh and all checks passed

_Build lock saturated in the shared multi-agent environment; full build/test not
run locally. `dotnet format` verified no changes._

Closes #2342
