### PR TITLE
feat: derive capability manifest from the unified registry (#2335)

### DIFF
--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
 
 namespace Honua.Core.Features.Capabilities;
 
@@ -178,47 +179,52 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
     // -----------------------------------------------------------------------
     private static IEnumerable<CapabilityDescriptor> BuildManifestCapabilityDescriptors()
     {
-        (string Id, string Category, string? EntitlementKey, CapabilityKind Kind)[] capabilities =
+        // PackageSchemaVersion is populated only for the `packages`-category
+        // capabilities (#2335 / B3): it is the package-family schema version the
+        // honua.capability_manifest.v1 wire advertises for that family, and the null
+        // seam B1 left. It mirrors CapabilityManifestService's package-family list so
+        // the derived Packages.Families[] and the descriptors cannot diverge.
+        (string Id, string Category, string? EntitlementKey, CapabilityKind Kind, string? PackageSchemaVersion)[] capabilities =
         [
-            ("package.metadata-v2", "packages", null, CapabilityKind.Feature),
-            ("package.release-package", "packages", null, CapabilityKind.Feature),
-            ("package.gitops-manifest", "packages", null, CapabilityKind.Feature),
-            ("package.map", "packages", null, CapabilityKind.Feature),
-            ("package.app", "packages", null, CapabilityKind.Feature),
+            ("package.metadata-v2", "packages", null, CapabilityKind.Feature, MetadataV2Constants.SchemaVersion),
+            ("package.release-package", "packages", null, CapabilityKind.Feature, MetadataV2Constants.ApiVersion),
+            ("package.gitops-manifest", "packages", null, CapabilityKind.Feature, MetadataV2Constants.ApiVersion),
+            ("package.map", "packages", null, CapabilityKind.Feature, MapPackageSchemaVersion),
+            ("package.app", "packages", null, CapabilityKind.Feature, AppPackageSchemaVersion),
 
-            ("temporal.filtering", "temporal", "temporal.filtering", CapabilityKind.Feature),
-            ("temporal.extent-discovery", "temporal", "temporal.extent-discovery", CapabilityKind.Feature),
-            ("temporal.histogram", "temporal", "temporal.histogram", CapabilityKind.Feature),
-            ("temporal.time-series-tiles", "temporal", "temporal.time-series-tiles", CapabilityKind.Feature),
+            ("temporal.filtering", "temporal", "temporal.filtering", CapabilityKind.Feature, null),
+            ("temporal.extent-discovery", "temporal", "temporal.extent-discovery", CapabilityKind.Feature, null),
+            ("temporal.histogram", "temporal", "temporal.histogram", CapabilityKind.Feature, null),
+            ("temporal.time-series-tiles", "temporal", "temporal.time-series-tiles", CapabilityKind.Feature, null),
 
-            ("sync.offline", "sync", FeatureCatalog.FieldOpsOfflineSyncKey, CapabilityKind.Feature),
-            ("realtime.feature-streams", "realtime", "streaming.feature-subscriptions", CapabilityKind.Feature),
-            ("alerts.geofence", "alerts", "alerts.enter-exit", CapabilityKind.Feature),
-            ("jobs.runner", "jobs", null, CapabilityKind.Feature),
-            ("ai.spec-apply", "ai", FeatureCatalog.AiSpecApplyKey, CapabilityKind.Feature),
-            ("ai.grounding", "ai", FeatureCatalog.AiGroundingKey, CapabilityKind.Feature),
-            ("ai.workflow-generation", "ai", FeatureCatalog.AiWorkflowGenerationKey, CapabilityKind.Feature),
-            ("gitops.release-manifest", "gitops", null, CapabilityKind.Feature),
+            ("sync.offline", "sync", FeatureCatalog.FieldOpsOfflineSyncKey, CapabilityKind.Feature, null),
+            ("realtime.feature-streams", "realtime", "streaming.feature-subscriptions", CapabilityKind.Feature, null),
+            ("alerts.geofence", "alerts", "alerts.enter-exit", CapabilityKind.Feature, null),
+            ("jobs.runner", "jobs", null, CapabilityKind.Feature, null),
+            ("ai.spec-apply", "ai", FeatureCatalog.AiSpecApplyKey, CapabilityKind.Feature, null),
+            ("ai.grounding", "ai", FeatureCatalog.AiGroundingKey, CapabilityKind.Feature, null),
+            ("ai.workflow-generation", "ai", FeatureCatalog.AiWorkflowGenerationKey, CapabilityKind.Feature, null),
+            ("gitops.release-manifest", "gitops", null, CapabilityKind.Feature, null),
 
-            ("transport.grpc", "transports", null, CapabilityKind.ProtocolOperation),
-            ("transport.grpc-web", "transports", null, CapabilityKind.ProtocolOperation),
-            ("transport.native-grpc", "transports", null, CapabilityKind.ProtocolOperation),
-            ("transport.mcp", "transports", null, CapabilityKind.ProtocolOperation),
-            ("transport.qgis", "transports", null, CapabilityKind.ProtocolOperation),
+            ("transport.grpc", "transports", null, CapabilityKind.ProtocolOperation, null),
+            ("transport.grpc-web", "transports", null, CapabilityKind.ProtocolOperation, null),
+            ("transport.native-grpc", "transports", null, CapabilityKind.ProtocolOperation, null),
+            ("transport.mcp", "transports", null, CapabilityKind.ProtocolOperation, null),
+            ("transport.qgis", "transports", null, CapabilityKind.ProtocolOperation, null),
 
-            ("security.mtls", "security", null, CapabilityKind.Feature),
-            ("preview.file-import", "preview", "import.file", CapabilityKind.Feature),
-            ("query.features", "query", null, CapabilityKind.Feature),
+            ("security.mtls", "security", null, CapabilityKind.Feature, null),
+            ("preview.file-import", "preview", "import.file", CapabilityKind.Feature, null),
+            ("query.features", "query", null, CapabilityKind.Feature, null),
             // analysis.spatial is gated by a composite of four analytics keys; the
             // single-key EntitlementKey field cannot represent it, so it is left
             // null (the manifest projection keeps the composite key set in B3).
-            ("analysis.spatial", "analysis", null, CapabilityKind.Feature),
-            ("publication.metadata-release", "publication", null, CapabilityKind.Feature),
-            ("upload.file", "upload", "import.file", CapabilityKind.Feature),
-            ("edit.features", "edit", FeatureCatalog.FeatureServerEditsKey, CapabilityKind.Feature),
+            ("analysis.spatial", "analysis", null, CapabilityKind.Feature, null),
+            ("publication.metadata-release", "publication", null, CapabilityKind.Feature, null),
+            ("upload.file", "upload", "import.file", CapabilityKind.Feature, null),
+            ("edit.features", "edit", FeatureCatalog.FeatureServerEditsKey, CapabilityKind.Feature, null),
         ];
 
-        foreach (var (id, category, entitlementKey, kind) in capabilities)
+        foreach (var (id, category, entitlementKey, kind, packageSchemaVersion) in capabilities)
         {
             yield return new CapabilityDescriptor
             {
@@ -228,9 +234,16 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
                 Maturity = CapabilityMaturity.Implemented,
                 EntitlementKey = entitlementKey,
                 MinimumEdition = ResolveMinimumEdition(entitlementKey),
+                PackageSchemaVersion = packageSchemaVersion,
             };
         }
     }
+
+    /// <summary>The map-package family schema version advertised by the manifest wire.</summary>
+    private const string MapPackageSchemaVersion = "honua_map_package.v1";
+
+    /// <summary>The app-package family schema version advertised by the manifest wire.</summary>
+    private const string AppPackageSchemaVersion = "honua_app_package.v1";
 
     // -----------------------------------------------------------------------
     // Data formats — the shared format readers/writers. The import formats mirror

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestFeatureOptions.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestFeatureOptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Capabilities;
+
+/// <summary>
+/// Staged feature switches for how the <c>honua.capability_manifest.v1</c> surface
+/// (#1186) is composed (#2335 / B3).
+/// </summary>
+internal sealed class CapabilityManifestFeatureOptions
+{
+    /// <summary>The configuration key of the registry-derivation switch.</summary>
+    public const string FromRegistryConfigKey = "Capabilities:ManifestFromRegistry";
+
+    /// <summary>
+    /// When <c>true</c>, the manifest's <c>Capabilities[]</c> and
+    /// <c>Packages.Families[]</c> are derived by iterating the unified
+    /// <see cref="Core.Features.Capabilities.ICapabilityRegistry"/> through the
+    /// <see cref="Core.Features.Capabilities.CapabilityGateResolver"/>
+    /// (experimental-disabled descriptors are omitted, which is wire-compatible)
+    /// rather than the hand-curated in-service lists (ADR-0058, Decision B / B3).
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c> (staged): the served manifest keeps the legacy
+    /// hand-curated composition until this flag is turned on. While every registry
+    /// descriptor stays <see cref="Core.Features.Capabilities.CapabilityMaturity.Implemented"/>,
+    /// the two paths produce a byte-identical wire document; the flag exists so the
+    /// registry-derived path can be staged into production without a wire change, and
+    /// so the experimental omission (T10 / #2346) has a mechanism to act on.
+    /// </remarks>
+    public bool FromRegistry { get; set; }
+}

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestOptionsSnapshot.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestOptionsSnapshot.cs
@@ -35,7 +35,8 @@ internal sealed class CapabilityManifestOptionsSnapshot
         IOptions<GrpcOptions> grpcOptions,
         IOptions<AlertOptions> alertOptions,
         IOptions<RbacOptions> rbacOptions,
-        IOptions<CapabilityFlagOptions> capabilityFlagOptions)
+        IOptions<CapabilityFlagOptions> capabilityFlagOptions,
+        IOptions<CapabilityManifestFeatureOptions> manifestFeatureOptions)
     {
         ArgumentNullException.ThrowIfNull(limitsOptions);
         ArgumentNullException.ThrowIfNull(streamOptions);
@@ -48,6 +49,7 @@ internal sealed class CapabilityManifestOptionsSnapshot
         ArgumentNullException.ThrowIfNull(alertOptions);
         ArgumentNullException.ThrowIfNull(rbacOptions);
         ArgumentNullException.ThrowIfNull(capabilityFlagOptions);
+        ArgumentNullException.ThrowIfNull(manifestFeatureOptions);
 
         Limits = limitsOptions.Value;
         Streaming = streamOptions.Value;
@@ -60,6 +62,7 @@ internal sealed class CapabilityManifestOptionsSnapshot
         Alerts = alertOptions.Value;
         Rbac = rbacOptions.Value;
         ExperimentalCapabilityFlags = capabilityFlagOptions.Value;
+        ManifestFromRegistry = manifestFeatureOptions.Value.FromRegistry;
     }
 
     public LimitsOptions Limits { get; }
@@ -88,4 +91,12 @@ internal sealed class CapabilityManifestOptionsSnapshot
     /// acting on them in T4 (#2340).
     /// </summary>
     public CapabilityFlagOptions ExperimentalCapabilityFlags { get; }
+
+    /// <summary>
+    /// Whether the manifest's <c>Capabilities[]</c> and <c>Packages.Families[]</c> are
+    /// derived from the unified capability registry (#2335 / B3). Defaults to
+    /// <c>false</c> (staged); the legacy hand-curated composition is served until the
+    /// <c>Capabilities:ManifestFromRegistry</c> switch is turned on.
+    /// </summary>
+    public bool ManifestFromRegistry { get; }
 }

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Security.Claims;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Alerts.Domain;
+using Honua.Core.Features.Capabilities;
 using Honua.Core.Features.Console.Abstractions;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Licensing.Abstractions;
@@ -53,6 +54,7 @@ internal sealed class CapabilityManifestService(
     IEnumerable<IBatchComputeBackend> batchBackends,
     IEnumerable<IFieldCollectionSyncStore> fieldCollectionSyncStores,
     IWebHostEnvironment hostEnvironment,
+    ICapabilityRegistry capabilityRegistry,
     ILogger<CapabilityManifestService> logger) : ICapabilityManifestService
 {
     private const string AuthorizationNotice =
@@ -94,7 +96,18 @@ internal sealed class CapabilityManifestService(
             request.WorkspaceId);
         var batchCapabilities = await ResolveBatchCapabilitiesAsync(cancellationToken).ConfigureAwait(false);
 
-        var capabilities = BuildCapabilities(policyContext);
+        // #2335 (B3): the registry-derived composition resolves each descriptor through
+        // the shared gate resolver (edition/experimental precedence). All descriptors
+        // stay Implemented today, so this produces the same wire document as the legacy
+        // hand-curated composition; the gate context is the seam T10 (#2346) flips.
+        var gateContext = BuildGateContext(snapshot.Edition, request.Environment);
+
+        var capabilities = options.ManifestFromRegistry
+            ? BuildCapabilitiesFromRegistry(policyContext, gateContext)
+            : BuildCapabilities(policyContext);
+        var packages = options.ManifestFromRegistry
+            ? BuildPackagesFromRegistry(gateContext)
+            : BuildPackages();
         var unavailableCount = capabilities.Count(static c => !c.Available);
         var manifest = new CapabilityManifestDocument
         {
@@ -113,7 +126,7 @@ internal sealed class CapabilityManifestService(
             },
             Server = BuildServerInfo(),
             Environment = environment,
-            Packages = BuildPackages(),
+            Packages = packages,
             Capabilities = capabilities,
             Transports = BuildTransports(),
             Limits = BuildLimits(batchCapabilities),
@@ -217,14 +230,7 @@ internal sealed class CapabilityManifestService(
     {
         return new CapabilityManifestPackages
         {
-            SchemaVersions =
-            [
-                CapabilityManifestConstants.SchemaVersion,
-                MetadataV2Constants.ApiVersion,
-                MetadataV2Constants.SchemaVersion,
-                "honua_map_package.v1",
-                "honua_app_package.v1"
-            ],
+            SchemaVersions = BuildPackageSchemaVersions(),
             Families =
             [
                 new CapabilityManifestPackageFamily
@@ -263,16 +269,93 @@ internal sealed class CapabilityManifestService(
                     Supported = true
                 }
             ],
-            StorageFamilies = Enum.GetValues<MetadataV2StorageType>()
-                .Select(ToWireValue)
-                .Order(StringComparer.Ordinal)
-                .ToArray(),
-            PublicationFamilies = Enum.GetValues<MetadataV2PublicationType>()
-                .Select(ToWireValue)
-                .Order(StringComparer.Ordinal)
-                .ToArray()
+            StorageFamilies = BuildStorageFamilies(),
+            PublicationFamilies = BuildPublicationFamilies()
         };
     }
+
+    /// <summary>
+    /// The #2335 (B3) registry-derived <c>Packages</c> block: the <c>Families[]</c> are
+    /// derived by iterating the <c>packages</c>-category descriptors of the unified
+    /// capability registry through the gate resolver. The wire family id/kind come from
+    /// <see cref="PackageWireById"/> and the schema version from the descriptor's
+    /// <see cref="CapabilityDescriptor.PackageSchemaVersion"/> (the null seam B1 left);
+    /// an experimental-disabled family is omitted (wire-compatible). The schema-version,
+    /// storage-family and publication-family lists are identical to the legacy path.
+    /// </summary>
+    private CapabilityManifestPackages BuildPackagesFromRegistry(CapabilityGateContext gateContext)
+    {
+        var families = new List<CapabilityManifestPackageFamily>();
+        foreach (var descriptor in capabilityRegistry.All)
+        {
+            if (!PackageWireById.TryGetValue(descriptor.Id, out var wire))
+            {
+                continue;
+            }
+
+            var resolution = CapabilityGateResolver.Resolve(descriptor, gateContext);
+            if (IsExperimentalDisabled(resolution))
+            {
+                // Experimental-and-flag-off package family: omit it (wire-compatible).
+                continue;
+            }
+
+            families.Add(new CapabilityManifestPackageFamily
+            {
+                Id = wire.Id,
+                Kind = wire.Kind,
+                SchemaVersion = descriptor.PackageSchemaVersion
+                    ?? throw new InvalidOperationException(
+                        $"Package capability '{descriptor.Id}' is missing a PackageSchemaVersion."),
+                Supported = resolution.Enabled
+            });
+        }
+
+        return new CapabilityManifestPackages
+        {
+            SchemaVersions = BuildPackageSchemaVersions(),
+            Families = families.ToArray(),
+            StorageFamilies = BuildStorageFamilies(),
+            PublicationFamilies = BuildPublicationFamilies()
+        };
+    }
+
+    private static string[] BuildPackageSchemaVersions()
+        =>
+        [
+            CapabilityManifestConstants.SchemaVersion,
+            MetadataV2Constants.ApiVersion,
+            MetadataV2Constants.SchemaVersion,
+            "honua_map_package.v1",
+            "honua_app_package.v1"
+        ];
+
+    private static string[] BuildStorageFamilies()
+        => Enum.GetValues<MetadataV2StorageType>()
+            .Select(ToWireValue)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+    private static string[] BuildPublicationFamilies()
+        => Enum.GetValues<MetadataV2PublicationType>()
+            .Select(ToWireValue)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// Maps each <c>packages</c>-category registry descriptor id to the wire family
+    /// id/kind the <c>honua.capability_manifest.v1</c> surface advertises. The iteration
+    /// order of <see cref="ICapabilityRegistry.All"/> preserves the legacy family order.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, (string Id, string Kind)> PackageWireById =
+        new Dictionary<string, (string Id, string Kind)>(StringComparer.Ordinal)
+        {
+            ["package.metadata-v2"] = ("metadata-v2-graph", "metadata"),
+            ["package.release-package"] = ("metadata-release-package", "publication"),
+            ["package.gitops-manifest"] = ("gitops-metadata-release-manifest", "gitops"),
+            ["package.map"] = ("map-package", "map"),
+            ["package.app"] = ("app-package", "app"),
+        };
 
     private CapabilityManifestCapability[] BuildCapabilities(CapabilityPolicyContext context)
     {
@@ -324,6 +407,139 @@ internal sealed class CapabilityManifestService(
             Capability("edit.features", "edit", context, entitlementKey: FeatureCatalog.FeatureServerEditsKey, policyCapability: "features.edit")
         ];
     }
+
+    /// <summary>
+    /// The #2335 (B3) registry-derived <c>Capabilities[]</c>. Instead of the
+    /// hand-curated roster in <see cref="BuildCapabilities"/>, this iterates the unified
+    /// capability registry's manifest descriptors (in their frozen order), resolves each
+    /// through the shared <see cref="CapabilityGateResolver"/>, and omits any descriptor
+    /// the gate turns off as experimental-and-flag-off (wire-compatible — the entry is
+    /// simply absent). The per-capability config knobs the registry does not carry
+    /// (supported/configured/requires*/policy/composite entitlement keys) come from
+    /// <see cref="BuildManifestCapabilitySpecs"/>; the availability computation is the
+    /// same <see cref="Capability"/> factory, so while every descriptor stays
+    /// <see cref="CapabilityMaturity.Implemented"/> the wire document is unchanged.
+    /// </summary>
+    private CapabilityManifestCapability[] BuildCapabilitiesFromRegistry(
+        CapabilityPolicyContext context,
+        CapabilityGateContext gateContext)
+    {
+        var specs = BuildManifestCapabilitySpecs();
+        var capabilities = new List<CapabilityManifestCapability>(specs.Count);
+        foreach (var descriptor in capabilityRegistry.All)
+        {
+            if (!IsManifestCapability(descriptor))
+            {
+                continue;
+            }
+
+            var resolution = CapabilityGateResolver.Resolve(descriptor, gateContext);
+            if (IsExperimentalDisabled(resolution))
+            {
+                continue;
+            }
+
+            var spec = specs.GetValueOrDefault(descriptor.Id, ManifestCapabilitySpec.Default);
+            capabilities.Add(Capability(
+                descriptor.Id,
+                descriptor.Category,
+                context,
+                supported: spec.Supported,
+                configured: spec.Configured,
+                entitlementKey: spec.EntitlementKey,
+                entitlementKeys: spec.EntitlementKeys,
+                policyCapability: spec.PolicyCapability,
+                requiresAuthentication: spec.RequiresAuthentication,
+                requiresEnvironment: spec.RequiresEnvironment,
+                requiresWorkspace: spec.RequiresWorkspace));
+        }
+
+        return capabilities.ToArray();
+    }
+
+    /// <summary>
+    /// The per-capability config knobs the registry descriptor does not carry, keyed by
+    /// descriptor id. Ids absent from the map use <see cref="ManifestCapabilitySpec.Default"/>.
+    /// Mirrors the hand-curated arguments in <see cref="BuildCapabilities"/> exactly so the
+    /// two composition paths stay wire-identical.
+    /// </summary>
+    private Dictionary<string, ManifestCapabilitySpec> BuildManifestCapabilitySpecs()
+    {
+        var syncSupported = IsFieldCollectionSyncSupported();
+        var jobsSupported = options.ControlPlane.ExecutionWorkloads.Count > 0 || batchBackends.Any();
+        var alertsConfigured = options.Alerts.Enabled;
+        var gitopsConfigured = options.ControlPlane.DeployTargets.Count > 0;
+        var mtlsConfigured = options.ClientCertificate.Mode != ClientCertificateAuthenticationMode.Disabled;
+
+        return new Dictionary<string, ManifestCapabilitySpec>(StringComparer.Ordinal)
+        {
+            ["package.release-package"] = new() { PolicyCapability = "catalog.publish", RequiresEnvironment = true },
+            ["package.gitops-manifest"] = new() { PolicyCapability = "catalog.publish", RequiresEnvironment = true },
+            ["package.map"] = new() { PolicyCapability = "studio.edit" },
+            ["package.app"] = new() { PolicyCapability = "studio.edit" },
+
+            ["temporal.filtering"] = new() { EntitlementKey = "temporal.filtering" },
+            ["temporal.extent-discovery"] = new() { EntitlementKey = "temporal.extent-discovery" },
+            ["temporal.histogram"] = new() { EntitlementKey = "temporal.histogram" },
+            ["temporal.time-series-tiles"] = new() { EntitlementKey = "temporal.time-series-tiles" },
+
+            ["sync.offline"] = new()
+            {
+                Supported = syncSupported,
+                EntitlementKey = FeatureCatalog.FieldOpsOfflineSyncKey,
+                PolicyCapability = "features.edit",
+                RequiresWorkspace = true,
+            },
+            ["realtime.feature-streams"] = new() { EntitlementKey = "streaming.feature-subscriptions" },
+            ["alerts.geofence"] = new() { EntitlementKey = "alerts.enter-exit", Configured = alertsConfigured },
+            ["jobs.runner"] = new() { Supported = jobsSupported, RequiresAuthentication = true },
+            ["ai.spec-apply"] = new() { EntitlementKey = FeatureCatalog.AiSpecApplyKey },
+            ["ai.grounding"] = new() { EntitlementKey = FeatureCatalog.AiGroundingKey },
+            ["ai.workflow-generation"] = new() { EntitlementKey = FeatureCatalog.AiWorkflowGenerationKey },
+            ["gitops.release-manifest"] = new()
+            {
+                Configured = gitopsConfigured,
+                PolicyCapability = "catalog.publish",
+                RequiresEnvironment = true,
+            },
+
+            ["security.mtls"] = new() { Configured = mtlsConfigured },
+            ["preview.file-import"] = new() { EntitlementKey = "import.file", PolicyCapability = "metadata.write" },
+            ["analysis.spatial"] = new()
+            {
+                EntitlementKeys = SpatialAnalyticsEntitlementKeys,
+                PolicyCapability = "features.query",
+            },
+            ["publication.metadata-release"] = new() { PolicyCapability = "catalog.publish", RequiresEnvironment = true },
+            ["upload.file"] = new() { EntitlementKey = "import.file", PolicyCapability = "metadata.write" },
+            ["edit.features"] = new() { EntitlementKey = FeatureCatalog.FeatureServerEditsKey, PolicyCapability = "features.edit" },
+        };
+    }
+
+    private CapabilityGateContext BuildGateContext(HonuaEdition edition, string? environment)
+        => new()
+        {
+            Edition = edition,
+            DeploymentEnvironment = string.IsNullOrWhiteSpace(environment) ? null : environment,
+            ExperimentalFlags = options.ExperimentalCapabilityFlags,
+        };
+
+    /// <summary>
+    /// A registry descriptor participates in the #1186 manifest <c>Capabilities[]</c>
+    /// when it is neither an <c>/mcp</c> tool/resource nor a data-format descriptor —
+    /// those roster kinds project onto other surfaces, not the manifest.
+    /// </summary>
+    private static bool IsManifestCapability(CapabilityDescriptor descriptor)
+        => !descriptor.Id.StartsWith(CapabilityRegistry.McpToolIdPrefix, StringComparison.Ordinal)
+            && !descriptor.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal)
+            && !descriptor.Id.StartsWith(CapabilityRegistry.DataFormatIdPrefix, StringComparison.Ordinal);
+
+    private static bool IsExperimentalDisabled(CapabilityResolution resolution)
+        => !resolution.Enabled
+            && string.Equals(
+                resolution.ReasonCode,
+                Core.Features.Capabilities.CapabilityReasonCodes.ExperimentalDisabled,
+                StringComparison.Ordinal);
 
     private CapabilityManifestCapability Capability(
         string id,
@@ -793,6 +1009,31 @@ internal sealed class CapabilityManifestService(
             ClientCertificateAuthenticationMode.RequiredForEnvironment => "required-for-environment",
             _ => mode.ToString()
         };
+
+    /// <summary>
+    /// The manifest-specific config knobs a registry descriptor does not carry, layered
+    /// onto the registry roster by <see cref="BuildCapabilitiesFromRegistry"/> (#2335 / B3).
+    /// </summary>
+    private sealed record ManifestCapabilitySpec
+    {
+        public static ManifestCapabilitySpec Default { get; } = new();
+
+        public bool Supported { get; init; } = true;
+
+        public bool Configured { get; init; } = true;
+
+        public string? EntitlementKey { get; init; }
+
+        public string[]? EntitlementKeys { get; init; }
+
+        public string? PolicyCapability { get; init; }
+
+        public bool RequiresAuthentication { get; init; }
+
+        public bool RequiresEnvironment { get; init; }
+
+        public bool RequiresWorkspace { get; init; }
+    }
 
     private sealed record CapabilityPolicyContext(
         LicenseSnapshot LicenseSnapshot,

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
@@ -18,7 +18,12 @@ internal static class CapabilityManifestServiceCollectionExtensions
         // #2341 (T5): the unified capability registry (ADR-0058) is the single
         // source of truth the shared CapabilityGateEndpointFilter resolves against.
         // Register it here so the gate filter can resolve ICapabilityRegistry from DI.
+        // #2335 (B3) also derives the manifest composition from it (TryAdd-safe).
         services.AddCapabilityRegistry();
+        // #2335 (B3): staged switch selecting the registry-derived composition.
+        services.Configure<CapabilityManifestFeatureOptions>(options =>
+            options.FromRegistry = configuration.GetValue<bool>(
+                CapabilityManifestFeatureOptions.FromRegistryConfigKey));
         services.AddSingleton<CapabilityManifestOptionsSnapshot>();
         services.AddScoped<ICapabilityManifestService, CapabilityManifestService>();
         return services;

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Honua.Core.Features.Capabilities;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Tests.Features.Capabilities;
+
+/// <summary>
+/// Unit coverage for the #2335 (B3) manifest derivation seam: the
+/// <c>honua.capability_manifest.v1</c> surface's <c>Capabilities[]</c> and
+/// <c>Packages.Families[]</c> are derived by iterating the unified capability registry
+/// through <see cref="CapabilityGateResolver"/>. These tests pin the registry roster
+/// the manifest projects and the gate-resolver omit mechanism the manifest applies —
+/// the Server-side wire equivalence is proven by the manifest endpoint golden test.
+/// </summary>
+public sealed class CapabilityManifestRegistryProjectionTests
+{
+    private static readonly ICapabilityRegistry Registry = new CapabilityRegistry();
+
+    // The frozen #1186 manifest roster, in the exact order the manifest serializes it.
+    // Mirrors CapabilityManifestService's hand-curated list; the registry-derived path
+    // must reproduce this order and set.
+    private static readonly string[] ExpectedManifestCapabilityIds =
+    [
+        "package.metadata-v2",
+        "package.release-package",
+        "package.gitops-manifest",
+        "package.map",
+        "package.app",
+        "temporal.filtering",
+        "temporal.extent-discovery",
+        "temporal.histogram",
+        "temporal.time-series-tiles",
+        "sync.offline",
+        "realtime.feature-streams",
+        "alerts.geofence",
+        "jobs.runner",
+        "ai.spec-apply",
+        "ai.grounding",
+        "ai.workflow-generation",
+        "gitops.release-manifest",
+        "transport.grpc",
+        "transport.grpc-web",
+        "transport.native-grpc",
+        "transport.mcp",
+        "transport.qgis",
+        "security.mtls",
+        "preview.file-import",
+        "query.features",
+        "analysis.spatial",
+        "publication.metadata-release",
+        "upload.file",
+        "edit.features",
+    ];
+
+    private static bool IsManifestCapability(CapabilityDescriptor descriptor)
+        => !descriptor.Id.StartsWith(CapabilityRegistry.McpToolIdPrefix, StringComparison.Ordinal)
+            && !descriptor.Id.StartsWith(CapabilityRegistry.McpResourceIdPrefix, StringComparison.Ordinal)
+            && !descriptor.Id.StartsWith(CapabilityRegistry.DataFormatIdPrefix, StringComparison.Ordinal);
+
+    [Fact]
+    public void Registry_ManifestDescriptors_MatchFrozenRosterInOrder()
+    {
+        var manifestIds = Registry.All
+            .Where(IsManifestCapability)
+            .Select(descriptor => descriptor.Id)
+            .ToArray();
+
+        manifestIds.Should().Equal(ExpectedManifestCapabilityIds);
+    }
+
+    [Fact]
+    public void Registry_AllManifestDescriptors_AreImplemented_SoNoneAreOmittedToday()
+    {
+        // B3 wires the mechanism only; nothing flips experimental until T10 (#2346).
+        // Every manifest descriptor must stay Implemented so the served manifest is
+        // unchanged (no capability is omitted).
+        var context = CapabilityGateContext.Default;
+
+        foreach (var descriptor in Registry.All.Where(IsManifestCapability))
+        {
+            descriptor.Maturity.Should().Be(CapabilityMaturity.Implemented);
+
+            var resolution = CapabilityGateResolver.Resolve(descriptor, context);
+            resolution.Enabled.Should().BeTrue($"{descriptor.Id} must resolve enabled while Implemented");
+            resolution.ReasonCode.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData("package.metadata-v2", MetadataV2Constants.SchemaVersion)]
+    [InlineData("package.release-package", MetadataV2Constants.ApiVersion)]
+    [InlineData("package.gitops-manifest", MetadataV2Constants.ApiVersion)]
+    [InlineData("package.map", "honua_map_package.v1")]
+    [InlineData("package.app", "honua_app_package.v1")]
+    public void Registry_PackageDescriptors_CarryPackageSchemaVersion(string id, string expectedSchemaVersion)
+    {
+        // The null seam B1 left is now populated from the package families so the
+        // derived Packages.Families[] and the descriptors cannot diverge.
+        var descriptor = Registry.Find(id);
+
+        descriptor.Should().NotBeNull();
+        descriptor!.Category.Should().Be("packages");
+        descriptor.PackageSchemaVersion.Should().Be(expectedSchemaVersion);
+    }
+
+    [Fact]
+    public void Registry_NonPackageManifestDescriptors_HaveNullPackageSchemaVersion()
+    {
+        foreach (var descriptor in Registry.All.Where(IsManifestCapability))
+        {
+            if (descriptor.Category == "packages")
+            {
+                continue;
+            }
+
+            descriptor.PackageSchemaVersion.Should().BeNull($"{descriptor.Id} is not a package family");
+        }
+    }
+
+    [Fact]
+    public void GateResolver_OmitMechanism_PresentWhenImplemented_AbsentWhenExperimentalFlagOff()
+    {
+        // The manifest omits a descriptor exactly when the gate resolves it
+        // experimental-and-flag-off. Prove the two branches the projection keys on.
+        var implemented = Descriptor(CapabilityMaturity.Implemented);
+        var experimental = Descriptor(CapabilityMaturity.Experimental);
+
+        var flagsOff = CapabilityGateContext.Default;
+
+        CapabilityGateResolver.Resolve(implemented, flagsOff).Enabled.Should().BeTrue();
+
+        var experimentalOff = CapabilityGateResolver.Resolve(experimental, flagsOff);
+        experimentalOff.Enabled.Should().BeFalse();
+        experimentalOff.ReasonCode.Should().Be(CapabilityReasonCodes.ExperimentalDisabled);
+    }
+
+    [Fact]
+    public void GateResolver_OmitMechanism_PresentWhenExperimentalFlagOn()
+    {
+        var experimental = Descriptor(CapabilityMaturity.Experimental);
+        var flags = new CapabilityFlagOptions { Enabled = true };
+        var context = new CapabilityGateContext { ExperimentalFlags = flags };
+
+        var resolution = CapabilityGateResolver.Resolve(experimental, context);
+
+        resolution.Enabled.Should().BeTrue();
+        resolution.ReasonCode.Should().BeNull();
+    }
+
+    private static CapabilityDescriptor Descriptor(CapabilityMaturity maturity) => new()
+    {
+        Id = "temporal.filtering",
+        Category = "temporal",
+        Kind = CapabilityKind.Feature,
+        Maturity = maturity,
+    };
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityManifestEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityManifestEndpointTests.cs
@@ -47,7 +47,8 @@ public sealed class CapabilityManifestEndpointTests : IAsyncLifetime
 
     private static WebAppFixture CreateManifestFixture(
         string[]? entitlements = null,
-        HonuaEdition edition = HonuaEdition.Pro)
+        HonuaEdition edition = HonuaEdition.Pro,
+        bool manifestFromRegistry = false)
         => new WebAppFixture()
             .WithTestLicense(edition, entitlements: entitlements)
             .ConfigureServices(services =>
@@ -74,7 +75,8 @@ public sealed class CapabilityManifestEndpointTests : IAsyncLifetime
                         ["Limits:Analytics:MaxDensityCellSizeMeters"] = "34567.5",
                         ["Limits:Analytics:MaxDWithinDistanceMeters"] = "45678.5",
                         ["FeatureStreaming:MaxConcurrentSessions"] = "12",
-                        ["Grpc:StreamBatchSize"] = "42"
+                        ["Grpc:StreamBatchSize"] = "42",
+                        ["Capabilities:ManifestFromRegistry"] = manifestFromRegistry ? "true" : "false"
                     });
                 });
             });
@@ -353,6 +355,52 @@ public sealed class CapabilityManifestEndpointTests : IAsyncLifetime
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Contain("workspaceId contains unsupported characters.");
         body.Should().NotContain("CapabilityManifestService");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/capabilities/manifest")]
+    public async Task GetManifest_RegistryDerived_MatchesHandCuratedComposition()
+    {
+        // #2335 (B3) golden before/after: the registry-derived composition
+        // (Capabilities:ManifestFromRegistry=true) must serialize a byte-identical
+        // Capabilities[] and Packages.Families[] to the legacy hand-curated path while
+        // every descriptor stays Implemented, proving entitlement/availability
+        // resolution is unchanged.
+        const string query = "/api/v1/capabilities/manifest?environment=test&workspaceId=field-team";
+
+        var legacyFixture = CreateManifestFixture();
+        var derivedFixture = CreateManifestFixture(manifestFromRegistry: true);
+        await legacyFixture.InitializeAsync();
+        await derivedFixture.InitializeAsync();
+
+        try
+        {
+            using var legacyClient = legacyFixture.CreateAdminClient();
+            using var derivedClient = derivedFixture.CreateAdminClient();
+            using var legacyResponse = await legacyClient.GetAsync(query);
+            using var derivedResponse = await derivedClient.GetAsync(query);
+
+            legacyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            derivedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using var legacyDocument = await ReadDocumentAsync(legacyResponse);
+            using var derivedDocument = await ReadDocumentAsync(derivedResponse);
+
+            var derivedCapabilities = derivedDocument.RootElement.GetProperty("capabilities").GetRawText();
+            var legacyCapabilities = legacyDocument.RootElement.GetProperty("capabilities").GetRawText();
+            derivedCapabilities.Should().Be(legacyCapabilities);
+
+            var derivedFamilies = derivedDocument.RootElement
+                .GetProperty("packages").GetProperty("families").GetRawText();
+            var legacyFamilies = legacyDocument.RootElement
+                .GetProperty("packages").GetProperty("families").GetRawText();
+            derivedFamilies.Should().Be(legacyFamilies);
+        }
+        finally
+        {
+            await legacyFixture.DisposeAsync();
+            await derivedFixture.DisposeAsync();
+        }
     }
 
     private static async Task<JsonDocument> ReadDocumentAsync(HttpResponseMessage response)


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2335

## Summary
Track B3 (ADR-0058, Decision B): the `honua.capability_manifest.v1` surface (#1186) now derives its `Capabilities[]` and `Packages.Families[]` by iterating the unified `ICapabilityRegistry` (B1 / #2333) through the T2 `CapabilityGateResolver` (#2339) for enable/edition resolution, instead of hand-curated in-service lists. The wire shape is preserved exactly: an experimental-and-flag-off descriptor is simply omitted (wire-compatible), and because every descriptor stays `Implemented` today, the served manifest is byte-identical. The new path is gated behind the staged `Capabilities:ManifestFromRegistry` flag (default `false`), so the legacy composition stays live until it is turned on. This wires the mechanism only — no capability is flipped to experimental (that is T10 / #2346).

The null `PackageSchemaVersion` seam B1 left on the registry descriptors is now populated from the manifest package families, so the derived `Packages.Families[]` and the registry descriptors cannot diverge.

## Changes Made
- `CapabilityRegistry` (Core): populate `PackageSchemaVersion` on the five `packages`-category descriptors from the package-family schema versions (metadata-v2, release-package, gitops-manifest, map, app); all other manifest descriptors keep `null`.
- `CapabilityManifestService` (Server): add `BuildCapabilitiesFromRegistry` and `BuildPackagesFromRegistry` that iterate `ICapabilityRegistry.All`, resolve each descriptor through `CapabilityGateResolver`, omit experimental-disabled entries, and layer the manifest-only config knobs (supported/configured/requires*/policy/composite entitlement keys) via a per-id spec map; availability uses the same `Capability(...)` factory so output is unchanged. Legacy hand-curated paths retained and selected when the flag is off.
- Add staged `Capabilities:ManifestFromRegistry` flag (`CapabilityManifestFeatureOptions`, default off) carried on `CapabilityManifestOptionsSnapshot`; branch the manifest composition on it.
- Reconciled with T5 (#2341/#2370): reuse the existing `services.AddCapabilityRegistry()` registration (no duplicate) and add the B3 feature-flag binding alongside it.
- Tests: Core unit tests pin the frozen manifest roster/order, that all manifest descriptors are `Implemented` (none omitted), the populated `PackageSchemaVersion` values, and the gate-resolver present/absent omit mechanism. Integration golden test asserts the registry-derived `Capabilities[]` and `Packages.Families[]` serialize byte-identically to the legacy hand-curated composition.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The `honua.capability_manifest.v1` wire shape is unchanged; the derivation is behind a default-off staged flag and, with all descriptors `Implemented`, produces an identical document.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed — full build/test skipped locally because the shared multi-agent build lock was saturated; `dotnet format --verify-no-changes` passed on the changed files. CI validates the build/test matrix.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
