### PR TITLE
feat(admin): project capability registry into feature overview (#2344)

### DIFF
--- a/src/Honua.Server/Features/Admin/FeatureOverviewEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/FeatureOverviewEndpoints.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Capabilities;
 using Honua.Core.Features.Licensing.Abstractions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Server.Features.Admin.Models;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Features.Admin;
 
@@ -33,6 +35,9 @@ internal static class FeatureOverviewEndpoints
 
     private static IResult HandleGetFeatureOverview(
         [FromServices] ILicenseEntitlementService entitlementService,
+        [FromServices] ICapabilityRegistry capabilityRegistry,
+        [FromServices] IOptions<CapabilityFlagOptions> experimentalFlags,
+        [FromServices] IWebHostEnvironment hostEnvironment,
         [FromServices] ILogger<FeatureOverviewEndpointsLog> logger)
     {
         AdminLog.FeatureOverviewQueried(logger);
@@ -54,14 +59,54 @@ internal static class FeatureOverviewEndpoints
             };
         }).ToArray();
 
+        // The capability roster is resolved for the current edition/environment
+        // through the same T2 gate resolver every surface uses, so the READ view
+        // shows the exact enabled/reason state the live gates enforce.
+        var gateContext = new CapabilityGateContext
+        {
+            Edition = snapshot.Edition,
+            DeploymentEnvironment = hostEnvironment.EnvironmentName,
+            ExperimentalFlags = experimentalFlags.Value
+        };
+
+        var capabilities = ProjectCapabilities(capabilityRegistry.All, gateContext);
+
         var response = new FeatureOverviewResponse
         {
             CurrentEdition = snapshot.Edition.ToString(),
-            Features = features
+            Features = features,
+            Capabilities = capabilities
         };
 
         return Results.Json(
             ApiResponse<FeatureOverviewResponse>.CreateSuccess(response),
             FeatureOverviewJsonContext.Default.ApiResponseFeatureOverviewResponse);
+    }
+
+    /// <summary>
+    /// Projects the unified capability roster into the admin read model, resolving
+    /// each descriptor's enabled/reason state through the T2
+    /// <see cref="CapabilityGateResolver"/> for the given context. Extracted as a
+    /// pure function so the resolution projection (including the experimental-disabled
+    /// reason) is unit-testable without spinning up the endpoint.
+    /// </summary>
+    /// <param name="descriptors">The capability descriptors to project.</param>
+    /// <param name="context">The edition/environment/flag context to resolve against.</param>
+    internal static CapabilityOverviewItem[] ProjectCapabilities(
+        IEnumerable<CapabilityDescriptor> descriptors,
+        CapabilityGateContext context)
+    {
+        return descriptors.Select(descriptor =>
+        {
+            var resolution = CapabilityGateResolver.Resolve(descriptor, context);
+            return new CapabilityOverviewItem
+            {
+                Id = descriptor.Id,
+                Kind = descriptor.Kind.ToString(),
+                Maturity = descriptor.Maturity.ToString(),
+                Enabled = resolution.Enabled,
+                ReasonCode = resolution.ReasonCode
+            };
+        }).ToArray();
     }
 }

--- a/src/Honua.Server/Features/Admin/Models/FeatureOverviewJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/FeatureOverviewJsonContext.cs
@@ -18,6 +18,8 @@ namespace Honua.Server.Features.Admin.Models;
 [JsonSerializable(typeof(FeatureOverviewResponse))]
 [JsonSerializable(typeof(FeatureOverviewItem))]
 [JsonSerializable(typeof(FeatureOverviewItem[]))]
+[JsonSerializable(typeof(CapabilityOverviewItem))]
+[JsonSerializable(typeof(CapabilityOverviewItem[]))]
 internal sealed partial class FeatureOverviewJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Server/Features/Admin/Models/FeatureOverviewModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/FeatureOverviewModels.cs
@@ -17,6 +17,53 @@ public sealed class FeatureOverviewResponse
     /// All platform features with their enabled/disabled state.
     /// </summary>
     public required FeatureOverviewItem[] Features { get; init; }
+
+    /// <summary>
+    /// The full unified capability roster (ADR-0058, Decision B) projected from
+    /// <see cref="Honua.Core.Features.Capabilities.ICapabilityRegistry"/>, resolved
+    /// for the current edition/environment through the T2 gate resolver so operators
+    /// can see every capability and <b>why</b> each is on or off. Read-only — there
+    /// is deliberately no mutable toggle endpoint (the flag design defers writes to
+    /// the config-bound experimental switches).
+    /// </summary>
+    public required CapabilityOverviewItem[] Capabilities { get; init; }
+}
+
+/// <summary>
+/// One capability from the unified registry, projected with its resolved
+/// enabled/reason state for the current edition and environment.
+/// </summary>
+public sealed class CapabilityOverviewItem
+{
+    /// <summary>
+    /// Stable, unique capability identifier (for example <c>format.geoparquet</c>
+    /// or <c>protocol.mcp.tool.plan_analysis</c>).
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The broad kind of capability (<c>Feature</c>, <c>ProtocolOperation</c>, or
+    /// <c>DataFormat</c>).
+    /// </summary>
+    public required string Kind { get; init; }
+
+    /// <summary>
+    /// The product-lifecycle maturity (<c>Planned</c>, <c>Deferred</c>,
+    /// <c>Experimental</c>, <c>Partial</c>, or <c>Implemented</c>).
+    /// </summary>
+    public required string Maturity { get; init; }
+
+    /// <summary>
+    /// Whether the capability resolves enabled for the current edition/environment.
+    /// </summary>
+    public required bool Enabled { get; init; }
+
+    /// <summary>
+    /// The stable machine-readable reason the capability is disabled (for example
+    /// <c>experimental-disabled</c> or <c>license-required</c>), or <c>null</c> when
+    /// the capability is enabled.
+    /// </summary>
+    public string? ReasonCode { get; init; }
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/FeatureOverviewCapabilityProjectionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/FeatureOverviewCapabilityProjectionTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Capabilities;
+using Honua.Server.Features.Admin;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Unit coverage for the admin feature-overview capability projection (Track T8 /
+/// #2344): the read-only surface that projects the unified capability registry
+/// (ADR-0058, Decision B) through the T2 gate resolver so operators can see the
+/// full roster and <b>why</b> each capability is on or off.
+/// </summary>
+public sealed class FeatureOverviewCapabilityProjectionTests
+{
+    private static readonly CapabilityDescriptor ImplementedDescriptor = new()
+    {
+        Id = "test.implemented.capability",
+        Category = "test",
+        Kind = CapabilityKind.Feature,
+        Maturity = CapabilityMaturity.Implemented,
+    };
+
+    private static readonly CapabilityDescriptor ExperimentalDescriptor = new()
+    {
+        Id = "test.experimental.capability",
+        Category = "test",
+        Kind = CapabilityKind.ProtocolOperation,
+        Maturity = CapabilityMaturity.Experimental,
+    };
+
+    [Fact]
+    public void ProjectCapabilities_CarriesIdKindMaturityAndResolvedState()
+    {
+        var items = FeatureOverviewEndpoints.ProjectCapabilities(
+            [ImplementedDescriptor],
+            CapabilityGateContext.Default);
+
+        var item = items.Should().ContainSingle().Subject;
+        item.Id.Should().Be("test.implemented.capability");
+        item.Kind.Should().Be(nameof(CapabilityKind.Feature));
+        item.Maturity.Should().Be(nameof(CapabilityMaturity.Implemented));
+        item.Enabled.Should().BeTrue();
+        item.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void ProjectCapabilities_ExperimentalWithFlagsOff_ShowsDisabledWithReasonCode()
+    {
+        // Default context leaves the experimental flags off, so an experimental
+        // capability resolves disabled with the experimental-disabled reason code.
+        var items = FeatureOverviewEndpoints.ProjectCapabilities(
+            [ExperimentalDescriptor],
+            CapabilityGateContext.Default);
+
+        var item = items.Should().ContainSingle().Subject;
+        item.Id.Should().Be("test.experimental.capability");
+        item.Maturity.Should().Be(nameof(CapabilityMaturity.Experimental));
+        item.Enabled.Should().BeFalse();
+        item.ReasonCode.Should().Be(CapabilityReasonCodes.ExperimentalDisabled);
+    }
+
+    [Fact]
+    public void ProjectCapabilities_ExperimentalWithFlagOn_ShowsEnabled()
+    {
+        var flags = new CapabilityFlagOptions { Enabled = true };
+        var context = new CapabilityGateContext { ExperimentalFlags = flags };
+
+        var items = FeatureOverviewEndpoints.ProjectCapabilities([ExperimentalDescriptor], context);
+
+        var item = items.Should().ContainSingle().Subject;
+        item.Enabled.Should().BeTrue();
+        item.ReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void ProjectCapabilities_PreservesRegistryOrder()
+    {
+        var items = FeatureOverviewEndpoints.ProjectCapabilities(
+            [ImplementedDescriptor, ExperimentalDescriptor],
+            CapabilityGateContext.Default);
+
+        items.Should().HaveCount(2);
+        items[0].Id.Should().Be(ImplementedDescriptor.Id);
+        items[1].Id.Should().Be(ExperimentalDescriptor.Id);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/PlatformAdminEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/PlatformAdminEndpointsTests.cs
@@ -394,6 +394,50 @@ public sealed class PlatformAdminEndpointsTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Features)]
     [Endpoint("GET /api/v1/admin/features")]
+    public async Task GetFeatureOverview_ReturnsCapabilityRegistryProjection()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/features");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var data = document.RootElement.GetProperty("data");
+
+        // T8: the read-only projection of the unified capability registry.
+        var capabilities = data.GetProperty("capabilities");
+        capabilities.GetArrayLength().Should().BeGreaterThan(0);
+
+        // Each capability carries id + kind + maturity + resolved enabled state.
+        var firstCapability = capabilities[0];
+        firstCapability.GetProperty("id").GetString().Should().NotBeNullOrEmpty();
+        firstCapability.GetProperty("kind").GetString().Should().NotBeNullOrEmpty();
+        firstCapability.GetProperty("maturity").GetString().Should().NotBeNullOrEmpty();
+        firstCapability.TryGetProperty("enabled", out _).Should().BeTrue();
+
+        // Every disabled capability must carry a machine-readable reason code, and
+        // every enabled one must omit it (WhenWritingNull) — operators can always
+        // see WHY a capability is off.
+        foreach (var capability in capabilities.EnumerateArray())
+        {
+            var enabled = capability.GetProperty("enabled").GetBoolean();
+            var hasReason = capability.TryGetProperty("reasonCode", out var reason)
+                && reason.ValueKind == JsonValueKind.String
+                && !string.IsNullOrEmpty(reason.GetString());
+
+            if (enabled)
+            {
+                hasReason.Should().BeFalse("an enabled capability has no disable reason");
+            }
+            else
+            {
+                hasReason.Should().BeTrue("a disabled capability must explain why");
+            }
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Features)]
+    [Endpoint("GET /api/v1/admin/features")]
     public async Task GetFeatureOverview_ProEdition_ShowsUpgradeMessagesForEnterprise()
     {
         var response = await _client.GetAsync("/api/v1/admin/features");


### PR DESCRIPTION
## Issue Link
Closes #2344

## Summary
Track T8 — the admin READ surface for the unified capability registry (ADR-0058, Decision B). Unblocked by B1 registry (#2356) and T2 resolver (#2357), both on trunk.

`GET /api/v1/admin/features` already projects `FeatureCatalog.All`. This adds a parallel projection of `ICapabilityRegistry.All` → `{ id, kind, maturity, enabled, reasonCode }` per capability, resolving `enabled`/`reasonCode` through the T2 `CapabilityGateResolver` for the current edition, deployment environment, and experimental flags. Operators can now see the full capability surface and WHY each capability is on or off.

Read-only by design — no mutable toggle endpoint (the flag design defers writes to the config-bound `Capabilities:Experimental` switches).

## Changes Made
- Add `CapabilityOverviewItem` model and a `Capabilities` array on `FeatureOverviewResponse`
- Register the new model shapes in the AOT `FeatureOverviewJsonContext`
- Inject `ICapabilityRegistry`, `IOptions<CapabilityFlagOptions>`, and `IWebHostEnvironment`; build a `CapabilityGateContext` for the current env/edition
- Extract a pure `ProjectCapabilities` helper that resolves each descriptor via the T2 `CapabilityGateResolver`

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- Unit: projection carries id/kind/maturity/enabled; an experimental descriptor with flags off shows `enabled=false` + `reasonCode=experimental-disabled`; flag-on shows enabled; registry order preserved
- Integration: endpoint returns the capability projection and every disabled capability carries a machine-readable reason code (enabled ones omit it)

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- Additive: new read-only `capabilities` array on the admin feature-overview response

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None