### PR TITLE
feat(capabilities): prune disabled-experimental operations from OpenAPI doc (#2343)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,12 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <!-- Pin Microsoft.OpenApi to the patched 2.7.5: Microsoft.AspNetCore.OpenApi 10.0.6
+         pulls Microsoft.OpenApi 2.0.0 transitively, which trips the NU1903 audit
+         (GHSA-v5pm-xwqc-g5wc, vulnerable <= 2.7.4, treated as an error). 2.7.5 is the
+         first patched release and stays API-compatible within the 2.x line. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.2" />

--- a/src/Honua.Hosting/Features/Capabilities/CapabilityGateOpenApiDocumentTransformer.cs
+++ b/src/Honua.Hosting/Features/Capabilities/CapabilityGateOpenApiDocumentTransformer.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net.Http;
+using Honua.Core.Features.Capabilities;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi;
+
+namespace Honua.Infrastructure.Capabilities;
+
+/// <summary>
+/// OpenAPI document transformer that prunes operations gated on a capability that
+/// resolves <b>experimental-disabled</b> (Track T7 / #2343). It is the description
+/// layer's counterpart to the runtime <see cref="CapabilityGateEndpointFilter"/>
+/// (Track T5): the filter returns <c>404</c> for a disabled-experimental route, and
+/// this transformer removes the matching operation from the generated OpenAPI
+/// document so the published contract never advertises an endpoint that 404s.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For every <see cref="ApiDescription"/> that carries a
+/// <see cref="CapabilityGateMetadata"/> marker (attached by <c>WithCapabilityGate</c>),
+/// the transformer resolves the descriptor id through the <see cref="ICapabilityRegistry"/>
+/// with the config-driven experimental precedence (#2339 / T2). Only the
+/// <see cref="CapabilityReasonCodes.ExperimentalDisabled"/> outcome drops the
+/// operation — exactly the outcome the endpoint filter short-circuits. Enabled
+/// capabilities (including flag-on experimental ones), unregistered ids, and the
+/// wrong-edition (<see cref="CapabilityReasonCodes.LicenseRequired"/>) outcome all
+/// stay in the document, mirroring the filter's pass-through set.
+/// </para>
+/// <para>
+/// This is a behavioural no-op until an experimental capability is actually flipped
+/// off-by-default (Track T10 / #2346): with no experimental descriptors gated, no
+/// operation resolves experimental-disabled and the document is unchanged. It is
+/// registered into the <c>AddOpenApi(...)</c> pipeline via
+/// <c>OpenApiOptions.AddCapabilityGate()</c>.
+/// </para>
+/// </remarks>
+internal sealed class CapabilityGateOpenApiDocumentTransformer : IOpenApiDocumentTransformer
+{
+    /// <inheritdoc />
+    public Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (document.Paths is null || document.Paths.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        // The registry is the single evaluation entry point; without it there is
+        // nothing to resolve against and the document is left untouched.
+        var registry = context.ApplicationServices.GetService<ICapabilityRegistry>();
+        if (registry is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var flags = context.ApplicationServices.GetService<IOptions<CapabilityFlagOptions>>()?.Value
+            ?? new CapabilityFlagOptions();
+        var gateContext = new CapabilityGateContext { ExperimentalFlags = flags };
+
+        foreach (var group in context.DescriptionGroups)
+        {
+            foreach (var apiDescription in group.Items)
+            {
+                var gate = GetGate(apiDescription);
+                if (gate is null)
+                {
+                    continue;
+                }
+
+                var resolution = registry.Resolve(gate.DescriptorId, gateContext);
+
+                // Only the experimental-disabled outcome is pruned here — the same
+                // single outcome the endpoint filter (T5) short-circuits with 404.
+                if (resolution.Enabled ||
+                    !string.Equals(
+                        resolution.ReasonCode,
+                        CapabilityReasonCodes.ExperimentalDisabled,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                DropOperation(document, apiDescription);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static CapabilityGateMetadata? GetGate(ApiDescription apiDescription)
+    {
+        var metadata = apiDescription.ActionDescriptor?.EndpointMetadata;
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        // Metadata added last (closest to the endpoint) wins, mirroring how the
+        // endpoint filter reads the most-specific CapabilityGateMetadata.
+        for (var i = metadata.Count - 1; i >= 0; i--)
+        {
+            if (metadata[i] is CapabilityGateMetadata gate)
+            {
+                return gate;
+            }
+        }
+
+        return null;
+    }
+
+    private static void DropOperation(OpenApiDocument document, ApiDescription apiDescription)
+    {
+        var pathKey = FindPathKey(document, apiDescription.RelativePath);
+        if (pathKey is null ||
+            document.Paths[pathKey] is not { Operations: { } operations })
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(apiDescription.HttpMethod))
+        {
+            operations.Remove(HttpMethod.Parse(apiDescription.HttpMethod));
+        }
+
+        // A path with no operations left should not linger in the document.
+        if (operations.Count == 0)
+        {
+            document.Paths.Remove(pathKey);
+        }
+    }
+
+    private static string? FindPathKey(OpenApiDocument document, string? relativePath)
+    {
+        var target = NormalizeKey(relativePath);
+        foreach (var entry in document.Paths)
+        {
+            if (string.Equals(NormalizeKey(entry.Key), target, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Key;
+            }
+        }
+
+        return null;
+    }
+
+    private static string NormalizeKey(string? path)
+        => string.IsNullOrEmpty(path) ? string.Empty : path.Trim('/');
+}

--- a/src/Honua.Hosting/Features/Capabilities/CapabilityGateOpenApiExtensions.cs
+++ b/src/Honua.Hosting/Features/Capabilities/CapabilityGateOpenApiExtensions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Infrastructure.Capabilities;
+
+/// <summary>
+/// Registration helpers that wire the <see cref="CapabilityGateOpenApiDocumentTransformer"/>
+/// into the <c>AddOpenApi(...)</c> pipeline (Track T7 / #2343) so disabled-experimental
+/// endpoints are pruned from the generated OpenAPI document, keeping the published
+/// contract in agreement with the runtime capability gate (Track T5).
+/// </summary>
+internal static class CapabilityGateOpenApiExtensions
+{
+    /// <summary>
+    /// Adds the capability-gate document transformer to an OpenAPI document's
+    /// transformer pipeline. Apply inside an <c>AddOpenApi</c> configuration callback:
+    /// <code>
+    /// builder.Services.AddOpenApi(options => options.AddCapabilityGate());
+    /// </code>
+    /// </summary>
+    /// <param name="options">The OpenAPI document options being configured.</param>
+    /// <returns>The same <see cref="OpenApiOptions"/> for chaining.</returns>
+    internal static OpenApiOptions AddCapabilityGate(this OpenApiOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.AddDocumentTransformer<CapabilityGateOpenApiDocumentTransformer>();
+        return options;
+    }
+
+    /// <summary>
+    /// Registers an OpenAPI document whose transformer pipeline prunes
+    /// disabled-experimental operations via the capability gate. Convenience wrapper
+    /// over <c>AddOpenApi(documentName, options =&gt; options.AddCapabilityGate())</c>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="documentName">The OpenAPI document name (default <c>v1</c>).</param>
+    /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+    internal static IServiceCollection AddCapabilityGatedOpenApi(
+        this IServiceCollection services,
+        string documentName = "v1")
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrEmpty(documentName);
+
+        services.AddOpenApi(documentName, options => options.AddCapabilityGate());
+        return services;
+    }
+}

--- a/src/Honua.Hosting/Honua.Hosting.csproj
+++ b/src/Honua.Hosting/Honua.Hosting.csproj
@@ -31,6 +31,14 @@
          (JWT bearer, OIDC, JWT handler) compiles standalone. -->
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <!-- Microsoft.AspNetCore.OpenApi provides the IOpenApiDocumentTransformer seam
+         (and the AddOpenApi/OpenApiOptions pipeline) the capability-gate transformer
+         registers into so disabled-experimental endpoints are pruned from the
+         generated OpenAPI document (Track T7 / #2343). -->
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <!-- Direct reference pins the transitive Microsoft.OpenApi up to the patched
+         2.7.5 (clears the NU1903 audit error from the 2.0.0 AspNetCore.OpenApi pulls). -->
+    <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <!-- NetTopologySuite is required by the carved Events / Validation surfaces
          (FeatureChangeEventEnrichment's WKB→GeoJSON envelope extraction,

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -11,6 +11,7 @@ using Honua.Server.Features.Admin;
 using Honua.ControlPlane;
 using Honua.Ai.AnalysisContent;
 using Honua.Server.Features.Capabilities;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Scene;
 using Honua.Alerts;
 using Honua.Server.Features.CloudDemo;
@@ -156,6 +157,13 @@ internal static class FeatureRegistrationExtensions
         services.AddTemporalHistory();
         services.AddAnalysisReporting(configuration);
         services.AddCapabilityManifest(configuration);
+        // #2343 (T7): register the capability-gate OpenAPI document transformer into
+        // the AddOpenApi pipeline so operations gated on a disabled-experimental
+        // capability are pruned from the generated OpenAPI document, keeping the
+        // published contract in agreement with the runtime gate (T5). No-op until an
+        // experimental capability is flipped off-by-default (T10 / #2346). Depends on
+        // the ICapabilityRegistry registered by AddCapabilityManifest above.
+        services.AddCapabilityGatedOpenApi();
         services.AddPackageReview();
         services.AddMcpOperatorSurface(configuration);
         services.AddSpecGrounding();

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityGateOpenApiDocumentTransformerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/CapabilityGateOpenApiDocumentTransformerTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Capabilities;
+using Honua.Infrastructure.Capabilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Honua.Server.Tests.Features.Capabilities;
+
+/// <summary>
+/// Component coverage for <see cref="CapabilityGateOpenApiDocumentTransformer"/>
+/// (Track T7 / #2343): the transformer wired into the <c>AddOpenApi</c> pipeline via
+/// <c>AddCapabilityGatedOpenApi</c> must prune an operation gated on a
+/// disabled-experimental capability from the generated OpenAPI document, while
+/// leaving enabled/ungated operations in place — the description-layer counterpart
+/// to the runtime 404 gate (T5).
+/// </summary>
+public sealed class CapabilityGateOpenApiDocumentTransformerTests
+{
+    private const string GatedDescriptorId = "test.experimental.capability";
+    private const string GatedPath = "/gated/ping";
+    private const string OpenPath = "/open/ping";
+
+    private static readonly CapabilityDescriptor ExperimentalDescriptor = new()
+    {
+        Id = GatedDescriptorId,
+        Category = "test",
+        Kind = CapabilityKind.Feature,
+        Maturity = CapabilityMaturity.Experimental,
+    };
+
+    [Fact]
+    public async Task Transform_WhenGatedCapabilityDisabled_DropsOperationFromDocument()
+    {
+        using var server = BuildServer(experimentalEnabled: false);
+        using var client = server.CreateClient();
+
+        var paths = await GetDocumentPathsAsync(client);
+
+        paths.Should().Contain(OpenPath, "ungated operations are always described");
+        paths.Should().NotContain(GatedPath, "a disabled-experimental operation must not appear in the document");
+    }
+
+    [Fact]
+    public async Task Transform_WhenGatedCapabilityEnabled_KeepsOperationInDocument()
+    {
+        using var server = BuildServer(experimentalEnabled: true);
+        using var client = server.CreateClient();
+
+        var paths = await GetDocumentPathsAsync(client);
+
+        paths.Should().Contain(OpenPath);
+        paths.Should().Contain(GatedPath, "an enabled experimental operation is described normally");
+    }
+
+    private static async Task<IReadOnlyCollection<string>> GetDocumentPathsAsync(HttpClient client)
+    {
+        var json = await client.GetStringAsync(new Uri("/openapi/v1.json", UriKind.Relative));
+        using var document = JsonDocument.Parse(json);
+
+        return document.RootElement.TryGetProperty("paths", out var pathsElement)
+            ? pathsElement.EnumerateObject().Select(property => property.Name).ToArray()
+            : [];
+    }
+
+    private static TestServer BuildServer(bool experimentalEnabled)
+    {
+        var builder = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddLogging();
+                        services.AddRouting();
+                        services.AddSingleton<ICapabilityRegistry>(
+                            new StubCapabilityRegistry(ExperimentalDescriptor));
+                        services.AddOptions<CapabilityFlagOptions>()
+                            .Configure(options => options.Enabled = experimentalEnabled);
+                        services.AddCapabilityGatedOpenApi();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapOpenApi();
+
+                            var gated = endpoints.MapGroup("/gated")
+                                .WithCapabilityGate(GatedDescriptorId);
+                            gated.MapGet("/ping", () => Results.Ok("pong"));
+
+                            endpoints.MapGet(OpenPath, () => Results.Ok("pong"));
+                        });
+                    });
+            });
+
+        var host = builder.Build();
+        host.Start();
+        return host.GetTestServer();
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ICapabilityRegistry"/> exposing a single experimental
+    /// descriptor and deferring resolution to the shared
+    /// <see cref="CapabilityGateResolver"/>, mirroring the production registry.
+    /// </summary>
+    private sealed class StubCapabilityRegistry : ICapabilityRegistry
+    {
+        private readonly CapabilityDescriptor _descriptor;
+
+        public StubCapabilityRegistry(CapabilityDescriptor descriptor) => _descriptor = descriptor;
+
+        public IReadOnlyList<CapabilityDescriptor> All => [_descriptor];
+
+        public CapabilityDescriptor? Find(string id)
+            => string.Equals(id, _descriptor.Id, StringComparison.Ordinal) ? _descriptor : null;
+
+        public CapabilityResolution Resolve(string id, CapabilityGateContext context)
+            => CapabilityGateResolver.Resolve(Find(id), context);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2343

## Summary
Track B extension (feature-flag system) — T7. Adds a `CapabilityGateOpenApiDocumentTransformer` (`IOpenApiDocumentTransformer`) that prunes OpenAPI operations gated on a capability which resolves **experimental-disabled**, so the published OpenAPI contract stays in agreement with the runtime gate (T5) and the manifest (T4): a disabled-experimental endpoint that 404s at runtime must not be advertised in the document.

For every `ApiDescription` carrying the `CapabilityGateMetadata` marker that `WithCapabilityGate` attaches (T5 / #2341), the transformer resolves the descriptor id through `ICapabilityRegistry` with the config-driven experimental precedence (T2 / #2339). Only the `experimental-disabled` outcome drops the operation — exactly the single outcome the endpoint filter short-circuits; enabled (incl. flag-on experimental), unregistered, and wrong-edition all pass through. It is registered into the `AddOpenApi(...)` pipeline via `OpenApiOptions.AddCapabilityGate()` / `AddCapabilityGatedOpenApi()`, wired alongside the capability registry.

This is a behavioral no-op today: nothing is flipped experimental-by-default until T10 (#2346), so no operation currently resolves experimental-disabled and the document is unchanged.

## Changes Made
- Add `CapabilityGateOpenApiDocumentTransformer` (`IOpenApiDocumentTransformer`) in `Honua.Hosting` that removes disabled-experimental operations (and now-empty paths) from the generated OpenAPI document.
- Add `CapabilityGateOpenApiExtensions` — `OpenApiOptions.AddCapabilityGate()` and `IServiceCollection.AddCapabilityGatedOpenApi()` — to register the transformer in the `AddOpenApi` pipeline; wire it in `FeatureRegistrationExtensions` after the capability registry.
- Add `Microsoft.AspNetCore.OpenApi` (10.0.6) to `Honua.Hosting`; pin `Microsoft.OpenApi` to the patched **2.7.5** to clear the NU1903 audit error (GHSA-v5pm-xwqc-g5wc, vulnerable ≤ 2.7.4) the transitive 2.0.0 trips.
- Add `CapabilityGateOpenApiDocumentTransformerTests` driving the full `AddOpenApi` pipeline: the gated operation is absent from the generated document when the experimental flag is off and present when on; the ungated operation is always present.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

<!-- Build lock saturated on this shared multi-agent host: could not run the full Release build / test suite. Verified `dotnet restore` succeeds (NU1903 cleared) and `dotnet format --verify-no-changes` passes on all changed files; validated the Microsoft.OpenApi 2.7.5 and Microsoft.AspNetCore.OpenApi 10.0.6 public API shapes used by the transformer via reflection probes. CI runs the full gate on this PR. -->

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
