### PR TITLE
feat(capabilities): flip built-experimental capabilities to Experimental (#2346)

### DIFF
--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -184,54 +184,72 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
         // honua.capability_manifest.v1 wire advertises for that family, and the null
         // seam B1 left. It mirrors CapabilityManifestService's package-family list so
         // the derived Packages.Families[] and the descriptors cannot diverge.
-        (string Id, string Category, string? EntitlementKey, CapabilityKind Kind, string? PackageSchemaVersion)[] capabilities =
+        // T10 (#2346): the built-experimental capabilities are flipped from
+        // Implemented to Experimental here. They are implemented server-side but
+        // gated OFF the first-release surface (ADR-0058): with the default config
+        // (Capabilities:Experimental:Enabled=false and no per-capability override)
+        // the T2 resolver reports them experimental-disabled, so the registry-derived
+        // manifest omits them (B3), the T5 endpoint gates 404 their route groups, and
+        // the feature catalog projects them as `experimental`. A customer opts in per
+        // capability via Capabilities:Experimental:{id}:Enabled=true. Concepts whose
+        // built-experimental surface has no distinct registry descriptor (versioned
+        // editing/VMS, SIEM/investigations, cross-environment promotion,
+        // rollback/auto-rollback, collaborative map sessions, governance auth
+        // SSO/OIDC/SAML/SCIM, forms/form-packages, mobile field-collection beyond
+        // offline sync) are intentionally left as-is — there is no descriptor to flip.
+        (string Id, string Category, string? EntitlementKey, CapabilityKind Kind, string? PackageSchemaVersion, CapabilityMaturity Maturity)[] capabilities =
         [
-            ("package.metadata-v2", "packages", null, CapabilityKind.Feature, MetadataV2Constants.SchemaVersion),
-            ("package.release-package", "packages", null, CapabilityKind.Feature, MetadataV2Constants.ApiVersion),
-            ("package.gitops-manifest", "packages", null, CapabilityKind.Feature, MetadataV2Constants.ApiVersion),
-            ("package.map", "packages", null, CapabilityKind.Feature, MapPackageSchemaVersion),
-            ("package.app", "packages", null, CapabilityKind.Feature, AppPackageSchemaVersion),
+            ("package.metadata-v2", "packages", null, CapabilityKind.Feature, MetadataV2Constants.SchemaVersion, CapabilityMaturity.Implemented),
+            ("package.release-package", "packages", null, CapabilityKind.Feature, MetadataV2Constants.ApiVersion, CapabilityMaturity.Implemented),
+            ("package.gitops-manifest", "packages", null, CapabilityKind.Feature, MetadataV2Constants.ApiVersion, CapabilityMaturity.Implemented),
+            ("package.map", "packages", null, CapabilityKind.Feature, MapPackageSchemaVersion, CapabilityMaturity.Implemented),
+            ("package.app", "packages", null, CapabilityKind.Feature, AppPackageSchemaVersion, CapabilityMaturity.Implemented),
 
-            ("temporal.filtering", "temporal", "temporal.filtering", CapabilityKind.Feature, null),
-            ("temporal.extent-discovery", "temporal", "temporal.extent-discovery", CapabilityKind.Feature, null),
-            ("temporal.histogram", "temporal", "temporal.histogram", CapabilityKind.Feature, null),
-            ("temporal.time-series-tiles", "temporal", "temporal.time-series-tiles", CapabilityKind.Feature, null),
+            // Temporal / data-versioning — built-experimental (T10 flip).
+            ("temporal.filtering", "temporal", "temporal.filtering", CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+            ("temporal.extent-discovery", "temporal", "temporal.extent-discovery", CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+            ("temporal.histogram", "temporal", "temporal.histogram", CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+            ("temporal.time-series-tiles", "temporal", "temporal.time-series-tiles", CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
 
-            ("sync.offline", "sync", FeatureCatalog.FieldOpsOfflineSyncKey, CapabilityKind.Feature, null),
-            ("realtime.feature-streams", "realtime", "streaming.feature-subscriptions", CapabilityKind.Feature, null),
-            ("alerts.geofence", "alerts", "alerts.enter-exit", CapabilityKind.Feature, null),
-            ("jobs.runner", "jobs", null, CapabilityKind.Feature, null),
-            ("ai.spec-apply", "ai", FeatureCatalog.AiSpecApplyKey, CapabilityKind.Feature, null),
-            ("ai.grounding", "ai", FeatureCatalog.AiGroundingKey, CapabilityKind.Feature, null),
-            ("ai.workflow-generation", "ai", FeatureCatalog.AiWorkflowGenerationKey, CapabilityKind.Feature, null),
-            ("gitops.release-manifest", "gitops", null, CapabilityKind.Feature, null),
+            // Disconnected-sync conflict review — built-experimental (T10 flip).
+            ("sync.offline", "sync", FeatureCatalog.FieldOpsOfflineSyncKey, CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+            // Realtime feature streaming — built-experimental (T10 flip).
+            ("realtime.feature-streams", "realtime", "streaming.feature-subscriptions", CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+            // Geofence enter/exit alerting — built-experimental (T10 flip).
+            ("alerts.geofence", "alerts", "alerts.enter-exit", CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+            ("jobs.runner", "jobs", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("ai.spec-apply", "ai", FeatureCatalog.AiSpecApplyKey, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("ai.grounding", "ai", FeatureCatalog.AiGroundingKey, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("ai.workflow-generation", "ai", FeatureCatalog.AiWorkflowGenerationKey, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("gitops.release-manifest", "gitops", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
 
-            ("transport.grpc", "transports", null, CapabilityKind.ProtocolOperation, null),
-            ("transport.grpc-web", "transports", null, CapabilityKind.ProtocolOperation, null),
-            ("transport.native-grpc", "transports", null, CapabilityKind.ProtocolOperation, null),
-            ("transport.mcp", "transports", null, CapabilityKind.ProtocolOperation, null),
-            ("transport.qgis", "transports", null, CapabilityKind.ProtocolOperation, null),
+            ("transport.grpc", "transports", null, CapabilityKind.ProtocolOperation, null, CapabilityMaturity.Implemented),
+            ("transport.grpc-web", "transports", null, CapabilityKind.ProtocolOperation, null, CapabilityMaturity.Implemented),
+            ("transport.native-grpc", "transports", null, CapabilityKind.ProtocolOperation, null, CapabilityMaturity.Implemented),
+            ("transport.mcp", "transports", null, CapabilityKind.ProtocolOperation, null, CapabilityMaturity.Implemented),
+            ("transport.qgis", "transports", null, CapabilityKind.ProtocolOperation, null, CapabilityMaturity.Implemented),
 
-            ("security.mtls", "security", null, CapabilityKind.Feature, null),
-            ("preview.file-import", "preview", "import.file", CapabilityKind.Feature, null),
-            ("query.features", "query", null, CapabilityKind.Feature, null),
+            // Native mTLS (client-certificate) authentication — built-experimental (T10 flip).
+            ("security.mtls", "security", null, CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+            ("preview.file-import", "preview", "import.file", CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("query.features", "query", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
             // analysis.spatial is gated by a composite of four analytics keys; the
             // single-key EntitlementKey field cannot represent it, so it is left
             // null (the manifest projection keeps the composite key set in B3).
-            ("analysis.spatial", "analysis", null, CapabilityKind.Feature, null),
-            ("publication.metadata-release", "publication", null, CapabilityKind.Feature, null),
-            ("upload.file", "upload", "import.file", CapabilityKind.Feature, null),
-            ("edit.features", "edit", FeatureCatalog.FeatureServerEditsKey, CapabilityKind.Feature, null),
+            ("analysis.spatial", "analysis", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("publication.metadata-release", "publication", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("upload.file", "upload", "import.file", CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            ("edit.features", "edit", FeatureCatalog.FeatureServerEditsKey, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
         ];
 
-        foreach (var (id, category, entitlementKey, kind, packageSchemaVersion) in capabilities)
+        foreach (var (id, category, entitlementKey, kind, packageSchemaVersion, maturity) in capabilities)
         {
             yield return new CapabilityDescriptor
             {
                 Id = id,
                 Category = category,
                 Kind = kind,
-                Maturity = CapabilityMaturity.Implemented,
+                Maturity = maturity,
                 EntitlementKey = entitlementKey,
                 MinimumEdition = ResolveMinimumEdition(entitlementKey),
                 PackageSchemaVersion = packageSchemaVersion,

--- a/src/Honua.Server/Features/Admin/AlertAdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/AlertAdminEndpoints.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.AuditLog.Abstractions;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Server.Features.Admin.Models;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
 using NetTopologySuite.IO;
@@ -36,6 +37,9 @@ internal static class AlertAdminEndpoints
     public static void MapAlertAdminEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/alerts")
+            // T10 (#2346): geofence alerting is built-experimental and gated OFF the
+            // first-release surface (404 when alerts.geofence is experimental-disabled).
+            .WithCapabilityGate("alerts.geofence")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Alerts")

--- a/src/Honua.Server/Features/Admin/ClientCertificateAdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ClientCertificateAdminEndpoints.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using Honua.Server.Features.Admin.Models;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Authentication.ClientCertificates;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,6 +25,10 @@ internal static class ClientCertificateAdminEndpoints
     public static void MapClientCertificateAdminEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/security/client-certificates")
+            // T10 (#2346): native mTLS / client-certificate authentication is
+            // built-experimental and gated OFF the first-release surface (404 when
+            // security.mtls is experimental-disabled).
+            .WithCapabilityGate("security.mtls")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Security", "Client Certificates")

--- a/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ReplicaManagementEndpoints.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Models;
 using Honua.Server.Features.Admin.Models;
 using Honua.Server.Features.Console;
@@ -60,6 +61,10 @@ internal static class ReplicaManagementEndpoints
     public static void MapReplicaManagementEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/services/{serviceId}/replicas")
+            // T10 (#2346): disconnected-sync replica/conflict review is
+            // built-experimental and gated OFF the first-release surface (404 when
+            // sync.offline is experimental-disabled).
+            .WithCapabilityGate("sync.offline")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Replicas")

--- a/src/Honua.Server/Features/Admin/StreamingOperationsEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/StreamingOperationsEndpoints.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Honua.Server.Features.Admin.Models;
 using Honua.Infrastructure.Abstractions;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,6 +20,10 @@ internal static class StreamingOperationsEndpoints
     public static void MapStreamingOperationsEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/operations/streaming")
+            // T10 (#2346): realtime streaming operations are built-experimental and
+            // gated OFF the first-release surface (404 when realtime.feature-streams
+            // is experimental-disabled).
+            .WithCapabilityGate("realtime.feature-streams")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Operations")

--- a/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
+++ b/src/Honua.Server/Features/Streaming/FeatureStreamEndpoints.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
@@ -34,6 +35,10 @@ internal static partial class FeatureStreamEndpoints
     public static void MapFeatureStreamEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var streamGroup = endpoints.MapGroup("/api/v{version:apiVersion}/streaming")
+            // T10 (#2346): realtime feature streaming is built-experimental and gated
+            // OFF the first-release surface (404 when realtime.feature-streams is
+            // experimental-disabled).
+            .WithCapabilityGate("realtime.feature-streams")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Streaming");
@@ -58,6 +63,7 @@ internal static partial class FeatureStreamEndpoints
 
         // Admin endpoints for session visibility
         var adminGroup = endpoints.MapGroup("/api/v{version:apiVersion}/admin/streaming/features")
+            .WithCapabilityGate("realtime.feature-streams")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Streaming")

--- a/src/Honua.Server/Features/Temporal/TemporalHistoryEndpoints.cs
+++ b/src/Honua.Server/Features/Temporal/TemporalHistoryEndpoints.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Honua.Core.Features.Temporal.Abstractions;
 using Honua.Core.Features.Temporal.Domain;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
@@ -33,6 +34,10 @@ internal static partial class TemporalHistoryEndpoints
         ArgumentNullException.ThrowIfNull(endpoints);
 
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/temporal/services/{serviceId}/layers/{layerId:int}")
+            // T10 (#2346): temporal/data-history is built-experimental and gated OFF
+            // the first-release surface. The capability gate short-circuits with 404
+            // when temporal.filtering resolves experimental-disabled (the default).
+            .WithCapabilityGate("temporal.filtering")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Temporal")

--- a/src/Honua.Server/Features/Temporal/TemporalHistorySlicesEndpoints.cs
+++ b/src/Honua.Server/Features/Temporal/TemporalHistorySlicesEndpoints.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Honua.Core.Features.Temporal.Abstractions;
 using Honua.Core.Features.Temporal.Domain;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Models;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
@@ -36,7 +37,10 @@ internal static partial class TemporalHistorySlicesEndpoints
         const string basePath = "/api/v{version:apiVersion}/temporal/services/{serviceId}/layers/{layerId:int}";
 
         // Diff: distinct diff-read permission (slice 2).
+        // T10 (#2346): temporal/data-history is built-experimental — gate every
+        // temporal group with a 404 short-circuit when it is experimental-disabled.
         var diffGroup = endpoints.MapGroup(basePath)
+            .WithCapabilityGate("temporal.filtering")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Temporal")
@@ -48,6 +52,7 @@ internal static partial class TemporalHistorySlicesEndpoints
 
         // Timeline + rollback planning: history-read permission (read-only analysis, slices 3 and 5).
         var readGroup = endpoints.MapGroup(basePath)
+            .WithCapabilityGate("temporal.filtering")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Temporal")
@@ -63,6 +68,7 @@ internal static partial class TemporalHistorySlicesEndpoints
 
         // Rollback execution: distinct rollback-execution permission (slice 5).
         var rollbackGroup = endpoints.MapGroup(basePath)
+            .WithCapabilityGate("temporal.filtering")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Temporal")

--- a/src/Honua.Server/appsettings.Test.json
+++ b/src/Honua.Server/appsettings.Test.json
@@ -6,5 +6,10 @@
       "AllowDevelopmentFeatures": true,
       "ReportOnly": true
     }
+  },
+  "Capabilities": {
+    "Experimental": {
+      "Enabled": true
+    }
   }
 }

--- a/src/Honua.Server/appsettings.json
+++ b/src/Honua.Server/appsettings.json
@@ -108,6 +108,13 @@
     "DataEditorRoles": [],
     "DataEditorServicePrefix": "data-editor:"
   },
+  "Capabilities": {
+    "RegistryBinding": true,
+    "ManifestFromRegistry": true,
+    "Experimental": {
+      "Enabled": false
+    }
+  },
   "Cache": {
     "Enabled": true,
     "DefaultTtlSeconds": 300,

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogDriftTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogDriftTests.cs
@@ -88,7 +88,7 @@ public sealed class FeatureCatalogDriftTests
     }
 
     [ArchitectureTest]
-    public void EveryCatalogEntry_IsImplementedMaturity_InSlice1()
+    public void EveryCatalogEntry_IsImplementedOrExperimentalMaturity()
     {
         var catalog = LoadCommittedCatalog();
 
@@ -97,10 +97,57 @@ public sealed class FeatureCatalogDriftTests
         catalog.Entries.Select(entry => entry.Id)
             .Should().OnlyHaveUniqueItems("the catalog id is the canonical per-entry key");
 
+        // T10 (#2346): the built-experimental route groups are flipped to the
+        // `experimental` tier; every other test-backed route stays `implemented`.
         catalog.Entries.Should().OnlyContain(
-            entry => entry.Maturity == FeatureCatalogGenerator.MaturityImplemented,
-            "slice 1 (#1946) projects only implemented, test-backed routes; "
-            + "status-from-CI and partial/deferred maturity are later slices.");
+            entry => entry.Maturity == FeatureCatalogGenerator.MaturityImplemented
+                || entry.Maturity == FeatureCatalogGenerator.MaturityExperimental,
+            "the catalog projects only implemented (in-release) or experimental "
+            + "(built-experimental, gated-off) test-backed routes.");
+    }
+
+    [ArchitectureTest]
+    public void ExperimentalEntries_AreExactlyTheGatedRouteGroups()
+    {
+        var catalog = LoadCommittedCatalog();
+
+        // The catalog `experimental` tier must be exactly the routes the T5
+        // endpoint gate 404s (the WithCapabilityGate route groups), no more and no
+        // less — the route → descriptor map is the single source both project from.
+        foreach (var entry in catalog.Entries)
+        {
+            var gatedDescriptorId = FeatureCatalogGenerator.ResolveDescriptorIdForRoute(entry.Route);
+            if (gatedDescriptorId is null)
+            {
+                entry.Maturity.Should().Be(
+                    FeatureCatalogGenerator.MaturityImplemented,
+                    "the in-release route {0} {1} is not part of a flipped experimental group",
+                    entry.Method,
+                    entry.Route);
+            }
+            else
+            {
+                entry.Maturity.Should().Be(
+                    FeatureCatalogGenerator.MaturityExperimental,
+                    "the built-experimental route {0} {1} is gated by {2}",
+                    entry.Method,
+                    entry.Route,
+                    gatedDescriptorId);
+            }
+        }
+
+        // Sanity: at least one experimental entry exists for every flipped family so
+        // a regression that silently stopped projecting `experimental` fails here.
+        var experimentalRoutes = catalog.Entries
+            .Where(entry => entry.Maturity == FeatureCatalogGenerator.MaturityExperimental)
+            .Select(entry => entry.Route)
+            .ToArray();
+
+        experimentalRoutes.Should().Contain(route => route.StartsWith("/api/v1/temporal/", StringComparison.OrdinalIgnoreCase));
+        experimentalRoutes.Should().Contain(route => route.StartsWith("/api/v1/admin/alerts", StringComparison.OrdinalIgnoreCase));
+        experimentalRoutes.Should().Contain(route => route.StartsWith("/api/v1/admin/security/client-certificates", StringComparison.OrdinalIgnoreCase));
+        experimentalRoutes.Should().Contain(route => route.Contains("/replicas", StringComparison.OrdinalIgnoreCase));
+        experimentalRoutes.Should().Contain(route => route.StartsWith("/api/v1/streaming/features", StringComparison.OrdinalIgnoreCase));
     }
 
     [ArchitectureTest]

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
@@ -65,6 +65,12 @@ internal static class FeatureCatalogGenerator
     public const string MaturityImplemented = "implemented";
 
     /// <summary>
+    /// Maturity tier for a built-experimental route group flipped in T10 (#2346):
+    /// gated OFF the first-release surface, opt-in per capability.
+    /// </summary>
+    public const string MaturityExperimental = "experimental";
+
+    /// <summary>
     /// The unified capability registry (ADR-0058) the generator joins against for
     /// each entry's <c>maturity</c>. It is a pure, static-backed projection, so a
     /// single shared instance is safe.
@@ -109,7 +115,7 @@ internal static class FeatureCatalogGenerator
                     CodeLocation = surface?.CodeLocation ?? "src/Honua.Server/EndpointRegistry.cs",
                     ProvingTests = provingTests,
                     ProofLedgerSurface = surface?.SurfaceId ?? string.Empty,
-                    Maturity = ResolveMaturity(surface?.SurfaceId, id)
+                    Maturity = ResolveMaturity(surface?.SurfaceId, id, endpoint.Path)
                 };
             })
             .OrderBy(entry => entry.Method, StringComparer.Ordinal)
@@ -195,19 +201,75 @@ internal static class FeatureCatalogGenerator
     }
 
     /// <summary>
-    /// Joins an entry to its capability descriptor by id — first by the
-    /// proof-ledger surface id, then by the entry's own route slug — and returns
-    /// the descriptor's maturity. Falls back to <see cref="MaturityImplemented"/>
-    /// when no descriptor claims the route, which is every test-backed route in
-    /// the API-surface slice today.
+    /// Joins an entry to its capability descriptor and returns the descriptor's
+    /// maturity. The join is attempted, in order, by (1) the proof-ledger surface
+    /// id, (2) the entry's own route slug, and (3) the route → descriptor map
+    /// (<see cref="ResolveDescriptorIdForRoute"/>). The third join is the one T10
+    /// (#2346) wires: the proof-ledger surfaces and route slugs never equalled a
+    /// registry descriptor id (the <c>control-plane-admin</c> surface, for example,
+    /// is a coarse bucket spanning many unrelated admin routes), so the
+    /// surface/slug joins were inert; the route-prefix map connects the flipped
+    /// route groups to their descriptor so the catalog reflects <c>experimental</c>
+    /// for exactly the routes the T5 endpoint gate 404s. Falls back to
+    /// <see cref="MaturityImplemented"/> when no descriptor claims the route.
     /// </summary>
-    private static string ResolveMaturity(string? proofLedgerSurfaceId, string entryId)
+    private static string ResolveMaturity(string? proofLedgerSurfaceId, string entryId, string route)
     {
+        var routeDescriptorId = ResolveDescriptorIdForRoute(route);
         var descriptor =
             (string.IsNullOrEmpty(proofLedgerSurfaceId) ? null : Registry.Find(proofLedgerSurfaceId))
-            ?? Registry.Find(entryId);
+            ?? Registry.Find(entryId)
+            ?? (routeDescriptorId is null ? null : Registry.Find(routeDescriptorId));
 
         return descriptor is null ? MaturityImplemented : MaturityLabel(descriptor.Maturity);
+    }
+
+    /// <summary>
+    /// Maps a shipped route to the capability descriptor that gates it, for the
+    /// built-experimental feature groups flipped in T10 (#2346). This is the single
+    /// projection of the same route groups the <c>WithCapabilityGate(...)</c> calls
+    /// guard in <c>Honua.Server</c>, so the catalog's <c>experimental</c> tier and
+    /// the runtime 404 gate stay in lock-step. Returns <c>null</c> for every route
+    /// that is not part of a flipped group (the in-release surface), which then
+    /// falls back to <c>implemented</c>.
+    /// </summary>
+    internal static string? ResolveDescriptorIdForRoute(string route)
+    {
+        // Temporal / data-history — /api/v1/temporal/*
+        if (route.StartsWith("/api/v1/temporal/", StringComparison.OrdinalIgnoreCase))
+        {
+            return "temporal.filtering";
+        }
+
+        // Geofence alerting — /api/v1/admin/alerts/*
+        if (route.StartsWith("/api/v1/admin/alerts", StringComparison.OrdinalIgnoreCase))
+        {
+            return "alerts.geofence";
+        }
+
+        // Native mTLS (client certificates) — /api/v1/admin/security/client-certificates/*
+        if (route.StartsWith("/api/v1/admin/security/client-certificates", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security.mtls";
+        }
+
+        // Disconnected-sync replica / conflict review — /api/v1/admin/services/{serviceId}/replicas/*
+        if (route.StartsWith("/api/v1/admin/services/", StringComparison.OrdinalIgnoreCase) &&
+            route.Contains("/replicas", StringComparison.OrdinalIgnoreCase))
+        {
+            return "sync.offline";
+        }
+
+        // Realtime feature streaming — /api/v1/streaming/features*, the admin
+        // session-visibility and streaming-operations surfaces.
+        if (route.StartsWith("/api/v1/streaming/features", StringComparison.OrdinalIgnoreCase) ||
+            route.StartsWith("/api/v1/admin/streaming/features", StringComparison.OrdinalIgnoreCase) ||
+            route.StartsWith("/api/v1/admin/operations/streaming", StringComparison.OrdinalIgnoreCase))
+        {
+            return "realtime.feature-streams";
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
@@ -74,17 +74,60 @@ public sealed class CapabilityManifestRegistryProjectionTests
         manifestIds.Should().Equal(ExpectedManifestCapabilityIds);
     }
 
+    // T10 (#2346): the built-experimental manifest capabilities flipped to
+    // Experimental. With the default (flag-off) context these resolve
+    // experimental-disabled, so the registry-derived manifest omits them.
+    private static readonly string[] ExperimentalManifestCapabilityIds =
+    [
+        "temporal.filtering",
+        "temporal.extent-discovery",
+        "temporal.histogram",
+        "temporal.time-series-tiles",
+        "sync.offline",
+        "realtime.feature-streams",
+        "alerts.geofence",
+        "security.mtls",
+    ];
+
     [Fact]
-    public void Registry_AllManifestDescriptors_AreImplemented_SoNoneAreOmittedToday()
+    public void Registry_ExperimentalManifestDescriptors_AreOmittedWhenFlagOff()
     {
-        // B3 wires the mechanism only; nothing flips experimental until T10 (#2346).
-        // Every manifest descriptor must stay Implemented so the served manifest is
-        // unchanged (no capability is omitted).
+        // T10 flip: each built-experimental manifest descriptor is Experimental and,
+        // with flags off (default), resolves experimental-disabled so the manifest
+        // omits it. Customers opt in per capability via Capabilities:Experimental.
         var context = CapabilityGateContext.Default;
+
+        foreach (var id in ExperimentalManifestCapabilityIds)
+        {
+            var descriptor = Registry.Find(id);
+            descriptor.Should().NotBeNull($"{id} is a manifest capability");
+            descriptor!.Maturity.Should().Be(CapabilityMaturity.Experimental);
+
+            var resolution = CapabilityGateResolver.Resolve(descriptor, context);
+            resolution.Enabled.Should().BeFalse($"{id} is experimental and flag-off");
+            resolution.ReasonCode.Should().Be(CapabilityReasonCodes.ExperimentalDisabled);
+        }
+    }
+
+    [Fact]
+    public void Registry_InReleaseManifestDescriptors_StayImplemented_AndAreNeverOmitted()
+    {
+        // Every manifest descriptor NOT in the built-experimental flip set stays
+        // Implemented and resolves enabled, so the in-release manifest surface is
+        // unaffected by T10.
+        var context = CapabilityGateContext.Default;
+        var experimental = ExperimentalManifestCapabilityIds.ToHashSet(StringComparer.Ordinal);
 
         foreach (var descriptor in Registry.All.Where(IsManifestCapability))
         {
-            descriptor.Maturity.Should().Be(CapabilityMaturity.Implemented);
+            if (experimental.Contains(descriptor.Id))
+            {
+                continue;
+            }
+
+            descriptor.Maturity.Should().Be(
+                CapabilityMaturity.Implemented,
+                $"{descriptor.Id} ships in the first release");
 
             var resolution = CapabilityGateResolver.Resolve(descriptor, context);
             resolution.Enabled.Should().BeTrue($"{descriptor.Id} must resolve enabled while Implemented");


### PR DESCRIPTION
## Issue Link
Closes #2346

## Summary
Track T10 — the experimental flip. Culmination of the capability-registry gating work
(B1 + T2 + B3 + T5 + T6 + T9 + T8): flips the built-experimental capabilities to
`Maturity = Experimental` in the unified `CapabilityRegistry` and wires the gating so
they are OFF the first-release surface by default. Customers opt in per capability via
`Capabilities:Experimental:{id}:Enabled=true`.

With the flip + release config, the registry-derived manifest OMITS the experimental
capabilities (B3), their route groups return 404 (T5), and the feature catalog projects
them as `experimental` (T9) — while every in-release surface (Studio, GP, protocols,
shipping formats) is unaffected.

## Changes Made
- **Flipped 8 registry manifest descriptors to `Experimental`**: `temporal.filtering`,
  `temporal.extent-discovery`, `temporal.histogram`, `temporal.time-series-tiles`,
  `sync.offline`, `realtime.feature-streams`, `alerts.geofence`, `security.mtls`.
- **Attached `.WithCapabilityGate(...)`** to the flipped endpoint groups: temporal
  (`/api/v1/temporal/*`, 4 groups → `temporal.filtering`), geofence alerts
  (`/api/v1/admin/alerts` → `alerts.geofence`), client certificates
  (`/api/v1/admin/security/client-certificates` → `security.mtls`), replica/disconnected-sync
  admin (`/api/v1/admin/services/{serviceId}/replicas` → `sync.offline`), and feature
  streaming (`/api/v1/streaming/features`, `/api/v1/admin/streaming/features`,
  `/api/v1/admin/operations/streaming` → `realtime.feature-streams`).
- **Wired the catalog route → descriptor join** T9 flagged inert (coarse `control-plane-admin`
  surface and route slugs never equalled a descriptor id): the catalog now projects
  `experimental` for exactly the gated route groups.
- **Release config** (`appsettings.json`): `Capabilities:RegistryBinding=true`,
  `Capabilities:ManifestFromRegistry=true`, `Capabilities:Experimental:Enabled=false`.
  Test config (`appsettings.Test.json`) enables experimental so existing feature integration
  tests keep exercising the opted-in features; default-off gating is covered by the unit /
  gate-filter / catalog-drift tests.
- **Tests**: rewrote the B3 projection test and the catalog slice-1 maturity guard; added a
  guard that the catalog `experimental` tier is exactly the gated route groups.

### Concepts intentionally NOT flipped (no distinct registry descriptor — not guessed)
- versioned-editing (VMS), SIEM/investigations, cross-environment promotion,
  rollback/auto-rollback, collaborative map sessions, governance auth (SSO/OIDC/SAML/SCIM),
  forms/form-packages, mobile field-collection (beyond `sync.offline`).
- Formats `format.geoparquet` / `format.filegdb` exist but were NOT flipped: the T6 format
  seams evaluate the gate with `CapabilityGateContext.Default` (config-ignoring), so a flip
  would unconditionally block those imports/serving with no per-capability opt-in lever and
  break ~10+ existing format tests. Needs configured-flag threading (T6 follow-up) first.
- `format.geoarrow` / `format.geobuf` are NOT registry descriptors at all (only `flatgeobuf`,
  a shipping format) — nothing to flip.
- CAC/PIV left `Planned`; FIPS left as-is (attestation-only), per ticket.

## DEFERRED
**`docs/gis/data/feature-catalog.json` regeneration + `FeatureCatalogDriftTests` are DEFERRED
to the trunk-verification build.** The flip changes generated `maturity` for the gated routes;
the committed catalog is not yet regenerated (build lock saturated). The drift test
(`CommittedCatalog_EqualsFreshlyGeneratedOutput`) will be red until the catalog is regenerated
via `scripts/generate-feature-catalog.sh` (`HONUA_EMIT_FEATURE_CATALOG=1`) in that pass.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated

## Breaking Changes
Default served manifest + API surface change: temporal/data-history, disconnected-sync replica
review, geofence alerting, feature streaming, and native mTLS client-certificate admin are
experimental-off by default (manifest omits them; route groups 404). Intended first-release
scoping; opt-in per capability.
