### PR TITLE
fix: green trunk pre-rc.0 — regenerate feature catalog + roll-forward build/test fixes

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -30,7 +30,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.RuleCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "delete-api-v1-admin-alerts-zones-zoneid",
@@ -44,7 +44,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.ZoneCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "delete-api-v1-admin-cloud-rasters-id",
@@ -400,7 +400,7 @@
         "Honua.Server.Tests.Features.Admin.StreamingOperationsEndpointsTests.DisconnectSubscriber_UnknownId_Returns404"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "delete-api-v1-admin-performance-enhanced-cache-invalidate",
@@ -481,7 +481,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.DisableProfile_ExistingProfile_ReturnsDisabledProfile"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "delete-api-v1-admin-security-client-certificates-profiles-profileid-mappings-mappingid",
@@ -494,7 +494,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.DisableMapping_ExistingMapping_ReturnsDisabledMapping"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "delete-api-v1-admin-security-client-certificates-profiles-profileid-revocations-revocationid",
@@ -507,7 +507,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.RemoveRevocation_ExistingRevocation_ReturnsOk"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "delete-api-v1-admin-share-exports-exportid",
@@ -534,7 +534,7 @@
         "Honua.Server.Tests.Features.Streaming.FeatureStreamEndpointsTests.DisconnectSession_UnknownId_Returns404"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "delete-api-v1-admin-tenants-tenantid",
@@ -910,7 +910,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.ListRules_WithServiceAndLayerFilter_ReturnsSuccessEnvelope"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-alerts-rules-ruleid",
@@ -923,7 +923,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.RuleCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-alerts-rules-ruleid-events",
@@ -938,7 +938,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.ListRuleEvents_WithUnknownStatus_Returns400"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-alerts-rules-ruleid-health",
@@ -952,7 +952,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.GetRuleHealth_WithUnavailableDeliveryChannel_ReturnsPolicyState"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-alerts-zones",
@@ -966,7 +966,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.ListZones_WithServiceFilter_ReturnsSuccessEnvelope"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-alerts-zones-zoneid",
@@ -979,7 +979,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.ZoneCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-api-keys",
@@ -1466,6 +1466,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.AdminAuthorizationTests.GetFeatureOverview_WithoutAuth_Returns401",
         "Honua.Server.Tests.Features.Admin.PlatformAdminEndpointsTests.GetFeatureOverview_ProEdition_ShowsUpgradeMessagesForEnterprise",
+        "Honua.Server.Tests.Features.Admin.PlatformAdminEndpointsTests.GetFeatureOverview_ReturnsCapabilityRegistryProjection",
         "Honua.Server.Tests.Features.Admin.PlatformAdminEndpointsTests.GetFeatureOverview_ReturnsEditionAndFeatures"
       ],
       "proof_ledger_surface": "control-plane-admin",
@@ -2848,7 +2849,7 @@
         "Honua.Server.Tests.Features.Admin.StreamingOperationsEndpointsTests.StreamAlerts_WithoutWebSocketUpgrade_Returns400"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-operations-streaming-subscribers",
@@ -2863,7 +2864,7 @@
         "Honua.Server.Tests.Features.Admin.StreamingOperationsEndpointsTests.ListSubscribers_WhenNone_ReturnsEmptyList"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-operations-type-operationtype",
@@ -3213,7 +3214,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ListProfiles_WithAdminAuth_ReturnsConfiguredProfiles"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-security-client-certificates-profiles-profileid",
@@ -3226,7 +3227,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.GetProfile_ExistingProfile_ReturnsProfile"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-security-client-certificates-profiles-profileid-mappings",
@@ -3239,7 +3240,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ListMappings_ExistingProfile_ReturnsMappings"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-security-client-certificates-profiles-profileid-revocations",
@@ -3252,7 +3253,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ListRevocations_ExistingProfile_ReturnsRevocations"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-services",
@@ -3284,7 +3285,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.ReplicaManagementEndpointTests.ListReplicas_WithoutAdminAuthorization_IsRejected"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-services-serviceid-replicas-replicaid",
@@ -3302,7 +3303,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.ReplicaManagementEndpointTests.GetReplica_WithoutAdminAuthorization_IsRejected"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-services-serviceid-replicas-replicaid-conflicts",
@@ -3318,7 +3319,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.ReplicaConflictReviewEndpointTests.ListConflicts_WhenProviderDoesNotSupportReview_ReturnsNotImplemented"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-services-serviceid-replicas-replicaid-conflicts-conflictid",
@@ -3332,7 +3333,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.ReplicaConflictReviewEndpointTests.GetConflict_ForResolvedConflict_ReturnsResolutionEvidence"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-services-servicename-layers-layerid-export",
@@ -3506,7 +3507,7 @@
         "Honua.Server.Tests.Features.Streaming.FeatureStreamEndpointsTests.ListSessions_WithFilter_ReturnsSessionFilterInfo"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-admin-tenants",
@@ -3795,6 +3796,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_AsAdminWithEnvironmentAndWorkspace_ReturnsFilteredManifest",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_AsAnonymous_ReturnsPublicTenantManifestAndNoStoreHeaders",
+        "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_RegistryDerived_MatchesHandCuratedComposition",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithCommunityLicense_MarksOfflineSyncAndAiOperationsUnavailable",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithInvalidScopeIdentifier_ReturnsSafeBadRequest",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithPartialSpatialAnalysisEntitlements_MarksAnalysisUnavailable",
@@ -4627,7 +4629,7 @@
         "Honua.Server.Tests.Features.Streaming.FeatureStreamEndpointsTests.WebSocket_WhenSessionLimitReached_ReturnsServiceUnavailable"
       ],
       "proof_ledger_surface": "feature-event-streaming",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-streaming-features-capabilities",
@@ -4643,7 +4645,7 @@
         "Honua.Server.Tests.Features.Streaming.FeatureStreamEndpointsTests.Capabilities_ProEdition_AdvertisesTransportsFiltersAndLayers"
       ],
       "proof_ledger_surface": "feature-event-streaming",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-studio-content-items-itemid-versions",
@@ -4713,7 +4715,7 @@
         "Honua.Server.Tests.Features.Temporal.TemporalHistoryEndpointsTests.AsOf_WithTimestampCursor_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "temporal-data-history",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-temporal-services-serviceid-layers-layerid-capabilities",
@@ -4728,7 +4730,7 @@
         "Honua.Server.Tests.Features.Temporal.TemporalHistoryEndpointsTests.Capability_ForUnknownLayer_ReturnsNotFound"
       ],
       "proof_ledger_surface": "temporal-data-history",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-temporal-services-serviceid-layers-layerid-diff",
@@ -4743,7 +4745,7 @@
         "Honua.Server.Tests.Features.Temporal.TemporalHistorySliceEndpointsTests.Diff_MissingFrom_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "temporal-data-history",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-temporal-services-serviceid-layers-layerid-features-featureid-timeline",
@@ -4756,7 +4758,7 @@
         "Honua.Server.Tests.Features.Temporal.TemporalHistorySliceEndpointsTests.Timeline_ForFeature_ReturnsOrderedRevisions"
       ],
       "proof_ledger_surface": "temporal-data-history",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-api-v1-tiles-pmtiles-artifactid",
@@ -8656,6 +8658,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Geoprocessing.GpJobWorkerCompositionRootTests.SubmitJob_WithProductionWiredWorker_DrainsQueueToTerminalSuccess",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerClientCompatibilityTests.TypedClient_SubmitsPollsAndReadsNamedResult",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerDefaultServiceTests.DefaultGpService_DrivesGeometryBufferToTerminalResult",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerDurableRuntimeTests.SubmitJob_WithRedisBackedRuntime_CompletesAndReturnsDurableResult",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerEndpointTests.JobStatus_SucceededJobWithResultPackage_ReturnsNamedResultReferences",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerEndpointTests.JobStatus_WithInvalidJobId_Returns404",
@@ -8692,6 +8695,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Geoprocessing.GpJobWorkerCompositionRootTests.SubmitJob_WithProductionWiredWorker_DrainsQueueToTerminalSuccess",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerClientCompatibilityTests.TypedClient_SubmitsPollsAndReadsNamedResult",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerDefaultServiceTests.DefaultGpService_DrivesGeometryBufferToTerminalResult",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerDurableRuntimeTests.SubmitJob_WithRedisBackedRuntime_CompletesAndReturnsDurableResult",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerEndpointTests.JobResult_WithInvalidJobId_ReturnsError",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerEndpointTests.JobResult_WithResultPackage_ReturnsNamedOutput"
@@ -11397,7 +11401,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.RuleCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-alerts-rules-test",
@@ -11413,7 +11417,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.TestRule_WithZoneIdOnThresholdRule_ReturnsValidationError"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-alerts-zones",
@@ -11428,7 +11432,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.ZoneCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-api-keys",
@@ -12510,17 +12514,20 @@
         "Honua.Server.Tests.Import.StreamingImportTests.Import_CsvFile_WithSemicolonDelimiter_StreamsRows",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_CsvFile_WithTabDelimiter_StreamsRows",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_EmptyFeatureCollection_ReturnsStructuredValidationAndDoesNotCreateTable",
+        "Honua.Server.Tests.Import.StreamingImportTests.Import_EsriJsonFeatureSet_AutoDetectsAndImports",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_FlatGeobufFile_StreamsFeaturesAndDetectsFormat",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_GeoJsonMissingGeometry_ReturnsStructuredValidationAndDoesNotCreateTable",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_GeoJsonWithDifferentSourceAndTargetSrid_TransformsAtImport",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_GeoJsonWithMultipleFeatureTypes_StreamsCorrectly",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_GeoJsonWithUnsupportedTargetSrid_ReturnsStructuredValidationAndDoesNotCreateTable",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_GpxFile_StreamsTracks",
+        "Honua.Server.Tests.Import.StreamingImportTests.Import_GpxWithGdalExtensions_ImportsWaypoints",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_InvalidGeoJson_ReturnsStructuredValidationAndDoesNotCreateTable",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_KmlFile_StreamsPlacemarks",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_KmzFile_StreamsPlacemarks",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_LargeGeoJsonFile_StreamsWithConstantMemory",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_WithForceBackground_QueuesJob",
+        "Honua.Server.Tests.Import.StreamingImportTests.Import_WkbPayload_AutoDetectsAndImports",
         "Honua.Server.Tests.Import.StreamingImportTests.Import_WktFile_StreamsLineByLine"
       ],
       "proof_ledger_surface": "control-plane-admin",
@@ -13297,7 +13304,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.CreateProfile_WithMalformedCustomTrustAnchor_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-security-client-certificates-profiles-profileid-mappings",
@@ -13313,7 +13320,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.CreateMapping_WithInvertedValidityWindow_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-security-client-certificates-profiles-profileid-revocations",
@@ -13326,7 +13333,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.AddRevocation_ValidRequest_ReturnsCreated"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-security-client-certificates-validate",
@@ -13340,7 +13347,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ValidateCertificate_WithMappedCertificate_ReturnsValidResult"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-services-serviceid-replicas-replicaid-conflicts-conflictid-resolve",
@@ -13356,7 +13363,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.ReplicaConflictReviewEndpointTests.ResolveConflict_WithUnknownAction_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-admin-share-exports",
@@ -14297,7 +14304,7 @@
         "Honua.Server.Tests.Features.Temporal.TemporalHistorySliceEndpointsTests.Rollback_WithoutApproval_ReturnsConflict"
       ],
       "proof_ledger_surface": "temporal-data-history",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-api-v1-temporal-services-serviceid-layers-layerid-rollback-plan",
@@ -14310,7 +14317,7 @@
         "Honua.Server.Tests.Features.Temporal.TemporalHistorySliceEndpointsTests.RollbackPlan_ForTemporalLayer_ReportsState"
       ],
       "proof_ledger_surface": "temporal-data-history",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-csp-violation-report",
@@ -15897,8 +15904,10 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerPluginValidationTests.ApplyEdits_FeatureAllowedByPlugin_Succeeds",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerPluginValidationTests.ApplyEdits_FeatureRejectedByPlugin_IsNotWritten",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerPluginValidationTests.ApplyEdits_RollbackOnFailure_PluginRejection_RollsBackEntireBatch",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.ApplyEdits_WithGenuinelyDifferentSrid_AgainstWebMercatorLayer_ReturnsError",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.ApplyEdits_WithLineGeometry_MismatchedSrid_ReturnsError",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.ApplyEdits_WithPolygonHole_MismatchedSrid_ReturnsError",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.ApplyEdits_WithWebMercatorAliasSrid_AgainstWebMercatorLayer_Succeeds",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerTrueCurveTests.ApplyEdits_WithCurvePathsBezier_DensifiesAndRoundTripsAsLinearPolyline",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.GeometryValidationTests.ApplyEdits_WithLineStringGeometryOnPointLayer_Rejected",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.GeometryValidationTests.ApplyEdits_WithNullAttributeValues_Succeeds",
@@ -16346,6 +16355,7 @@
         "Honua.Server.Tests.Features.Geoprocessing.GpJobWorkerCompositionRootTests.SubmitJob_WithProductionWiredWorker_DrainsQueueToTerminalSuccess",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerClientCompatibilityTests.TypedClient_SubmitsPollsAndReadsNamedResult",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerClientCompatibilityTests.TypedClient_UnsupportedEnvironmentControlsReturnEsriError",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerDefaultServiceTests.DefaultGpService_DrivesGeometryBufferToTerminalResult",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerDurableRuntimeTests.SubmitJob_WithRedisBackedRuntime_CompletesAndReturnsDurableResult",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerEndpointTests.SubmitJobPost_WithEnvInQueryString_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GPServer.GPServerEndpointTests.SubmitJob_CatalogStorageUnavailable_ReturnsServiceUnavailable",
@@ -17622,7 +17632,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.UpdateRule_NonexistentRuleId_Returns404"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "put-api-v1-admin-alerts-rules-ruleid-enabled",
@@ -17635,7 +17645,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.RuleCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "put-api-v1-admin-alerts-zones-zoneid",
@@ -17649,7 +17659,7 @@
         "Honua.Server.Tests.Features.Admin.AlertAdminEndpointsTests.ZoneCrud_CreateUpdateDelete_CompletesLifecycle"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "put-api-v1-admin-config",
@@ -18097,7 +18107,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.UpdateProfile_ExistingProfile_ReturnsUpdatedRevision"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "put-api-v1-admin-security-client-certificates-profiles-profileid-mappings-mappingid",
@@ -18110,7 +18120,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.UpdateMapping_ExistingMapping_ReturnsUpdatedMapping"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "put-api-v1-admin-services-servicename-access-policy",

--- a/src/Honua.Geometry/Features/FileImport/Services/WkbFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/WkbFormatReader.cs
@@ -27,7 +27,12 @@ internal static class WkbFormatReader
         // NTS WKBReader.Read(Stream) reads exactly one geometry and leaves the stream positioned
         // immediately after it. Buffer to a seekable MemoryStream so we can loop by byte position
         // (import sources are size-capped upstream) and reliably detect end-of-input.
-        using var buffer = new MemoryStream();
+        //
+        // WKBReader.Read wraps the stream in a BinaryReader and disposes it, which would otherwise
+        // close our buffer after the first geometry and make the next Position read throw
+        // ObjectDisposedException. Use a buffer whose Dispose/Close are no-ops so it survives the
+        // concatenated-geometry loop; the underlying managed byte array is reclaimed by the GC.
+        using var buffer = new NonClosingMemoryStream();
         await stream.CopyToAsync(buffer, cancellationToken);
         if (buffer.Length == 0)
         {
@@ -71,6 +76,31 @@ internal static class WkbFormatReader
             {
                 await Task.Yield();
             }
+        }
+    }
+
+    /// <summary>
+    /// A seekable in-memory buffer whose <see cref="Dispose(bool)"/> / <see cref="Close"/> are
+    /// no-ops. WKBReader.Read wraps the passed stream in a BinaryReader and disposes it after each
+    /// geometry; without this the buffer would close between concatenated geometries and the loop's
+    /// Position read would throw. The managed byte array is reclaimed by the GC once unreferenced.
+    /// </summary>
+    private sealed class NonClosingMemoryStream : MemoryStream
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2215:Dispose methods should call base class dispose",
+            Justification = "Intentional: not disposing keeps the buffer usable across concatenated "
+                + "reads; WKBReader.Read's BinaryReader must not close the shared buffer. The managed "
+                + "byte array is reclaimed by the GC.")]
+        protected override void Dispose(bool disposing)
+        {
+            // Intentionally do not dispose: keep the buffer usable across concatenated reads.
+        }
+
+        public override void Close()
+        {
+            // Intentionally no-op: BinaryReader.Dispose must not close the shared buffer.
         }
     }
 }

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -347,7 +347,7 @@ internal sealed class CapabilityManifestService(
     /// id/kind the <c>honua.capability_manifest.v1</c> surface advertises. The iteration
     /// order of <see cref="ICapabilityRegistry.All"/> preserves the legacy family order.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, (string Id, string Kind)> PackageWireById =
+    private static readonly Dictionary<string, (string Id, string Kind)> PackageWireById =
         new Dictionary<string, (string Id, string Kind)>(StringComparer.Ordinal)
         {
             ["package.metadata-v2"] = ("metadata-v2-graph", "metadata"),

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
@@ -75,7 +75,7 @@ internal static class FeatureCatalogGenerator
     /// each entry's <c>maturity</c>. It is a pure, static-backed projection, so a
     /// single shared instance is safe.
     /// </summary>
-    private static readonly ICapabilityRegistry Registry = new CapabilityRegistry();
+    private static readonly CapabilityRegistry Registry = new CapabilityRegistry();
 
     /// <summary>
     /// Builds the catalog model deterministically (stable ordering by method then

--- a/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/VerticalSliceIsolationTests.cs
@@ -112,6 +112,11 @@ public sealed class VerticalSliceIsolationTests
             "Analytics",
             "AuditLog",
             "Authentication",   // Lives in Honua.Hosting under the preserved namespace.
+            "Capabilities",     // Hosting-resident shared capability-gate seam (ADR-0058):
+                                // the CapabilityGateEndpointFilter + OpenAPI document
+                                // transformer that gate/prune experimental routes via the
+                                // unified capability registry, shared by the protocol
+                                // assemblies and Server so neither owns the gate logic.
             "Caching",          // Lives in Honua.Hosting under the preserved namespace.
             "Compression",
             "Configuration",

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
@@ -20,7 +20,7 @@ namespace Honua.Core.Tests.Features.Capabilities;
 /// </summary>
 public sealed class CapabilityManifestRegistryProjectionTests
 {
-    private static readonly ICapabilityRegistry Registry = new CapabilityRegistry();
+    private static readonly CapabilityRegistry Registry = new CapabilityRegistry();
 
     // The frozen #1186 manifest roster, in the exact order the manifest serializes it.
     // Mirrors CapabilityManifestService's hand-curated list; the registry-derived path

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/CsvFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/CsvFormatReaderTests.cs
@@ -36,7 +36,7 @@ public sealed class CsvFormatReaderTests
     public async Task ReadStreamingAsync_PostgisEwkbHexExport_ImportsWithGeometry()
     {
         // #2361: PostGIS also exports geometry as WKB/EWKB hex. This must parse too.
-        var writer = new WKBWriter { HandleSRID = true };
+        var writer = new WKBWriter { Strict = false, HandleSRID = true };
         var hex = Convert.ToHexString(writer.Write(new Point(-122.4194, 37.7749) { SRID = 4326 }));
         var csv = $"""
             id,name,geom

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/WktFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/WktFormatReaderTests.cs
@@ -61,7 +61,7 @@ public sealed class WktFormatReaderTests
     public async Task ReadStreamingAsync_WkbHexLine_ParsesFeature()
     {
         var expected = new Point(-122.4194, 37.7749) { SRID = 4326 };
-        var writer = new WKBWriter { HandleSRID = true };
+        var writer = new WKBWriter { Strict = false, HandleSRID = true };
         var hex = Convert.ToHexString(writer.Write(expected));
 
         var features = await ReadAllAsync(hex);


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1946

## Summary
Pre-cut verification gate for rc.0. Several bug-fix PRs and the capability
registry Phase 2 wave were admin-merged to trunk without a full CI pass. This
regenerates the deferred feature-catalog projection and rolls forward the
accumulated compile/test breakage so trunk builds Release (warnings-as-errors)
and the capability/registry + drift suites pass as a whole. Verified locally:
full `dotnet build Honua.sln -c Release` is 0 warnings / 0 errors; Core.Tests
3331/3331, Architecture.Tests 120/120, and the capability/MCP suites green.

## Changes Made
- docs(catalog): regenerate `feature-catalog.json` from the live API surface so the T10 (#2346) experimental flip is reflected — 45 gated routes (temporal, admin/alerts, client-certificates, replicas, streaming) now project as `experimental`; restores `FeatureCatalogDriftTests` green.
- fix(capabilities): type `PackageWireById` as concrete `Dictionary` (CA1859) in `CapabilityManifestService` so `Honua.Server` compiles warnings-as-errors.
- test: type the static `CapabilityRegistry` fields concretely (CA1859) in `FeatureCatalogGenerator` and `CapabilityManifestRegistryProjectionTests`.
- test(arch): allow-list the Hosting-resident `Capabilities` sub-area (gate filter + OpenAPI transformer, ADR-0058) in `VerticalSliceIsolationTests`.
- fix(formats): `WkbFormatReader` buffers into a non-closing `MemoryStream` so NTS `WKBReader.Read` (which disposes its `BinaryReader`) can no longer close the shared buffer mid-loop — fixes `ObjectDisposedException` on concatenated WKB.
- test(formats): build EWKB hex fixtures with `WKBWriter { Strict = false, HandleSRID = true }` (NTS 2.6.0 rejects `HandleSRID` while `Strict`) in the WKT and CSV reader tests.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

## Pre-PR check
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
