### PR TITLE
fix(hosting): resolve CA1873 build break in CapabilityGateEndpointFilter

### DIFF
--- a/src/Honua.Hosting/Features/Capabilities/CapabilityGateEndpointFilter.cs
+++ b/src/Honua.Hosting/Features/Capabilities/CapabilityGateEndpointFilter.cs
@@ -89,7 +89,7 @@ internal sealed partial class CapabilityGateEndpointFilter : IEndpointFilter
         if (!resolution.Enabled &&
             string.Equals(resolution.ReasonCode, CapabilityReasonCodes.ExperimentalDisabled, StringComparison.Ordinal))
         {
-            Log.ExperimentalDisabled(_logger, gate.DescriptorId, httpContext.Request.Path);
+            Log.ExperimentalDisabled(_logger, gate.DescriptorId, httpContext.Request.Path.Value ?? string.Empty);
             return ValueTask.FromResult<object?>(CreateExperimentalDisabledProblem(httpContext, gate.DescriptorId));
         }
 


### PR DESCRIPTION
## Problem

honua-server trunk (`238cc63`) fails the warnings-as-errors build with:

```
CapabilityGateEndpointFilter.cs(92): error CA1873: Evaluation of this argument may be expensive and unnecessary if logging is disabled
```

This reads as a red `build-test` check-run in the honua-release gate. It is **not** a false positive: line 92 passed `httpContext.Request.Path` (a `PathString`) to the source-generated `Log.ExperimentalDisabled` LoggerMessage, whose `string path` parameter forces an implicit `PathString`->`string` conversion (`op_Implicit`) to run at the call site *before* the generated method's internal `IsEnabled` check. CA1873 flags that call-site conversion. (Reproduces locally on SDK 10.0.300, not just the CI SDK.)

## Fix

Pass `httpContext.Request.Path.Value ?? string.Empty` — the backing string field — instead of relying on the implicit conversion. This removes the flagged operation entirely.

- Log **level (Debug)**, **event id (4110)**, and **rendered message** are unchanged.
- No blanket suppression, no `#pragma`. An `IsEnabled(LogLevel.Debug)` guard was tried and rejected: CA1873 still fired because the analyzer evaluates the argument conversion independently of the guard for source-gen LoggerMessage calls. The cheap-argument fix is the correct, minimal resolution.

## Verification

- `dotnet build src/Honua.Hosting/Honua.Hosting.csproj -c Release /p:TreatWarningsAsErrors=true` → **0 warnings, 0 errors** (previously 1 error CA1873).
- `dotnet format ... --verify-no-changes` clean.

Closes the CA1873 warnings-as-errors build break on trunk so the honua-release build-test gate's honua-server check can go green on a re-run.