### PR TITLE
fix(import): allow .esrijson and .wkb upload extensions

### DIFF
--- a/src/Honua.Hosting/Features/Security/FileUploadSecurity.cs
+++ b/src/Honua.Hosting/Features/Security/FileUploadSecurity.cs
@@ -88,8 +88,10 @@ internal static class FileUploadSecurity
             ".csv", ".tsv", ".txt",
             ".xls", ".xlsx",
             ".geojson", ".json",
+            ".esrijson", // Esri JSON feature set (honua-server#2352)
             ".gpkg",
             ".wkt",
+            ".wkb", // Well-Known Binary geometry (honua-server#2353)
             ".gpx",
             ".kml", ".kmz",
             ".gml", ".xml",


### PR DESCRIPTION
## Summary

The FileImport CI shard was red on trunk (`f3c811b`) because two tests added by #2359 fail: `Import_EsriJsonFeatureSet_AutoDetectsAndImports` and `Import_WkbPayload_AutoDetectsAndImports`. Both uploads returned **400** before ever reaching the import pipeline.

Root cause: #2359 added `.esrijson`/`.wkb` to `FileFormatDetectionService`, the streaming readers, and the supported-formats surface — but did **not** add them to the separate `FileUploadSecurity._allowedExtensions` allowlist. The upload endpoint validates the file against that security allowlist first, so `.esrijson`/`.wkb` were rejected with `File extension '<ext>' is not allowed`.

Their MIME types (`application/json`, `application/octet-stream`) were already allow-listed; only the extension entries were missing. Content/magic-number validation does not reject them.

Verified locally against PostGIS Testcontainers: both tests now pass (2/2).

## Changes Made

- Add `.esrijson` and `.wkb` to `FileUploadSecurity._allowedExtensions`.

## Breaking Changes

None.

## Gate Impact

- [x] Fixes a failing build/test gate shard (FileImport) with no behavior change beyond allowing the two already-supported import formats to be uploaded.

## Testing

- [x] Ran the two previously-failing tests locally (Testcontainers + PostGIS): both pass.

Related to #2359
