### PR TITLE
Fix POST exportImage dropping time (#2364) and OGC Maps styled-vector tiff mislabeling (#2365)

### DIFF
--- a/src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/ImageServerEndpoints.cs
@@ -2848,6 +2848,7 @@ internal static class ImageServerEndpoints
             BandIds = GetString(values, "bandIds"),
             MosaicRule = GetString(values, "mosaicRule"),
             RenderingRule = GetString(values, "renderingRule"),
+            Time = GetString(values, "time"),
             F = GetString(values, "f") ?? "json"
         };
 

--- a/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsRenderingHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Maps/Handlers/OgcMapsRenderingHandler.cs
@@ -534,6 +534,17 @@ internal sealed class OgcMapsRenderingHandler
                 statusCode: StatusCodes.Status501NotImplemented);
         }
 
+        // The styled-vector renderer is Skia-based and has no GeoTIFF encoder; TIFF output is
+        // only produced by the GDAL raster-coverage pipeline. Rather than silently emit PNG
+        // bytes mislabeled as image/tiff (#2365), reject the format honestly so the returned
+        // bytes always match the Content-Type.
+        if (renderRequest.Format == RasterFormat.TIFF)
+        {
+            return CreateBadRequestResult(
+                context,
+                "Format 'tiff' is not supported for styled vector collections. Supported formats: png, jpeg.");
+        }
+
         // Resolve the requested style (canonical MapLibre). A missing/unknown style renders
         // with the collection's default styling rather than failing the request.
         string? mapLibreStyleJson = null;

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
@@ -272,6 +272,68 @@ public sealed class ImageServerMosaicIntegrationTests
     }
 
     [IntegrationTest]
+    [Endpoint("POST /rest/services/{id}/ImageServer/exportImage")]
+    [Operation(Operations.Export)]
+    public async Task ExportImagePost_WithTime_SelectsTemporalSliceAndAgreesWithGet()
+    {
+        // Regression for #2364: CreateExportImageRequest (the POST body/query merge builder)
+        // did not map the `time` parameter, so POST exportImage silently ignored it and always
+        // returned the default (newest) mosaic — diverging from the GET path, which binds time.
+        var fixture = await CreateFixtureAsync(HonuaEdition.Pro);
+        try
+        {
+            // bbox=1,0,3,2 straddles the overlap-newest raster (value 5, Feb 1). At time
+            // 2024-01-20 that raster is excluded, so the slice shows the older west/east
+            // rasters (values 20/40) instead — a visibly different mosaic than the default.
+            const string bbox = "?bbox=1,0,3,2&size=64,32&format=png&f=image";
+            const string time = "2024-01-20T00:00:00Z";
+
+            var getWithTime = await fixture.Client.GetAsync(
+                $"/rest/services/{WebAppFixture.TestLayerId}/ImageServer/exportImage{bbox}&time={time}");
+            getWithTime.StatusCode.Should().Be(HttpStatusCode.OK);
+            var getWithTimeBytes = await getWithTime.Content.ReadAsByteArrayAsync();
+
+            using var postWithTimeContent = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("bbox", "1,0,3,2"),
+                new KeyValuePair<string, string>("size", "64,32"),
+                new KeyValuePair<string, string>("format", "png"),
+                new KeyValuePair<string, string>("time", time),
+                new KeyValuePair<string, string>("f", "image"),
+            });
+            var postWithTime = await fixture.Client.PostAsync(
+                $"/rest/services/{WebAppFixture.TestLayerId}/ImageServer/exportImage",
+                postWithTimeContent);
+            postWithTime.StatusCode.Should().Be(HttpStatusCode.OK);
+            var postWithTimeBytes = await postWithTime.Content.ReadAsByteArrayAsync();
+
+            using var postNewestContent = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("bbox", "1,0,3,2"),
+                new KeyValuePair<string, string>("size", "64,32"),
+                new KeyValuePair<string, string>("format", "png"),
+                new KeyValuePair<string, string>("f", "image"),
+            });
+            var postNewest = await fixture.Client.PostAsync(
+                $"/rest/services/{WebAppFixture.TestLayerId}/ImageServer/exportImage",
+                postNewestContent);
+            postNewest.StatusCode.Should().Be(HttpStatusCode.OK);
+            var postNewestBytes = await postNewest.Content.ReadAsByteArrayAsync();
+
+            // POST with time must honor the requested slice: it agrees with GET for the same
+            // time, and differs from the default (newest) mosaic. Before the fix POST dropped
+            // `time`, so postWithTime == postNewest and postWithTime != getWithTime.
+            postWithTimeBytes.Should().NotBeEmpty();
+            postWithTimeBytes.Should().Equal(getWithTimeBytes, "POST and GET exportImage must honor time identically");
+            postWithTimeBytes.Should().NotEqual(postNewestBytes, "POST exportImage must apply the requested temporal slice, not the default newest mosaic");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Query, Operations.PerformanceTesting)]
     public async Task QueryRasters_ForTenOverlappingRasters_CompletesWithinTwoSeconds()
     {

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
@@ -251,6 +251,27 @@ public class OgcMapsBasicTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /ogc/maps/collections/{collectionId}/styles/{styleId}/map")]
+    [Operation(Operations.Render)]
+    public async Task GetStyledMap_VectorCollectionTiff_ReturnsCleanErrorNeverPngLabeledTiff()
+    {
+        // Regression for #2365: the Skia styled-vector renderer (ADR-0048) has no TIFF
+        // encoder and silently fell back to PNG, while the response Content-Type was set
+        // from the requested format — so f=tiff on a vector collection returned PNG bytes
+        // mislabeled as image/tiff, corrupting GDAL/rasterio clients. TIFF is only encodable
+        // on the GDAL raster-coverage path, so the styled-vector path must reject it cleanly.
+        // Layer 0 is a seeded vector (Point) collection, so this exercises the Skia path.
+        var queryParams = "?bbox=-180,-90,180,90&width=256&height=256&f=tiff";
+
+        var response = await _fixture.Client.GetAsync(
+            $"/ogc/maps/collections/{TestLayerId}/styles/default/map{queryParams}");
+
+        // The invariant: never return 200 with image/tiff carrying PNG bytes. A clean 4xx is required.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Content.Headers.ContentType?.MediaType.Should().NotBe("image/tiff");
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /ogc/maps/map")]
     [Operation(Operations.Render)]
     public async Task GetDatasetMap_WithCollections_ReturnsMap()


### PR DESCRIPTION
Two protocol-correctness fixes (both silent wrong-output on shipping surfaces).

## #2364 — ImageServer POST /exportImage silently drops `time`
**Root cause:** `CreateExportImageRequest` (the POST body/query merge builder in `ImageServerEndpoints`) mapped every field except `Time`. The GET path binds `Time` via `[AsParameters]`, so a POST exportImage with `time=<instant>` on a temporal image service returned the default (newest) mosaic instead of the requested slice — HTTP 200, no warning. GET/POST diverged.
**Fix:** Map `Time = GetString(values, "time")` in `CreateExportImageRequest` so POST honors it identically to GET.
**Test:** `ExportImagePost_WithTime_SelectsTemporalSliceAndAgreesWithGet` — POST with `time=` agrees byte-for-byte with GET for the same time, and differs from the default newest mosaic (proving the slice is applied).

## #2365 — OGC API Maps styled-vector `f=tiff` returned PNG bytes labeled `image/tiff`
**Root cause:** The styled-vector path renders through Skia (`SkiaMapRenderer.EncodeSurface`), which has no TIFF encoder and defaults unknown formats to PNG, while the response `Content-Type` was set from the requested format (`RasterFormat.ToContentType()`). So a styled-vector render with `f=tiff`/`Accept: image/tiff` returned PNG bytes mislabeled as `image/tiff`, corrupting GDAL/rasterio clients.
**Fix (option a — reject, do not fake-encode):** Real TIFF is only produced on the GDAL raster-coverage path (`ST_AsGDALRaster(..., 'GTiff')`); Skia cannot encode it. Rather than wire a heavyweight GeoTIFF encoder into the vector renderer, the styled-vector path (`RenderStyledVectorMapAsync`) now returns a clean 400 ("Supported formats: png, jpeg.") when `tiff` is requested. TIFF stays valid for raster coverages. Invariant restored: returned bytes always match the Content-Type.
**Test:** `GetStyledMap_VectorCollectionTiff_ReturnsCleanErrorNeverPngLabeledTiff` — `f=tiff` on a vector collection returns 400 and never `image/tiff`.

Closes #2364
Closes #2365