### PR TITLE
fix(formats): WKB content auto-detection, GPX route/track features, WKT unparseable diagnostics

### DIFF
--- a/src/Honua.Core/Features/FileImport/Services/FileFormatDetectionService.cs
+++ b/src/Honua.Core/Features/FileImport/Services/FileFormatDetectionService.cs
@@ -122,6 +122,16 @@ internal sealed class FileFormatDetectionService : IFileFormatDetectionService
             }
         }
 
+        // Well-Known Binary has no fixed magic string; it is identified structurally by a leading
+        // byte-order flag (0x00 XDR / 0x01 NDR) followed by a valid geometry-type uint32 (also
+        // EWKB with its SRID/Z/M flag bits). This runs before the text-decode branch because a WKB
+        // payload's low bytes are not printable text (honua-server#2353).
+        if (LooksLikeWkb(fileContent))
+        {
+            FileFormatDetectionLog.DetectedFromContentAnalysis(_logger, SupportedFileFormat.Wkb, fileName);
+            return SupportedFileFormat.Wkb;
+        }
+
         // Check for text-based formats
         var textContent = TryDecodeAsText(fileContent);
         if (!string.IsNullOrEmpty(textContent))
@@ -243,6 +253,39 @@ internal sealed class FileFormatDetectionService : IFileFormatDetectionService
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Structurally recognises a Well-Known Binary (WKB/EWKB) geometry payload from its leading
+    /// bytes: a byte-order flag (<c>0x00</c> big-endian/XDR or <c>0x01</c> little-endian/NDR)
+    /// followed by a geometry-type <c>uint32</c>. Standard WKB uses base types 1-7
+    /// (Point..GeometryCollection); ISO WKB adds Z/M variants (e.g. 1001, 2001, 3001); PostGIS
+    /// EWKB sets the high flag bits <c>0x80000000</c> (Z), <c>0x40000000</c> (M), and
+    /// <c>0x20000000</c> (SRID). After stripping the EWKB flag bits and normalising the ISO
+    /// thousands offset, the base type must fall in 1-7 for the payload to be WKB.
+    /// </summary>
+    private static bool LooksLikeWkb(ReadOnlySpan<byte> content)
+    {
+        if (content.Length < 5)
+        {
+            return false;
+        }
+
+        var byteOrder = content[0];
+        if (byteOrder is not (0x00 or 0x01))
+        {
+            return false;
+        }
+
+        // Read the 4-byte geometry type honouring the declared byte order.
+        uint geometryType = byteOrder == 0x01
+            ? (uint)(content[1] | (content[2] << 8) | (content[3] << 16) | (content[4] << 24))
+            : (uint)((content[1] << 24) | (content[2] << 16) | (content[3] << 8) | content[4]);
+
+        // Strip the EWKB Z/M/SRID flag bits (top three bits), then fold the ISO thousands offset
+        // (1000 = Z, 2000 = M, 3000 = ZM) so every representation reduces to a base type 1-7.
+        var baseType = (geometryType & 0x1FFFFFFF) % 1000;
+        return baseType is >= 1 and <= 7;
     }
 
     /// <summary>

--- a/src/Honua.Geometry/Features/FileImport/Services/GpxFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/GpxFormatReader.cs
@@ -156,82 +156,81 @@ internal static class GpxFormatReader
     private static bool IsContainerElement(string localName) =>
         string.Equals(localName, "extensions", StringComparison.OrdinalIgnoreCase);
 
-    private static async Task<IFeature?> ParseTrackAsync(
+    private static Task<IFeature?> ParseTrackAsync(
         XmlReader reader,
         GeometryFactory factory,
-        CancellationToken cancellationToken)
-    {
-        var attributes = new AttributesTable();
-        var allCoordinates = new List<Coordinate>();
+        CancellationToken cancellationToken) =>
+        ParseLineFeatureAsync(reader, factory, "trkpt", cancellationToken);
 
-        while (await reader.ReadAsync())
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "trk")
-                break;
-
-            if (reader.NodeType == XmlNodeType.Element)
-            {
-                if (reader.LocalName == "name")
-                {
-                    attributes.Add("name", await reader.ReadElementContentAsStringAsync());
-                }
-                else if (reader.LocalName == "trkpt")
-                {
-                    var lat = reader.GetAttribute("lat");
-                    var lon = reader.GetAttribute("lon");
-                    if (lat != null && lon != null &&
-                        double.TryParse(lat, NumberStyles.Float, CultureInfo.InvariantCulture, out var latitude) &&
-                        double.TryParse(lon, NumberStyles.Float, CultureInfo.InvariantCulture, out var longitude))
-                    {
-                        allCoordinates.Add(new Coordinate(longitude, latitude));
-                    }
-                }
-            }
-        }
-
-        if (allCoordinates.Count >= 2)
-        {
-            var geometry = factory.CreateLineString(allCoordinates.ToArray());
-            return new Feature(geometry, attributes);
-        }
-
-        return null;
-    }
-
-    private static async Task<IFeature?> ParseRouteAsync(
+    private static Task<IFeature?> ParseRouteAsync(
         XmlReader reader,
         GeometryFactory factory,
+        CancellationToken cancellationToken) =>
+        ParseLineFeatureAsync(reader, factory, "rtept", cancellationToken);
+
+    /// <summary>
+    /// Parses a GPX line container (<c>&lt;trk&gt;</c> or <c>&lt;rte&gt;</c>) into a
+    /// <see cref="LineString"/> feature. The container's subtree is walked in a single forward
+    /// pass, collecting every <paramref name="pointElement"/> (<c>trkpt</c>/<c>rtept</c>) across
+    /// any nesting (e.g. multiple <c>&lt;trkseg&gt;</c>) and recording the first <c>&lt;name&gt;</c>
+    /// as an attribute. It deliberately avoids <c>ReadElementContentAsString</c>: that call
+    /// advances the reader past the element that follows <c>&lt;name&gt;</c>, and combined with the
+    /// caller's loop it silently skipped the first point — dropping a two-point route to zero
+    /// features (honua-server#2354).
+    /// </summary>
+    private static async Task<IFeature?> ParseLineFeatureAsync(
+        XmlReader reader,
+        GeometryFactory factory,
+        string pointElement,
         CancellationToken cancellationToken)
     {
         var attributes = new AttributesTable();
         var coordinates = new List<Coordinate>();
+        string? pendingName = null;
 
-        while (await reader.ReadAsync())
+        using var subtree = reader.ReadSubtree();
+        await subtree.ReadAsync(); // Position on the container root (trk/rte).
+
+        while (await subtree.ReadAsync())
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "rte")
-                break;
-
-            if (reader.NodeType == XmlNodeType.Element)
+            switch (subtree.NodeType)
             {
-                if (reader.LocalName == "name")
-                {
-                    attributes.Add("name", await reader.ReadElementContentAsStringAsync());
-                }
-                else if (reader.LocalName == "rtept")
-                {
-                    var lat = reader.GetAttribute("lat");
-                    var lon = reader.GetAttribute("lon");
-                    if (lat != null && lon != null &&
-                        double.TryParse(lat, NumberStyles.Float, CultureInfo.InvariantCulture, out var latitude) &&
-                        double.TryParse(lon, NumberStyles.Float, CultureInfo.InvariantCulture, out var longitude))
+                case XmlNodeType.Element:
+                    pendingName = null;
+                    if (string.Equals(subtree.LocalName, pointElement, StringComparison.Ordinal))
                     {
-                        coordinates.Add(new Coordinate(longitude, latitude));
+                        var lat = subtree.GetAttribute("lat");
+                        var lon = subtree.GetAttribute("lon");
+                        if (lat != null && lon != null &&
+                            double.TryParse(lat, NumberStyles.Float, CultureInfo.InvariantCulture, out var latitude) &&
+                            double.TryParse(lon, NumberStyles.Float, CultureInfo.InvariantCulture, out var longitude))
+                        {
+                            coordinates.Add(new Coordinate(longitude, latitude));
+                        }
                     }
-                }
+                    else if (string.Equals(subtree.LocalName, "name", StringComparison.Ordinal) &&
+                             !subtree.IsEmptyElement && !attributes.Exists("name"))
+                    {
+                        pendingName = "name";
+                    }
+
+                    break;
+
+                case XmlNodeType.Text:
+                case XmlNodeType.CDATA:
+                    if (pendingName != null && !attributes.Exists(pendingName))
+                    {
+                        attributes.Add(pendingName, subtree.Value);
+                    }
+
+                    pendingName = null;
+                    break;
+
+                case XmlNodeType.EndElement:
+                    pendingName = null;
+                    break;
             }
         }
 

--- a/src/Honua.Geometry/Features/FileImport/Services/WktFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/WktFormatReader.cs
@@ -35,6 +35,22 @@ internal static class WktFormatReader
         Stream stream,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        await foreach (var feature in ReadStreamingAsync(stream, diagnostics: null, cancellationToken))
+        {
+            yield return feature;
+        }
+    }
+
+    /// <summary>
+    /// Streams features from a WKT file, recording any record that cannot be parsed into the
+    /// supplied <paramref name="diagnostics"/> sink so the loss is surfaced as an import warning
+    /// rather than silently swallowed (honua-server#2363).
+    /// </summary>
+    internal static async IAsyncEnumerable<IFeature> ReadStreamingAsync(
+        Stream stream,
+        WktGeometryDiagnostics? diagnostics,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
         var wktReader = new WKTReader();
         var wkbReader = GeometryValueParser.CreateWkbReader();
         using var reader = new StreamReader(stream, leaveOpen: true);
@@ -60,7 +76,7 @@ internal static class WktFormatReader
             // "POINT EMPTY"): it is a complete geometry, so parse and reset.
             if (depth <= 0)
             {
-                var feature = BuildFeature(buffer, wktReader, wkbReader);
+                var feature = BuildFeature(buffer, wktReader, wkbReader, diagnostics);
                 buffer.Clear();
                 depth = 0;
                 if (feature != null)
@@ -72,20 +88,31 @@ internal static class WktFormatReader
         // unbalanced tail we still attempt to parse rather than silently drop).
         if (buffer.Length > 0)
         {
-            var feature = BuildFeature(buffer, wktReader, wkbReader);
+            var feature = BuildFeature(buffer, wktReader, wkbReader, diagnostics);
             if (feature != null)
                 yield return feature;
         }
     }
 
-    private static Feature? BuildFeature(StringBuilder buffer, WKTReader wktReader, WKBReader wkbReader)
+    private static Feature? BuildFeature(
+        StringBuilder buffer,
+        WKTReader wktReader,
+        WKBReader wkbReader,
+        WktGeometryDiagnostics? diagnostics)
     {
         var text = buffer.ToString().Trim();
         if (text.Length == 0)
             return null;
 
         var geometry = GeometryValueParser.TryParse(text, wktReader, wkbReader);
-        return geometry != null ? new Feature(geometry, new AttributesTable()) : null;
+        if (geometry != null)
+            return new Feature(geometry, new AttributesTable());
+
+        // A non-empty record that parses to nothing is unparseable content (bad WKT, a stray
+        // header line, a truncated multi-line tail). Record it so the import surfaces a warning
+        // instead of silently dropping the record.
+        diagnostics?.RecordUnparseableRecord();
+        return null;
     }
 
     private static int ParenDelta(string line)
@@ -101,4 +128,21 @@ internal static class WktFormatReader
 
         return delta;
     }
+}
+
+/// <summary>
+/// Collects diagnostics emitted while streaming a WKT file so the import pipeline can surface a
+/// warning instead of silently dropping records it cannot parse. A single instance is passed to
+/// <see cref="WktFormatReader"/> and read after enumeration completes (honua-server#2363).
+/// </summary>
+internal sealed class WktGeometryDiagnostics
+{
+    /// <summary>
+    /// Number of non-empty records whose content could not be parsed as WKT, EWKT, or WKB/EWKB
+    /// hex. Such records are skipped; counting them keeps the loss visible.
+    /// </summary>
+    public int UnparseableRecords { get; private set; }
+
+    /// <summary>Records that a WKT record could not be parsed.</summary>
+    public void RecordUnparseableRecord() => UnparseableRecords++;
 }

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Streaming.cs
@@ -102,12 +102,16 @@ internal sealed partial class StreamingFileImportService
         // (e.g. malformed WKT). Surfaced as a completion warning so the loss is never silent.
         var csvGeometryDiagnostics = format == SupportedFileFormat.Csv ? new CsvGeometryDiagnostics() : null;
 
+        // Collects WKT records that could not be parsed (bad WKT/EWKT, stray header lines, a
+        // truncated multi-line tail). Surfaced as a completion warning so the loss is never silent.
+        var wktGeometryDiagnostics = format == SupportedFileFormat.Wkt ? new WktGeometryDiagnostics() : null;
+
         var featureStream = format switch
         {
             SupportedFileFormat.GeoJson => _geoJsonReader.ReadFeaturesAsync(fileStream, cancellationToken),
             SupportedFileFormat.EsriJson => EsriJsonFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Wkb => WkbFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
-            SupportedFileFormat.Wkt => WktFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
+            SupportedFileFormat.Wkt => WktFormatReader.ReadStreamingAsync(fileStream, wktGeometryDiagnostics, cancellationToken),
             SupportedFileFormat.Kml => KmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Gpx => GpxFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
             SupportedFileFormat.Gml => GmlFormatReader.ReadStreamingAsync(fileStream, cancellationToken),
@@ -228,6 +232,12 @@ internal sealed partial class StreamingFileImportService
         {
             completionWarningsBuilder.Add(string.Format(
                 null, _csvUnparseableGeometryWarningFormat, csvGeometryDiagnostics.UnparseableGeometryRows));
+        }
+
+        if (wktGeometryDiagnostics is { UnparseableRecords: > 0 })
+        {
+            completionWarningsBuilder.Add(string.Format(
+                null, _wktUnparseableGeometryWarningFormat, wktGeometryDiagnostics.UnparseableRecords));
         }
 
         if (_limits.ContinueOnError && totalFailed > 0)

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -73,6 +73,8 @@ internal sealed partial class StreamingFileImportService : IFileImportService
         CompositeFormat.Parse("{0} row(s) failed while continue-on-error was enabled; previously imported rows were retained.");
     private static readonly CompositeFormat _csvUnparseableGeometryWarningFormat =
         CompositeFormat.Parse("{0} row(s) had a geometry value that could not be parsed as WKT, EWKT, or WKB; each raw value was preserved as an attribute and the row was imported without geometry.");
+    private static readonly CompositeFormat _wktUnparseableGeometryWarningFormat =
+        CompositeFormat.Parse("{0} record(s) could not be parsed as WKT, EWKT, or WKB and were skipped.");
     private static readonly Regex _wktSridRegex = new(
         @"SRID\s*=\s*(\d+)\s*;",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/EsriJsonWkbFormatDetectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/EsriJsonWkbFormatDetectionTests.cs
@@ -5,6 +5,8 @@ using System.Text;
 using Honua.Core.Features.FileImport.Domain;
 using Honua.Core.Features.FileImport.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
 
 namespace Honua.Core.Tests.Features.Import;
 
@@ -64,6 +66,29 @@ public sealed class EsriJsonWkbFormatDetectionTests
 
         _service.DetectFormatFromContent(bytes, "payload.json")
             .Should().Be(SupportedFileFormat.EsriJson);
+    }
+
+    [Theory]
+    [InlineData(true)]  // little-endian (NDR)
+    [InlineData(false)] // big-endian (XDR)
+    public void DetectFormatFromContent_RawWkbGeometry_ReturnsWkb(bool littleEndian)
+    {
+        // #2353: a raw WKB payload uploaded without a recognisable extension must be detected
+        // structurally instead of falling through to null (generic multipart error).
+        var writer = new WKBWriter(littleEndian ? ByteOrder.LittleEndian : ByteOrder.BigEndian);
+        var wkb = writer.Write(new Point(-122.4194, 37.7749));
+
+        _service.DetectFormatFromContent(wkb, "payload.bin").Should().Be(SupportedFileFormat.Wkb);
+    }
+
+    [Fact]
+    public void DetectFormatFromContent_EwkbWithSrid_ReturnsWkb()
+    {
+        // EWKB carries SRID/Z/M flag bits in the geometry-type word; detection must strip them.
+        var writer = new WKBWriter { Strict = false, HandleSRID = true };
+        var wkb = writer.Write(new Point(-122.4194, 37.7749) { SRID = 4326 });
+
+        _service.DetectFormatFromContent(wkb, "payload.bin").Should().Be(SupportedFileFormat.Wkb);
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/GpxFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/GpxFormatReaderTests.cs
@@ -63,6 +63,93 @@ public sealed class GpxFormatReaderTests
     }
 
     [Fact]
+    public async Task ReadStreamingAsync_RouteWithNameAndTwoPoints_ReturnsSingleLineString()
+    {
+        // #2354: a <name> preceding the <rtept> points made the reader over-advance and drop the
+        // first point; a two-point route then fell below the 2-coordinate minimum and yielded
+        // zero features (silent data loss).
+        const string gpx = """
+            <?xml version="1.0"?>
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+            <rte>
+              <name>Route 1</name>
+              <rtept lat="1.0" lon="2.0"/>
+              <rtept lat="3.0" lon="4.0"/>
+            </rte>
+            </gpx>
+            """;
+
+        var features = await ReadAsync(gpx);
+
+        features.Should().ContainSingle();
+        var line = features[0].Geometry.Should().BeOfType<LineString>().Subject;
+        line.Coordinates.Should().HaveCount(2);
+        line.Coordinates[0].X.Should().Be(2.0);
+        line.Coordinates[0].Y.Should().Be(1.0);
+        line.Coordinates[1].X.Should().Be(4.0);
+        features[0].Attributes["name"].Should().Be("Route 1");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_TrackWithNameAndSegments_ReturnsSingleLineString()
+    {
+        // #2354: tracks must collect trkpt points across <trkseg> nesting even when a <name>
+        // precedes them, and even when trkpt carries child elements (<ele>).
+        const string gpx = """
+            <?xml version="1.0"?>
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+            <trk>
+              <name>Track 1</name>
+              <trkseg>
+                <trkpt lat="1.0" lon="2.0"><ele>10</ele></trkpt>
+                <trkpt lat="3.0" lon="4.0"><ele>20</ele></trkpt>
+              </trkseg>
+              <trkseg>
+                <trkpt lat="5.0" lon="6.0"/>
+              </trkseg>
+            </trk>
+            </gpx>
+            """;
+
+        var features = await ReadAsync(gpx);
+
+        features.Should().ContainSingle();
+        var line = features[0].Geometry.Should().BeOfType<LineString>().Subject;
+        line.Coordinates.Should().HaveCount(3);
+        features[0].Attributes["name"].Should().Be("Track 1");
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_MixedWaypointsRoutesTracks_ReturnsAllFeatures()
+    {
+        // #2354: a document combining all three GPX geometry kinds must emit one feature each.
+        const string gpx = """
+            <?xml version="1.0"?>
+            <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+            <wpt lat="10.0" lon="20.0"><name>WP</name></wpt>
+            <rte>
+              <name>R</name>
+              <rtept lat="1.0" lon="2.0"/>
+              <rtept lat="3.0" lon="4.0"/>
+            </rte>
+            <trk>
+              <name>T</name>
+              <trkseg>
+                <trkpt lat="5.0" lon="6.0"/>
+                <trkpt lat="7.0" lon="8.0"/>
+              </trkseg>
+            </trk>
+            </gpx>
+            """;
+
+        var features = await ReadAsync(gpx);
+
+        features.Should().HaveCount(3);
+        features.Select(f => f.Geometry!.GeometryType).Should()
+            .BeEquivalentTo(["Point", "LineString", "LineString"]);
+    }
+
+    [Fact]
     public async Task ReadStreamingAsync_SimpleWaypointChildren_ReturnsAttributes()
     {
         const string gpx = """

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/WktFormatReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/WktFormatReaderTests.cs
@@ -72,6 +72,45 @@ public sealed class WktFormatReaderTests
         point.SRID.Should().Be(4326);
     }
 
+    [Fact]
+    public async Task ReadStreamingAsync_UnparseableRecord_IsRecordedInDiagnostics()
+    {
+        // #2363: unparseable content must no longer be swallowed silently — the record is skipped
+        // but counted so the import pipeline can surface a warning.
+        var diagnostics = new WktGeometryDiagnostics();
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("""
+            POINT(-122.4194 37.7749)
+            not-a-geometry
+            LINESTRING(0 0, 1 1)
+            """));
+
+        var features = new List<IFeature>();
+        await foreach (var feature in WktFormatReader.ReadStreamingAsync(stream, diagnostics, CancellationToken.None))
+        {
+            features.Add(feature);
+        }
+
+        features.Should().HaveCount(2);
+        diagnostics.UnparseableRecords.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ReadStreamingAsync_AllValidRecords_RecordsNoDiagnostics()
+    {
+        var diagnostics = new WktGeometryDiagnostics();
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("""
+            POINT(-122.4194 37.7749)
+
+            LINESTRING(0 0, 1 1)
+            """));
+
+        await foreach (var _ in WktFormatReader.ReadStreamingAsync(stream, diagnostics, CancellationToken.None))
+        {
+        }
+
+        diagnostics.UnparseableRecords.Should().Be(0);
+    }
+
     private static async Task<List<IFeature>> ReadAllAsync(string content)
     {
         await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));


### PR DESCRIPTION
## Related Issues

Closes #2353
Closes #2354
Closes #2363

## Summary

Fixes three shipping-format import bugs surfaced by the Slice-1 e2e harness, all in the shared format import/detection subsystem. No silent data loss: each unreadable path now either imports correctly or surfaces a warning.

## Changes Made

- **#2353 WKB not auto-detected** — `FileFormatDetectionService.DetectFormatFromContent` now recognises a raw WKB/EWKB payload structurally (leading byte-order flag `0x00`/`0x01` + a valid geometry-type `uint32`, stripping the EWKB `Z`/`M`/`SRID` flag bits and folding the ISO thousands offset to a base type 1-7). A WKB upload without a recognisable extension now routes to the WKB reader instead of failing with the generic "Multipart import request is invalid." message. (#2379 added the `.wkb` extension/allowlist; this is the content-detection side.)
- **#2354 GPX yields 0 features** — GPX routes (and tracks) dropped their first point: a `<name>` preceding the points was read via `ReadElementContentAsString`, which over-advanced the reader, and combined with the caller's loop the first `<rtept>`/`<trkpt>` was skipped; a two-point route then fell below the 2-coordinate minimum and yielded nothing. `<trk>`/`<rte>` are now parsed in a single `ReadSubtree` forward pass that never over-advances and collects points across nested `<trkseg>`. Waypoints/routes/tracks all emit features.
- **#2363 .wkt EWKT/multi-line/silent-loss** — EWKT (`SRID=…;` prefix) and multi-line geometries already parse via `GeometryValueParser` (landed in #2367). This PR closes the remaining gap: unparseable records are no longer silently swallowed — they are recorded in a new `WktGeometryDiagnostics` sink and surfaced as an import completion warning (mirroring the CSV pattern from #2367). The WKT CRS-detection path is preserved.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact / internal only

## Testing

- [x] Added/updated unit tests
- New regression tests: raw WKB (NDR/XDR) + EWKB content detection; GPX route-with-name, track-with-segments, and mixed wpt/rte/trk documents; WKT unparseable-record diagnostics.
- `dotnet test Honua.Core.Tests --filter Features.Import` → 492 passed, 0 failed.
- Release build with `TreatWarningsAsErrors=true` and `dotnet format --verify-no-changes` both clean.
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
