### PR TITLE
fix: coalesce null Studio draft collections to empty (#2351)

### DIFF
--- a/src/Honua.Core/Features/Studio/Services/StudioPackageLifecycleService.cs
+++ b/src/Honua.Core/Features/Studio/Services/StudioPackageLifecycleService.cs
@@ -55,11 +55,12 @@ public sealed class StudioPackageLifecycleService : IStudioPackageLifecycleServi
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(command);
-        using var activity = Start("studio.package.draft.create", command.Envelope.Family, command.ItemId);
+        var envelope = NormalizeEnvelope(command.Envelope);
+        using var activity = Start("studio.package.draft.create", envelope.Family, command.ItemId);
         ValidatePackageKey(command.PackageKey);
 
         var now = _timeProvider.GetUtcNow();
-        var validation = _validator.Validate(command.Envelope);
+        var validation = _validator.Validate(envelope);
         var itemId = command.ItemId ?? Guid.NewGuid();
         var draft = new StudioPackageDraft
         {
@@ -68,8 +69,8 @@ public sealed class StudioPackageLifecycleService : IStudioPackageLifecycleServi
             PackageKey = command.PackageKey.Trim(),
             WorkspaceId = NormalizeOptional(command.WorkspaceId),
             OwnerId = NormalizeOptional(command.OwnerId ?? command.ActorId),
-            Family = command.Envelope.Family,
-            Envelope = command.Envelope with { Validation = validation },
+            Family = envelope.Family,
+            Envelope = envelope with { Validation = validation },
             Validation = validation,
             BaseVersionId = command.BaseVersionId,
             Generation = 1,
@@ -101,7 +102,8 @@ public sealed class StudioPackageLifecycleService : IStudioPackageLifecycleServi
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(command);
-        using var activity = Start("studio.package.draft.update", command.Envelope.Family, null);
+        var envelope = NormalizeEnvelope(command.Envelope);
+        using var activity = Start("studio.package.draft.update", envelope.Family, null);
         activity?.SetTag("studio.draft.id", draftId.ToString("D"));
         ValidatePackageKey(command.PackageKey);
 
@@ -112,14 +114,14 @@ public sealed class StudioPackageLifecycleService : IStudioPackageLifecycleServi
         }
 
         var requestedGeneration = command.Generation ?? existing.Generation;
-        var validation = _validator.Validate(command.Envelope);
+        var validation = _validator.Validate(envelope);
         var updated = existing with
         {
             PackageKey = command.PackageKey.Trim(),
             WorkspaceId = NormalizeOptional(command.WorkspaceId),
             OwnerId = NormalizeOptional(command.OwnerId ?? existing.OwnerId),
-            Family = command.Envelope.Family,
-            Envelope = command.Envelope with { Validation = validation },
+            Family = envelope.Family,
+            Envelope = envelope with { Validation = validation },
             Validation = validation,
             Generation = requestedGeneration,
             UpdatedBy = command.ActorId,
@@ -458,6 +460,32 @@ public sealed class StudioPackageLifecycleService : IStudioPackageLifecycleServi
 
     private static string? NormalizeOptional(string? value)
         => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    /// <summary>
+    /// Coalesces optional envelope collections (bindings, dependencies, provenance) that a client
+    /// may send as an explicit JSON <c>null</c> to their empty defaults, so that a null collection
+    /// is treated identically to an omitted one. This keeps the envelope's non-null collection
+    /// contract intact through persistence and downstream enumeration (for example the immutable
+    /// version sidecar path), preventing a spurious <see cref="ArgumentNullException"/> on the
+    /// otherwise-successful create/update path (honua-server#2351).
+    /// </summary>
+    private static StudioPackageEnvelope NormalizeEnvelope(StudioPackageEnvelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        if (envelope.Bindings is not null
+            && envelope.Dependencies is not null
+            && envelope.Provenance is not null)
+        {
+            return envelope;
+        }
+
+        return envelope with
+        {
+            Bindings = envelope.Bindings ?? Array.Empty<StudioPackageBinding>(),
+            Dependencies = envelope.Dependencies ?? Array.Empty<StudioPackageDependency>(),
+            Provenance = envelope.Provenance ?? Array.Empty<StudioProvenanceRef>(),
+        };
+    }
 
     private static string FormatValidationFailure(
         string prefix,

--- a/src/Honua.Postgres/Features/Studio/PostgresStudioPackageStore.cs
+++ b/src/Honua.Postgres/Features/Studio/PostgresStudioPackageStore.cs
@@ -271,11 +271,13 @@ internal sealed class PostgresStudioPackageStore : IStudioPackageStore
         var createdAt = DateTimeOffset.UtcNow;
         var envelopeJson = SerializeEnvelope(draft.Envelope);
         var validationJson = SerializeValidation(draft.Validation);
+        var dependencies = draft.Envelope.Dependencies ?? Array.Empty<StudioPackageDependency>();
+        var provenance = draft.Envelope.Provenance ?? Array.Empty<StudioProvenanceRef>();
         var dependenciesJson = JsonSerializer.Serialize(
-            draft.Envelope.Dependencies.ToArray(),
+            dependencies.ToArray(),
             StudioJsonContext.Default.StudioPackageDependencyArray);
         var provenanceJson = JsonSerializer.Serialize(
-            draft.Envelope.Provenance.ToArray(),
+            provenance.ToArray(),
             StudioJsonContext.Default.StudioProvenanceRefArray);
         var contentHash = StudioPackageHash.Compute(draft.Envelope);
         var versionId = Guid.NewGuid();
@@ -355,7 +357,7 @@ internal sealed class PostgresStudioPackageStore : IStudioPackageStore
                 await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            await InsertDependencySidecarsAsync(connection, transaction, draft.ItemId, versionId, draft.Envelope.Dependencies, cancellationToken).ConfigureAwait(false);
+            await InsertDependencySidecarsAsync(connection, transaction, draft.ItemId, versionId, dependencies, cancellationToken).ConfigureAwait(false);
             await UpdatePointersAsync(
                 connection,
                 transaction,

--- a/tests/dotnet/Honua.Core.Tests/Features/Studio/StudioPackageLifecycleServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Studio/StudioPackageLifecycleServiceTests.cs
@@ -147,6 +147,107 @@ public sealed class StudioPackageLifecycleServiceTests
     }
 
     [UnitTest]
+    public async Task CreateDraft_WithNullCollections_CoalescesToEmptyWithoutError()
+    {
+        // Regression: honua-server#2351 — a client sending an explicit JSON null for
+        // bindings/dependencies/provenance must be treated identically to omitting them
+        // (empty), not persisted as a null collection that later triggers a spurious
+        // ArgumentNullException ("source") on the otherwise-successful path.
+        var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IStudioPackageLifecycleService>();
+
+        const string envelopeJson = """
+        {
+          "family": 0,
+          "schemaVersion": "1.0",
+          "format": "studio_query_package.v1",
+          "bindings": null,
+          "dependencies": null,
+          "provenance": null,
+          "body": {"where":"1=1"}
+        }
+        """;
+        var envelope = JsonSerializer.Deserialize(envelopeJson, StudioJsonContext.Default.StudioPackageEnvelope)!;
+        Assert.Null(envelope.Bindings);
+        Assert.Null(envelope.Dependencies);
+        Assert.Null(envelope.Provenance);
+
+        var draft = await service.CreateDraftAsync(new CreateStudioPackageDraftCommand
+        {
+            PackageKey = "parcels-query",
+            WorkspaceId = "studio",
+            Envelope = envelope,
+            ActorId = "tester",
+        });
+
+        // Null collections are coalesced to empty and never persisted as null.
+        Assert.NotNull(draft.Envelope.Bindings);
+        Assert.NotNull(draft.Envelope.Dependencies);
+        Assert.NotNull(draft.Envelope.Provenance);
+        Assert.Empty(draft.Envelope.Bindings);
+        Assert.Empty(draft.Envelope.Dependencies);
+        Assert.Empty(draft.Envelope.Provenance);
+
+        // Behaves like omitted collections: no spurious "must be an array" diagnostics.
+        Assert.DoesNotContain(draft.Validation.Diagnostics, d => d.Code == "studio.bindings.array");
+        Assert.DoesNotContain(draft.Validation.Diagnostics, d => d.Code == "studio.dependencies.array");
+        Assert.DoesNotContain(draft.Validation.Diagnostics, d => d.Code == "studio.provenance.array");
+        Assert.Equal(StudioPackageValidationStatus.Valid, draft.Validation.Status);
+
+        // The immutable version sidecar path enumerates these collections; with the null
+        // coalesced away it completes without throwing.
+        var version = await service.SaveDraftAsVersionAsync(draft.DraftId, "first save", "tester");
+        Assert.NotNull(version);
+        Assert.Empty(version!.Dependencies);
+        Assert.Empty(version.Provenance);
+    }
+
+    [UnitTest]
+    public async Task UpdateDraft_WithNullCollections_CoalescesToEmptyWithoutError()
+    {
+        var provider = BuildServiceProvider();
+        var service = provider.GetRequiredService<IStudioPackageLifecycleService>();
+        var draft = await service.CreateDraftAsync(new CreateStudioPackageDraftCommand
+        {
+            PackageKey = "parcels-query",
+            WorkspaceId = "studio",
+            Envelope = BuildEnvelope("1=1", "content.parcels"),
+            ActorId = "tester",
+        });
+
+        const string envelopeJson = """
+        {
+          "family": 0,
+          "schemaVersion": "1.0",
+          "format": "studio_query_package.v1",
+          "bindings": null,
+          "dependencies": null,
+          "provenance": null,
+          "body": {"where":"POPULATION > 1000"}
+        }
+        """;
+        var envelope = JsonSerializer.Deserialize(envelopeJson, StudioJsonContext.Default.StudioPackageEnvelope)!;
+
+        var updated = await service.UpdateDraftAsync(draft.DraftId, new UpdateStudioPackageDraftCommand
+        {
+            PackageKey = draft.PackageKey,
+            WorkspaceId = draft.WorkspaceId,
+            OwnerId = draft.OwnerId,
+            Envelope = envelope,
+            Generation = draft.Generation,
+            ActorId = "tester",
+        });
+
+        Assert.NotNull(updated);
+        Assert.NotNull(updated!.Envelope.Bindings);
+        Assert.NotNull(updated.Envelope.Dependencies);
+        Assert.NotNull(updated.Envelope.Provenance);
+        Assert.Empty(updated.Envelope.Bindings);
+        Assert.Empty(updated.Envelope.Dependencies);
+        Assert.Empty(updated.Envelope.Provenance);
+    }
+
+    [UnitTest]
     public void Validate_WithDuplicateBindingsAndInvalidCrs_ReturnsInvalidDiagnostics()
     {
         var provider = BuildServiceProvider();

--- a/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
@@ -219,6 +219,55 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("POST /api/v1/studio/package-drafts")]
+    public async Task CreateDraft_WithNullCollections_Returns201WithEmptyCollections()
+    {
+        // Regression: honua-server#2351 — an explicit JSON null for bindings/dependencies/
+        // provenance must be treated like an omitted (empty) collection: a clean 201 with
+        // empty collections and no spurious ArgumentNullException logged on the success path.
+        const string requestJson = """
+        {
+          "packageKey": "null-collections-query",
+          "workspaceId": "studio",
+          "envelope": {
+            "family": 0,
+            "schemaVersion": "1.0",
+            "format": "studio_query_package.v1",
+            "bindings": null,
+            "dependencies": null,
+            "provenance": null,
+            "body": { "where": "1=1" }
+          }
+        }
+        """;
+
+        using var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        var createResponse = await _client.PostAsync("/api/v1/studio/package-drafts", content);
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var draft = await ReadAsync<StudioPackageDraft>(
+            createResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioPackageDraft);
+
+        draft.Envelope.Bindings.Should().NotBeNull().And.BeEmpty();
+        draft.Envelope.Dependencies.Should().NotBeNull().And.BeEmpty();
+        draft.Envelope.Provenance.Should().NotBeNull().And.BeEmpty();
+        draft.Validation.Status.Should().Be(StudioPackageValidationStatus.Valid);
+        draft.Validation.Diagnostics.Should().NotContain(d =>
+            d.Code == "studio.bindings.array"
+            || d.Code == "studio.dependencies.array"
+            || d.Code == "studio.provenance.array");
+
+        // Saving the draft as an immutable version enumerates the (now non-null) collections;
+        // this completes cleanly rather than throwing on the success path.
+        var saveResponse = await PostAsync(
+            $"/api/v1/studio/package-drafts/{draft.DraftId:D}/content-versions",
+            new SaveStudioContentVersionRequest { ChangeNote = "first save" },
+            StudioApiJsonContext.Default.SaveStudioContentVersionRequest);
+        saveResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [IntegrationTest]
     [Endpoint("PUT /api/v1/studio/package-drafts/{draftId}")]
     public async Task UpdateDraft_WithStaleGeneration_ReturnsConflictProblem()
     {


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2351

## Summary
Studio draft creation logged a spurious `ArgumentNullException (source)` when a request sent an explicit JSON `null` for the envelope's `bindings`, `dependencies`, or `provenance`, while still returning **201**. The domain model declares these as non-null collections (default `Array.Empty<>`), so omitting them already yields a clean, valid 201 with empty collections — but an explicit `null` was persisted as a null collection and later hit `Enumerable.ToArray(null)` (param name `source`) on the immutable-version sidecar path, polluting logs on the success path.

Decision: **coalesce null → empty** (not 400-reject). Per the Studio contract these collections are optional (non-null model defaults; omitting them is already a valid 201), so an explicit `null` should be treated identically to an omitted field. Rejecting `null` with a 400 would make it diverge from the semantically-identical omitted case, and the draft endpoint intentionally persists validation-imperfect drafts as 201 (validation is advisory, surfaced via the validation summary). Coalescing keeps behavior well-defined and consistent.

## Changes Made
- Coalesce null `bindings`/`dependencies`/`provenance` to empty at the canonical lifecycle chokepoint (`StudioPackageLifecycleService.CreateDraftAsync` + `UpdateDraftAsync`, which also covers reopen) via a new `NormalizeEnvelope` helper, so the persisted envelope always honours its non-null collection contract and validation reports the same clean result as an omitted field.
- Harden `PostgresStudioPackageStore.CreateVersionAsync` defensively (`?? Array.Empty<>` before `ToArray`) so a direct store caller cannot hit the same NRE.
- Add a Core unit test (`CreateDraft_WithNullCollections_CoalescesToEmptyWithoutError`, plus an update variant) and a Server integration test (`CreateDraft_WithNullCollections_Returns201WithEmptyCollections`) asserting 201, empty non-null collections, `Valid` status, no `studio.*.array` diagnostics, and a clean save-as-version.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
