### PR TITLE
fix(catalog): regenerate feature catalog for e2e bug-fix proving tests

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5951,6 +5951,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetStyledMap_VectorCollectionTiff_ReturnsCleanErrorNeverPngLabeledTiff",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetStyledMap_VectorCollection_RendersPngInsteadOf501",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetStyledMap_WithValidStyle_ReachesStyledMapEndpoint",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsErrorHandlingTests.GetStyledMap_NonExistentCollection_ReturnsNotFound",
@@ -14227,6 +14228,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.CreateDraft_WithNullCollections_Returns201WithEmptyCollections",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback"
       ],
       "proof_ledger_surface": "studio-package-lifecycle",
@@ -15305,6 +15307,7 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerBasicTests.ExportImage_PostFormBody_ReturnsImageOrNotFound",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerMosaicIntegrationTests.ExportImagePost_WithTime_SelectsTemporalSliceAndAgreesWithGet",
         "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerParameterValidationTests.ExportImage_PostFormBody_WithEsriJsonSpatialReferences_DoesNotReturnBadRequest",
         "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerParameterValidationTests.ExportImage_PostJsonBody_WithEsriJsonSpatialReferences_DoesNotReturnBadRequest"
       ],


### PR DESCRIPTION
## What
Regenerates `docs/gis/data/feature-catalog.json` so `FeatureCatalogDriftTests.CommittedCatalog_EqualsFreshlyGeneratedOutput` (Architecture shard, .NET Foundation Tests) goes green.

## Why
The e2e bug-fix batch added three `[Endpoint]`-attributed proving tests but did not regenerate the generated catalog projection, so the drift guard went red on trunk tip:

- `OgcMapsBasicTests.GetStyledMap_VectorCollectionTiff_ReturnsCleanErrorNeverPngLabeledTiff` (#2381 — OGC Maps styled-vector tiff mislabeling)
- `ImageServerMosaicIntegrationTests.ExportImagePost_WithTime_SelectsTemporalSliceAndAgreesWithGet` (#2381 — ImageServer POST exportImage time)
- `StudioPackageEndpointsTests.CreateDraft_WithNullCollections_Returns201WithEmptyCollections` (#2383 — Studio null collections)

## How
`scripts/generate-feature-catalog.sh` (deterministic projection of the live API surface). Diff is exactly the three new proving tests added to their route families (+3 lines). Verified the emitter/drift test passes locally.

Unblocks the rc.0 final re-pin.