### PR TITLE
ci(cite): wait for KML generateKml endpoint instead of single-shot probe

### DIFF
--- a/scripts/conformance/cite/run-cite-kml22-tests.sh
+++ b/scripts/conformance/cite/run-cite-kml22-tests.sh
@@ -218,10 +218,23 @@ HONUA_BASE_URL="http://localhost:${HONUA_CITE_KML22_SERVER_PORT}"
 KML_URL_HOST="$HONUA_BASE_URL/rest/services/cite/MapServer/generateKml"
 
 echo -e "${YELLOW}Verifying KML endpoint...${NC}"
-if ! curl -s -f "$KML_URL_HOST" > /dev/null; then
-    echo -e "${RED}KML generateKml endpoint not accessible${NC}"
-    exit 1
-fi
+# The container healthcheck is /healthz/ready, which gates on migrations + database + cache health
+# but NOT on the in-memory service catalog being warm. After the post-seed server restart there is a
+# brief window where /healthz/ready returns 200 while the seeded `cite` MapServer service has not yet
+# been loaded, so a single-shot probe of generateKml can race the catalog warm-up and 404. Poll the
+# endpoint until it actually serves (bounded) instead of probing once. If it never becomes accessible
+# the loop still fails after the timeout, so a genuine endpoint break is not masked.
+KML_ENDPOINT_TIMEOUT="${KML_ENDPOINT_TIMEOUT:-60}"
+kml_start_time=$(date +%s)
+until curl -s -f "$KML_URL_HOST" > /dev/null; do
+    if [[ $(( $(date +%s) - kml_start_time )) -ge $KML_ENDPOINT_TIMEOUT ]]; then
+        echo -e "${RED}KML generateKml endpoint not accessible after ${KML_ENDPOINT_TIMEOUT}s${NC}"
+        echo "Check logs with: $COMPOSE_CMD -f $CITE_COMPOSE_FILE logs honua-server"
+        exit 1
+    fi
+    echo "Waiting for KML generateKml endpoint (service catalog warm-up)..."
+    sleep 2
+done
 
 echo -e "${GREEN}KML endpoint is accessible${NC}"
 


### PR DESCRIPTION
## Summary

The scheduled **OGC KML 2.2 CITE** run went red on `trunk` (release-candidate SHA `91082da25`) with `KML generateKml endpoint not accessible` and **0 conformance tests executed** — a harness readiness race, not a KML output/conformance regression.

Root cause: `scripts/conformance/cite/run-cite-kml22-tests.sh` probes `/rest/services/cite/MapServer/generateKml` **once**, immediately after the container healthcheck flips healthy. That healthcheck is `/healthz/ready`, which gates on migrations + database + cache health but **not** on the in-memory service catalog being warm (see `ReadinessCheckService`). After the post-seed server restart there is a brief window where `/healthz/ready` is 200 while the seeded `cite` MapServer service has not finished loading, so the single-shot probe races catalog warm-up and 404s. Growth in server startup work widened the window enough that the immediate probe now loses reliably.

Verified against the pinned image (`ghcr.io/honua-io/honua-server:nightly-aot`, == trunk `91082da25`): once warm, `generateKml` returns **HTTP 200 with valid KML 2.2** — the endpoint and the 42/42 conformance suite are unchanged.

## Changes Made

- Poll `generateKml` until it serves (bounded `KML_ENDPOINT_TIMEOUT`, default 60s) instead of a single-shot probe. A genuinely broken endpoint still fails after the timeout, so a real regression cannot be masked.

## Breaking Changes

None.

## Gate Impact

- [x] CI/test-infrastructure only (no runtime/product code changed)

## Testing

- [x] Reproduced the race locally with the pinned image and confirmed `generateKml` serves valid KML 2.2 once the catalog is warm; the bounded wait closes the race.

Related to the 2026.1-rc.0 release-train build-test gate (KML 2.2 CITE red).
