### PR TITLE
fix(cite): disable default GP sample seed so MapServer CITE seed loads

### DIFF
--- a/docker/cite/gml32/compose.yml
+++ b/docker/cite/gml32/compose.yml
@@ -12,6 +12,14 @@ services:
       - PUBLIC_BASE_URL=http://honua-server:8080
       - HONUA_DEV_AUTH=true
       - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      # The CITE seed writes the `cite` service directly into the legacy (v1) catalog
+      # tables after the server's first start. The default GPServer sample seeder
+      # (honua-server#2349/#2362) force-activates a geoprocessing-only Metadata v2
+      # snapshot on that empty first start, which then shadows the live v1-compat
+      # projection so the post-seed `cite` service never enters the v2 catalog that
+      # MapServer resolution reads (generateKml/WMS/WMTS would 404). Disable the sample
+      # seed so v1-compat projection stays authoritative for the directly-seeded service.
+      - HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false
       - Cache__Enabled=false
       - DataSource__Provider=postgres
       - HostValidation__Enabled=false

--- a/docker/cite/gpkg12/compose.yml
+++ b/docker/cite/gpkg12/compose.yml
@@ -12,6 +12,14 @@ services:
       - PUBLIC_BASE_URL=http://honua-server:8080
       - HONUA_DEV_AUTH=true
       - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      # The CITE seed writes the `cite` service directly into the legacy (v1) catalog
+      # tables after the server's first start. The default GPServer sample seeder
+      # (honua-server#2349/#2362) force-activates a geoprocessing-only Metadata v2
+      # snapshot on that empty first start, which then shadows the live v1-compat
+      # projection so the post-seed `cite` service never enters the v2 catalog that
+      # MapServer resolution reads (generateKml/WMS/WMTS would 404). Disable the sample
+      # seed so v1-compat projection stays authoritative for the directly-seeded service.
+      - HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false
       - Cache__Enabled=false
       - DataSource__Provider=postgres
       - HostValidation__Enabled=false

--- a/docker/cite/kml22/compose.yml
+++ b/docker/cite/kml22/compose.yml
@@ -12,6 +12,14 @@ services:
       - PUBLIC_BASE_URL=http://honua-server:8080
       - HONUA_DEV_AUTH=true
       - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      # The CITE seed writes the `cite` service directly into the legacy (v1) catalog
+      # tables after the server's first start. The default GPServer sample seeder
+      # (honua-server#2349/#2362) force-activates a geoprocessing-only Metadata v2
+      # snapshot on that empty first start, which then shadows the live v1-compat
+      # projection so the post-seed `cite` service never enters the v2 catalog that
+      # MapServer resolution reads (generateKml/WMS/WMTS would 404). Disable the sample
+      # seed so v1-compat projection stays authoritative for the directly-seeded service.
+      - HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false
       - Cache__Enabled=false
       - DataSource__Provider=postgres
       - HostValidation__Enabled=false

--- a/docker/cite/wms11/compose.yml
+++ b/docker/cite/wms11/compose.yml
@@ -12,6 +12,14 @@ services:
       - PUBLIC_BASE_URL=http://honua-server:8080
       - HONUA_DEV_AUTH=true
       - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      # The CITE seed writes the `cite` service directly into the legacy (v1) catalog
+      # tables after the server's first start. The default GPServer sample seeder
+      # (honua-server#2349/#2362) force-activates a geoprocessing-only Metadata v2
+      # snapshot on that empty first start, which then shadows the live v1-compat
+      # projection so the post-seed `cite` service never enters the v2 catalog that
+      # MapServer resolution reads (generateKml/WMS/WMTS would 404). Disable the sample
+      # seed so v1-compat projection stays authoritative for the directly-seeded service.
+      - HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false
       - Cache__Enabled=false
       - DataSource__Provider=postgres
       - HostValidation__Enabled=false

--- a/docker/cite/wms13/compose.yml
+++ b/docker/cite/wms13/compose.yml
@@ -12,6 +12,14 @@ services:
       - PUBLIC_BASE_URL=http://honua-server:8080
       - HONUA_DEV_AUTH=true
       - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      # The CITE seed writes the `cite` service directly into the legacy (v1) catalog
+      # tables after the server's first start. The default GPServer sample seeder
+      # (honua-server#2349/#2362) force-activates a geoprocessing-only Metadata v2
+      # snapshot on that empty first start, which then shadows the live v1-compat
+      # projection so the post-seed `cite` service never enters the v2 catalog that
+      # MapServer resolution reads (generateKml/WMS/WMTS would 404). Disable the sample
+      # seed so v1-compat projection stays authoritative for the directly-seeded service.
+      - HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false
       - Cache__Enabled=false
       - DataSource__Provider=postgres
       - HostValidation__Enabled=false

--- a/docker/cite/wmts10/compose.yml
+++ b/docker/cite/wmts10/compose.yml
@@ -12,6 +12,14 @@ services:
       - PUBLIC_BASE_URL=http://honua-server:8080
       - HONUA_DEV_AUTH=true
       - HONUA_REGISTER_TEST_INFRASTRUCTURE=true
+      # The CITE seed writes the `cite` service directly into the legacy (v1) catalog
+      # tables after the server's first start. The default GPServer sample seeder
+      # (honua-server#2349/#2362) force-activates a geoprocessing-only Metadata v2
+      # snapshot on that empty first start, which then shadows the live v1-compat
+      # projection so the post-seed `cite` service never enters the v2 catalog that
+      # MapServer resolution reads (generateKml/WMS/WMTS would 404). Disable the sample
+      # seed so v1-compat projection stays authoritative for the directly-seeded service.
+      - HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false
       - Cache__Enabled=false
       - DataSource__Provider=postgres
       - HostValidation__Enabled=false


### PR DESCRIPTION
## Root cause (proven locally against trunk 273090e8)

The KML 2.2 CITE workflow regressed to failure on the 07-03 nightly (green through 06-26). It fails at the `generateKml` readiness probe: the endpoint returns **404 "Service 'cite' not found"** for the full 60s window, so the ETS KML 2.2 suite never runs (`FAILED_TESTS=0`, exit 1).

**generateKml/KML output is NOT broken.** The endpoint, its route registration, and the KML writer are unchanged and produce valid KML (verified: HTTP 200, 16 placemarks) whenever the `cite` service is in the catalog. This is a harness/seed × snapshot-activation incompatibility:

- The CITE MapServer suites seed the `cite` service **directly into the legacy (v1) catalog tables** *after* the server's first start, then restart and drive it. They rely on the live **v1-compat Metadata v2 projection** surfacing that service.
- The default GPServer sample seeder (#2349 / #2362) **force-activates a geoprocessing-only Metadata v2 snapshot** on the empty first start. An activated snapshot takes precedence over the live v1-compat projection, so the `cite` service seeded into v1 afterwards never enters the v2 catalog that MapServer resolution (`IMetadataV2GraphProvider.GetCurrentAsync`) reads → 404.

### Evidence (identical trunk code + DB, A/B on the one variable)
| Flow | generateKml |
|------|-------------|
| fresh trunk migrate → seed → restart, GP seeder **on** (default) | **404** "Service 'cite' not found" |
| same, `HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false` | **200**, valid KML, 16 placemarks |

The pre-#2362 nightly image (264a7d381) has no seeder → no activated snapshot → v1-compat serves `cite` → 200, matching the green history.

## Fix
Set `HONUA_GEOPROCESSING_SEED_DEFAULT_SERVICE=false` in the six CITE composes that seed the MapServer `cite` service directly into v1 (kml22, wms13, wms11, wmts10, gpkg12, gml32). No snapshot is force-activated, so the v1-compat projection stays authoritative. None of these suites exercise the GPServer facade, so dropping the sample service is inconsequential.