### PR TITLE
docs(adr): describe the two gating mechanisms accurately in ADR-0058/0059

### DIFF
--- a/docs/internal/contributor/adr/0058-unified-capability-registry-single-source-of-truth.md
+++ b/docs/internal/contributor/adr/0058-unified-capability-registry-single-source-of-truth.md
@@ -100,25 +100,41 @@ is preserved**: consumers see the same manifest shape; only its source of truth
 changes from a hand-kept list to a registry projection. Per-env behavior (which
 capabilities an environment exposes) stays a property of the resolver layer.
 
-### The manifest is the single deferred-capability lever
+### Two mechanisms hold the experimental + disabled set OFF (the registry flag is one, not both)
 
-Because every surface derives from the registry, the registry-derived manifest
-is the **one lever** that controls advertised scope. First-release scope
-advertises **only in-first-release capabilities**; the deferred capabilities are
-marked `maturity:deferred` in the feature catalog and **gated / flag-off**:
-temporal (`/api/v1/temporal/*`), disconnected-sync (replica/conflict endpoints),
-realtime/geofence (`/api/v1/admin/alerts/*`), cross-env metadata-promotion
-(`/api/v1/admin/metadata` + deploy `MetadataRelease` ops), SIEM
-(`/api/v1/admin/investigations/*`), mTLS
-(`/api/v1/admin/security/client-certificates/validate`), and — per the
-release-owner scope update (2026-07) — **forms** (`form.package` / forms
-authoring + field forms), **mobile / offline**, and **field data collection**
-(honua-collect). Note only **cross-environment** metadata-promotion is deferred;
-**single-instance GitOps change-safety stays as the release operate floor**.
-Flipping a capability
-off in the registry removes it from the manifest, `/mcp`, Studio availability,
-and Console at once. This is the manifest lever the Console release gate
-(honua-io/honua-console#264) already consumes.
+The registry-derived manifest is **one of two** levers that keep the
+experimental + disabled set (ADR-0059 §2) out of a default deployment — not a
+single uniform lever over the whole set.
+
+**(a) Registry-flag gating** covers exactly the experimental-tier capabilities
+whose API routes are enumerated in the feature catalog's `experimental` tier —
+the route-bearing descriptors: **temporal** analytics/versioning
+(`/api/v1/temporal/*`, incl. as-of/diff/timeline and rollback/rollback-plan),
+**disconnected-sync / replicas** (`/api/v1/admin/services/{id}/replicas` +
+conflict-resolution), **realtime feature-streams**
+(`/api/v1/streaming/features` + `/api/v1/admin/(operations/)streaming/*`),
+**geofence alerting** (`/api/v1/admin/alerts/*`), and **mTLS client-certificate
+validation** (`/api/v1/admin/security/client-certificates/*`). For these,
+flipping the capability off in the registry removes it from the manifest,
+`/mcp`, Studio availability, and Console at once — the single-lever behavior this
+ADR gives the registry, and the manifest lever the Console release gate
+(honua-io/honua-console#264) consumes.
+
+**(b) Edition/entitlement + Console-UI gating** covers the remainder of the
+experimental + disabled set — the capabilities that are **not** held back by a
+route-level registry flag: SSO/OIDC/SAML/SCIM, **forms** authoring + **field
+data collection** (honua-collect), **mobile / offline**, **branch / versioned
+editing**, SIEM / investigations, **cross-environment** metadata-promotion
+(`/api/v1/admin/metadata` + deploy `MetadataRelease` ops) and dev→staging→prod
+promotion, the **rollback** operate loop, collaborative map sessions, and
+experimental format surfaces. These are held OFF by edition/entitlement checks
+and Console-UI availability, not by the registry manifest flag. Note only
+**cross-environment** metadata-promotion is gated; **single-instance GitOps
+change-safety stays as the release operate floor.**
+
+Folding more of the entitlement/UI-gated set (b) behind the registry flag (a) —
+so the manifest becomes the uniform advertised-scope lever — is
+post-first-release registry work, not a first-release claim.
 
 ### Studio stays REST; it binds via SDK projections
 
@@ -149,9 +165,12 @@ shared engines; only description/discovery is unified.
 - One conformance truth: the spec/`index.json` and the served `/mcp` catalog
   cannot disagree without failing CI — closing the gate-c false-pass
   (geospatial-mcp#25).
-- One scope lever: advertised-vs-served is governed by a single registry flag,
-  so first-release scoping (and the Console gate) is a data decision, not five
-  code edits.
+- Registry-flag scope lever (for the route-bearing experimental descriptors):
+  advertised-vs-served is governed by the registry flag, so scoping those (and
+  the Console gate) is a data decision, not five code edits. The rest of the
+  experimental + disabled set stays held back by edition/entitlement + Console-UI
+  gating (see "Two mechanisms hold the experimental + disabled set OFF") — a
+  second lever the registry does not yet subsume.
 - No re-fork: Console and the SDKs consume server-owned projections instead of
   local shim DTOs, ending the five-roster drift.
 - Studio and `/mcp` inherit new capabilities automatically once a descriptor is

--- a/docs/internal/contributor/adr/0059-first-release-scope-and-fix-forward-operate-model.md
+++ b/docs/internal/contributor/adr/0059-first-release-scope-and-fix-forward-operate-model.md
@@ -19,8 +19,10 @@ their own, pin the release line:
 - ADR-0058 (capability registry — the `ICapabilityRegistry` /
   `CapabilityDescriptor` single-source-of-truth recorded in
   honua-io/honua-release#32) makes the registry-derived **capability manifest**
-  the single lever that decides what is advertised and reachable, but does not
-  itself enumerate the first-release in/out split.
+  the lever that decides what is advertised and reachable **for its route-bearing
+  capabilities**, but does not itself enumerate the first-release in/out split
+  (and is not the only gate — see §2 for the entitlement/UI mechanism that holds
+  the rest of the disabled set off).
 - honua-console `docs/roadmap/FIRST_RELEASE_STRATEGY_AND_CUT_LINE.md` draws the
   depth cut-line and, critically, asserts a **"non-negotiable operate floor"**
   whose exit criterion is *"propose → preflight → approve → apply → **roll
@@ -71,7 +73,9 @@ advertised in the capability manifest):
 The following are **built server-side and gated OFF for the first release**.
 They carry `maturity: experimental` in the feature catalog, are **NOT advertised
 in the capability manifest**, and their surfaces/endpoints are **disabled by
-default** — reachable only as a **customer opt-in via the capability flag**.
+default** — reachable only as a **customer opt-in** (via the registry capability
+flag for the route-bearing capabilities, or via edition/entitlement + Console-UI
+for the rest — see the two-mechanism note below).
 Present, wired, and tested in the binary, they still must not appear in the
 manifest, `/mcp`, Studio availability, or Console in a default deployment. This
 is a "built, gated off, customer-opt-in" posture — **not** "deferred / not
@@ -103,7 +107,23 @@ built." Each links its tracking issue:
 
 These are certified-off, not absent: the code is present, wired, and tested, but
 it is not certified for this release and is not reachable by a default
-deployment. It lights up when a customer opts in via the capability flag.
+deployment. It lights up when the customer opts in.
+
+**Two mechanisms hold this set OFF — not one uniform registry flag.** The
+route-bearing experimental capabilities — **temporal** analytics/versioning
+(`/api/v1/temporal/*`), **disconnected-sync / replicas**, **realtime
+feature-streams**, **geofence alerting** (`/api/v1/admin/alerts/*`), and **mTLS
+client-certificate validation** — are gated by the **registry capability flag**:
+flipping them off in the registry drops them from the manifest, `/mcp`, Studio,
+and Console at once (the single-lever behavior ADR-0058 gives the registry, over
+exactly the descriptors whose routes are in the catalog's `experimental` tier).
+The remainder — **SSO/OIDC/SAML/SCIM**, **forms + field data collection**,
+**mobile / offline**, **branch / versioned editing**, **SIEM / investigations**,
+**cross-environment promotion**, the **rollback** operate loop, and
+**collaborative map sessions** — are held OFF by **edition/entitlement checks and
+Console-UI availability**, not by the registry manifest flag. Folding more of the
+entitlement/UI-gated set behind the registry flag is post-first-release registry
+work (see ADR-0058, "Two mechanisms hold the experimental + disabled set OFF").
 
 **Genuinely not built (`planned`).** The only items in this space that are *not*
 built are the federal smart-card auth paths — **CAC / PIV**


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2337

## Summary
Release-documentation accuracy fix. ADR-0058 and ADR-0059 claimed the capability
registry flag is the single uniform lever gating the whole experimental + disabled
set. In reality (corroborated by `docs/gis/data/feature-catalog.json`) there are
**two** mechanisms, and this PR rewords both ADRs to describe them truthfully.
Decisions are unchanged — the fix-forward / no-auto-rollback operate model stays as-is.

## Changes Made
- ADR-0058: replaced the "single deferred-capability lever" section with "Two mechanisms hold the experimental + disabled set OFF": (a) registry-flag gating covers exactly the route-bearing experimental-tier descriptors (temporal.*, disconnected-sync/replicas, realtime feature-streams, geofence alerts, mTLS client-cert validation); (b) edition/entitlement + Console-UI gating covers the rest.
- ADR-0058: reworded the "one scope lever" Consequences bullet to match.
- ADR-0059 §2: reworded the "reachable only via the capability flag" claim and added a two-mechanism note; softened the Context bullet describing ADR-0058's lever.

## Testing
- [x] Manual testing performed

Docs-only change; grounded against `feature-catalog.json` experimental tier (route-bearing temporal/replica/streaming/alerts/client-certificate endpoints).

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
