### PR TITLE
docs(adr): formats ship supported for rc.0 (not experimental)

### DIFF
--- a/docs/internal/contributor/adr/0058-unified-capability-registry-single-source-of-truth.md
+++ b/docs/internal/contributor/adr/0058-unified-capability-registry-single-source-of-truth.md
@@ -126,9 +126,11 @@ route-level registry flag: SSO/OIDC/SAML/SCIM, **forms** authoring + **field
 data collection** (honua-collect), **mobile / offline**, **branch / versioned
 editing**, SIEM / investigations, **cross-environment** metadata-promotion
 (`/api/v1/admin/metadata` + deploy `MetadataRelease` ops) and dev→staging→prod
-promotion, the **rollback** operate loop, collaborative map sessions, and
-experimental format surfaces. These are held OFF by edition/entitlement checks
-and Console-UI availability, not by the registry manifest flag. Note only
+promotion, the **rollback** operate loop, and collaborative map sessions. These
+are held OFF by edition/entitlement checks and Console-UI availability, not by
+the registry manifest flag. (Format surfaces — GeoParquet / GeoArrow / GeoBuf /
+FileGDB — are **not** in either gating set; they are ungated and ship as
+supported for the first release, see ADR-0059 §1.) Note only
 **cross-environment** metadata-promotion is gated; **single-instance GitOps
 change-safety stays as the release operate floor.**
 

--- a/docs/internal/contributor/adr/0059-first-release-scope-and-fix-forward-operate-model.md
+++ b/docs/internal/contributor/adr/0059-first-release-scope-and-fix-forward-operate-model.md
@@ -66,6 +66,10 @@ advertised in the capability manifest):
   environment.
 - **Migration / interop** — live Esri REST migration, FileGDB import, Esri REST
   northbound interop (sufficient, not exhaustive parity).
+- **Data formats** — GeoParquet, GeoArrow, GeoBuf, and FileGDB read/serve
+  support are **supported (in-scope)** for the first release. They were never
+  gated (ungated = served), so they are neither registry-flag nor
+  entitlement/UI gated — they simply ship. Not experimental.
 - **AI operator surface with fix-forward** — the operate model below.
 
 ### 2. Experimental + disabled set (built server-side, gated off)


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2337

## Summary
Follow-up to #2387. Owner scope decision: the vector/columnar + FileGDB formats
(GeoParquet / GeoArrow / GeoBuf / FileGDB) were never actually gated in code
(ungated = served — the capability-flag flip skipped formats), so they ship as
**supported / in-scope for the first release**, not experimental. This corrects
the ADR wording so formats are not described as part of the experimental +
disabled set.

## Changes Made
- ADR-0058: dropped "experimental format surfaces" from the entitlement/UI-gated (mechanism b) set; added a note that format surfaces are in neither gating mechanism and ship supported.
- ADR-0059 §1: added a "Data formats" in-scope bullet listing GeoParquet/GeoArrow/GeoBuf/FileGDB read+serve as supported.

## Testing
- [x] Manual testing performed

Docs-only; no code change (formats already ungated/served).

## Gate Impact
- [x] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
