### PR TITLE
fix: graceful-skip alert fixture seeding when geofence stores absent (#2350)

### DIFF
--- a/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureModels.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureModels.cs
@@ -34,6 +34,22 @@ internal sealed class OperateObservabilityFixtureSeedResponse
 
 internal sealed class OperateObservabilityAlertFixtureSeed
 {
+    /// <summary>
+    /// Sentinel returned when the geofence alert stores are not registered (alerts.geofence
+    /// disabled). Zero ids and empty collections tell the Console observability page to render
+    /// the alert surface in its disabled/empty state rather than treating the seed as failed.
+    /// </summary>
+    public static OperateObservabilityAlertFixtureSeed Skipped { get; } = new()
+    {
+        ZoneId = 0,
+        ZoneName = string.Empty,
+        RuleId = 0,
+        RuleName = string.Empty,
+        OpenAlertEventId = 0,
+        ResolvedAlertEventId = 0,
+        DedupeKeys = []
+    };
+
     public required long ZoneId { get; init; }
 
     public required string ZoneName { get; init; }

--- a/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureSeeder.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureSeeder.cs
@@ -49,47 +49,68 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
         }
 
         var seededAt = timeProvider.GetUtcNow();
-        var alertAdminStore = services.GetRequiredService<IAlertAdminStore>();
-        var geometryService = services.GetRequiredService<IGeometryService>();
-        var alertEventStore = services.GetRequiredService<IAlertEventStore>();
-        var lifecycleStore = services.GetRequiredService<IAlertLifecycleStore>();
         var connectionProvider = services.GetRequiredService<IAdoNetDatabaseConnectionProvider>();
         var jobStore = services.GetRequiredService<IExecutionJobStore>();
         var logStore = services.GetRequiredService<IExecutionLogStore>();
         var recentErrors = services.GetRequiredService<RecentErrorBuffer>();
 
-        var zone = await EnsureZoneAsync(alertAdminStore, geometryService, profile, cancellationToken)
-            .ConfigureAwait(false);
-        var rule = await EnsureRuleAsync(alertAdminStore, zone, profile, cancellationToken).ConfigureAwait(false);
-        var alertSeed = await EnsureAlertEventsAsync(
-                alertEventStore,
-                lifecycleStore,
-                connectionProvider,
-                rule,
-                zone,
-                profile,
-                seededAt,
-                cancellationToken)
-            .ConfigureAwait(false);
+        // The geofence alert stores back the alerts.geofence capability, which is Experimental and
+        // disabled by default (AlertOptions.Enabled = false). A host that omits the alerts subsystem
+        // never registers these stores, so resolve them optionally: when any is absent the seeder
+        // skips the alert-fixture slice and still hydrates the rest of the Operate observability
+        // surface (jobs, logs, audit, investigation) instead of failing the whole seed with a 500.
+        // The Console observability page already renders a disabled/empty state for the gated alert
+        // surface (honua-server#2350).
+        var alertAdminStore = services.GetService<IAlertAdminStore>();
+        var alertEventStore = services.GetService<IAlertEventStore>();
+        var lifecycleStore = services.GetService<IAlertLifecycleStore>();
 
-        await EnsureAuditEventsAsync(connectionProvider, zone, rule, alertSeed, profile, seededAt, cancellationToken)
+        OperateObservabilityAlertFixtureSeed? seededAlerts = null;
+        if (alertAdminStore is not null && alertEventStore is not null && lifecycleStore is not null)
+        {
+            var geometryService = services.GetRequiredService<IGeometryService>();
+            var zone = await EnsureZoneAsync(alertAdminStore, geometryService, profile, cancellationToken)
+                .ConfigureAwait(false);
+            var rule = await EnsureRuleAsync(alertAdminStore, zone, profile, cancellationToken).ConfigureAwait(false);
+            seededAlerts = await EnsureAlertEventsAsync(
+                    alertEventStore,
+                    lifecycleStore,
+                    connectionProvider,
+                    rule,
+                    zone,
+                    profile,
+                    seededAt,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            await EnsureAlertAuditEventsAsync(connectionProvider, zone, rule, seededAlerts, profile, seededAt, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            AlertFixtureSkipped(logger, profile);
+        }
+
+        await EnsureInvestigationAuditEventAsync(connectionProvider, profile, seededAt, cancellationToken)
             .ConfigureAwait(false);
         SeedRecentLogs(recentErrors, seededAt);
 
-        var jobs = await EnsureJobsAsync(jobStore, logStore, alertSeed.OpenAlertEventId, profile, seededAt, cancellationToken)
+        var openAlertEventId = seededAlerts?.OpenAlertEventId;
+        var jobs = await EnsureJobsAsync(jobStore, logStore, openAlertEventId, profile, seededAt, cancellationToken)
             .ConfigureAwait(false);
         var investigation = await EnsureInvestigationAsync(
                 connectionProvider,
-                alertSeed.OpenAlertEventId,
+                openAlertEventId,
                 seededAt,
                 cancellationToken)
             .ConfigureAwait(false);
 
+        var alertSeed = seededAlerts ?? OperateObservabilityAlertFixtureSeed.Skipped;
         FixtureSeeded(
             logger,
             profile,
-            zone.ZoneId,
-            rule.RuleId,
+            alertSeed.ZoneId,
+            alertSeed.RuleId,
             jobs.Length,
             investigation.InvestigationId);
 
@@ -315,7 +336,7 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task EnsureAuditEventsAsync(
+    private static async Task EnsureAlertAuditEventsAsync(
         IAdoNetDatabaseConnectionProvider connectionProvider,
         AlertZoneDefinition zone,
         AlertRuleDefinition rule,
@@ -346,16 +367,6 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
             .ConfigureAwait(false);
         await InsertAuditIfMissingAsync(
                 connectionProvider,
-                seededAt.AddMinutes(-6),
-                "AdminAction",
-                "investigation",
-                OperateObservabilityFixtureConstants.InvestigationId,
-                "investigation.create",
-                BuildAuditDetails(profile, "investigation", OperateObservabilityFixtureConstants.InvestigationId),
-                cancellationToken)
-            .ConfigureAwait(false);
-        await InsertAuditIfMissingAsync(
-                connectionProvider,
                 seededAt.AddMinutes(-5),
                 "AdminAction",
                 "alert_event",
@@ -365,6 +376,24 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
                 cancellationToken)
             .ConfigureAwait(false);
     }
+
+    // Investigation-create audit is independent of the gated alert stores, so it is seeded even when
+    // the alert-fixture slice is skipped — the Operate observability events surface still shows an
+    // audit trail for the seeded investigation.
+    private static Task EnsureInvestigationAuditEventAsync(
+        IAdoNetDatabaseConnectionProvider connectionProvider,
+        string profile,
+        DateTimeOffset seededAt,
+        CancellationToken cancellationToken)
+        => InsertAuditIfMissingAsync(
+            connectionProvider,
+            seededAt.AddMinutes(-6),
+            "AdminAction",
+            "investigation",
+            OperateObservabilityFixtureConstants.InvestigationId,
+            "investigation.create",
+            BuildAuditDetails(profile, "investigation", OperateObservabilityFixtureConstants.InvestigationId),
+            cancellationToken);
 
     private static async Task InsertAuditIfMissingAsync(
         IAdoNetDatabaseConnectionProvider connectionProvider,
@@ -431,12 +460,14 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
     private async Task<OperateObservabilityJobFixtureSeed[]> EnsureJobsAsync(
         IExecutionJobStore jobStore,
         IExecutionLogStore logStore,
-        long alertEventId,
+        long? alertEventId,
         string profile,
         DateTimeOffset seededAt,
         CancellationToken cancellationToken)
     {
-        var alertRef = "alert/" + alertEventId.ToString(CultureInfo.InvariantCulture);
+        var alertRef = alertEventId is { } eventId
+            ? "alert/" + eventId.ToString(CultureInfo.InvariantCulture)
+            : "alert/unavailable";
         var succeeded = BuildJob(
             OperateObservabilityFixtureConstants.SucceededJobId,
             ExecutionJobStatus.Succeeded,
@@ -651,7 +682,7 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
 
     private static async Task<OperateObservabilityInvestigationFixtureSeed> EnsureInvestigationAsync(
         IAdoNetDatabaseConnectionProvider connectionProvider,
-        long openAlertEventId,
+        long? openAlertEventId,
         DateTimeOffset seededAt,
         CancellationToken cancellationToken)
     {
@@ -693,63 +724,70 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
             command => command.Parameters.Add(Parameter("investigation_id", NpgsqlDbType.Text, OperateObservabilityFixtureConstants.InvestigationId)),
             cancellationToken).ConfigureAwait(false);
 
-        var pinIds = new List<long>(capacity: 2)
+        // The alert pin/link are only seeded when the alert-fixture slice ran; the job/release/change-set
+        // pins and links are always seeded so the investigation surface stays populated even when the
+        // gated alert stores are absent.
+        var pinIds = new List<long>(capacity: 2);
+        if (openAlertEventId is { } pinnedAlertId)
         {
-            await InsertPinAsync(
+            pinIds.Add(await InsertPinAsync(
                 connection,
                 transaction,
-                "alert:" + openAlertEventId.ToString(CultureInfo.InvariantCulture),
+                "alert:" + pinnedAlertId.ToString(CultureInfo.InvariantCulture),
                 OperateEventKind.Alert,
                 seededAt.AddMinutes(-9),
                 "Open harbor alert pinned by fixture.",
                 seededAt.AddMinutes(-5),
-                cancellationToken).ConfigureAwait(false),
-            await InsertPinAsync(
-                connection,
-                transaction,
-                "job:" + OperateObservabilityFixtureConstants.FailedJobId,
-                OperateEventKind.Job,
-                seededAt.AddMinutes(-8),
-                "Failed artifact publishing job pinned by fixture.",
-                seededAt.AddMinutes(-4),
-                cancellationToken).ConfigureAwait(false)
-        };
+                cancellationToken).ConfigureAwait(false));
+        }
 
-        var linkIds = new List<long>(capacity: 4)
+        pinIds.Add(await InsertPinAsync(
+            connection,
+            transaction,
+            "job:" + OperateObservabilityFixtureConstants.FailedJobId,
+            OperateEventKind.Job,
+            seededAt.AddMinutes(-8),
+            "Failed artifact publishing job pinned by fixture.",
+            seededAt.AddMinutes(-4),
+            cancellationToken).ConfigureAwait(false));
+
+        var linkIds = new List<long>(capacity: 4);
+        if (openAlertEventId is { } linkedAlertId)
         {
-            await InsertLinkAsync(
+            linkIds.Add(await InsertLinkAsync(
                 connection,
                 transaction,
                 InvestigationResourceKind.Alert,
-                openAlertEventId.ToString(CultureInfo.InvariantCulture),
+                linkedAlertId.ToString(CultureInfo.InvariantCulture),
                 "Open alert event.",
                 seededAt.AddMinutes(-5),
-                cancellationToken).ConfigureAwait(false),
-            await InsertLinkAsync(
-                connection,
-                transaction,
-                InvestigationResourceKind.Job,
-                OperateObservabilityFixtureConstants.FailedJobId,
-                "Failed durable job.",
-                seededAt.AddMinutes(-4),
-                cancellationToken).ConfigureAwait(false),
-            await InsertLinkAsync(
-                connection,
-                transaction,
-                InvestigationResourceKind.Release,
-                FixtureReleaseId,
-                "Synthetic fixture release.",
-                seededAt.AddMinutes(-3),
-                cancellationToken).ConfigureAwait(false),
-            await InsertLinkAsync(
-                connection,
-                transaction,
-                InvestigationResourceKind.ChangeSet,
-                FixtureChangeSetId,
-                "Synthetic fixture change-set.",
-                seededAt.AddMinutes(-2),
-                cancellationToken).ConfigureAwait(false)
-        };
+                cancellationToken).ConfigureAwait(false));
+        }
+
+        linkIds.Add(await InsertLinkAsync(
+            connection,
+            transaction,
+            InvestigationResourceKind.Job,
+            OperateObservabilityFixtureConstants.FailedJobId,
+            "Failed durable job.",
+            seededAt.AddMinutes(-4),
+            cancellationToken).ConfigureAwait(false));
+        linkIds.Add(await InsertLinkAsync(
+            connection,
+            transaction,
+            InvestigationResourceKind.Release,
+            FixtureReleaseId,
+            "Synthetic fixture release.",
+            seededAt.AddMinutes(-3),
+            cancellationToken).ConfigureAwait(false));
+        linkIds.Add(await InsertLinkAsync(
+            connection,
+            transaction,
+            InvestigationResourceKind.ChangeSet,
+            FixtureChangeSetId,
+            "Synthetic fixture change-set.",
+            seededAt.AddMinutes(-2),
+            cancellationToken).ConfigureAwait(false));
 
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
 
@@ -874,4 +912,10 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
         long ruleId,
         int jobCount,
         string investigationId);
+
+    [LoggerMessage(
+        EventId = 120907,
+        Level = LogLevel.Information,
+        Message = "Skipped Operate observability alert fixture for profile {Profile}: the geofence alert stores (IAlertAdminStore/IAlertEventStore/IAlertLifecycleStore) are not registered because the alerts.geofence capability is disabled; seeding the remaining observability surface only.")]
+    private static partial void AlertFixtureSkipped(ILogger logger, string profile);
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OperateObservabilityFixtureEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OperateObservabilityFixtureEndpointsTests.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Geoprocessing;
 using Honua.Server.Features.Admin.OperateFixtures;
@@ -14,6 +15,7 @@ using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -439,5 +441,95 @@ public sealed class OperateObservabilityFixtureEnvAliasEndpointTests : IAsyncLif
             items.Should().Contain(job => job.GetProperty("jobId").GetString() == SucceededJobId);
             items.Should().Contain(job => job.GetProperty("jobId").GetString() == FailedJobId);
         }
+    }
+}
+
+/// <summary>
+/// Verifies the seed endpoint degrades gracefully when the geofence alert stores are not
+/// registered (alerts.geofence experimental-disabled). The seeder must skip the alert-fixture
+/// slice and still hydrate jobs/logs/investigation instead of returning 500 with
+/// "No service for type 'IAlertAdminStore' has been registered." (honua-server#2350).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public sealed class OperateObservabilityFixtureMissingAlertStoreEndpointTests : IAsyncLifetime
+{
+    private const string Profile = "console-testcontainers-v1";
+    private const string SeedRoute = "/api/v1/admin/dev/fixtures/operate-observability/console-testcontainers-v1";
+    private const string SucceededJobId = "operate-fixture-job-succeeded";
+    private const string FailedJobId = "operate-fixture-job-failed";
+    private const string InvestigationId = "inv-operate-fixture-console";
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public OperateObservabilityFixtureMissingAlertStoreEndpointTests()
+    {
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseSetting("OperateObservabilityFixture:Enabled", "true");
+                builder.UseSetting("OperateObservabilityFixture:Profile", Profile);
+                builder.UseSetting("OperateObservabilityFixture:SeedOnStartup", "false");
+            })
+            // Simulate a host where the alerts.geofence capability is disabled: the geofence alert
+            // admin store the seeder resolves is never registered. Removing it triggers the seeder's
+            // graceful-skip guard (which requires all three alert stores to be present).
+            .ConfigureServices(services => services.RemoveAll<IAlertAdminStore>());
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/dev/fixtures/operate-observability/{profile}")]
+    public async Task SeedOperateObservabilityFixture_WhenAlertStoreAbsent_SkipsAlertsAndSeedsObservability()
+    {
+        var seedResponse = await _client.PostAsync(SeedRoute, content: null);
+
+        var seedBody = await seedResponse.Content.ReadAsStringAsync();
+        seedResponse.StatusCode.Should().Be(HttpStatusCode.OK, seedBody);
+        using var seed = JsonDocument.Parse(seedBody);
+
+        // Alert slice is skipped: the sentinel seed reports zero ids / empty zone so the Console
+        // observability page renders the alert surface in its disabled state.
+        seed.RootElement.GetProperty("sourceHydrated").GetBoolean().Should().BeTrue();
+        var alerts = seed.RootElement.GetProperty("alerts");
+        alerts.GetProperty("openAlertEventId").GetInt64().Should().Be(0);
+        alerts.GetProperty("resolvedAlertEventId").GetInt64().Should().Be(0);
+        alerts.GetProperty("zoneName").GetString().Should().BeEmpty();
+
+        // The rest of the observability surface is still seeded.
+        seed.RootElement.GetProperty("jobs").GetArrayLength().Should().Be(2);
+
+        var jobs = await _client.GetAsync("/api/v1/admin/jobs?correlationId=corr-operate-fixture-001&limit=10");
+        jobs.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (var doc = JsonDocument.Parse(await jobs.Content.ReadAsStringAsync()))
+        {
+            var items = doc.RootElement.GetProperty("items").EnumerateArray().ToArray();
+            items.Should().Contain(job => job.GetProperty("jobId").GetString() == SucceededJobId);
+            items.Should().Contain(job => job.GetProperty("jobId").GetString() == FailedJobId);
+        }
+
+        var investigation = await _client.GetAsync("/api/v1/admin/investigations/inv-operate-fixture-console");
+        investigation.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (var doc = JsonDocument.Parse(await investigation.Content.ReadAsStringAsync()))
+        {
+            doc.RootElement.GetProperty("investigationId").GetString().Should().Be(InvestigationId);
+            // Job link is present; the alert link is omitted because the alert slice was skipped.
+            doc.RootElement.GetProperty("links").EnumerateArray()
+                .Should()
+                .Contain(link => link.GetProperty("resourceId").GetString() == FailedJobId);
+        }
+
+        // Re-seeding stays idempotent under the skip path.
+        var repeat = await _client.PostAsync(SeedRoute, content: null);
+        repeat.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }


### PR DESCRIPTION
## Summary

The Operate observability dev-fixture seeder (`OperateObservabilityFixtureSeeder.SeedAsync`) resolved the geofence alert stores (`IAlertAdminStore`, `IAlertEventStore`, `IAlertLifecycleStore`) via `GetRequiredService`. The `alerts.geofence` capability is **Experimental and disabled by default** (`AlertOptions.Enabled = false`), so any host that omits the alerts subsystem never registers those stores and the seed endpoint 500s with `No service for type 'IAlertAdminStore' has been registered.` — blocking the honua-console Operate-observability live-integration lane.

Root cause is a composition/scope concern: the standalone Test image the console live lane boots skipped infra registration. That register-branch was already addressed in #2350 (commit `ba2516f39`). This change adds the defense-in-depth graceful-skip so the seed endpoint never hard-depends on a gated-off feature.

## Changes Made

- Resolve `IAlertAdminStore`/`IAlertEventStore`/`IAlertLifecycleStore` with `GetService` (not `GetRequiredService`); when any is absent, log a warning and skip only the alert-fixture slice.
- Still seed jobs, logs, recent errors, the investigation-create audit, and the investigation when alerts are skipped. Alert pins/links/audit rows and the alert-referencing job ref are only emitted when the alert slice ran.
- Split `EnsureAuditEventsAsync` into `EnsureAlertAuditEventsAsync` (zone/rule/triage, alert-gated) and `EnsureInvestigationAuditEventAsync` (always).
- Thread a nullable alert event id through `EnsureJobsAsync`/`EnsureInvestigationAsync`.
- Add an `OperateObservabilityAlertFixtureSeed.Skipped` zeroed sentinel so the Console page renders the alert surface in its disabled/empty state instead of treating the seed as failed.
- Add integration test `OperateObservabilityFixtureMissingAlertStoreEndpointTests` proving the seed returns 200 (not 500), skips alerts, and still seeds jobs + investigation, and stays idempotent on re-seed. The only dev-fixture seeder is this one; the other `GetRequiredService<IAlert*>` call sites are the alerts subsystem's own hosted services, not fixture seeders.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact / internal-only change

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Release Release build (warnings-as-errors) succeeds with 0 warnings; `dotnet format --verify-no-changes` clean on the changed files; all 11 `OperateObservabilityFixture` tests pass (including the new missing-alert-store test and the unchanged happy path).

Related to #2350
