### PR TITLE
fix(geoprocessing): S1 hardening - SSRF guard, callback-status correctness, OTel spans (PA-194/209/198)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutor.cs
@@ -2,10 +2,12 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Frozen;
+using System.Diagnostics;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.ControlPlane;
+using Honua.ServiceDefaults;
 
 namespace Honua.Geoprocessing.Execution;
 
@@ -79,17 +81,29 @@ internal sealed partial class GeoprocessingDispatchJobExecutor : IJobExecutor
 
         var processId = GeoprocessingDispatchHelper.ResolveProcessId(job.Spec.Parameters);
 
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity(
+            HonuaTelemetry.Activities.GeoprocessingDispatch, ActivityKind.Internal);
+        activity?.SetTag(HonuaTelemetry.Tags.JobId, job.OperationId);
+        activity?.SetTag("honua.gp.process_id", processId ?? "<none>");
+        activity?.SetTag("honua.gp.backend", job.Spec.Backend);
+
         if (string.IsNullOrWhiteSpace(processId)
             || !_handlers.TryGetValue(processId, out var handler))
         {
             var supported = string.Join(", ", _handlers.Keys.OrderBy(id => id, StringComparer.Ordinal));
             Log.UnsupportedProcessId(_logger, job.OperationId, processId ?? "<none>");
+            activity?.SetStatus(ActivityStatusCode.Error, "Unsupported process id");
             return JobExecutionResult.Failed(
                 $"Process id '{processId ?? "<none>"}' is not supported by the geoprocessing runtime. " +
                 $"Supported ids in this slice: {supported}.");
         }
 
         var result = await handler.ExecuteAsync(job, context, cancellationToken).ConfigureAwait(false);
+
+        if (result.Status != ExecutionJobStatus.Succeeded)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, result.ErrorMessage);
+        }
 
         // Usage-ranked tiering (#2144): record every dispatched invocation with its
         // outcome. Recording never throws, so it cannot affect the job result.

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Infrastructure.Validation;
 using Honua.Core.Features.Migration.Domain;
 using Honua.Core.Features.Security.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
@@ -97,6 +98,27 @@ internal sealed partial class RemoteSourceExecutor : IProcessExecutor
         await context.ReportProgressAsync(5, $"Resolving {_processId} source", cancellationToken).ConfigureAwait(false);
 
         var inputs = new StepInputReader(job.Spec.Parameters);
+
+        // SSRF guard (PA-194): validate serviceUrl for remote HTTP sources before any
+        // DI scope or network activity. The Esri path (source.esri-featureserver) is
+        // guarded at configuration time via ArcGisRestUrlValidator; WFS and OGC-features
+        // receive a user-supplied URL per-submit and must be validated here.
+        if (_processId is "source.ogc-features" or "source.wfs")
+        {
+            if (!inputs.TryGet("serviceUrl", out var rawServiceUrl) || string.IsNullOrWhiteSpace(rawServiceUrl))
+            {
+                return JobExecutionResult.Failed($"Invalid {_processId} inputs: serviceUrl is required.");
+            }
+
+            var ssrfResult = await OutboundHttpUrlValidator.ValidateAsync(rawServiceUrl, cancellationToken)
+                .ConfigureAwait(false);
+            if (!ssrfResult.IsValid)
+            {
+                Log.SsrfRejected(_logger, job.OperationId, _processId, ssrfResult.ErrorMessage ?? "blocked URL");
+                return JobExecutionResult.Failed(
+                    $"Invalid {_processId} inputs: serviceUrl {ssrfResult.ErrorMessage}");
+            }
+        }
 
         using var scope = _serviceScopeFactory.CreateScope();
         var services = scope.ServiceProvider;
@@ -380,5 +402,9 @@ internal sealed partial class RemoteSourceExecutor : IProcessExecutor
         [LoggerMessage(9281, LogLevel.Error,
             "Remote source executor failed job {OperationId} during {ProcessId} read")]
         public static partial void SourceReadFailed(ILogger logger, string operationId, string processId, Exception exception);
+
+        [LoggerMessage(9282, LogLevel.Warning,
+            "Remote source executor blocked job {OperationId} for {ProcessId}: SSRF guard rejected serviceUrl — {Reason}")]
+        public static partial void SsrfRejected(ILogger logger, string operationId, string processId, string reason);
     }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobTerminalCallback.cs
@@ -96,6 +96,9 @@ internal sealed partial class GeoprocessingJobTerminalCallback(
         }
         catch (Exception ex)
         {
+            // PA-209: ensure the terminal-success gate sees the failure so a Succeeded job
+            // whose result package was never written does not report Completed to callers.
+            artifactPersistenceError = "Failed to persist the result package; results may be unavailable.";
             Log.ResultPackageSyncFailed(logger, job.OperationId, ex);
         }
 

--- a/src/Honua.ServiceDefaults/HonuaTelemetry.cs
+++ b/src/Honua.ServiceDefaults/HonuaTelemetry.cs
@@ -223,6 +223,9 @@ public static class HonuaTelemetry
         /// <summary>Operator execution admission evaluation activity.</summary>
         public const string ExecutionAdmission = "honua.execution.admission";
 
+        /// <summary>Geoprocessing job dispatch and execution activity.</summary>
+        public const string GeoprocessingDispatch = "honua.geoprocessing.dispatch";
+
         /// <summary>Share export trigger activity.</summary>
         public const string ShareExportTrigger = "honua.share.export.trigger";
     }

--- a/tests/dotnet/Honua.Geoprocessing.Testing.Tests/GeoprocessingHardeningTests.cs
+++ b/tests/dotnet/Honua.Geoprocessing.Testing.Tests/GeoprocessingHardeningTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Geoprocessing.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Honua.TestKit.Attributes;
+using Xunit;
+
+namespace Honua.Geoprocessing.Testing.Tests;
+
+/// <summary>
+/// Unit tests for S1 security hardening: SSRF validation on WFS/OGC-features
+/// remote sources (PA-194) and terminal-callback status correctness when the
+/// result-package store write fails (PA-209).
+/// </summary>
+public sealed class GeoprocessingHardeningTests
+{
+    // Step-input parameter prefix for step ordinal 0 (matches ExecutionJobParameterKeys internals).
+    private const string StepInputPrefix = "honua.geoprocessing.step.0.";
+
+    // GP process-definitions parameter key (matches ExecutionJobParameterKeys internals).
+    private const string ProcessDefinitionsKey = "honua.geoprocessing.process_definitions";
+
+    // -----------------------------------------------------------------------
+    // PA-194: SSRF guard on source.wfs and source.ogc-features
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("source.wfs", "https://192.168.1.1/wfs")]
+    [InlineData("source.wfs", "https://10.0.0.1/wfs")]
+    [InlineData("source.wfs", "https://169.254.169.254/latest/meta-data")]
+    [InlineData("source.wfs", "https://172.16.0.1/wfs")]
+    [InlineData("source.ogc-features", "https://192.168.100.1/ows")]
+    [InlineData("source.ogc-features", "https://10.10.10.10/ogcapi")]
+    public async Task RemoteSource_BlockedServiceUrl_ReturnsFailed(string processId, string serviceUrl)
+    {
+        var executor = BuildRemoteSourceExecutor(processId);
+        var job = BuildJob(processId, serviceUrl);
+        var context = BuildContext();
+
+        var result = await executor.ExecuteAsync(job, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed,
+            "the SSRF guard must reject URLs that resolve to private/reserved addresses");
+        result.ErrorMessage.Should().Contain("serviceUrl",
+            "the error should name the offending input");
+    }
+
+    [Theory]
+    [InlineData("source.wfs")]
+    [InlineData("source.ogc-features")]
+    public async Task RemoteSource_MissingServiceUrl_ReturnsFailed(string processId)
+    {
+        var executor = BuildRemoteSourceExecutor(processId);
+        var job = BuildJob(processId, serviceUrl: null);
+        var context = BuildContext();
+
+        var result = await executor.ExecuteAsync(job, context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed,
+            "serviceUrl is required for remote HTTP sources");
+        result.ErrorMessage.Should().Contain("serviceUrl");
+    }
+
+    // -----------------------------------------------------------------------
+    // PA-209: terminal callback must set Failed when result-package SetAsync throws
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    public async Task TerminalCallback_ResultPackageSetAsyncThrows_ProgressMarkedFailed()
+    {
+        const string operationId = "test-pa209-op";
+
+        // --- mocks ---
+        var progressStore = Substitute.For<IUniversalProgressStore>();
+        var processCatalog = Substitute.For<IProcessCatalog>();
+        var resultPackageStore = Substitute.For<IGeoprocessingResultPackageStore>();
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+
+        var options = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        options.CurrentValue.Returns(new GeoprocessingExecutorOptions
+        {
+            ResultRetention = TimeSpan.FromDays(1)
+        });
+
+        // Simulate a transient storage failure on the result-package write.
+        resultPackageStore
+            .SetAsync(
+                Arg.Any<string>(),
+                Arg.Any<AnalysisResultPackage>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("Storage backend unavailable")));
+
+        // Return a non-terminal (Running) progress so the callback does not bail out early.
+        var runningProgress = new GeoprocessingProgress
+        {
+            OperationId = operationId,
+            WorkflowStatus = GeoprocessingWorkflowStatus.Running,
+            CurrentStage = GeoprocessingStageKind.Execute,
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+        };
+        progressStore
+            .GetProgressAsync<GeoprocessingProgress>(operationId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<GeoprocessingProgress?>(runningProgress));
+
+        var callback = new GeoprocessingJobTerminalCallback(
+            progressStore,
+            processCatalog,
+            options,
+            resultPackageStore,
+            scopeFactory,
+            NullLogger<GeoprocessingJobTerminalCallback>.Instance);
+
+        // Succeeded job — without the fix the outer catch would leave
+        // artifactPersistenceError null, so effectiveStatus stays Succeeded
+        // and the progress would be written as Completed (wrong).
+        var job = new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Succeeded,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "managed",
+                WorkloadName = "test-workload",
+                Parameters = new Dictionary<string, string>
+                {
+                    // Include process definitions so the factory does not need catalog lookups.
+                    [ProcessDefinitionsKey] = "geometry.buffer"
+                }
+            }
+        };
+
+        // --- act ---
+        await callback.OnTerminalAsync(job, CancellationToken.None);
+
+        // --- assert ---
+        // After the fix the outer catch sets artifactPersistenceError, so
+        // effectiveStatus flips to Failed and progress must be written as Failed.
+        await progressStore.Received(1).SetProgressAsync(
+            operationId,
+            Arg.Is<IOperationProgress>(p =>
+                ((GeoprocessingProgress)p).WorkflowStatus == GeoprocessingWorkflowStatus.Failed),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static RemoteSourceExecutor BuildRemoteSourceExecutor(string processId)
+    {
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        var options = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        options.CurrentValue.Returns(new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7),
+        });
+        return RemoteSourceExecutor.ForProcess(
+            processId,
+            scopeFactory,
+            options,
+            NullLogger<RemoteSourceExecutor>.Instance);
+    }
+
+    private static ExecutionJobRecord BuildJob(string processId, string? serviceUrl)
+    {
+        var parameters = new Dictionary<string, string>
+        {
+            [ProcessDefinitionsKey] = processId
+        };
+        if (!string.IsNullOrWhiteSpace(serviceUrl))
+        {
+            parameters[StepInputPrefix + "serviceUrl"] = serviceUrl;
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "test-job-" + Guid.NewGuid().ToString("N"),
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "managed",
+                WorkloadName = "test-workload",
+                Parameters = parameters
+            }
+        };
+    }
+
+    private static IJobExecutionContext BuildContext()
+    {
+        var context = Substitute.For<IJobExecutionContext>();
+        context
+            .ReportProgressAsync(Arg.Any<double?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return context;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
PA-194, PA-209, PA-198 (pre-release audit findings)

## Summary
Three validated S1 fixes in the geoprocessing execution pipeline, addressed in three independent commits on this branch.

**PA-194 — SSRF guard on remote DAG sources**
`RemoteSourceExecutor.ExecuteAsync` now calls `OutboundHttpUrlValidator.ValidateAsync` on the user-supplied `serviceUrl` before proceeding for `source.ogc-features` and `source.wfs` jobs. URLs resolving to private, loopback, or reserved IP ranges are rejected immediately with a `Failed` result and a structured log entry (message ID 9282). The Esri path (`source.esri-featureserver`) is intentionally unchanged.

**PA-209 — terminal callback status gate**
In `GeoprocessingJobTerminalCallback.OnTerminalAsync`, the outer `catch` block that wraps `resultPackageStore.SetAsync` logged the exception but never set `artifactPersistenceError`. As a result, `effectiveStatus` stayed `Succeeded` and the progress store was updated with `WorkflowStatus.Completed` even when the result package was never written. The fix sets `artifactPersistenceError` before logging so the success gate correctly flips `effectiveStatus` to `Failed`.

**PA-198 — OTel observability for dispatch**
`GeoprocessingDispatchJobExecutor.ExecuteAsync` now wraps the dispatch path in a `honua.geoprocessing.dispatch` activity on `HonuaTelemetry.ActivitySource`. Tags: `honua.job.id`, `honua.gp.process_id`, `honua.gp.backend`. Both the unsupported-process-id branch and non-Succeeded execution results set `ActivityStatusCode.Error` so failures surface in distributed traces.

## Changes Made
- `RemoteSourceExecutor.cs` — SSRF guard + `SsrfRejected` log message (9282)
- `GeoprocessingJobTerminalCallback.cs` — set `artifactPersistenceError` in outer catch
- `GeoprocessingDispatchJobExecutor.cs` — OTel activity span wrapping ExecuteAsync
- `HonuaTelemetry.cs` — add `GeoprocessingDispatch = "honua.geoprocessing.dispatch"` constant
- `GeoprocessingHardeningTests.cs` — 9 unit tests for PA-194 (blocked IPs x 2 process IDs, missing serviceUrl) and PA-209 (Failed progress when SetAsync throws)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Commit messages follow conventional format: `type: description (PA-NNN)`
- [x] Tests added for new functionality (PA-194, PA-209)
- [x] If protocol/auth behavior changed: updated compatibility contract
