### PR TITLE
fix: harden generateToken against credential exposure in query strings (PA-059)

### DIFF
--- a/src/Honua.Hosting/Features/Authentication/PortalTokenLog.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalTokenLog.cs
@@ -39,4 +39,16 @@ internal static partial class PortalTokenLog
     [LoggerMessage(EventId = 7006, Level = LogLevel.Warning,
         Message = "Portal token store could not remove distributed cache entry {KeyHash}.")]
     public static partial void DistributedCacheRemoveFailed(ILogger logger, string keyHash, Exception exception);
+
+    /// <summary>
+    /// Emitted when a <c>generateToken</c> request carries credentials via the URL query
+    /// string rather than a POST form body. The password value is never included in the
+    /// log line; this entry is an audit signal for operators monitoring for insecure
+    /// credential transmission patterns.
+    /// </summary>
+    [LoggerMessage(EventId = 7007, Level = LogLevel.Warning,
+        Message = "Portal token request received credentials via URL query string; " +
+                  "POST with a form-encoded body is preferred to avoid credential exposure " +
+                  "in HTTP-layer logs.")]
+    public static partial void CredentialsFromQueryString(ILogger logger);
 }

--- a/src/Honua.Protocols.GeoServices/Sharing/SharingRestEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Sharing/SharingRestEndpoints.cs
@@ -68,6 +68,14 @@ public static class SharingRestEndpoints
             .WithDisplayName("ArcGIS Portal Generate Token (GET)")
             .WithName("SharingRestGenerateTokenGet")
             .WithSummary("Issue an ArcGIS-compatible portal token via query parameters")
+            .WithDescription(
+                "Issues an ArcGIS-compatible portal token using query-string parameters. " +
+                "Supported for ArcGIS client compatibility. " +
+                "POST with a form-encoded body is strongly preferred: credentials in URL " +
+                "query strings are recorded verbatim by web servers, reverse proxies, and " +
+                "load balancers. When the server enforces HTTPS (RequireHttps=true, the " +
+                "default) this endpoint rejects plaintext HTTP requests that carry " +
+                "credentials in the URL.")
             .WithTags("GeoServices Sharing")
             .AllowAnonymous()
             .Produces<GenerateTokenResponse>(StatusCodes.Status200OK, JsonContentType)
@@ -185,6 +193,11 @@ public static class SharingRestEndpoints
         var (username, password, clientType, refererInput, expirationMinutes, format, formatValid) =
             await ReadParametersAsync(context).ConfigureAwait(false);
 
+        // Detect whether credentials arrived via query string (GET or non-form POST). This is
+        // used both for the HTTPS enforcement message and for the per-request audit log entry.
+        var credentialsInQueryString =
+            !HttpMethods.IsPost(context.Request.Method) || !context.Request.HasFormContentType;
+
         if (!formatValid)
         {
             PortalTokenLog.TokenIssuanceRejected(logger, "unsupported response format");
@@ -194,9 +207,24 @@ public static class SharingRestEndpoints
         if (settings.RequireHttps && !IsHttpsRequest(context))
         {
             PortalTokenLog.TokenIssuanceRejected(logger, "https required");
-            return StandardErrorHelpers.CreateForbidden(
-                context,
-                "Token issuance requires a secure (HTTPS) transport.");
+
+            // Give a more actionable error when the caller sent credentials in the URL:
+            // query-string passwords are recorded by every HTTP-layer observer (web
+            // server access logs, reverse proxies, load-balancer logs, browser history,
+            // and Referer headers). Direct the client to POST or HTTPS.
+            var httpsMessage = credentialsInQueryString
+                ? "Credentials in URL query strings are not safe over plaintext HTTP. " +
+                  "Use POST with a form-encoded body, or enable HTTPS."
+                : "Token issuance requires a secure (HTTPS) transport.";
+
+            return StandardErrorHelpers.CreateForbidden(context, httpsMessage);
+        }
+
+        // Emit a warning-level audit entry when credentials arrived via the query string
+        // even over a secure channel. The password value is never included in the log line.
+        if (credentialsInQueryString)
+        {
+            PortalTokenLog.CredentialsFromQueryString(logger);
         }
 
         if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(password))

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -1085,8 +1085,21 @@ app.UsePerformanceMonitoring();
 // Configure Serilog request logging before short-circuiting middleware so every request is observable.
 app.UseSerilogRequestLogging(options =>
 {
+    // PA-059: The default Serilog request-logging message template includes
+    // {RequestPath} (path only, no query string), which means sensitive query
+    // parameters such as "password" and "token" on /sharing/rest/generateToken
+    // are never written to the application log. Set this explicitly so that
+    // any future template change goes through a deliberate code review rather
+    // than silently inheriting a new format that might expose credentials.
+    options.MessageTemplate =
+        "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
+
     options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
     {
+        // PA-059: Query-string parameters are intentionally excluded from every
+        // diagnostic property below. For the generateToken endpoint in particular,
+        // "password" and "token" values in the URL must never reach log sinks.
+        // The RequestPath property above carries only the path component.
         diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value);
         diagnosticContext.Set("UserAgent", httpContext.Request.Headers.UserAgent.ToString());
         diagnosticContext.Set("Protocol", httpContext.Request.Protocol);

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestTokenTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestTokenTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
@@ -362,6 +362,60 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
         {
             await fixture.DisposeAsync();
         }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/generateToken")]
+    public async Task GenerateToken_CredentialsInQueryStringOverPlainHttp_Returns403WithHelpfulMessage()
+    {
+        // PA-059: When RequireHttps=true (the default), a GET request carrying
+        // credentials in the URL query string over plain HTTP must be rejected
+        // with an actionable error that directs the caller to POST or HTTPS.
+        var fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                // RequireHttps=true is the default; set it explicitly for clarity.
+                builder.UseSetting("Authentication:PortalToken:RequireHttps", "true");
+            });
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            var query = $"/sharing/rest/generateToken?username=admin" +
+                $"&password={Uri.EscapeDataString(AdminPassword)}&client=ip&f=json";
+            using var response = await client.GetAsync(query);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            var body = await response.Content.ReadAsStringAsync();
+            // The error body should mention POST or HTTPS as alternatives so the
+            // caller understands how to proceed without the credential exposure risk.
+            body.Should().ContainAny("POST", "HTTPS", "query string", "plaintext");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Security)]
+    [Endpoint("GET /sharing/rest/generateToken")]
+    public async Task GenerateToken_CredentialsInQueryStringWithInsecureMode_Succeeds()
+    {
+        // PA-059: When RequireHttps=false (explicit dev/test opt-out), GET with
+        // credentials in the query string is still accepted — ArcGIS clients use
+        // this flow and the dev override must not break them.
+        using var client = _fixture.CreateClient();
+        var query = $"/sharing/rest/generateToken?username=admin" +
+            $"&password={Uri.EscapeDataString(AdminPassword)}&client=ip&f=json";
+        using var response = await client.GetAsync(query);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await ReadTokenPayloadAsync(response);
+        payload.Token.Should().NotBeNullOrWhiteSpace();
     }
 
     private static async Task<HttpResponseMessage> PostFormAsync(HttpClient client, params (string Key, string Value)[] pairs)


### PR DESCRIPTION
## Summary

- PA-059 S1 security fix: passwords sent via URL query string to GET /sharing/rest/generateToken are recorded verbatim in web server, reverse-proxy, and load-balancer access logs
- Real ArcGIS/Esri clients use GET with credentials in the query string, so a blanket 400 rejection would break compatibility. This fix preserves the GET path while hardening it.

## Changes

SharingRestEndpoints.cs: When RequireHttps=true (the default) and a GET request carries credentials in the URL over plain HTTP, the 403 now says "Credentials in URL query strings are not safe over plaintext HTTP. Use POST with a form-encoded body, or enable HTTPS." The GET endpoint WithDescription also now explicitly recommends POST.

PortalTokenLog.cs: Added EventId 7007. Every generateToken request that delivers credentials via the query string emits a Warning-level log event. The password value is never written; only the channel is noted.

Program.cs: UseSerilogRequestLogging now pins the MessageTemplate to the path-only format. This ensures query strings — including password and token values on the generateToken endpoint — can never reach log sinks even if a future enricher or template change would otherwise expose them.

## How HTTPS is detected

IsHttpsRequest calls context.Request.IsHttps. ASP.NET Core resolves this correctly after the trusted ForwardedHeaders middleware applies X-Forwarded-Proto.

## Redaction mechanism

Serilog default {RequestPath} already excludes query strings; pinning the template makes this an explicit, auditable guarantee. Application-level logging uses LogValueRedactor.Hash for sensitive values. EventId 7007 records only the credential channel, never the password value.

## Test plan

- [x] GenerateToken_CredentialsInQueryStringOverPlainHttp_Returns403WithHelpfulMessage
- [x] GenerateToken_CredentialsInQueryStringWithInsecureMode_Succeeds
- [x] All 17 pre-existing SharingRestTokenTests pass
- [x] dotnet build Honua.Protocols.GeoServices: 0 warnings, 0 errors
- [x] dotnet build Honua.Server: 0 warnings, 0 errors

Fixes PA-059.