### PR TITLE
fix: three S1 reliability fixes - DuckDB /ready, Postgres async secret, Redis N+1 (PA-158/PA-077/PA-052)

### DIFF
--- a/src/Honua.DuckDB/Features/HealthCheck/DuckDBDatabaseHealthChecker.cs
+++ b/src/Honua.DuckDB/Features/HealthCheck/DuckDBDatabaseHealthChecker.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.HealthCheck.Abstractions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.DuckDB.Features.HealthCheck;
+
+/// <summary>
+/// DuckDB implementation of <see cref="IDatabaseHealthChecker"/>.
+/// </summary>
+/// <remarks>
+/// Routes through the shared <see cref="IAdoNetDatabaseConnectionProvider"/> so the
+/// readiness probe exercises the same pooled DuckDB connection the feature store uses.
+/// Mirrors the MySQL and Postgres implementations: cheap <c>SELECT 1</c> with a 5 s
+/// command timeout. Required so <c>/healthz/ready</c> does not throw
+/// <see cref="InvalidOperationException"/> when <c>DataSource:Provider=duckdb</c>
+/// (PA-158).
+/// </remarks>
+internal sealed partial class DuckDBDatabaseHealthChecker(
+    IAdoNetDatabaseConnectionProvider connectionProvider,
+    ILogger<DuckDBDatabaseHealthChecker> logger)
+    : IDatabaseHealthChecker
+{
+    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider =
+        connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+
+    private readonly ILogger<DuckDBDatabaseHealthChecker> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// Checks DuckDB connectivity and responsiveness via a lightweight probe query.
+    /// </summary>
+    public async Task<bool> IsDatabaseHealthyAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+            command.CommandTimeout = 5;
+            _ = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+
+            return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.HealthCheckFailed(_logger, ex);
+            return false;
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 8806,
+            Level = LogLevel.Warning,
+            Message = "DuckDB database health check failed")]
+        public static partial void HealthCheckFailed(ILogger logger, Exception exception);
+    }
+}

--- a/src/Honua.DuckDB/ServiceCollectionExtensions.cs
+++ b/src/Honua.DuckDB/ServiceCollectionExtensions.cs
@@ -6,11 +6,13 @@ using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+using Honua.Core.Features.HealthCheck.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.DuckDB.Features.FeatureStore;
 using Honua.DuckDB.Features.FeatureStore.Services;
+using Honua.DuckDB.Features.HealthCheck;
 using DuckDB.NET.Data;
 using Honua.DuckDB.Features.Infrastructure;
 using Honua.DuckDB.Queries.Filters;
@@ -129,6 +131,12 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IStreamingFeatureStore>(sp => sp.GetRequiredService<DuckDBFeatureStore>());
         services.AddScoped<ITileProvider>(_ => new ReadOnlyTileProvider("DuckDB"));
         services.AddScoped<IGmlFeatureStore>(_ => new ReadOnlyGmlFeatureStore("DuckDB"));
+
+        // ReadinessCheckService requires IDatabaseHealthChecker; without this registration
+        // resolving /healthz/ready under DataSource:Provider=duckdb fails DI activation
+        // with InvalidOperationException (PA-158). The checker drives a SELECT 1 through
+        // the same scoped connection provider the feature store uses.
+        services.AddScoped<IDatabaseHealthChecker, DuckDBDatabaseHealthChecker>();
 
         // Capability provider for the feature-change transactional outbox (#692). DuckDB is
         // read-only so it reports SupportsTransactionalOutbox = false. The dispatcher will

--- a/src/Honua.Hosting/Features/Caching/CacheServiceResponseCache.cs
+++ b/src/Honua.Hosting/Features/Caching/CacheServiceResponseCache.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using Honua.Core.Features.Caching.Abstractions;
 using Honua.Core.Features.Infrastructure.Caching;
@@ -12,6 +13,17 @@ internal sealed class CacheServiceResponseCache : IResponseCache
     private const string KeyPrefix = "response:";
     private const string VersionPrefix = "response-version:";
     private static readonly TimeSpan VersionTtl = TimeSpan.FromDays(30);
+
+    // Short-lived in-process cache for namespace version strings (PA-052).
+    // Reduces per-cache-operation Redis reads from O(N namespaces) sequential
+    // calls to zero for warm paths. A 30-second TTL is well within VersionTtl
+    // (30 days) and ensures invalidations from this node propagate immediately
+    // (eviction in TryInvalidateNamespaceAsync). Invalidations from remote nodes
+    // are visible within 30 s, which is safe because a stale version causes a
+    // cache miss (DB fetch) rather than stale data.
+    private static readonly TimeSpan VersionLocalCacheTtl = TimeSpan.FromSeconds(30);
+    private readonly ConcurrentDictionary<string, (string Version, DateTimeOffset Expiry)> _localVersionCache
+        = new(StringComparer.Ordinal);
     private static readonly Regex FeatureServerKeyPattern = new("^(?:response:)?query:featureserver:service:(?<service>[^:]+):layer:(?<layer>\\d+):", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FeatureServerLayerPattern = new("^(?:response:)?query:featureserver:service:\\*:layer:(?<layer>\\d+):\\*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex FeatureServerServiceLayerPattern = new("^(?:response:)?query:featureserver:service:(?<service>[^:]+):layer:(?<layer>\\d+):\\*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -88,12 +100,42 @@ internal sealed class CacheServiceResponseCache : IResponseCache
             return [];
         }
 
-        var resolved = new List<string>(namespaces.Count);
+        var now = DateTimeOffset.UtcNow;
+        var resolved = new string[namespaces.Count];
+        List<int>? missIndices = null;
 
-        foreach (var ns in namespaces)
+        // Local-cache pass: O(N) dictionary lookups, zero Redis round-trips for warm namespaces.
+        for (var i = 0; i < namespaces.Count; i++)
         {
-            var version = await _cacheService.GetAsync<string>(VersionPrefix + ns, cancellationToken).ConfigureAwait(false);
-            resolved.Add(string.IsNullOrWhiteSpace(version) ? "0" : version);
+            if (_localVersionCache.TryGetValue(namespaces[i], out var entry) && entry.Expiry > now)
+            {
+                resolved[i] = entry.Version;
+            }
+            else
+            {
+                (missIndices ??= new List<int>(namespaces.Count - i)).Add(i);
+            }
+        }
+
+        if (missIndices is { Count: > 0 })
+        {
+            // Batch-fetch all missing namespace versions concurrently so that N misses
+            // result in a single Redis pipeline round-trip rather than N sequential ones.
+            var fetchTasks = new Task<string?>[missIndices.Count];
+            for (var j = 0; j < missIndices.Count; j++)
+            {
+                fetchTasks[j] = _cacheService.GetAsync<string>(VersionPrefix + namespaces[missIndices[j]], cancellationToken);
+            }
+
+            var versions = await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+
+            for (var j = 0; j < missIndices.Count; j++)
+            {
+                var i = missIndices[j];
+                var version = string.IsNullOrWhiteSpace(versions[j]) ? "0" : versions[j]!;
+                resolved[i] = version;
+                _localVersionCache[namespaces[i]] = (version, now.Add(VersionLocalCacheTtl));
+            }
         }
 
         return resolved;
@@ -115,6 +157,10 @@ internal sealed class CacheServiceResponseCache : IResponseCache
                     VersionTtl,
                     cancellationToken)
                 .ConfigureAwait(false);
+
+            // Evict from the local in-process cache so this node sees the new version
+            // on the very next cache operation, without waiting for the 30 s local TTL.
+            _localVersionCache.TryRemove(ns, out _);
         }
 
         return true;

--- a/src/Honua.Postgres/Features/Infrastructure/PostgresConnectionStringCache.cs
+++ b/src/Honua.Postgres/Features/Infrastructure/PostgresConnectionStringCache.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Security.Abstractions;
+
+namespace Honua.Postgres.Features.Infrastructure;
+
+/// <summary>
+/// Singleton that resolves (and caches) the Postgres connection string exactly once,
+/// eliminating the sync-over-async pattern on the per-request scoped factory path
+/// (PA-077).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The previous design called
+/// <c>resolver.ResolveSecretAsync(...).GetAwaiter().GetResult()</c> inside every
+/// scoped DI factory lambda — once per request for each catalog that needed the
+/// connection string. On cloud deployments this blocked a thread-pool thread for
+/// every AWS Secrets Manager / Azure Key Vault network call, risking thread-pool
+/// exhaustion under load.
+/// </para>
+/// <para>
+/// This singleton starts the async resolution immediately upon construction (which
+/// happens at DI registration time, before the server begins serving requests) and
+/// exposes the result as <see cref="ResolvedConnectionStringTask"/>. Scoped
+/// consumers <c>await</c> the task directly; by the time the first HTTP request
+/// arrives the task is already completed, so the await is effectively free
+/// (zero I/O, no thread blocking). If resolution is still in-flight (edge case at
+/// startup) the await yields properly without blocking any thread.
+/// </para>
+/// <para>
+/// A bounded 30-second <see cref="CancellationTokenSource"/> guards against a hung
+/// secret provider. <c>CancellationToken.None</c> is no longer passed to the
+/// resolver from this path.
+/// </para>
+/// </remarks>
+internal sealed class PostgresConnectionStringCache
+{
+    /// <summary>
+    /// A <see cref="Task{TResult}"/> that resolves to the fully-substituted Postgres
+    /// connection string. Completed at most once; await freely — it is thread-safe.
+    /// </summary>
+    public Task<string> ResolvedConnectionStringTask { get; }
+
+    /// <summary>
+    /// Initialises the cache and starts background async secret resolution.
+    /// </summary>
+    /// <param name="rawConnectionString">
+    /// The raw connection string from configuration (may contain a secret reference).
+    /// </param>
+    /// <param name="resolver">
+    /// Optional secret resolver. When <see langword="null"/> the raw string is used as-is.
+    /// </param>
+    public PostgresConnectionStringCache(string rawConnectionString, IConnectionSecretResolver? resolver)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rawConnectionString);
+        ResolvedConnectionStringTask = ResolveAsync(rawConnectionString, resolver);
+    }
+
+    private static async Task<string> ResolveAsync(string raw, IConnectionSecretResolver? resolver)
+    {
+        if (resolver == null || !resolver.CanResolve(raw))
+        {
+            return raw;
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        try
+        {
+            return await resolver.ResolveSecretAsync(raw, cts.Token).ConfigureAwait(false) ?? raw;
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                "Timed out after 30 s while resolving the Postgres connection string secret.", null);
+        }
+    }
+}

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
@@ -20,15 +20,16 @@ namespace Honua.Postgres.Features.Migration;
 /// </summary>
 internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatchRunCatalog
 {
-    private readonly string _connectionString;
+    // Resolved once from PostgresConnectionStringCache (PA-077): awaiting an already-completed
+    // Task<string> is effectively free and avoids blocking the thread pool on secret calls.
+    private readonly Task<string> _connectionStringTask;
     private readonly ILogger<PostgresMigrationBatchRunCatalog> _logger;
 
     public PostgresMigrationBatchRunCatalog(
-        string connectionString,
+        Task<string> connectionStringTask,
         ILogger<PostgresMigrationBatchRunCatalog> logger)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
-        _connectionString = connectionString;
+        _connectionStringTask = connectionStringTask ?? throw new ArgumentNullException(nameof(connectionStringTask));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -42,7 +43,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
         ArgumentException.ThrowIfNullOrWhiteSpace(record.BatchId);
         ArgumentNullException.ThrowIfNull(children);
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 
@@ -137,7 +138,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         return await GetInternalAsync(connection, batchId, cancellationToken).ConfigureAwait(false);
     }
@@ -147,7 +148,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string sql = """
@@ -176,7 +177,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string sql = """
@@ -206,7 +207,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         // Terminal child states are sticky: don't overwrite a row that already
@@ -250,7 +251,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(batchId);
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         // Terminal batch states are sticky.
@@ -286,7 +287,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
     public async Task<IReadOnlyList<string>> GetActiveBatchIdsAsync(
         CancellationToken cancellationToken = default)
     {
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string sql = """

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationRunCatalog.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationRunCatalog.cs
@@ -28,15 +28,16 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
     private const int MaxPageLimit = 100;
     private const int DefaultPageLimit = 25;
 
-    private readonly string _connectionString;
+    // Resolved once from PostgresConnectionStringCache (PA-077): awaiting an already-completed
+    // Task<string> is effectively free and avoids blocking the thread pool on secret calls.
+    private readonly Task<string> _connectionStringTask;
     private readonly ILogger<PostgresMigrationRunCatalog> _logger;
 
     public PostgresMigrationRunCatalog(
-        string connectionString,
+        Task<string> connectionStringTask,
         ILogger<PostgresMigrationRunCatalog> logger)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
-        _connectionString = connectionString;
+        _connectionStringTask = connectionStringTask ?? throw new ArgumentNullException(nameof(connectionStringTask));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -48,7 +49,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
         ArgumentException.ThrowIfNullOrWhiteSpace(record.RunId);
         ArgumentException.ThrowIfNullOrWhiteSpace(record.SourceKind);
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         // ON CONFLICT DO NOTHING keeps re-recording the same run id a no-op
@@ -123,7 +124,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
             throw new ArgumentException("RecordCompletedAsync requires a terminal status.", nameof(status));
         }
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         // Terminal state is sticky: the WHERE clause refuses to overwrite an
@@ -171,7 +172,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(runId);
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string sql = """
@@ -206,7 +207,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(runId);
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
         return await GetInternalAsync(connection, runId, cancellationToken).ConfigureAwait(false);
     }
@@ -222,7 +223,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
         var sourceKindFilter = string.IsNullOrWhiteSpace(query.SourceKind) ? null : query.SourceKind!.Trim().ToLowerInvariant();
         var statusFilter = query.Status.HasValue ? StatusToText(query.Status.Value) : null;
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string countSql = """
@@ -294,7 +295,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(runId);
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string sql = """
@@ -326,7 +327,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
         ArgumentException.ThrowIfNullOrWhiteSpace(scorecardFingerprint);
         ArgumentException.ThrowIfNullOrWhiteSpace(scorecardBody);
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string updateSql = """
@@ -355,7 +356,7 @@ internal sealed partial class PostgresMigrationRunCatalog : IMigrationRunCatalog
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(runId);
 
-        await using var connection = new NpgsqlConnection(_connectionString);
+        await using var connection = new NpgsqlConnection(await _connectionStringTask.ConfigureAwait(false));
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
         const string sql = """

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -100,10 +100,32 @@ internal static class ServiceCollectionExtensions
         // Factory form so the DI container tracks the IDisposable for shutdown disposal.
         services.TryAddSingleton(_ => new QueryConcurrencyGate(connectionLimits));
 
+        // Singleton cache that resolves the connection string / secret exactly once (PA-077).
+        // Scoped factories must await ResolvedConnectionStringTask instead of calling the
+        // blocking ResolveConnectionString helper so that thread-pool threads are never
+        // blocked on a cloud secret call (AWS Secrets Manager / Azure Key Vault).
+        services.TryAddSingleton(serviceProvider =>
+        {
+            var rawConnectionString = configuration.GetConnectionString("DefaultConnection");
+            if (string.IsNullOrWhiteSpace(rawConnectionString))
+            {
+                throw new InvalidOperationException("DefaultConnection connection string is required for PostgreSQL services");
+            }
+            var resolver = serviceProvider.GetService<IConnectionSecretResolver>();
+            return new PostgresConnectionStringCache(rawConnectionString, resolver);
+        });
+
         // Register NpgsqlDataSource as specified in Issue #3
         services.TryAddSingleton<NpgsqlDataSource>(serviceProvider =>
         {
-            var connectionString = ResolveConnectionString(serviceProvider, configuration);
+            // The NpgsqlDataSource singleton is created at startup (before requests).
+            // Block here is acceptable: this is a one-time startup cost on the
+            // dedicated startup thread, not the request thread pool. The singleton
+            // path is noted as lower-priority in PA-077.
+            var connectionString = serviceProvider.GetRequiredService<PostgresConnectionStringCache>()
+                .ResolvedConnectionStringTask
+                .GetAwaiter()
+                .GetResult();
             return PostgresDataSourceFactory.Create(connectionString, schemaHeadersEnabled, connectionLimits, defaultSchema);
         });
 
@@ -494,16 +516,18 @@ internal static class ServiceCollectionExtensions
         // Footprint-driven batch import run catalog (#1253). Persists batch
         // composition, ordering, and per-child status backing the batch
         // orchestration endpoints. Scoped to align with the scoped orchestrator.
+        // The Task<string> is sourced from the singleton PostgresConnectionStringCache so
+        // the secret is resolved once at startup and per-request awaits are free (PA-077).
         services.AddScoped<IMigrationBatchRunCatalog>(serviceProvider =>
             new PostgresMigrationBatchRunCatalog(
-                ResolveConnectionString(serviceProvider, configuration),
+                serviceProvider.GetRequiredService<PostgresConnectionStringCache>().ResolvedConnectionStringTask,
                 serviceProvider.GetRequiredService<ILogger<PostgresMigrationBatchRunCatalog>>()));
 
         // Migration run catalog (#1015/#1598). Persists lifecycle rows backing the
         // admin run-history write/read API.
         services.AddScoped<IMigrationRunCatalog>(serviceProvider =>
             new PostgresMigrationRunCatalog(
-                ResolveConnectionString(serviceProvider, configuration),
+                serviceProvider.GetRequiredService<PostgresConnectionStringCache>().ResolvedConnectionStringTask,
                 serviceProvider.GetRequiredService<ILogger<PostgresMigrationRunCatalog>>()));
 
         // Register the post-publish reconciliation service (issues #1247/#1380). It probes the

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBProviderResolutionTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBProviderResolutionTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.HealthCheck.Abstractions;
+using Honua.DuckDB.Features.HealthCheck;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.DuckDB.Tests;
+
+/// <summary>
+/// Verifies that DI registration for the DuckDB provider activates all required
+/// protocol-handler contracts, including the readiness-check health checker (PA-158).
+/// </summary>
+public sealed class DuckDBProviderResolutionTests
+{
+    [Fact]
+    public void AddDuckDBServices_RegistersDatabaseHealthChecker()
+    {
+        // ReadinessCheckService takes IDatabaseHealthChecker as a REQUIRED ctor param.
+        // Before PA-158, resolving /healthz/ready under DataSource:Provider=duckdb threw
+        // InvalidOperationException because no IDatabaseHealthChecker was registered.
+        using var provider = BuildDuckDbServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var checker = scope.ServiceProvider.GetRequiredService<IDatabaseHealthChecker>();
+
+        Assert.IsType<DuckDBDatabaseHealthChecker>(checker);
+    }
+
+    [Fact]
+    public void AddDuckDBServices_RegistersDatabaseHealthChecker_AsScoped()
+    {
+        // The checker is scoped to align with the scoped IDatabaseConnectionProvider it depends on.
+        using var provider = BuildDuckDbServiceProvider();
+
+        // Resolve from two separate scopes to confirm they are different instances.
+        DuckDBDatabaseHealthChecker? first;
+        DuckDBDatabaseHealthChecker? second;
+
+        using (var s1 = provider.CreateScope())
+        {
+            first = s1.ServiceProvider.GetRequiredService<IDatabaseHealthChecker>() as DuckDBDatabaseHealthChecker;
+        }
+        using (var s2 = provider.CreateScope())
+        {
+            second = s2.ServiceProvider.GetRequiredService<IDatabaseHealthChecker>() as DuckDBDatabaseHealthChecker;
+        }
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        // Scoped instances across different scopes must be different objects.
+        Assert.NotSame(first, second);
+    }
+
+    private static ServiceProvider BuildDuckDbServiceProvider()
+    {
+        // Minimal DuckDB configuration — in-memory mode with no layers so no real
+        // file or schema discovery is attempted. The DI tests resolve types only;
+        // they do not execute SQL or open connections.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DuckDB:DatabasePath"] = ":memory:",
+                ["DuckDB:ReadOnly"] = "false"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        ServiceCollectionExtensions.AddDuckDBServices(services, config);
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Caching/CacheServiceResponseCacheLocalCacheTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Caching/CacheServiceResponseCacheLocalCacheTests.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Caching.Abstractions;
+using Honua.Core.Features.Infrastructure.Caching;
+using Honua.Infrastructure.Caching;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Caching;
+
+/// <summary>
+/// Verifies the in-process namespace-version cache and concurrent-fetch behaviour
+/// introduced in PA-052.
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class CacheServiceResponseCacheLocalCacheTests
+{
+    /// <summary>
+    /// The second call with the same namespace keys must NOT issue any additional
+    /// GetAsync calls to the backing cache service (local cache hit within TTL).
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_SecondCallWithSameNamespaces_ServesLocalCacheWithoutRedis()
+    {
+        var versions = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["response-version:query:featureserver"] = "v1",
+            ["response-version:query:featureserver:layer:3"] = "v2",
+            ["response-version:query:featureserver:service:alpha"] = "v3",
+            ["response-version:query:featureserver:service:alpha:layer:3"] = "v4"
+        };
+        var cache = new CountingCacheService(versions);
+        var responseCache = new CacheServiceResponseCache(cache);
+
+        // First call — 4 namespace version lookups expected.
+        await responseCache.SetAsync("query:featureserver:service:alpha:layer:3:keyA", "payload", TimeSpan.FromMinutes(1));
+        var getCountAfterFirst = cache.GetCallCount;
+
+        // Second call with the SAME four namespace keys — should hit local cache.
+        await responseCache.SetAsync("query:featureserver:service:alpha:layer:3:keyB", "payload", TimeSpan.FromMinutes(1));
+        var getCountAfterSecond = cache.GetCallCount;
+
+        Assert.Equal(4, getCountAfterFirst);
+        // No additional GetAsync calls for namespace versions on the second call.
+        Assert.Equal(getCountAfterFirst, getCountAfterSecond);
+    }
+
+    /// <summary>
+    /// After a RemoveByPatternAsync invalidates a namespace version, the local
+    /// cache entry for that namespace must be evicted so the next call re-fetches
+    /// from Redis rather than serving a stale version key.
+    /// </summary>
+    [Fact]
+    public async Task RemoveByPatternAsync_InvalidatesLocalCache_NextCallRefetchesFromRedis()
+    {
+        var versions = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["response-version:query:featureserver:service:alpha:layer:3"] = "v1"
+        };
+        var cache = new CountingCacheService(versions);
+        var responseCache = new CacheServiceResponseCache(cache);
+
+        // Warm the local cache.
+        await responseCache.SetAsync("query:featureserver:service:alpha:layer:3:key1", "payload", TimeSpan.FromMinutes(1));
+        var warmGetCount = cache.GetCallCount;
+
+        // Invalidate the namespace — this should evict the local cache entry.
+        await responseCache.RemoveByPatternAsync("query:featureserver:service:alpha:layer:3:*");
+
+        // Next SetAsync must re-fetch namespace versions from Redis (local cache is cold).
+        await responseCache.SetAsync("query:featureserver:service:alpha:layer:3:key2", "payload", TimeSpan.FromMinutes(1));
+        var postInvalidationGetCount = cache.GetCallCount;
+
+        Assert.True(postInvalidationGetCount > warmGetCount,
+            "Expected at least one additional namespace version lookup after invalidation, " +
+            $"but GetCallCount stayed at {warmGetCount}.");
+    }
+
+    /// <summary>
+    /// Namespace version lookups for a cold cache are issued concurrently via Task.WhenAll
+    /// rather than sequentially, so N missing namespaces produce a single round-trip latency.
+    /// We verify this by checking that all N GetAsync calls are started before any
+    /// completes — using a gate-based fake cache service.
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_MultipleNamespaceMisses_IssuedConcurrently()
+    {
+        // Gate-based cache: each namespace-version GetAsync waits for all expected tasks
+        // to start before any returns. If the implementation issued tasks sequentially,
+        // the gate would never open (task 2 can't start until task 1 returns) and the
+        // test would time out. Completion without timeout proves concurrency.
+        const int expectedNamespaces = 4;
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var versions = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["response-version:query:featureserver"] = "a",
+            ["response-version:query:featureserver:layer:7"] = "b",
+            ["response-version:query:featureserver:service:svc"] = "c",
+            ["response-version:query:featureserver:service:svc:layer:7"] = "d"
+        };
+
+        var cache = new GatedCacheService(versions, expectedConcurrency: expectedNamespaces, onAllStarted: gate);
+        var responseCache = new CacheServiceResponseCache(cache);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await responseCache
+            .SetAsync("query:featureserver:service:svc:layer:7:key1", "payload", TimeSpan.FromMinutes(1), cts.Token)
+            .WaitAsync(cts.Token);
+
+        // All 4 namespace-version lookups started before any returned.
+        Assert.Equal(expectedNamespaces, cache.StartedCount);
+    }
+
+    /// <summary>
+    /// Missing namespace version ("0") default is preserved by the new batched path.
+    /// </summary>
+    [Fact]
+    public async Task SetAsync_MissingNamespaceVersion_DefaultsToZero()
+    {
+        // Provide a cache that returns null for all namespace version keys.
+        var cache = new CountingCacheService(new Dictionary<string, string>(StringComparer.Ordinal));
+        var responseCache = new CacheServiceResponseCache(cache);
+
+        await responseCache.SetAsync("query:featureserver:service:alpha:layer:3:keyA", "payload", TimeSpan.FromMinutes(1));
+
+        // Storage key must contain :v:0:0:0:0 (four namespaces all defaulting to "0").
+        Assert.Single(cache.ValueWrites);
+        Assert.Contains(":v:0:0:0:0", cache.ValueWrites[0], StringComparison.Ordinal);
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private sealed class CountingCacheService : ICacheService
+    {
+        private readonly Dictionary<string, string> _versionValues;
+        private int _getCallCount;
+
+        public CountingCacheService(IReadOnlyDictionary<string, string>? versions = null)
+        {
+            _versionValues = versions is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(versions, StringComparer.Ordinal);
+        }
+
+        public int GetCallCount => Volatile.Read(ref _getCallCount);
+        public List<string> ValueWrites { get; } = [];
+
+        public Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+        {
+            if (key.StartsWith("response-version:", StringComparison.Ordinal))
+            {
+                Interlocked.Increment(ref _getCallCount);
+                if (typeof(T) == typeof(string) && _versionValues.TryGetValue(key, out var v))
+                    return Task.FromResult<T?>((T?)(object?)v);
+            }
+            return Task.FromResult<T?>(null);
+        }
+
+        public Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default) where T : class
+            => SetAsync(key, value, TimeSpan.FromMinutes(1), cancellationToken);
+
+        public Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken = default) where T : class
+        {
+            if (!key.StartsWith("response-version:", StringComparison.Ordinal))
+            {
+                ValueWrites.Add(key);
+            }
+            else
+            {
+                _versionValues[key] = value?.ToString() ?? string.Empty;
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RemoveByPatternAsync(string pattern, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<T?> GetOrSetAsync<T>(string key, Func<CancellationToken, Task<T?>> factory, CancellationToken cancellationToken = default) where T : class
+            => GetOrSetAsync(key, factory, TimeSpan.FromMinutes(1), cancellationToken);
+
+        public async Task<T?> GetOrSetAsync<T>(string key, Func<CancellationToken, Task<T?>> factory, TimeSpan ttl, CancellationToken cancellationToken = default) where T : class
+        {
+            var v = await GetAsync<T>(key, cancellationToken).ConfigureAwait(false);
+            if (v != null) return v;
+            v = await factory(cancellationToken).ConfigureAwait(false);
+            if (v != null) await SetAsync(key, v, ttl, cancellationToken).ConfigureAwait(false);
+            return v;
+        }
+
+        public Task<CacheEntryMetadata<T>> GetWithMetadataAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+            => Task.FromResult(CacheEntryMetadata<T>.Miss());
+    }
+
+    /// <summary>
+    /// A <see cref="ICacheService"/> whose namespace-version GetAsync calls wait
+    /// for all expected concurrent calls to start before any returns, proving
+    /// that the callers issued them concurrently via Task.WhenAll.
+    /// </summary>
+    private sealed class GatedCacheService : ICacheService
+    {
+        private readonly Dictionary<string, string> _versions;
+        private readonly int _expectedConcurrency;
+        private readonly TaskCompletionSource<bool> _gate;
+        private int _startedCount;
+
+        public int StartedCount => Volatile.Read(ref _startedCount);
+
+        public GatedCacheService(
+            Dictionary<string, string> versions,
+            int expectedConcurrency,
+            TaskCompletionSource<bool> onAllStarted)
+        {
+            _versions = versions;
+            _expectedConcurrency = expectedConcurrency;
+            _gate = onAllStarted;
+        }
+
+        public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+        {
+            if (key.StartsWith("response-version:", StringComparison.Ordinal))
+            {
+                var count = Interlocked.Increment(ref _startedCount);
+                if (count >= _expectedConcurrency)
+                {
+                    _gate.TrySetResult(true);
+                }
+                // Wait until all expected tasks have started before any returns.
+                await _gate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                if (typeof(T) == typeof(string) && _versions.TryGetValue(key, out var v))
+                    return (T?)(object?)v;
+            }
+            return null;
+        }
+
+        public Task SetAsync<T>(string key, T value, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+        public Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken = default) where T : class => Task.CompletedTask;
+        public Task RemoveAsync(string key, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task RemoveByPatternAsync(string pattern, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<T?> GetOrSetAsync<T>(string key, Func<CancellationToken, Task<T?>> factory, CancellationToken cancellationToken = default) where T : class
+            => GetOrSetAsync(key, factory, TimeSpan.FromMinutes(1), cancellationToken);
+
+        public async Task<T?> GetOrSetAsync<T>(string key, Func<CancellationToken, Task<T?>> factory, TimeSpan ttl, CancellationToken cancellationToken = default) where T : class
+        {
+            var v = await GetAsync<T>(key, cancellationToken).ConfigureAwait(false);
+            if (v != null) return v;
+            v = await factory(cancellationToken).ConfigureAwait(false);
+            return v;
+        }
+
+        public Task<CacheEntryMetadata<T>> GetWithMetadataAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+            => Task.FromResult(CacheEntryMetadata<T>.Miss());
+    }
+}


### PR DESCRIPTION
## Summary

Three S1 reliability issues fixed in a single batch — all self-contained, no API surface changes.

### PA-158 — DuckDB: /healthz/ready throws InvalidOperationException

`ReadinessCheckService` takes `IDatabaseHealthChecker` as a required constructor parameter. `AddDuckDBServices` never registered it, so every `/healthz/ready` probe under `DataSource:Provider=duckdb` failed with a DI activation exception.

**Fix:** Added `DuckDBDatabaseHealthChecker` (mirrors `MySqlDatabaseHealthChecker`: runs `SELECT 1` through the scoped `IAdoNetDatabaseConnectionProvider`, 5 s command timeout, `[LoggerMessage]` EventId 8806) and registered it as scoped in `AddDuckDBServices`.

Files: `src/Honua.DuckDB/Features/HealthCheck/DuckDBDatabaseHealthChecker.cs`, `src/Honua.DuckDB/ServiceCollectionExtensions.cs`
Tests: `tests/dotnet/Honua.DuckDB.Tests/DuckDBProviderResolutionTests.cs`

---

### PA-077 — Postgres: sync-over-async secret resolution on every DI scope

`IMigrationBatchRunCatalog` and `IMigrationRunCatalog` scoped factories called `ResolveConnectionString()`, which internally called `resolver.ResolveSecretAsync(..., CancellationToken.None).GetAwaiter().GetResult()` — blocking a thread-pool thread on a cloud secret fetch (AWS Secrets Manager / Azure Key Vault) on every scope creation. Under concurrency this risks thread-pool starvation and priority inversion.

**Fix:** Introduced `PostgresConnectionStringCache` (singleton) that resolves the secret exactly once at startup with a 30 s `CancellationToken`. It exposes `Task<string> ResolvedConnectionStringTask`, which is already completed by the time any scoped catalog is created. Both catalog classes now store `Task<string>` and `await` it inside their async DB methods — zero blocking, zero `CancellationToken.None`.

Files: `src/Honua.Postgres/Features/Infrastructure/PostgresConnectionStringCache.cs`, `src/Honua.Postgres/ServiceCollectionExtensions.cs`, `src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs`, `src/Honua.Postgres/Features/Migration/PostgresMigrationRunCatalog.cs`

**Deferred:** The `NpgsqlDataSource` singleton factory at startup also calls `.GetAwaiter().GetResult()` on the same path, but now awaits the already-resolved `PostgresConnectionStringCache.ResolvedConnectionStringTask` (a no-op). A full async startup refactor is out of scope.

---

### PA-052 — Redis: N sequential round-trips per cache operation in namespace version resolution

`CacheServiceResponseCache.ResolveNamespaceVersionsAsync` issued up to 4 sequential `GetAsync<string>` calls before every `SetAsync`/`GetAsync`/`RemoveByPatternAsync` — roughly 5 Redis round-trips per cache hit or miss on a FeatureServer key.

**Fix (two-phase):**

1. **Local in-process cache** (`ConcurrentDictionary<string, (string Version, DateTimeOffset Expiry)>`, 30 s TTL) eliminates all Redis reads on the warm path. Evicted immediately in `TryInvalidateNamespaceAsync` so this node sees invalidations with zero lag.
2. **Concurrent fetch on cold misses** via `Task.WhenAll` — N missing versions fetched concurrently, producing a single Redis pipeline round-trip instead of N sequential ones.

Semantics preserved: missing version → `0`. Remote invalidations visible within 30 s (local TTL), producing a cache miss rather than stale data.

Files: `src/Honua.Hosting/Features/Caching/CacheServiceResponseCache.cs`
Tests: `tests/dotnet/Honua.Server.Tests/Features/Caching/CacheServiceResponseCacheLocalCacheTests.cs`

---

## Test plan

- [ ] `dotnet test tests/dotnet/Honua.DuckDB.Tests` — `DuckDBProviderResolutionTests` (2 tests: scoped registration + correct impl type)
- [ ] `dotnet test tests/dotnet/Honua.Server.Tests --filter CacheServiceResponseCacheLocalCacheTests` — 4 tests: local cache warm path, eviction on invalidation, concurrency proof, missing-version default
- [ ] Deploy to a DuckDB-backed dev environment and confirm `/healthz/ready` returns 200
- [ ] Confirm no regression on Postgres-backed environments (secret resolution log shows single resolution at startup)