### PR TITLE
feat(security): gate experimental features off by default (PA-096/PA-181/PA-182/PA-001)

### DIFF
--- a/src/Honua.Server/Features/Admin/Services/ConfigurationValidationService.cs
+++ b/src/Honua.Server/Features/Admin/Services/ConfigurationValidationService.cs
@@ -47,6 +47,13 @@ internal static class ConfigurationValidationService
         LogFeatureStatus(configuration, logger, "HONUA_OPENTELEMETRY", "OpenTelemetry tracing");
         LogFeatureStatus(configuration, logger, "HONUA_SKIP_MIGRATIONS", "Skip migrations");
 
+        // Experimental feature gates (audit PA-096/PA-103/PA-116/PA-145/PA-001/PA-181/PA-182).
+        // Each is default-off; operators must explicitly opt in.
+        LogExperimentalFeatureStatus(configuration, logger, "Experimental:Features:SensorThings", "SensorThings API");
+        LogExperimentalFeatureStatus(configuration, logger, "Experimental:Features:FederatedQuery", "Federated Query");
+        LogExperimentalFeatureStatus(configuration, logger, "Experimental:Features:RedshiftProvider", "Redshift provider");
+        LogExperimentalFeatureStatus(configuration, logger, "Experimental:Features:SnowflakeProvider", "Snowflake provider");
+
         // Warn about dev-only settings in production
         var basicAuthCompatibilityEnabled = configuration.GetValue(
             "Authentication:BasicCompatibility:Enabled",
@@ -315,6 +322,18 @@ internal static class ConfigurationValidationService
     {
         var isEnabled = configuration.IsFeatureEnabled(featureName.Replace("HONUA_", ""));
         ConfigurationLog.FeatureStatus(logger, displayName, isEnabled ? "enabled" : "disabled");
+    }
+
+    /// <summary>
+    /// Logs an experimental feature flag using the same EventId 4010 log structure.
+    /// Experimental features are off by default; the status reflects whether the
+    /// opt-in configuration key is present and set to true.
+    /// </summary>
+    private static void LogExperimentalFeatureStatus(IConfiguration configuration, ILogger logger, string configKey, string displayName)
+    {
+        var isEnabled = configuration.GetValue<bool>(configKey, false);
+        var status = isEnabled ? "experimental (enabled)" : "disabled (experimental, default)";
+        ConfigurationLog.FeatureStatus(logger, displayName, status);
     }
 
     private static void LogConfigurationSummary(IConfiguration configuration, ILogger logger)

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -126,7 +126,12 @@ internal static class FeatureRegistrationExtensions
         services.AddNlQuery(configuration);
         services.AddWorkflowGeneration(configuration);
         services.AddStac();
-        services.AddSensorThings();
+        // Experimental gate (PA-096/PA-103/PA-116/PA-145): SensorThings is off by default.
+        // Set Experimental__Features__SensorThings=true to opt in.
+        if (configuration.GetValue<bool>("Experimental:Features:SensorThings", false))
+        {
+            services.AddSensorThings();
+        }
         services.AddStaticMap();
         services.AddTerrain();
         services.AddScene(configuration);
@@ -291,7 +296,12 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapODataEndpoints();
         endpoints.MapGeometryServiceEndpoints();
         endpoints.MapStacEndpoints();
-        endpoints.MapSensorThingsEndpoints();
+        // Experimental gate (PA-096/PA-103/PA-116/PA-145): SensorThings is off by default.
+        var staConfig = endpoints.ServiceProvider.GetRequiredService<IConfiguration>();
+        if (staConfig.GetValue<bool>("Experimental:Features:SensorThings", false))
+        {
+            endpoints.MapSensorThingsEndpoints();
+        }
         endpoints.MapStaticMapEndpoints();
         endpoints.MapNAServerEndpoints();
         endpoints.MapPrintingToolsEndpoints();

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -521,7 +521,12 @@ builder.Services.Configure<FileUploadSecurityOptions>(
     builder.Configuration.GetSection(FileUploadSecurityOptions.SectionName));
 
 // Federated-query planning and source configuration (#341).
-builder.Services.AddFederationServices(builder.Configuration);
+// Experimental gate (PA-001): federated query is off by default. Set
+// Experimental__Features__FederatedQuery=true to opt in.
+if (builder.Configuration.GetValue<bool>("Experimental:Features:FederatedQuery", false))
+{
+    builder.Services.AddFederationServices(builder.Configuration);
+}
 
 // Register configuration validators to ensure application fails fast on invalid configuration
 StartupConfigurationHelpers.RegisterConfigurationValidators(builder.Services);
@@ -1325,7 +1330,11 @@ app.MapComplianceAdminEndpoints();
 
 // Configure secure connection management endpoints
 app.MapSecureConnectionEndpoints();
-app.MapFederationEndpoints();
+// Experimental gate (PA-001): only map federation endpoints when the feature is enabled.
+if (app.Configuration.GetValue<bool>("Experimental:Features:FederatedQuery", false))
+{
+    app.MapFederationEndpoints();
+}
 app.MapClientCertificateAdminEndpoints();
 
 // Configure control plane IAM endpoints (#511)

--- a/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
+++ b/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
@@ -75,9 +75,24 @@ internal static class InfrastructureCompositionRoot
         // Metadata v2 publications whose connection resolves to provider 'redshift' are routed here through
         // the shared FeatureProviderQueryRouter. Disabled when Redshift:Enabled is explicitly false. Redshift
         // speaks the PostgreSQL wire protocol (Npgsql) and is AOT-friendly, so it needs no AOT carve-out.
-        if (configuration.GetValue("Redshift:Enabled", true))
+        // Experimental gate (PA-181): Redshift requires the experimental feature flag.
+        // Fail closed if the operator explicitly enables Redshift without opting into the experimental gate.
+        var redshiftExperimental = configuration.GetValue<bool>("Experimental:Features:RedshiftProvider", false);
+        var redshiftExplicitlyEnabled = string.Equals(configuration["Redshift:Enabled"], "true", StringComparison.OrdinalIgnoreCase);
+        if (redshiftExperimental)
         {
-            Honua.Redshift.ServiceCollectionExtensions.AddRedshiftFeatureProvider(services, configuration);
+            if (configuration.GetValue("Redshift:Enabled", true))
+            {
+                Honua.Redshift.ServiceCollectionExtensions.AddRedshiftFeatureProvider(services, configuration);
+            }
+        }
+        else if (redshiftExplicitlyEnabled)
+        {
+            throw new InvalidOperationException(
+                "Configuration conflict: Redshift:Enabled is set to true but the experimental gate " +
+                "'Experimental:Features:RedshiftProvider' is not enabled (PA-181). " +
+                "Set Experimental__Features__RedshiftProvider=true to opt in to this experimental provider, " +
+                "or set Redshift__Enabled=false to disable it.");
         }
 
         // Register the federated ArcGIS REST read-through provider (#1251). Metadata v2 publications whose
@@ -112,10 +127,25 @@ internal static class InfrastructureCompositionRoot
         // (HonuaSkipSnowflakeForAotVerification) drops the Honua.Snowflake ProjectReference and defines
         // HONUA_SKIP_SNOWFLAKE, so this registration is compiled out and the non-single-file-safe driver is
         // never linked into the AOT image.
+        // Experimental gate (PA-182): Snowflake requires the experimental feature flag.
+        // Fail closed if the operator explicitly enables Snowflake without opting into the experimental gate.
 #if !HONUA_SKIP_SNOWFLAKE
-        if (configuration.GetValue("Snowflake:Enabled", true))
+        var snowflakeExperimental = configuration.GetValue<bool>("Experimental:Features:SnowflakeProvider", false);
+        var snowflakeExplicitlyEnabled = string.Equals(configuration["Snowflake:Enabled"], "true", StringComparison.OrdinalIgnoreCase);
+        if (snowflakeExperimental)
         {
-            Honua.Snowflake.ServiceCollectionExtensions.AddSnowflakeFeatureProvider(services, configuration);
+            if (configuration.GetValue("Snowflake:Enabled", true))
+            {
+                Honua.Snowflake.ServiceCollectionExtensions.AddSnowflakeFeatureProvider(services, configuration);
+            }
+        }
+        else if (snowflakeExplicitlyEnabled)
+        {
+            throw new InvalidOperationException(
+                "Configuration conflict: Snowflake:Enabled is set to true but the experimental gate " +
+                "'Experimental:Features:SnowflakeProvider' is not enabled (PA-182). " +
+                "Set Experimental__Features__SnowflakeProvider=true to opt in to this experimental provider, " +
+                "or set Snowflake__Enabled=false to disable it.");
         }
 #endif
 

--- a/src/Honua.Server/appsettings.Test.json
+++ b/src/Honua.Server/appsettings.Test.json
@@ -11,5 +11,13 @@
     "Experimental": {
       "Enabled": true
     }
+  },
+  "Experimental": {
+    "Features": {
+      "SensorThings": true,
+      "FederatedQuery": true,
+      "RedshiftProvider": true,
+      "SnowflakeProvider": true
+    }
   }
 }

--- a/src/Honua.Server/appsettings.json
+++ b/src/Honua.Server/appsettings.json
@@ -115,6 +115,14 @@
       "Enabled": false
     }
   },
+  "Experimental": {
+    "Features": {
+      "SensorThings": false,
+      "FederatedQuery": false,
+      "RedshiftProvider": false,
+      "SnowflakeProvider": false
+    }
+  },
   "Cache": {
     "Enabled": true,
     "DefaultTtlSeconds": 300,

--- a/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsFeatureGateTests.cs
+++ b/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/SensorThingsFeatureGateTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using System.Net;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Features.Protocols.SensorThings;
+
+/// <summary>
+/// Verifies the experimental feature gate for OGC SensorThings API (PA-096/PA-103/PA-116/PA-145).
+/// When <c>Experimental:Features:SensorThings</c> is <c>false</c> (the default), no STA routes
+/// are registered and all <c>/sta/v1.1/...</c> paths return 404. When the flag is <c>true</c>,
+/// the routes are active and return expected responses.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.SensorThings)]
+[Trait("Category", "ExperimentalGate")]
+public sealed class SensorThingsFeatureGateTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture;
+
+    public SensorThingsFeatureGateTests()
+    {
+        // Override the test-environment flag (appsettings.Test.json sets it to true)
+        // to simulate the production default of false.
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, cfg) =>
+                {
+                    cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Experimental:Features:SensorThings"] = "false",
+                    });
+                });
+            });
+    }
+
+    public async Task InitializeAsync() => await _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Trait("Tier", "Fast")]
+    public async Task StaThings_WhenFeatureDisabled_Returns404()
+    {
+        var response = await _fixture.Client.GetAsync("/sta/v1.1/Things");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "SensorThings routes must not be registered when Experimental:Features:SensorThings is false");
+    }
+
+    [IntegrationTest]
+    [Trait("Tier", "Fast")]
+    public async Task StaObservationsPost_WhenFeatureDisabled_Returns404()
+    {
+        var response = await _fixture.Client.PostAsync(
+            "/sta/v1.1/Observations",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "SensorThings ingest routes must not be registered when Experimental:Features:SensorThings is false");
+    }
+
+    [IntegrationTest]
+    [Trait("Tier", "Fast")]
+    public async Task StaDatastreamsPost_WhenFeatureDisabled_Returns404()
+    {
+        var response = await _fixture.Client.PostAsync(
+            "/sta/v1.1/Datastreams",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "SensorThings datastream creation routes must not be registered when Experimental:Features:SensorThings is false");
+    }
+
+    [IntegrationTest]
+    [Trait("Tier", "Fast")]
+    public async Task StaObservations_WhenFeatureDisabled_Returns404()
+    {
+        var response = await _fixture.Client.GetAsync("/sta/v1.1/Observations");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "SensorThings read routes must not be registered when Experimental:Features:SensorThings is false");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Experimental/ExperimentalProviderGateTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Experimental/ExperimentalProviderGateTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Honua.Server.Startup;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Experimental;
+
+/// <summary>
+/// Unit tests for the fail-closed startup gates on experimental data providers
+/// (Redshift: PA-181, Snowflake: PA-182). When a provider is explicitly enabled
+/// via its legacy <c>X:Enabled=true</c> flag but the corresponding experimental
+/// feature gate is not set, startup must throw <see cref="InvalidOperationException"/>
+/// with a clear diagnostic pointing at the required flag. When neither the legacy
+/// flag nor the experimental gate is set, startup must succeed silently.
+/// </summary>
+[Trait("Category", "ExperimentalGate")]
+public sealed class ExperimentalProviderGateTests
+{
+    // ---- Redshift fail-closed ----
+
+    [Fact]
+    public void Redshift_ExplicitlyEnabledWithoutExperimentalFlag_ThrowsAtStartup()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Redshift:Enabled"] = "true",
+            ["Experimental:Features:RedshiftProvider"] = "false",
+        });
+
+        var act = () => InfrastructureCompositionRoot.RegisterInfrastructureServices(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection(),
+            configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Redshift:Enabled*Experimental:Features:RedshiftProvider*",
+                "startup must fail with a clear message pointing to the experimental gate");
+    }
+
+    [Fact]
+    public void Redshift_ExplicitlyEnabledWithExperimentalFlag_DoesNotThrow()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Redshift:Enabled"] = "true",
+            ["Experimental:Features:RedshiftProvider"] = "true",
+            // Minimal required keys so the composition root does not throw on other checks.
+            ["DataSource:Provider"] = "postgis",
+            ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=test",
+        });
+
+        // Should not throw — registration proceeds normally.
+        var act = () => InfrastructureCompositionRoot.RegisterInfrastructureServices(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection(),
+            configuration);
+
+        // We only care that the fail-closed gate does not trigger.
+        // Other exceptions (e.g., provider-not-found) are acceptable.
+        act.Should().NotThrow<InvalidOperationException>(
+            because: "the experimental gate must not block when both flags are set");
+    }
+
+    [Fact]
+    public void Redshift_NotExplicitlyEnabled_ExperimentalFlagOff_DoesNotThrow()
+    {
+        // Redshift:Enabled not set (defaults to absent). Experimental flag off.
+        // Must NOT fail — the default was true before this gate was added, so
+        // operators who didn't set either flag should see a silent skip.
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Experimental:Features:RedshiftProvider"] = "false",
+            ["DataSource:Provider"] = "postgis",
+            ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=test",
+        });
+
+        var act = () => InfrastructureCompositionRoot.RegisterInfrastructureServices(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection(),
+            configuration);
+
+        act.Should().NotThrow<InvalidOperationException>(
+            because: "when Redshift:Enabled is not set, the fail-closed gate must not trigger");
+    }
+
+    // ---- Snowflake fail-closed ----
+
+    [Fact]
+    public void Snowflake_ExplicitlyEnabledWithoutExperimentalFlag_ThrowsAtStartup()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Snowflake:Enabled"] = "true",
+            ["Experimental:Features:SnowflakeProvider"] = "false",
+        });
+
+        var act = () => InfrastructureCompositionRoot.RegisterInfrastructureServices(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection(),
+            configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Snowflake:Enabled*Experimental:Features:SnowflakeProvider*",
+                "startup must fail with a clear message pointing to the experimental gate");
+    }
+
+    [Fact]
+    public void Snowflake_NotExplicitlyEnabled_ExperimentalFlagOff_DoesNotThrow()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Experimental:Features:SnowflakeProvider"] = "false",
+            ["DataSource:Provider"] = "postgis",
+            ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=test",
+        });
+
+        var act = () => InfrastructureCompositionRoot.RegisterInfrastructureServices(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection(),
+            configuration);
+
+        act.Should().NotThrow<InvalidOperationException>(
+            because: "when Snowflake:Enabled is not set, the fail-closed gate must not trigger");
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1883

## Summary
Release-hardening: four experimental features that are not production-ready are
now gated off by default. Operators must explicitly set an
`Experimental__Features__*` environment variable to opt in. The gate also
applies a **fail-closed** pattern for Redshift and Snowflake — if an operator
sets the legacy `Redshift:Enabled=true` or `Snowflake:Enabled=true` flag
without the corresponding experimental gate, startup aborts with a clear
diagnostic rather than silently activating an unqualified provider.

Audit findings addressed: PA-096, PA-103, PA-116, PA-145, PA-001, PA-181, PA-182.

## Changes Made
- Gate `AddSensorThings()` / `MapSensorThingsEndpoints()` in `FeatureRegistrationExtensions.cs` behind `Experimental:Features:SensorThings` (default false); existing tests still pass because `appsettings.Test.json` sets the flag to true
- Gate `AddFederationServices()` / `MapFederationEndpoints()` in `Program.cs` behind `Experimental:Features:FederatedQuery` (default false); same test-environment override pattern
- Redshift fail-closed gate in `InfrastructureCompositionRoot.cs`: throws `InvalidOperationException` at startup if `Redshift:Enabled=true` without `Experimental:Features:RedshiftProvider=true`; silent skip when neither is set (PA-181)
- Snowflake fail-closed gate (same pattern, PA-182)
- `appsettings.json`: document the new `Experimental:Features` section with all four flags set to false
- `appsettings.Test.json`: set all four flags to true so existing integration tests are unaffected
- `ConfigurationValidationService`: log each gate's status at EventId 4010 via `LogExperimentalFeatureStatus`
- `ExperimentalProviderGateTests` (5 unit tests): verify fail-closed throws and silent-skip paths against `InfrastructureCompositionRoot` directly
- `SensorThingsFeatureGateTests` (4 integration tests, Tier=Fast): verify `/sta/v1.1/*` returns 404 when gate is disabled

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [x] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

Operators who currently rely on SensorThings, FederatedQuery, Redshift, or Snowflake without the new flags will see those features disappear on upgrade. They must add the corresponding `Experimental__Features__*=true` environment variable to restore the previous behaviour.

## Breaking Changes
Feature surfaces that were previously active by default are now disabled by default. Operators must opt in:

| Feature | Flag to set |
|---|---|
| SensorThings API | `Experimental__Features__SensorThings=true` |
| Federated Query | `Experimental__Features__FederatedQuery=true` |
| Redshift provider | `Experimental__Features__RedshiftProvider=true` |
| Snowflake provider | `Experimental__Features__SnowflakeProvider=true` |

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
