### PR TITLE
fix: fail-closed event endpoint + Open-policy admin gate (PA-060, PA-196)

### DIFF
--- a/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCodeJobSubmissionGate.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/CustomCodeJobSubmissionGate.cs
@@ -63,6 +63,15 @@ internal sealed class CustomCodeJobSubmissionGate
                 "Custom-code geoprocessing is not enabled on this server (no scoped-job token issuer is configured).");
         }
 
+        // Open-policy gate (PA-196): an unrestricted-repo execution surface requires admin
+        // elevation. A non-admin caller is rejected even when Open is configured so that
+        // arbitrary code execution from any HTTPS repo is never reachable by a normal user.
+        if (_customCodeOptions.CurrentValue.RepoPolicy == CustomCodeRepoPolicy.Open
+            && !principal.IsInRole("admin"))
+        {
+            throw new GeoprocessingAuthorizationException(requiresAuthentication: false);
+        }
+
         try
         {
             var result = await _coordinator.ValidateMintAndInjectAsync(

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneEventEndpoints.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneEventEndpoints.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text.Json.Serialization;
+using Honua.Server.Features.CloudDemo;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -52,7 +54,7 @@ internal static class ControlPlaneEventEndpoints
 
         // HANDLER-AUTHORIZED (#1144): these internal event/backstop routes enforce their own
         // authorization in-handler via the shared-secret X-Honua-ControlPlane-Token check
-        // (see IsAuthorized) and are reachable only from the EventBridge-invoked Lambda inside
+        // (see CheckAuthorization) and are reachable only from the EventBridge-invoked Lambda inside
         // the deployment trust boundary — they are not a framework-policy surface. Marked
         // AllowAnonymous on the group so the audit architecture guard records the explicit,
         // intentional decision for both child mutation routes.
@@ -80,9 +82,10 @@ internal static class ControlPlaneEventEndpoints
         HttpRequest httpRequest,
         CancellationToken cancellationToken)
     {
-        if (!IsAuthorized(httpRequest, configuration))
+        var authResult = CheckAuthorization(httpRequest, configuration);
+        if (authResult is not null)
         {
-            return Results.Unauthorized();
+            return authResult;
         }
 
         await handler
@@ -103,9 +106,10 @@ internal static class ControlPlaneEventEndpoints
         HttpRequest httpRequest,
         CancellationToken cancellationToken)
     {
-        if (!IsAuthorized(httpRequest, configuration))
+        var authResult = CheckAuthorization(httpRequest, configuration);
+        if (authResult is not null)
         {
-            return Results.Unauthorized();
+            return authResult;
         }
 
         var staleThreshold = options.Value.StaleThreshold > TimeSpan.Zero
@@ -116,26 +120,54 @@ internal static class ControlPlaneEventEndpoints
         return Results.Ok();
     }
 
-    private static bool IsAuthorized(HttpRequest httpRequest, IConfiguration configuration)
+    /// <summary>
+    /// Returns <see langword="null"/> when the request is authorized; otherwise returns an
+    /// <see cref="IResult"/> to return immediately. Fails closed (503) when the token is not
+    /// configured (PA-060) so an unconfigured deployment cannot be invoked unauthenticated.
+    /// </summary>
+    internal static IResult? CheckAuthorization(HttpRequest httpRequest, IConfiguration configuration)
     {
         var expected = configuration["ControlPlane:EventToken"]
             ?? configuration["HONUA_CONTROL_PLANE_EVENT_TOKEN"];
 
-        // No token configured => the surface is reachable only inside the deployment trust boundary
-        // (private VPC, EventBridge-invoked Lambda). When a token IS configured it is required and
-        // compared in fixed time.
+        // No token configured => fail closed (PA-060). Previously this returned true (fail-open),
+        // allowing unauthenticated access on deployments that had not set a token. Now 503 is
+        // returned so operators discover a misconfiguration rather than silently getting no auth.
         if (string.IsNullOrEmpty(expected))
         {
-            return true;
+            return Problem(
+                StatusCodes.Status503ServiceUnavailable,
+                "control_plane_event_token_not_configured",
+                "Control-plane event token is not configured.");
         }
 
-        if (!httpRequest.Headers.TryGetValue(TokenHeader, out var provided) || provided.Count != 1)
+        if (!CloudDemoCredentials.TokenMatches(httpRequest, TokenHeader, expected))
         {
-            return false;
+            var statusCode = CloudDemoCredentials.HasPresentedToken(httpRequest, TokenHeader)
+                ? StatusCodes.Status403Forbidden
+                : StatusCodes.Status401Unauthorized;
+            return Problem(statusCode, "control_plane_event_token_invalid", "A valid control-plane token is required.");
         }
 
-        return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
-            System.Text.Encoding.UTF8.GetBytes(provided.ToString()),
-            System.Text.Encoding.UTF8.GetBytes(expected));
+        return null; // authorized
     }
+
+    private static IResult Problem(int statusCode, string code, string message)
+        => Results.Json(
+            new ControlPlaneEventProblem(code, message),
+            ControlPlaneEventJsonContext.Default.ControlPlaneEventProblem,
+            statusCode: statusCode,
+            contentType: "application/json");
 }
+
+/// <summary>Problem response returned by the control-plane event endpoints.</summary>
+/// <param name="Code">Stable machine-readable error code.</param>
+/// <param name="Message">Human-readable message.</param>
+internal sealed record ControlPlaneEventProblem(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("message")] string Message);
+
+/// <summary>Source-generated JSON context for the control-plane event endpoint payloads (AOT-safe).</summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ControlPlaneEventProblem))]
+internal sealed partial class ControlPlaneEventJsonContext : JsonSerializerContext;

--- a/src/Honua.Server/Properties/AssemblyInfo.cs
+++ b/src/Honua.Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Honua.Server.Tests")]

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/CustomCodeSubmitTests.cs
@@ -90,6 +90,56 @@ public sealed class CustomCodeSubmitTests
     }
 
     // -----------------------------------------------------------------------
+    // Open policy admin gate (PA-196)
+    // -----------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_OpenPolicy_NonAdminPrincipal_Forbidden()
+    {
+        // Open policy accepts any HTTPS repo but must require admin elevation (PA-196) so
+        // the widest-policy execution surface is never reachable from a non-admin caller.
+        var sut = CreateService(options => options.RepoPolicy = CustomCodeRepoPolicy.Open);
+
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        await act.Should().ThrowAsync<GeoprocessingAuthorizationException>()
+            .Where(e => !e.RequiresAuthentication,
+                "a non-admin authenticated caller must be forbidden (403), not unauthenticated (401)");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_OpenPolicy_AdminPrincipal_Allowed()
+    {
+        // An admin caller should be permitted to submit under the Open policy.
+        var sut = CreateService(options => options.RepoPolicy = CustomCodeRepoPolicy.Open);
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, AdminPrincipal(), CustomCodeMetadata());
+
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Security)]
+    [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
+    public async Task SubmitJob_CustomCode_OrgAllowlistPolicy_NonAdminPrincipal_AllowedWhenOnList()
+    {
+        // OrgAllowlist must NOT be affected by the admin gate — only Open requires elevation.
+        var sut = CreateService(options =>
+        {
+            options.RepoPolicy = CustomCodeRepoPolicy.OrgAllowlist;
+            options.RepoAllowlist = ["github.com"];
+        });
+
+        var job = await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), CustomCodeMetadata());
+
+        job.Spec.RuntimeProfile.Should().Be(CustomCodeJobContract.RuntimeProfile);
+    }
+
+    // -----------------------------------------------------------------------
     // repo_url: https + allowlist policy
     // -----------------------------------------------------------------------
 
@@ -112,10 +162,12 @@ public sealed class CustomCodeSubmitTests
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJob_CustomCode_NonHttpsRepo_Rejected()
     {
+        // Use an admin principal so the Open-policy admin gate (PA-196) is satisfied and
+        // the URL scheme check is reached — the non-https rejection must still apply to admins.
         var sut = CreateService(options => options.RepoPolicy = CustomCodeRepoPolicy.Open);
         var metadata = CustomCodeMetadata(repoUrl: "http://github.com/honua-io/example.git");
 
-        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, OwnerPrincipal(), metadata);
+        var act = async () => await sut.SubmitJobAsync(CustomCodePlan(), null, AdminPrincipal(), metadata);
 
         await act.Should().ThrowAsync<Exception>()
             .Where(e => e.Message.Contains("https"));
@@ -759,6 +811,17 @@ public sealed class CustomCodeSubmitTests
                 new Claim(ClaimTypes.Name, "bob"),
                 new Claim(TenantClaimType, "tenant-A"),
                 new Claim(ClaimTypes.Role, "data-editor:parcels")
+            ],
+            "Test"));
+
+    // Admin carries the "admin" role that gates the Open repo policy (PA-196).
+    private static ClaimsPrincipal AdminPrincipal()
+        => new(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, "admin-user"),
+                new Claim(TenantClaimType, "tenant-A"),
+                new Claim(ClaimTypes.Role, "admin"),
+                new Claim("permission", "read:parcels")
             ],
             "Test"));
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneEventAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneEventAuthorizationTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Security tests for the control-plane event endpoint authorization gate (PA-060).
+/// Verifies that the endpoint fails closed (503) when no token is configured, rather
+/// than the prior fail-open behaviour that admitted any caller on unconfigured deployments.
+/// </summary>
+public sealed class ControlPlaneEventAuthorizationTests
+{
+    // ---- Fail-closed when no token is configured (PA-060) -------------------
+
+    [Fact]
+    public void CheckAuthorization_NoTokenConfigured_Returns503()
+    {
+        var request = Request();
+        var config = Configuration(); // no token entries
+
+        var result = ControlPlaneEventEndpoints.CheckAuthorization(request, config);
+
+        result.Should().NotBeNull("an unconfigured deployment must not be accessible");
+        StatusOf(result!).Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public void CheckAuthorization_TokenConfiguredViaControlPlaneKey_AndHeaderAbsent_Returns401()
+    {
+        var request = Request();
+        var config = Configuration("ControlPlane:EventToken", "secret-token");
+
+        var result = ControlPlaneEventEndpoints.CheckAuthorization(request, config);
+
+        result.Should().NotBeNull();
+        StatusOf(result!).Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public void CheckAuthorization_TokenConfiguredViaEnvVar_AndHeaderAbsent_Returns401()
+    {
+        var request = Request();
+        var config = Configuration("HONUA_CONTROL_PLANE_EVENT_TOKEN", "secret-token");
+
+        var result = ControlPlaneEventEndpoints.CheckAuthorization(request, config);
+
+        result.Should().NotBeNull();
+        StatusOf(result!).Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public void CheckAuthorization_TokenConfigured_WrongTokenInHeader_Returns403()
+    {
+        const string correctToken = "correct-secret";
+        var request = Request(token: "wrong-token");
+        var config = Configuration("ControlPlane:EventToken", correctToken);
+
+        var result = ControlPlaneEventEndpoints.CheckAuthorization(request, config);
+
+        result.Should().NotBeNull();
+        StatusOf(result!).Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public void CheckAuthorization_TokenConfigured_CorrectTokenInHeader_ReturnsNull()
+    {
+        const string token = "the-correct-token";
+        var request = Request(token: token);
+        var config = Configuration("ControlPlane:EventToken", token);
+
+        var result = ControlPlaneEventEndpoints.CheckAuthorization(request, config);
+
+        result.Should().BeNull("a correct token must be authorized");
+    }
+
+    [Fact]
+    public void CheckAuthorization_TokenConfigured_CorrectTokenAsBearer_ReturnsNull()
+    {
+        const string token = "the-correct-bearer-token";
+        var request = Request(bearerToken: token);
+        var config = Configuration("ControlPlane:EventToken", token);
+
+        var result = ControlPlaneEventEndpoints.CheckAuthorization(request, config);
+
+        result.Should().BeNull("Bearer authorization header must be accepted alongside the named header");
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static HttpRequest Request(string? token = null, string? bearerToken = null)
+    {
+        var context = new DefaultHttpContext();
+        if (token is not null)
+        {
+            context.Request.Headers[ControlPlaneEventEndpoints.TokenHeader] = token;
+        }
+
+        if (bearerToken is not null)
+        {
+            context.Request.Headers["Authorization"] = $"Bearer {bearerToken}";
+        }
+
+        return context.Request;
+    }
+
+    private static IConfiguration Configuration(string? key = null, string? value = null)
+    {
+        var values = new Dictionary<string, string?>();
+        if (key is not null)
+        {
+            values[key] = value;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    /// <summary>
+    /// Extracts the HTTP status code from an <see cref="IResult"/> by executing it against a
+    /// minimal <see cref="DefaultHttpContext"/> with the services needed by JSON results.
+    /// </summary>
+    private static int StatusOf(IResult result)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptions<JsonOptions>>(Options.Create(new JsonOptions()));
+        services.AddLogging();
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        context.Response.Body = System.IO.Stream.Null;
+        result.ExecuteAsync(context).GetAwaiter().GetResult();
+        return context.Response.StatusCode;
+    }
+}


### PR DESCRIPTION
## Summary

Two security-posture fixes identified in the pre-release audit.

### PA-060 — Control-plane event endpoint fails closed when token unconfigured

`ControlPlaneEventEndpoints.IsAuthorized` previously returned `true` when
`ControlPlane:EventToken` / `HONUA_CONTROL_PLANE_EVENT_TOKEN` was absent, silently
admitting any caller on deployments that had not configured a token (fail-open).

The sibling `ScheduledTickEndpoints` already fails closed (503) in the same
situation. This PR makes `ControlPlaneEventEndpoints` consistent:

- **Unconfigured token → 503** `control_plane_event_token_not_configured` with a
  JSON problem body, so an operator discovers the misconfiguration rather than
  silently getting no authentication.
- Header absent → 401 Unauthorized
- Wrong token presented → 403 Forbidden
- Correct token → authorized (proceed)

Reuses `CloudDemoCredentials.TokenMatches` / `HasPresentedToken` (the same helper
`ScheduledTickEndpoints` uses) and adds an AOT-safe `ControlPlaneEventJsonContext`
mirroring `ScheduledTickJsonContext`. Adds `InternalsVisibleTo(Honua.Server.Tests)`
and unit tests covering all four authorization outcomes.

### PA-196 — CustomCode `Open` policy allows code execution without admin elevation

`CustomCodeRepoPolicy.Open` accepts any HTTPS repository. Any authenticated caller
could previously submit arbitrary code from an unconstrained URL. This PR adds an
admin gate in `CustomCodeJobSubmissionGate.ValidateMintAndInjectAsync`:

- When the effective policy is `Open` and the caller does not hold the `admin`
  role, the submission is rejected with `GeoprocessingAuthorizationException`
  (`requiresAuthentication: false` → **403 Forbidden**) before URL or scope
  validation runs.
- `OrgAllowlist`, `SignedOnly`, and `Disabled` policies are unaffected.

Reuses `principal.IsInRole("admin")` — the same pattern `GeoprocessingJobService`
uses for admin visibility elsewhere. `GeoprocessingAuthorizationException` is the
existing 403-channel exception; all protocol adapters already map it to Forbidden.

## Files changed

| File | Change |
|---|---|
| `src/Honua.Server/Features/ControlPlane/ControlPlaneEventEndpoints.cs` | PA-060: fail-closed 503 + `CheckAuthorization` |
| `src/Honua.Server/Properties/AssemblyInfo.cs` | `InternalsVisibleTo(Honua.Server.Tests)` |
| `src/Honua.Geoprocessing/Features/Geoprocessing/CustomCodeJobSubmissionGate.cs` | PA-196: admin gate on Open policy |
| `tests/.../ControlPlaneEventAuthorizationTests.cs` | PA-060 unit tests (5 cases) |
| `tests/.../CustomCodeSubmitTests.cs` | PA-196 tests (3 new + 1 updated) |

## Test plan

- [x] `dotnet build Honua.sln --configuration Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet format Honua.sln --verify-no-changes` — passes
- [x] All 9 new security tests pass (5 PA-060, 4 PA-196)
- [x] Full `Tier=Fast` suite: 2341 passed, 0 failed