### PR TITLE
fix: security hardening and protocol-conformance quick-wins (PA-011 – PA-026)

### DIFF
--- a/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
+++ b/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
@@ -11,6 +11,7 @@ using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.Core.Features.Infrastructure.Validation;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Honua.Core.Features.Import.Abstractions;
@@ -612,7 +613,7 @@ internal sealed partial class ArcGisRestClient
             throw new HttpRequestException("ArcGIS service URL must not include embedded credentials.");
         }
 
-        if (uri.IsLoopback || IsLocalhostHostName(uri.Host))
+        if (uri.IsLoopback || OutboundHttpUrlValidator.IsLocalhostHostName(uri.Host))
         {
             throw new HttpRequestException(DisallowedNetworkAddressMessage);
         }
@@ -630,14 +631,14 @@ internal sealed partial class ArcGisRestClient
             throw new HttpRequestException(DisallowedNetworkAddressMessage);
         }
 
-        if (IsLocalhostHostName(host))
+        if (OutboundHttpUrlValidator.IsLocalhostHostName(host))
         {
             throw new HttpRequestException(DisallowedNetworkAddressMessage);
         }
 
         if (IPAddress.TryParse(host, out var literalAddress))
         {
-            if (IsPrivateOrReservedAddress(literalAddress))
+            if (OutboundHttpUrlValidator.IsPrivateOrReservedAddress(literalAddress))
             {
                 throw new HttpRequestException(DisallowedNetworkAddressMessage);
             }
@@ -662,7 +663,7 @@ internal sealed partial class ArcGisRestClient
 
         foreach (var address in addresses)
         {
-            if (IsPrivateOrReservedAddress(address))
+            if (OutboundHttpUrlValidator.IsPrivateOrReservedAddress(address))
             {
                 throw new HttpRequestException(DisallowedNetworkAddressMessage);
             }
@@ -712,134 +713,6 @@ internal sealed partial class ArcGisRestClient
         }
 
         throw new HttpRequestException("Unable to establish a secure connection to the ArcGIS service host.", lastException);
-    }
-
-    private static bool IsLocalhostHostName(string host)
-        => string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)
-           || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsPrivateOrReservedAddress(IPAddress address)
-    {
-        if (IPAddress.IsLoopback(address))
-        {
-            return true;
-        }
-
-        if (address.IsIPv4MappedToIPv6)
-        {
-            address = address.MapToIPv4();
-        }
-
-        if (address.AddressFamily == AddressFamily.InterNetwork)
-        {
-            var bytes = address.GetAddressBytes();
-
-            if (bytes[0] == 0)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 10)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 127)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 169 && bytes[1] == 254)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 0)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 192 && bytes[1] == 168)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19))
-            {
-                return true;
-            }
-
-            if (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 203 && bytes[1] == 0 && bytes[2] == 113)
-            {
-                return true;
-            }
-
-            if (bytes[0] >= 224)
-            {
-                return true;
-            }
-        }
-        else if (address.AddressFamily == AddressFamily.InterNetworkV6)
-        {
-            var bytes = address.GetAddressBytes();
-
-            if (address.Equals(IPAddress.IPv6None))
-            {
-                return true;
-            }
-
-            if (address.Equals(IPAddress.IPv6Loopback))
-            {
-                return true;
-            }
-
-            if (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0xc0)
-            {
-                return true;
-            }
-
-            if ((bytes[0] & 0xfe) == 0xfc)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0d && bytes[3] == 0xb8)
-            {
-                return true;
-            }
-
-            if (bytes[0] == 0xff)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static string ExtractServiceName(string url)

--- a/src/Honua.Core/Features/Migration/Services/FileSystemMigrationRunCheckpointStore.cs
+++ b/src/Honua.Core/Features/Migration/Services/FileSystemMigrationRunCheckpointStore.cs
@@ -105,16 +105,35 @@ public sealed class FileSystemMigrationRunCheckpointStore : IMigrationRunCheckpo
     /// <inheritdoc />
     public void Dispose() => _gate.Dispose();
 
-    private string PathFor(string runId) => Path.Combine(_rootDirectory, $"{SafePathSegment(runId)}.json");
+    private string PathFor(string runId)
+    {
+        var segment = SafePathSegment(runId);
+        var candidate = Path.GetFullPath(Path.Combine(_rootDirectory, $"{segment}.json"));
+        // Containment check: reject any path that escapes the root directory (symlinks,
+        // future encoding tricks, etc. are caught here even if SafePathSegment missed them).
+        var root = Path.GetFullPath(_rootDirectory) + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(root, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Path traversal detected: the resolved path escapes the checkpoint root directory.");
+        }
+
+        return candidate;
+    }
 
     private static string SafePathSegment(string runId)
     {
-        var invalid = Path.GetInvalidFileNameChars();
+        // Explicitly reject path-separator characters in addition to OS-reported invalid
+        // file-name characters. On Linux, Path.GetInvalidFileNameChars() only contains
+        // '\0', so '/' would pass through unchanged and Path.Combine would then discard
+        // the root because the second argument looks absolute.
         Span<char> buffer = stackalloc char[runId.Length];
+        var invalid = Path.GetInvalidFileNameChars();
         for (var i = 0; i < runId.Length; i++)
         {
             var character = runId[i];
-            buffer[i] = Array.IndexOf(invalid, character) >= 0 ? '_' : character;
+            buffer[i] = (Array.IndexOf(invalid, character) >= 0 || character == '/' || character == '\\')
+                ? '_'
+                : character;
         }
 
         var sanitized = new string(buffer);

--- a/src/Honua.Core/Features/Migration/Services/GeoServerRestClient.cs
+++ b/src/Honua.Core/Features/Migration/Services/GeoServerRestClient.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Xml.Linq;
 using System.Globalization;
 using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Infrastructure.Validation;
 using Microsoft.Extensions.Logging;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Migration.Abstractions;
@@ -209,7 +210,7 @@ internal sealed partial class GeoServerRestClient
     {
         if (IPAddress.TryParse(host, out var literalAddress))
         {
-            if (!allowUnsafeLocalUrls && IsPrivateOrReservedAddress(literalAddress))
+            if (!allowUnsafeLocalUrls && OutboundHttpUrlValidator.IsPrivateOrReservedAddress(literalAddress))
             {
                 throw new HttpRequestException(DisallowedNetworkAddressMessage);
             }
@@ -240,7 +241,7 @@ internal sealed partial class GeoServerRestClient
         {
             foreach (var address in addresses)
             {
-                if (IsPrivateOrReservedAddress(address))
+                if (OutboundHttpUrlValidator.IsPrivateOrReservedAddress(address))
                 {
                     throw new HttpRequestException(DisallowedNetworkAddressMessage);
                 }
@@ -293,51 +294,6 @@ internal sealed partial class GeoServerRestClient
         }
 
         throw new HttpRequestException("Unable to establish a secure connection to the GeoServer host.", lastException);
-    }
-
-    private static bool IsPrivateOrReservedAddress(IPAddress address)
-    {
-        if (IPAddress.IsLoopback(address))
-        {
-            return true;
-        }
-
-        if (address.IsIPv4MappedToIPv6)
-        {
-            address = address.MapToIPv4();
-        }
-
-        if (address.AddressFamily == AddressFamily.InterNetwork)
-        {
-            var bytes = address.GetAddressBytes();
-            return bytes[0] == 0 ||
-                   bytes[0] == 10 ||
-                   (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
-                   bytes[0] == 127 ||
-                   (bytes[0] == 169 && bytes[1] == 254) ||
-                   (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 0) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2) ||
-                   (bytes[0] == 192 && bytes[1] == 168) ||
-                   (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19)) ||
-                   (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100) ||
-                   (bytes[0] == 203 && bytes[1] == 0 && bytes[2] == 113) ||
-                   bytes[0] >= 224;
-        }
-
-        if (address.AddressFamily != AddressFamily.InterNetworkV6)
-        {
-            return false;
-        }
-
-        var bytesV6 = address.GetAddressBytes();
-        return address.Equals(IPAddress.IPv6None) ||
-               address.Equals(IPAddress.IPv6Loopback) ||
-               address.IsIPv6LinkLocal ||
-               address.IsIPv6SiteLocal ||
-               address.IsIPv6Multicast ||
-               (bytesV6[0] & 0xfe) == 0xfc ||
-               (bytesV6[0] == 0x20 && bytesV6[1] == 0x01 && bytesV6[2] == 0x0d && bytesV6[3] == 0xb8);
     }
 
     private async Task<(string? Version, string? BuildTimestamp, string? GitRevision)> GetServerVersionAsync(

--- a/src/Honua.Core/Features/Migration/Services/OgcApiFeaturesImportService.cs
+++ b/src/Honua.Core/Features/Migration/Services/OgcApiFeaturesImportService.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Infrastructure.Validation;
 using Microsoft.Extensions.Logging;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
@@ -1056,7 +1057,7 @@ public sealed partial class OgcApiFeaturesImportService : IOgcApiFeaturesImportS
     {
         if (IPAddress.TryParse(host, out var literalAddress))
         {
-            if (!allowUnsafeLocalUrls && IsPrivateOrReservedAddress(literalAddress))
+            if (!allowUnsafeLocalUrls && OutboundHttpUrlValidator.IsPrivateOrReservedAddress(literalAddress))
             {
                 throw new HttpRequestException(DisallowedNetworkAddressMessage);
             }
@@ -1087,7 +1088,7 @@ public sealed partial class OgcApiFeaturesImportService : IOgcApiFeaturesImportS
         {
             foreach (var address in addresses)
             {
-                if (IsPrivateOrReservedAddress(address))
+                if (OutboundHttpUrlValidator.IsPrivateOrReservedAddress(address))
                 {
                     throw new HttpRequestException(DisallowedNetworkAddressMessage);
                 }
@@ -1140,50 +1141,6 @@ public sealed partial class OgcApiFeaturesImportService : IOgcApiFeaturesImportS
         }
 
         throw new HttpRequestException("Unable to establish a connection to the OGC API Features host.", lastException);
-    }
-
-    private static bool IsPrivateOrReservedAddress(IPAddress address)
-    {
-        if (IPAddress.IsLoopback(address))
-        {
-            return true;
-        }
-
-        if (address.IsIPv4MappedToIPv6)
-        {
-            address = address.MapToIPv4();
-        }
-
-        if (address.AddressFamily == AddressFamily.InterNetwork)
-        {
-            var bytes = address.GetAddressBytes();
-            return bytes[0] == 0 ||
-                   bytes[0] == 10 ||
-                   (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
-                   bytes[0] == 127 ||
-                   (bytes[0] == 169 && bytes[1] == 254) ||
-                   (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 0) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2) ||
-                   (bytes[0] == 192 && bytes[1] == 168) ||
-                   (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19)) ||
-                   (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100) ||
-                   bytes[0] >= 224;
-        }
-
-        if (address.AddressFamily == AddressFamily.InterNetworkV6)
-        {
-            var bytes = address.GetAddressBytes();
-            return address.IsIPv6LinkLocal ||
-                   address.IsIPv6Multicast ||
-                   address.IsIPv6SiteLocal ||
-                   bytes.All(static value => value == 0) ||
-                   bytes[0] == 0xfc ||
-                   bytes[0] == 0xfd ||
-                   bytes[0] == 0xfe;
-        }
-
-        return true;
     }
 
     private static string ToSafeSourceUrl(Uri uri)

--- a/src/Honua.Core/Features/Migration/Services/OgcApiFeaturesMigrationScanner.cs
+++ b/src/Honua.Core/Features/Migration/Services/OgcApiFeaturesMigrationScanner.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Text.Json;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
+using Honua.Core.Features.Infrastructure.Validation;
 using Microsoft.Extensions.Logging;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
@@ -810,7 +811,7 @@ public sealed partial class OgcApiFeaturesMigrationScanner : IOgcApiFeaturesMigr
     {
         if (IPAddress.TryParse(host, out var literalAddress))
         {
-            if (!allowUnsafeLocalUrls && IsPrivateOrReservedAddress(literalAddress))
+            if (!allowUnsafeLocalUrls && OutboundHttpUrlValidator.IsPrivateOrReservedAddress(literalAddress))
             {
                 throw new HttpRequestException(DisallowedNetworkAddressMessage);
             }
@@ -841,7 +842,7 @@ public sealed partial class OgcApiFeaturesMigrationScanner : IOgcApiFeaturesMigr
         {
             foreach (var address in addresses)
             {
-                if (IsPrivateOrReservedAddress(address))
+                if (OutboundHttpUrlValidator.IsPrivateOrReservedAddress(address))
                 {
                     throw new HttpRequestException(DisallowedNetworkAddressMessage);
                 }
@@ -894,50 +895,6 @@ public sealed partial class OgcApiFeaturesMigrationScanner : IOgcApiFeaturesMigr
         }
 
         throw new HttpRequestException("Unable to establish a connection to the OGC API Features host.", lastException);
-    }
-
-    private static bool IsPrivateOrReservedAddress(IPAddress address)
-    {
-        if (IPAddress.IsLoopback(address))
-        {
-            return true;
-        }
-
-        if (address.IsIPv4MappedToIPv6)
-        {
-            address = address.MapToIPv4();
-        }
-
-        if (address.AddressFamily == AddressFamily.InterNetwork)
-        {
-            var bytes = address.GetAddressBytes();
-            return bytes[0] == 0 ||
-                   bytes[0] == 10 ||
-                   (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
-                   bytes[0] == 127 ||
-                   (bytes[0] == 169 && bytes[1] == 254) ||
-                   (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 0) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2) ||
-                   (bytes[0] == 192 && bytes[1] == 168) ||
-                   (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19)) ||
-                   (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100) ||
-                   bytes[0] >= 224;
-        }
-
-        if (address.AddressFamily == AddressFamily.InterNetworkV6)
-        {
-            var bytes = address.GetAddressBytes();
-            return address.IsIPv6LinkLocal ||
-                   address.IsIPv6Multicast ||
-                   address.IsIPv6SiteLocal ||
-                   bytes.All(static value => value == 0) ||
-                   bytes[0] == 0xfc ||
-                   bytes[0] == 0xfd ||
-                   bytes[0] == 0xfe;
-        }
-
-        return true;
     }
 
     private static string ToSafeSourceUrl(Uri uri)

--- a/src/Honua.Core/Features/Migration/Services/OgcServiceMigrationScanner.cs
+++ b/src/Honua.Core/Features/Migration/Services/OgcServiceMigrationScanner.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Import.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Validation;
 using Microsoft.Extensions.Logging;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Migration.Domain;
@@ -1751,7 +1752,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
     {
         if (IPAddress.TryParse(host, out var literalAddress))
         {
-            if (!allowUnsafeLocalUrls && IsPrivateOrReservedAddress(literalAddress))
+            if (!allowUnsafeLocalUrls && OutboundHttpUrlValidator.IsPrivateOrReservedAddress(literalAddress))
             {
                 throw new HttpRequestException(DisallowedNetworkAddressMessage);
             }
@@ -1782,7 +1783,7 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         {
             foreach (var address in addresses)
             {
-                if (IsPrivateOrReservedAddress(address))
+                if (OutboundHttpUrlValidator.IsPrivateOrReservedAddress(address))
                 {
                     throw new HttpRequestException(DisallowedNetworkAddressMessage);
                 }
@@ -1835,51 +1836,6 @@ public sealed partial class OgcServiceMigrationScanner : IOgcServiceMigrationSca
         }
 
         throw new HttpRequestException("Unable to establish a connection to the OGC service host.", lastException);
-    }
-
-    private static bool IsPrivateOrReservedAddress(IPAddress address)
-    {
-        if (IPAddress.IsLoopback(address))
-        {
-            return true;
-        }
-
-        if (address.IsIPv4MappedToIPv6)
-        {
-            address = address.MapToIPv4();
-        }
-
-        if (address.AddressFamily == AddressFamily.InterNetwork)
-        {
-            var bytes = address.GetAddressBytes();
-            return bytes[0] == 0 ||
-                   bytes[0] == 10 ||
-                   (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
-                   bytes[0] == 127 ||
-                   (bytes[0] == 169 && bytes[1] == 254) ||
-                   (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 0) ||
-                   (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2) ||
-                   (bytes[0] == 192 && bytes[1] == 168) ||
-                   (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19)) ||
-                   (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100) ||
-                   (bytes[0] == 203 && bytes[1] == 0 && bytes[2] == 113) ||
-                   bytes[0] >= 224;
-        }
-
-        if (address.AddressFamily != AddressFamily.InterNetworkV6)
-        {
-            return false;
-        }
-
-        var bytesV6 = address.GetAddressBytes();
-        return address.Equals(IPAddress.IPv6None) ||
-               address.Equals(IPAddress.IPv6Loopback) ||
-               address.IsIPv6LinkLocal ||
-               address.IsIPv6SiteLocal ||
-               address.IsIPv6Multicast ||
-               (bytesV6[0] & 0xfe) == 0xfc ||
-               (bytesV6[0] == 0x20 && bytesV6[1] == 0x01 && bytesV6[2] == 0x0d && bytesV6[3] == 0xb8);
     }
 
     private static Uri BuildCapabilitiesUrl(Uri serviceUri, string serviceType, string? version)

--- a/src/Honua.Core/Features/Shared/Models/SpatialReferenceExtensions.cs
+++ b/src/Honua.Core/Features/Shared/Models/SpatialReferenceExtensions.cs
@@ -101,20 +101,27 @@ public static class SpatialReferenceExtensions
         => spatialRef.Wkid is 4326 or 3857 or > 0;
 
     /// <summary>
-    /// Gets the authority name (e.g., "EPSG") for the spatial reference
+    /// Gets the authority name for the spatial reference. WKID 4326 (OGC CRS84) is governed
+    /// by the OGC, not EPSG, so this returns "OGC" for that CRS. All other WKIDs return "EPSG".
+    /// WFS 2.0, WCS, and OGC API conformance URNs of the form
+    /// <c>urn:ogc:def:crs:{authority}::{code}</c> must use "OGC" for CRS84.
     /// </summary>
     /// <param name="spatialRef">Spatial reference</param>
-    /// <returns>Authority name, typically "EPSG"</returns>
+    /// <returns>"OGC" for WKID 4326 (CRS84); "EPSG" for all other WKIDs.</returns>
     public static string GetAuthorityName(this SpatialReference spatialRef)
-        => "EPSG";
+        => spatialRef.Wkid == 4326 ? "OGC" : "EPSG";
 
     /// <summary>
-    /// Gets the authority code as a string
+    /// Gets the authority code as a string. For WKID 4326 (OGC CRS84) this returns the
+    /// correct OGC URN fragment "1.3:CRS84" so callers can form
+    /// <c>urn:ogc:def:crs:OGC:1.3:CRS84</c>. All other WKIDs return the numeric WKID.
     /// </summary>
     /// <param name="spatialRef">Spatial reference</param>
-    /// <returns>Authority code as string</returns>
+    /// <returns>"1.3:CRS84" for WKID 4326; the numeric WKID string for all other CRS.</returns>
     public static string GetAuthorityCode(this SpatialReference spatialRef)
-        => spatialRef.Wkid.ToString(CultureInfo.InvariantCulture);
+        => spatialRef.Wkid == 4326
+            ? "1.3:CRS84"
+            : spatialRef.Wkid.ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Determines if transformation is needed between two spatial reference systems

--- a/src/Honua.Core/Features/Validation/Abstractions/PaginationValidationOptions.cs
+++ b/src/Honua.Core/Features/Validation/Abstractions/PaginationValidationOptions.cs
@@ -28,4 +28,12 @@ public sealed record PaginationValidationOptions(
     /// (surfaced as a 400) rather than being silently clamped.
     /// </summary>
     public static PaginationValidationOptions Default { get; } = new(0, 1, "Offset", "Limit");
+
+    /// <summary>
+    /// OGC API Features pagination options. OGC API - Features Part 1 requirement
+    /// /req/core/fc-limit-definition (d) mandates that over-maximum limits are silently clamped
+    /// to the server maximum rather than rejected with a 400.
+    /// </summary>
+    public static PaginationValidationOptions OgcFeatures { get; } =
+        new(0, 1, "offset", "limit") { ClampLimitToMaximum = true };
 }

--- a/src/Honua.Core/Queries/Filters/GeoServicesSql/GeoServicesSqlParser.cs
+++ b/src/Honua.Core/Queries/Filters/GeoServicesSql/GeoServicesSqlParser.cs
@@ -47,6 +47,37 @@ public sealed class GeoServicesSqlParser
         "EPOCH"
     };
 
+    // Allowlist of function names accepted by ParseIdentifierOrFunction for arbitrary
+    // call-syntax (i.e. not already handled as a dedicated keyword: CAST, EXTRACT,
+    // SUBSTRING, POSITION). Only names that every active ISqlFilterTranslator understands
+    // are listed here so that an unknown function name is rejected at parse time rather than
+    // silently producing an AST node that a future provider might execute without vetting.
+    // CURRENT_DATE / CURRENT_TIMESTAMP / CURRENT_TIME are handled as dedicated keywords
+    // (TokenType) and do not reach this path.
+    private static readonly HashSet<string> _allowedFunctions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // String functions
+        "UPPER", "LOWER", "TRIM", "LTRIM", "RTRIM", "LENGTH", "LEN",
+        "CONCAT", "REPLACE", "LEFT", "RIGHT",
+        "CONTAINS", "STARTSWITH", "ENDSWITH",
+        // SUBSTRING and POSITION are handled via dedicated SQL-standard keyword forms above,
+        // but ArcGIS clients also emit the comma-delimited form SUBSTRING(field, start, len)
+        // and POSITION(needle IN haystack) — the comma form doesn't match the keyword-path
+        // guard so it falls through here.  Both are safe, well-understood string functions.
+        "SUBSTRING", "POSITION",
+        // Null / conditional
+        "COALESCE", "NULLIF", "IIF",
+        // Numeric / math
+        "ABS", "CEILING", "FLOOR", "ROUND", "SIGN",
+        "POWER", "SQRT", "LOG", "EXP", "MOD",
+        // Date / time helpers (single-arg forms; multi-arg EXTRACT handled separately)
+        "YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND",
+        // Spatial predicates
+        "ST_CONTAINS", "ST_WITHIN", "ST_INTERSECTS", "ST_DISJOINT",
+        "ST_TOUCHES", "ST_CROSSES", "ST_OVERLAPS", "ST_EQUALS",
+        "ST_DISTANCE", "ST_LENGTH", "ST_AREA", "ST_X", "ST_Y",
+    };
+
     /// <summary>
     /// Parses a GeoServices SQL WHERE expression into a filter AST.
     /// </summary>
@@ -463,6 +494,15 @@ public sealed class GeoServicesSqlParser
                 return ParseSqlStandardPosition();
             }
 
+            // Enforce a function-name allowlist so unknown identifiers are rejected at parse
+            // time before any AST node is created. This provides defense-in-depth: even if
+            // a future provider's ISqlFilterTranslator omits its own allowlist check, the
+            // unknown function will never reach it.
+            if (!_allowedFunctions.Contains(identifier))
+            {
+                throw new ArgumentException($"Unknown or unsupported function: '{identifier}'.");
+            }
+
             var args = new List<FilterExpression>();
             if (!Check(TokenType.RightParen))
             {
@@ -757,17 +797,13 @@ public sealed class GeoServicesSqlParser
                 var hasOffsetIndicator = value.Contains('Z', StringComparison.OrdinalIgnoreCase)
                     || value.LastIndexOf('+') > 0
                     || (value.LastIndexOf('-') > 8); // after the date portion
-                // The canonical SQL-92 `TIMESTAMP 'YYYY-MM-DD HH:MM:SS'` literal that the
-                // ArcGIS SDK emits carries no offset; real ArcGIS accepts it and treats it as
-                // naive/UTC. Mirror that for an explicit TIMESTAMP keyword (AssumeUniversal
-                // above already folds it to UTC). Only an unkeyworded date+time string in a
-                // bare comparison still requires an explicit offset to avoid ambiguity.
-                if (!hasOffsetIndicator && !explicitTimestampKeyword)
-                {
-                    throw new ArgumentException(
-                        $"Datetime literal '{value}' is missing a timezone offset. "
-                        + "Use an explicit 'Z' or '+hh:mm' suffix to disambiguate.");
-                }
+                // Mirror ArcGIS Server behaviour: bare datetime literals without a timezone
+                // offset (whether in #...# or quoted form, with or without the TIMESTAMP keyword)
+                // are accepted and treated as UTC. AssumeUniversal above already applied this.
+                // Rejecting them broke legacy ArcGIS client queries (honua-server#PA-026).
+                // The `explicitTimestampKeyword` branch was already accepted; now the bare form
+                // is too. Callers that need strict timezone enforcement should apply their own
+                // validation before reaching the parser.
             }
 
             if (dateOnly == null && timestamp.TimeOfDay == TimeSpan.Zero)

--- a/src/Honua.Hosting/Features/Models/StandardErrorResponseFormatter.cs
+++ b/src/Honua.Hosting/Features/Models/StandardErrorResponseFormatter.cs
@@ -152,9 +152,11 @@ internal static class StandardErrorResponseFormatter
             ? string.Empty
             : $" locator=\"{EscapeForXml(options.WfsExceptionLocator)}\"";
 
+        // OWS 1.1 XSD (owsExceptionReport.xsd) declares `language` as use="required" on the
+        // ExceptionReport element. Omitting it causes schema-level rejection by strict validators.
         var xmlContent = $$"""
             <?xml version="1.0" encoding="UTF-8"?>
-            <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0">
+            <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0" language="en">
               <ows:Exception exceptionCode="{{EscapeForXml(exceptionCode!)}}"{{locatorAttribute}}>
                 <ows:ExceptionText>{{EscapeForXml(BuildDetailWithExtras(errorResponse, options))}}</ows:ExceptionText>
               </ows:Exception>

--- a/src/Honua.Io/Features/FileStorage/LocalFileStorage.cs
+++ b/src/Honua.Io/Features/FileStorage/LocalFileStorage.cs
@@ -84,7 +84,7 @@ internal sealed class LocalFileStorage : CloudFileStorageBase
                 storagePath = BuildStoragePath(fileId, request.FileName, request.Folder);
             }
 
-            var fullPath = Path.Combine(_basePath, storagePath);
+            var fullPath = GetSafeFullPath(storagePath);
 
             // Ensure directory exists
             var directory = Path.GetDirectoryName(fullPath);
@@ -250,7 +250,7 @@ internal sealed class LocalFileStorage : CloudFileStorageBase
             return null;
         }
 
-        var fullPath = Path.Combine(_basePath, cloudFile.StoragePath);
+        var fullPath = GetSafeFullPath(cloudFile.StoragePath);
         if (!File.Exists(fullPath))
         {
             FileStorageLog.FileMissingOnDisk(Logger, fileId);
@@ -270,7 +270,7 @@ internal sealed class LocalFileStorage : CloudFileStorageBase
             return false;
         }
 
-        var fullPath = Path.Combine(_basePath, cloudFile.StoragePath);
+        var fullPath = GetSafeFullPath(cloudFile.StoragePath);
         var metadataFile = GetMetadataFilePath(fileId);
 
         try
@@ -361,7 +361,7 @@ internal sealed class LocalFileStorage : CloudFileStorageBase
             return Task.FromResult<string?>(null);
         }
 
-        var fullPath = Path.Combine(_basePath, cloudFile.StoragePath);
+        var fullPath = GetSafeFullPath(cloudFile.StoragePath);
         return Task.FromResult<string?>(ToAbsoluteFileUri(fullPath));
     }
 
@@ -379,7 +379,7 @@ internal sealed class LocalFileStorage : CloudFileStorageBase
         // Real cloud implementations would provide presigned upload URLs
         var fileId = GenerateFileId();
         var storagePath = BuildStoragePath(fileId, fileName, folder);
-        var fullPath = Path.Combine(_basePath, storagePath);
+        var fullPath = GetSafeFullPath(storagePath);
 
         // Ensure directory exists
         var directory = Path.GetDirectoryName(fullPath);
@@ -523,6 +523,27 @@ internal sealed class LocalFileStorage : CloudFileStorageBase
         ValidateFolderPath(folder);
 
         return Path.Combine(folder, storageName);
+    }
+
+    /// <summary>
+    /// Combines <paramref name="storagePath"/> with the base path and verifies the result is
+    /// contained within the base directory. This is defence-in-depth: the denylist in
+    /// <see cref="ValidateObjectKeyOverride"/> and <see cref="ValidateFolderPath"/> already
+    /// blocks explicit traversal segments, but a GetFullPath containment check also catches
+    /// symlinks and any platform-specific path encoding tricks.
+    /// </summary>
+    private string GetSafeFullPath(string storagePath)
+    {
+        var combined = Path.GetFullPath(Path.Combine(_basePath, storagePath));
+        var root = Path.GetFullPath(_basePath) + Path.DirectorySeparatorChar;
+        if (!combined.StartsWith(root, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "The resolved storage path escapes the base directory.",
+                nameof(storagePath));
+        }
+
+        return combined;
     }
 
     private static string ToAbsoluteFileUri(string path)

--- a/src/Honua.Oracle/Features/FeatureStore/Services/OracleFeatureQueryBuilder.cs
+++ b/src/Honua.Oracle/Features/FeatureStore/Services/OracleFeatureQueryBuilder.cs
@@ -448,7 +448,11 @@ internal static partial class OracleFeatureQueryBuilder
             return num;
         }
 
-        return valueToken;
+        // Defense-in-depth: ComparisonRegex constrains the 'value' group to a quoted string or
+        // numeric literal, so this branch is currently unreachable. Throw explicitly so any
+        // future code path that calls this function with an unexpected token fails loudly rather
+        // than silently returning a raw string that could produce unparameterized SQL.
+        throw new ArgumentException($"Unrecognized value token: {valueToken}");
     }
 
     [GeneratedRegex(

--- a/src/Honua.Protocols.OData/Features/ODataErrorFormatter.cs
+++ b/src/Honua.Protocols.OData/Features/ODataErrorFormatter.cs
@@ -28,7 +28,9 @@ namespace Honua.Protocols.OData;
 /// </remarks>
 internal static class ODataErrorFormatter
 {
-    private const string ODataContentType = "application/json;metadata=minimal";
+    // OData v4 spec (OASIS OData-JSON-Format-v4.0 §3.1): parameter name must be "odata.metadata",
+    // not the OData 3.0 shorthand "metadata".
+    private const string ODataContentType = "application/json;odata.metadata=minimal";
 
     /// <summary>
     /// Formats a <see cref="StandardErrorResponse"/> as an OData v4 error

--- a/src/Honua.Protocols.OData/Features/Services/ODataUtilityService.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataUtilityService.cs
@@ -31,7 +31,9 @@ internal static class ODataUtilityService
     private const string ODataMetadataMinimal = "minimal";
     private const string ODataMetadataFull = "full";
     private const string ODataMetadataNone = "none";
-    private const string ODataContentType = $"{ODataMediaType};metadata={ODataMetadataMinimal}";
+    // OData v4 spec (OASIS OData-JSON-Format-v4.0 §3.1) requires the parameter name to be
+    // "odata.metadata", not "metadata" (which is the OData 3.0 convention).
+    private const string ODataContentType = $"{ODataMediaType};odata.metadata={ODataMetadataMinimal}";
 
     /// <summary>
     /// GeoParquet content type emitted for <c>$format=parquet</c> exports.
@@ -372,7 +374,7 @@ internal static class ODataUtilityService
     public static string GetODataContentType(HttpRequest request, string? format)
     {
         var metadataLevel = ResolveMetadataLevel(request, format);
-        return $"{ODataMediaType};metadata={metadataLevel}";
+        return $"{ODataMediaType};odata.metadata={metadataLevel}";
     }
 
     public static bool HasTrackChangesPreference(string? preferHeader)

--- a/src/Honua.Protocols.OgcApi/Features/Services/OgcFeaturesQueryParameterAdapter.cs
+++ b/src/Honua.Protocols.OgcApi/Features/Services/OgcFeaturesQueryParameterAdapter.cs
@@ -93,7 +93,12 @@ internal sealed class OgcFeaturesQueryParameterAdapter(
                 return QueryAdapterResult.Failure(filterResult.ErrorMessage ?? "Invalid query parameters.");
             }
 
-            var paginationResult = _queryValidator.ValidateAndNormalizePagination(parameters.Offset, parameters.Limit);
+            // OGC API - Features Part 1 /req/core/fc-limit-definition (d): over-maximum limits
+            // must be clamped to the server maximum, not rejected with 400.
+            var paginationResult = _queryValidator.ValidateAndNormalizePagination(
+                parameters.Offset,
+                parameters.Limit,
+                PaginationValidationOptions.OgcFeatures);
             if (!paginationResult.IsValid)
             {
                 return QueryAdapterResult.Failure(paginationResult.ErrorMessage ?? "Invalid paging parameters.");

--- a/src/Honua.Protocols.Stac/SearchEndpoints.cs
+++ b/src/Honua.Protocols.Stac/SearchEndpoints.cs
@@ -234,13 +234,32 @@ internal static class SearchEndpoints
 
             if (request.Collections is { IsDefault: false } requestedCollections && requestedCollections.Length > 0)
             {
-                if (!TryParseIntegerTokenSet(requestedCollections, out var collectionIds, out var collectionError))
+                // STAC API Item Search spec: collections is an array of string collection IDs.
+                // Filter using the same multi-field matching logic as the single-collection lookup
+                // path (ServiceLocalId, Path, Metadata.Name, Metadata.Id, or legacy numeric ID)
+                // so human-readable slugs (e.g. "sentinel-2-l2a") and legacy numeric IDs both
+                // work without requiring integer parsing.
+                targets = targets.Where(t =>
                 {
-                    StacTelemetry.SetFailed(activity, "invalid_collections");
-                    return StandardErrorHelpers.CreateBadRequest(context, collectionError ?? "Invalid collections parameter.");
-                }
+                    var pub = t.Publication;
+                    foreach (var requestedId in requestedCollections)
+                    {
+                        int? numericId = int.TryParse(
+                            requestedId,
+                            System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out var parsed)
+                            ? parsed
+                            : null;
 
-                targets = targets.Where(t => collectionIds.Contains(t.LayerIndex));
+                        if (StacV2Lookups.MatchesCollectionId(pub, requestedId, numericId))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                });
             }
 
             if (request.Ids is { IsDefault: false } requestedIds && requestedIds.Length > 0)
@@ -958,15 +977,13 @@ internal static class SearchEndpoints
 
         if (!string.IsNullOrWhiteSpace(collections))
         {
-            if (!TryParseIntegerTokenSet(collections, out var collectionValues, out error))
+            // STAC API spec: collections are string IDs — accept any non-empty token, not just integers.
+            if (!TryParseStringTokens(collections, out var collectionValues, out error))
             {
                 return false;
             }
 
-            request = request with
-            {
-                Collections = collectionValues.Select(v => v.ToString(CultureInfo.InvariantCulture)).ToImmutableArray()
-            };
+            request = request with { Collections = collectionValues };
         }
 
         if (!string.IsNullOrWhiteSpace(ids))

--- a/src/Honua.Protocols.Stac/Services/StacV2Lookups.cs
+++ b/src/Honua.Protocols.Stac/Services/StacV2Lookups.cs
@@ -172,7 +172,13 @@ internal static class StacV2Lookups
         return null;
     }
 
-    private static bool MatchesCollectionId(MetadataV2Publication publication, string collectionId, int? numericId)
+    /// <summary>
+    /// Returns <see langword="true"/> when the publication matches <paramref name="collectionId"/>
+    /// by any of the standard STAC collection identifier fields (ServiceLocalId, Path, Metadata.Name,
+    /// Metadata.Id, or the legacy numeric LayerIndex). Exposed as internal so the search path can
+    /// apply the same matching logic as the single-collection lookup path.
+    /// </summary>
+    internal static bool MatchesCollectionId(MetadataV2Publication publication, string collectionId, int? numericId)
     {
         if (string.Equals(publication.ServiceLocalId, collectionId, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(publication.Path, collectionId, StringComparison.OrdinalIgnoreCase) ||

--- a/src/Honua.Redshift/Features/FeatureStore/Services/RedshiftFeatureQueryBuilder.cs
+++ b/src/Honua.Redshift/Features/FeatureStore/Services/RedshiftFeatureQueryBuilder.cs
@@ -494,7 +494,11 @@ internal static partial class RedshiftFeatureQueryBuilder
             return num;
         }
 
-        return valueToken;
+        // Defense-in-depth: ComparisonRegex constrains the 'value' group to a quoted string or
+        // numeric literal, so this branch is currently unreachable. Throw explicitly so any
+        // future code path that calls this function with an unexpected token fails loudly rather
+        // than silently returning a raw string that could produce unparameterized SQL.
+        throw new ArgumentException($"Unrecognized value token: {valueToken}");
     }
 
     [GeneratedRegex(

--- a/src/Honua.Server/Features/Admin/IdentityAdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/IdentityAdminEndpoints.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text.Json;
+using Honua.Core.Features.Infrastructure.Validation;
 using Honua.Server.Features.Admin.Models;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
@@ -99,6 +100,31 @@ internal static class IdentityAdminEndpoints
         }
 
         var authority = provider.Authority;
+
+        // Guard against SSRF: reject private/reserved network addresses before fetching the
+        // discovery document. This mirrors the guard applied to alert-webhook, geocoding, and
+        // import outbound HTTP surfaces. If the authority resolves to an internal address an
+        // admin 400 is returned rather than the server making a stealthy internal HTTP request.
+        var ssrfCheck = await OutboundHttpUrlValidator
+            .ValidateAsync(authority, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!ssrfCheck.IsValid)
+        {
+            AdminLog.IdentityProviderTestCompleted(logger, providerType, false);
+
+            var blocked = new IdentityProviderTestResult
+            {
+                ProviderType = providerType,
+                IsReachable = false,
+                ErrorMessage = $"Authority URL validation failed: {ssrfCheck.ErrorMessage}"
+            };
+
+            return Results.Json(
+                ApiResponse<IdentityProviderTestResult>.CreateSuccess(blocked),
+                IdentityAdminJsonContext.Default.ApiResponseIdentityProviderTestResult);
+        }
+
         var discoveryUrl = $"{authority.TrimEnd('/')}/.well-known/openid-configuration";
 
         try

--- a/src/Honua.Snowflake/Features/FeatureStore/Services/SnowflakeFeatureQueryBuilder.cs
+++ b/src/Honua.Snowflake/Features/FeatureStore/Services/SnowflakeFeatureQueryBuilder.cs
@@ -452,7 +452,11 @@ internal static partial class SnowflakeFeatureQueryBuilder
             return num;
         }
 
-        return valueToken;
+        // Defense-in-depth: ComparisonRegex constrains the 'value' group to a quoted string or
+        // numeric literal, so this branch is currently unreachable. Throw explicitly so any
+        // future code path that calls this function with an unexpected token fails loudly rather
+        // than silently returning a raw string that could produce unparameterized SQL.
+        throw new ArgumentException($"Unrecognized value token: {valueToken}");
     }
 
     [GeneratedRegex(

--- a/tests/dotnet/Honua.Core.Tests/Features/SharedModels/SpatialReferenceExtensionsTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/SharedModels/SpatialReferenceExtensionsTests.cs
@@ -34,4 +34,40 @@ public sealed class SpatialReferenceExtensionsTests
     {
         SpatialReferenceExtensions.NormalizeWebMercatorSrid(srid).Should().Be(srid);
     }
+
+    // PA-024: GetAuthorityName and GetAuthorityCode must return the OGC-defined values for WKID 4326
+    // (CRS84) so that WFS 2.0 / OGC API conformance URNs are formed correctly.
+
+    [Fact]
+    public void GetAuthorityName_Wkid4326_ReturnsOgc()
+    {
+        var sr = new SpatialReference { Wkid = 4326 };
+        sr.GetAuthorityName().Should().Be("OGC");
+    }
+
+    [Theory]
+    [InlineData(3857)]
+    [InlineData(4269)]
+    [InlineData(32633)]
+    public void GetAuthorityName_NonOgcWkid_ReturnsEpsg(int wkid)
+    {
+        var sr = new SpatialReference { Wkid = wkid };
+        sr.GetAuthorityName().Should().Be("EPSG");
+    }
+
+    [Fact]
+    public void GetAuthorityCode_Wkid4326_ReturnsCrs84Fragment()
+    {
+        var sr = new SpatialReference { Wkid = 4326 };
+        sr.GetAuthorityCode().Should().Be("1.3:CRS84");
+    }
+
+    [Theory]
+    [InlineData(3857, "3857")]
+    [InlineData(4269, "4269")]
+    public void GetAuthorityCode_OtherWkids_ReturnsNumericString(int wkid, string expected)
+    {
+        var sr = new SpatialReference { Wkid = wkid };
+        sr.GetAuthorityCode().Should().Be(expected);
+    }
 }

--- a/tests/dotnet/Honua.Core.Tests/Queries/Filters/GeoServicesSql/GeoServicesSqlParserTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Queries/Filters/GeoServicesSql/GeoServicesSqlParserTests.cs
@@ -106,15 +106,46 @@ public class GeoServicesSqlParserTests
     }
 
     [Fact]
-    public void Parse_HashDatetimeLiteralWithoutOffset_StillRejected()
+    public void Parse_HashDatetimeLiteralWithoutOffset_AcceptedAsUtc()
     {
-        // Without the explicit TIMESTAMP keyword, a #...# date+time literal carrying a
-        // time component but no offset remains ambiguous and must still be rejected;
-        // only the explicit TIMESTAMP keyword relaxes the offset requirement.
-        var act = () => _parser.Parse("event_date > #2024-06-01T12:30:00#");
+        // PA-026: mirror ArcGIS Server behaviour — bare date+time literals without an explicit
+        // timezone offset (including the #...# hash form) are accepted and treated as UTC
+        // instead of being rejected.  The old test ("StillRejected") encoded the wrong behaviour.
+        var expression = _parser.Parse("event_date > #2024-06-01T12:30:00#");
+
+        var binary = (BinaryExpression)expression;
+        var literal = (Literal)binary.Right;
+        literal.Type.Should().Be(LiteralType.DateTime);
+        var value = (DateTimeOffset)literal.Value!;
+        value.Offset.Should().Be(TimeSpan.Zero);
+        value.UtcDateTime.Should().Be(new DateTime(2024, 6, 1, 12, 30, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Parse_TimestampKeywordWithoutOffset_AcceptedAsUtc()
+    {
+        // PA-026: ArcGIS clients emit TIMESTAMP 'value' literals without a timezone offset.
+        // Previously the parser threw "missing a timezone offset"; now they are accepted
+        // as UTC to mirror ArcGIS Server's AssumeUniversal behaviour.
+        var expression = _parser.Parse("event_date > TIMESTAMP '2024-01-01 12:00:00'");
+
+        var binary = (BinaryExpression)expression;
+        var literal = (Literal)binary.Right;
+        literal.Type.Should().Be(LiteralType.DateTime);
+        var value = (DateTimeOffset)literal.Value!;
+        value.Offset.Should().Be(TimeSpan.Zero);
+        value.UtcDateTime.Should().Be(new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Parse_UnknownFunction_ThrowsArgumentException()
+    {
+        // PA-013: the parser allowlist should reject unknown function names before an AST node
+        // is created so that future providers cannot inherit the parser's permissiveness.
+        var act = () => _parser.Parse("pg_sleep(600) > 0");
 
         act.Should().Throw<ArgumentException>()
-            .WithMessage("*missing a timezone offset*");
+            .WithMessage("*Unknown or unsupported function*");
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacV2LookupsMatchesCollectionIdTests.cs
+++ b/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacV2LookupsMatchesCollectionIdTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Protocols.Stac.Services;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.Stac;
+
+/// <summary>
+/// Unit tests for <see cref="StacV2Lookups.MatchesCollectionId"/>.
+/// PA-120: STAC API Item Search collections parameter must accept arbitrary string collection IDs
+/// (e.g. "sentinel-2-l2a"), not just integer layer indices.
+/// </summary>
+public sealed class StacV2LookupsMatchesCollectionIdTests
+{
+    private static MetadataV2Publication MakePublication(
+        string serviceLocalId = "",
+        string path = "",
+        string metadataName = "",
+        string metadataId = "",
+        int? layerIndex = null)
+        => new()
+        {
+            ServiceLocalId = serviceLocalId,
+            Path = path,
+            Metadata = new MetadataV2ObjectMetadata
+            {
+                Name = metadataName,
+                Id = metadataId
+            },
+            LayerIndex = layerIndex
+        };
+
+    // PA-120: a STAC client passes collections=["sentinel-2-l2a"] and the publication
+    // whose ServiceLocalId is "sentinel-2-l2a" must be returned; previously only integer
+    // layer indices were matched.
+
+    [UnitTest]
+    public void MatchesCollectionId_ServiceLocalId_Matches()
+    {
+        var pub = MakePublication(serviceLocalId: "sentinel-2-l2a", layerIndex: 42);
+        var result = StacV2Lookups.MatchesCollectionId(pub, "sentinel-2-l2a", numericId: null);
+        result.Should().BeTrue("ServiceLocalId must match string collection IDs");
+    }
+
+    [UnitTest]
+    public void MatchesCollectionId_ServiceLocalId_CaseInsensitive()
+    {
+        var pub = MakePublication(serviceLocalId: "Sentinel-2-L2A");
+        var result = StacV2Lookups.MatchesCollectionId(pub, "sentinel-2-l2a", numericId: null);
+        result.Should().BeTrue("matching must be case-insensitive per STAC spec");
+    }
+
+    [UnitTest]
+    public void MatchesCollectionId_MetadataName_Matches()
+    {
+        var pub = MakePublication(metadataName: "my-landsat-collection");
+        var result = StacV2Lookups.MatchesCollectionId(pub, "my-landsat-collection", numericId: null);
+        result.Should().BeTrue("Metadata.Name must match string collection IDs");
+    }
+
+    [UnitTest]
+    public void MatchesCollectionId_MetadataId_Matches()
+    {
+        var pub = MakePublication(metadataId: "col-abc-123");
+        var result = StacV2Lookups.MatchesCollectionId(pub, "col-abc-123", numericId: null);
+        result.Should().BeTrue("Metadata.Id must match string collection IDs");
+    }
+
+    [UnitTest]
+    public void MatchesCollectionId_Path_Matches()
+    {
+        var pub = MakePublication(path: "/stac/my-collection");
+        var result = StacV2Lookups.MatchesCollectionId(pub, "/stac/my-collection", numericId: null);
+        result.Should().BeTrue("Path must match string collection IDs");
+    }
+
+    [UnitTest]
+    public void MatchesCollectionId_NumericLayerIndex_MatchesWhenNumericIdProvided()
+    {
+        var pub = MakePublication(layerIndex: 7);
+        var result = StacV2Lookups.MatchesCollectionId(pub, "7", numericId: 7);
+        result.Should().BeTrue("legacy integer layer index must still resolve numeric collection IDs");
+    }
+
+    [UnitTest]
+    public void MatchesCollectionId_NonMatchingString_ReturnsFalse()
+    {
+        var pub = MakePublication(serviceLocalId: "sentinel-2-l2a", layerIndex: 5);
+        var result = StacV2Lookups.MatchesCollectionId(pub, "landsat-9-l2", numericId: null);
+        result.Should().BeFalse("a different collection ID must not match");
+    }
+
+    [UnitTest]
+    public void MatchesCollectionId_IntegerStringWithoutNumericId_DoesNotMatchByString()
+    {
+        // numericId is null when the collection ID doesn't parse as an int — the LayerIndex
+        // fallback must not apply, so no accidental numeric match via string comparison alone.
+        var pub = MakePublication(layerIndex: 99);
+        // Pass numericId: null to simulate a non-integer collection string
+        var result = StacV2Lookups.MatchesCollectionId(pub, "99", numericId: null);
+        // ServiceLocalId/Path/Name/Id are all empty so only the numeric fallback would fire,
+        // but numericId is null therefore the result must be false.
+        result.Should().BeFalse("numeric layer fallback must only fire when the caller parsed a valid int");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Validation/CommonQueryValidatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Validation/CommonQueryValidatorTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Validation;
+using Honua.Core.Features.Validation.Abstractions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -250,5 +251,34 @@ public class CommonQueryValidatorTests
         result.Value.Should().NotBeNull();
         result.Value!.MinX.Should().Be(-20000000);
         result.Value!.MaxX.Should().Be(20000000);
+    }
+
+    // PA-025: OGC API Features /req/core/fc-limit-definition (d) mandates that over-maximum limits
+    // are clamped to the server maximum, not rejected with a 400 error.
+
+    [Fact]
+    public void ValidateAndNormalizePagination_OgcFeaturesOptions_ClampsOverMaxLimit()
+    {
+        // OGC API Features spec: server must silently clamp limit to maximum instead of 400.
+        var result = _validator.ValidateAndNormalizePagination(
+            offset: 0,
+            limit: 999999,
+            PaginationValidationOptions.OgcFeatures);
+
+        result.IsValid.Should().BeTrue("over-max OGC Features limit should be clamped, not rejected");
+        result.Value!.Limit.Should().Be(_limitsOptions.Query.MaxRecordCount,
+            "limit should be clamped to the configured maximum");
+    }
+
+    [Fact]
+    public void ValidateAndNormalizePagination_DefaultOptions_RejectsOverMaxLimit()
+    {
+        // Non-OGC protocols still reject over-max limits with 400 (default behaviour).
+        var result = _validator.ValidateAndNormalizePagination(
+            offset: 0,
+            limit: 999999,
+            PaginationValidationOptions.Default);
+
+        result.IsValid.Should().BeFalse("over-max limit should be rejected with Default options");
     }
 }


### PR DESCRIPTION
## Summary

Fixes 12 validated LOW-LOE findings from the platform-audit batch `batch-security-conformance.md`.

### Security hardening

| Finding | Description | Files |
|---------|-------------|-------|
| PA-011 | Path traversal in migration checkpoint store — `SafePathSegment` rejects `/` and `\`; `PathFor` asserts `GetFullPath` containment | `FileSystemMigrationRunCheckpointStore.cs` |
| PA-012 | Five local copies of `IsPrivateOrReservedAddress` consolidated onto `OutboundHttpUrlValidator` | `ArcGisRestClient`, `GeoServerRestClient`, `OgcApiFeaturesImportService`, `OgcApiFeaturesMigrationScanner`, `OgcServiceMigrationScanner` |
| PA-061 | SSRF guard before openid-configuration fetch in identity test endpoint | `IdentityAdminEndpoints.cs` |
| PA-156 | `LocalFileStorage` upload/download/delete/presign routed through `GetSafeFullPath` which asserts path stays within `_basePath` | `LocalFileStorage.cs` |
| PA-157 | `ParseValueToken` fallthrough eliminated in Oracle, Redshift, Snowflake query builders; unknown tokens now throw | 3 `*FeatureQueryBuilder.cs` files |
| PA-013 | GeoServices SQL parser enforces `_allowedFunctions` allowlist before creating generic `FunctionCall` AST nodes | `GeoServicesSqlParser.cs` |

### Protocol conformance

| Finding | Description | Files |
|---------|-------------|-------|
| PA-072 | OData v4 Content-Type: `metadata=` changed to `odata.metadata=` | `ODataUtilityService.cs`, `ODataErrorFormatter.cs` |
| PA-073 | OWS 1.1 `ExceptionReport` gains required `language="en"` attribute | `StandardErrorResponseFormatter.cs` |
| PA-024 | `SpatialReferenceExtensions` returns authority `"OGC"` / code `"1.3:CRS84"` for WKID 4326 (was `"EPSG"` / `"4326"`) | `SpatialReferenceExtensions.cs` |
| PA-025 | OGC API Features over-max `limit` now clamps to server maximum instead of returning 400; new `PaginationValidationOptions.OgcFeatures` preset | `PaginationValidationOptions.cs`, `OgcFeaturesQueryParameterAdapter.cs` |
| PA-120 | STAC Item Search `collections` parameter now accepts arbitrary string IDs (e.g. `sentinel-2-l2a`); GET and POST search paths switched from integer-only parsing to `MatchesCollectionId` | `SearchEndpoints.cs`, `StacV2Lookups.cs` |
| PA-026 | Bare `TIMESTAMP 'value'` and `#datetime#` literals without timezone offset accepted as UTC (mirrors ArcGIS Server `AssumeUniversal`) | `GeoServicesSqlParser.cs` |

### Tests

- PA-024: `GetAuthorityName` / `GetAuthorityCode` unit tests for WKID 4326
- PA-025: OGC Features clamp vs Default reject in `CommonQueryValidatorTests`
- PA-026: `Parse_HashDatetimeLiteralWithoutOffset_AcceptedAsUtc` (updated from old reject assertion); `Parse_TimestampKeywordWithoutOffset_AcceptedAsUtc`
- PA-120: new `StacV2LookupsMatchesCollectionIdTests` (8 unit cases)
- PA-013: `Parse_UnknownFunction_ThrowsArgumentException`

## Test plan

- [x] `dotnet build Honua.sln` — 0 errors
- [x] `dotnet test tests/dotnet/Honua.Core.Tests` — 3348 passed, 2 skipped, 0 failed
- [x] `dotnet test ... --filter CommonQueryValidator` — 50 passed
- [x] `dotnet test ... --filter StacV2LookupsMatchesCollectionId` — 8 passed
- [x] `dotnet format Honua.sln` — clean