### PR TITLE
fix: harden exception handling and resilience findings from platform audit (#2404)

### DIFF
--- a/src/Honua.ArcGisRest/ServiceCollectionExtensions.cs
+++ b/src/Honua.ArcGisRest/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Honua.ArcGisRest.Features.FeatureStore;
 using Honua.ArcGisRest.Features.FeatureStore.Services;
 using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Infrastructure.Resilience;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -43,10 +44,17 @@ public static class ServiceCollectionExtensions
         // ULA/reserved ranges (incl. 169.254.169.254 cloud metadata). Without
         // this, the federated client would follow redirects and apply no IP
         // filtering at runtime — a full SSRF + DNS-rebinding exposure.
+        //
+        // A per-request timeout and the shared retry/circuit-breaker policy (reused from
+        // Honua.Core.Features.Infrastructure.Resilience rather than a bespoke policy here)
+        // guard against a slow/unresponsive federated ArcGIS endpoint hanging a request or
+        // hammering a downed one (#2404 PA-123).
         services
             .AddHttpClient<IArcGisRestFeatureClient, ArcGisRestFeatureClient>(ArcGisRestServiceClientName.Default)
             .ConfigurePrimaryHttpMessageHandler(
-                static () => ArcGisRestOutboundGuard.CreatePinnedDnsHttpMessageHandler());
+                static () => ArcGisRestOutboundGuard.CreatePinnedDnsHttpMessageHandler())
+            .ConfigureHttpClient(static client => client.Timeout = TimeSpan.FromSeconds(30))
+            .AddHttpResiliencePolicy("arcgis-rest");
 
         services.AddScoped<ArcGisRestFeatureStore>();
         services.AddScoped<IFeatureDataProvider>(sp => sp.GetRequiredService<ArcGisRestFeatureStore>());

--- a/src/Honua.Core/Features/Compliance/Domain/KeyRotationOutcome.cs
+++ b/src/Honua.Core/Features/Compliance/Domain/KeyRotationOutcome.cs
@@ -29,4 +29,13 @@ public sealed record KeyRotationOutcome
     /// exception text — call-sites translate exceptions to a sanitized reason.
     /// </summary>
     public required string Message { get; init; }
+
+    /// <summary>
+    /// Whether the rotation event was also persisted to the audit log. The in-memory
+    /// posture (<see cref="Succeeded"/>) always advances once the rotation is
+    /// committed; this flag is <c>false</c> when that commit's audit trail write
+    /// failed, so callers/operators can tell "rotated" apart from "rotated AND
+    /// auditable" and reconcile the missing audit event out-of-band.
+    /// </summary>
+    public bool AuditRecorded { get; init; } = true;
 }

--- a/src/Honua.Core/Features/Compliance/Services/InMemoryEncryptionPostureProvider.cs
+++ b/src/Honua.Core/Features/Compliance/Services/InMemoryEncryptionPostureProvider.cs
@@ -126,6 +126,7 @@ internal sealed partial class InMemoryEncryptionPostureProvider : IEncryptionPos
         // with no persisted audit trail (SOC 2 CC6 / FedRAMP IR-4 violation). Use a
         // bounded, request-independent token and treat failures as best-effort.
         using var auditCts = new CancellationTokenSource(AuditTimeout);
+        var auditRecorded = true;
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
@@ -147,7 +148,10 @@ internal sealed partial class InMemoryEncryptionPostureProvider : IEncryptionPos
         catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
             // Don't roll back the in-memory rotation — it's already visible to GetPosture.
-            // Surface the failure as a high-signal log line so operators can reconcile.
+            // Surface the failure as a high-signal log line so operators can reconcile, and
+            // report it on the outcome (AuditRecorded = false) so callers can tell "rotated"
+            // apart from "rotated AND auditable" instead of seeing an unconditional success.
+            auditRecorded = false;
             LogAuditWriteFailed(previous, next, ex);
         }
 
@@ -157,7 +161,10 @@ internal sealed partial class InMemoryEncryptionPostureProvider : IEncryptionPos
             PreviousVersion = previous,
             NewVersion = next,
             RotatedAt = now,
-            Message = $"Compliance key-version posture advanced from v{previous} to v{next}. This records an auditor-facing rotation event; actual cipher key material is managed by IConnectionEncryptionService and is unaffected by this endpoint.",
+            AuditRecorded = auditRecorded,
+            Message = auditRecorded
+                ? $"Compliance key-version posture advanced from v{previous} to v{next}. This records an auditor-facing rotation event; actual cipher key material is managed by IConnectionEncryptionService and is unaffected by this endpoint."
+                : $"Compliance key-version posture advanced from v{previous} to v{next}, but the audit-log write failed; this rotation event is not yet recorded for auditor traceability. See server logs and reconcile the missing audit event.",
         };
     }
 

--- a/src/Honua.Core/Features/Edit/EditProcessor.cs
+++ b/src/Honua.Core/Features/Edit/EditProcessor.cs
@@ -138,7 +138,12 @@ public sealed class EditProcessor : IEditProcessor
 
             return EditValidationResult.Success(warnings.Count > 0 ? warnings : null);
         }
-        catch (Exception ex)
+        // Narrowed to the exception shapes that can genuinely arise from malformed input
+        // reaching the validation helpers above (e.g. a default/uninitialized field
+        // collection on a malformed resource). Anything else is an unexpected bug, not a
+        // client validation failure, so it propagates to the shared global exception
+        // middleware instead of being disguised as "your edit request is invalid".
+        catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException)
         {
             EditLog.ValidateEditFailed(_logger, resource.Metadata.Id, ex);
             return EditValidationResult.Failure("Failed to validate edit request");
@@ -179,7 +184,10 @@ public sealed class EditProcessor : IEditProcessor
 
             return optimizedRequest;
         }
-        catch (Exception ex)
+        // Narrowed to the exception shapes an optimization pass could plausibly raise from
+        // malformed/edge-case input. Anything else is an unexpected bug and should not be
+        // silently masked by falling back to the unoptimized request.
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
             EditLog.OptimizeEditFailed(_logger, resource.Metadata.Id, ex);
             return editRequest;

--- a/src/Honua.Core/Features/FeatureStore/Services/VersionJobRunner.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/VersionJobRunner.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Honua.Core.Features.FeatureStore.Services;
@@ -28,19 +29,29 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IVersionJobStore _jobStore;
     private readonly ILogger<VersionJobRunner> _logger;
+    private readonly IHostApplicationLifetime? _lifetime;
 
     /// <summary>Initializes the runner.</summary>
     /// <param name="scopeFactory">Factory used to resolve a fresh DI scope for each background job.</param>
     /// <param name="jobStore">Durable job store used to record and poll job state.</param>
     /// <param name="logger">Logger.</param>
+    /// <param name="lifetime">
+    /// Optional host lifetime (matches the <c>InProcessTemporalCorrectiveJobSink</c> pattern).
+    /// When supplied, <see cref="IHostApplicationLifetime.ApplicationStopping"/> is observed by
+    /// the detached background job so a graceful shutdown records a terminal state instead of
+    /// leaving the job silently abandoned mid-flight. Optional so the runner still works in
+    /// hosts/tests that do not register <see cref="IHostApplicationLifetime"/>.
+    /// </param>
     public VersionJobRunner(
         IServiceScopeFactory scopeFactory,
         IVersionJobStore jobStore,
-        ILogger<VersionJobRunner> logger)
+        ILogger<VersionJobRunner> logger,
+        IHostApplicationLifetime? lifetime = null)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _jobStore = jobStore ?? throw new ArgumentNullException(nameof(jobStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _lifetime = lifetime;
     }
 
     /// <inheritdoc />
@@ -105,6 +116,12 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
 
         var running = job with { Status = VersionJobStatus.Running, StartedAt = DateTimeOffset.UtcNow };
 
+        // Observed only by the manager call below (not by the Running/terminal-state saves,
+        // which must always be attempted best-effort): lets a real host shutdown interrupt a
+        // long-running reconcile/post cooperatively instead of the job running unobserved
+        // against a process that is already tearing down.
+        var shutdownToken = _lifetime?.ApplicationStopping ?? CancellationToken.None;
+
         // The whole body — including scope creation, service resolution, and the Running-state save —
         // must sit inside the try: this task is detached (fire-and-forget), so an exception escaping
         // here would be unobserved and the job would sit in Pending forever with no log line.
@@ -117,8 +134,8 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
             await store.SaveAsync(running, CancellationToken.None).ConfigureAwait(false);
 
             VersionJob completed = job.Kind == VersionJobKind.Reconcile
-                ? await RunReconcileAsync(manager, running, CancellationToken.None).ConfigureAwait(false)
-                : await RunPostAsync(manager, running, CancellationToken.None).ConfigureAwait(false);
+                ? await RunReconcileAsync(manager, running, shutdownToken).ConfigureAwait(false)
+                : await RunPostAsync(manager, running, shutdownToken).ConfigureAwait(false);
 
             activity?.SetTag("honua.version.conflict_count", completed.ConflictCount);
             activity?.SetTag("honua.version.auto_resolved_count", completed.AutoResolvedCount);
@@ -126,6 +143,22 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
             activity?.SetTag("honua.version.outcome", "succeeded");
             activity?.SetStatus(ActivityStatusCode.Ok);
             await store.SaveAsync(completed, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (shutdownToken.IsCancellationRequested)
+        {
+            // The host is shutting down: record a well-understood terminal state (not a stack
+            // trace) so an operator/poller sees a clear reason and knows to resubmit after
+            // restart, rather than the job sitting unobserved past process teardown.
+            activity?.SetTag("honua.version.outcome", "shutdown");
+            activity?.SetStatus(ActivityStatusCode.Error, "Server shutting down");
+            Log.JobAbortedForShutdown(_logger, job.Kind.ToString(), job.VersionId, job.JobId);
+            var aborted = running with
+            {
+                Status = VersionJobStatus.Failed,
+                CompletedAt = DateTimeOffset.UtcNow,
+                ErrorMessage = "The reconcile/post job was aborted because the server is shutting down. Resubmit after restart.",
+            };
+            await SaveTerminalStateAsync(aborted).ConfigureAwait(false);
         }
         catch (VersionLockedException)
         {
@@ -226,5 +259,11 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
             Level = LogLevel.Error,
             Message = "Failed to persist terminal state for version {JobKind} job {JobId} (version {VersionId}); polling clients may see a stale status.")]
         public static partial void TerminalSaveFailed(ILogger logger, string jobKind, Guid versionId, Guid jobId, Exception exception);
+
+        [LoggerMessage(
+            EventId = 7103,
+            Level = LogLevel.Warning,
+            Message = "Version {JobKind} job for version {VersionId} (job {JobId}) aborted: server is shutting down.")]
+        public static partial void JobAbortedForShutdown(ILogger logger, string jobKind, Guid versionId, Guid jobId);
     }
 }

--- a/src/Honua.Core/Features/Infrastructure/Monitoring/SystemMetricsCollector.cs
+++ b/src/Honua.Core/Features/Infrastructure/Monitoring/SystemMetricsCollector.cs
@@ -4,6 +4,8 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using Honua.Core.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Core.Features.Infrastructure.Monitoring;
@@ -13,8 +15,9 @@ namespace Honua.Core.Features.Infrastructure.Monitoring;
 /// Provides real-time system performance data without external dependencies.
 /// Designed for self-hosted installations with minimal overhead.
 /// </summary>
-public sealed class SystemMetricsCollector : ISystemMetricsCollector, IDisposable
+public sealed partial class SystemMetricsCollector : ISystemMetricsCollector, IDisposable
 {
+    private readonly ILogger<SystemMetricsCollector> _logger;
     private readonly Timer _metricsTimer;
     private readonly ConcurrentQueue<(DateTime Timestamp, bool IsError)> _recentRequests = new();
     private readonly TimeSpan _errorWindow;
@@ -32,8 +35,11 @@ public sealed class SystemMetricsCollector : ISystemMetricsCollector, IDisposabl
     /// <summary>
     /// Initializes a new SystemMetricsCollector with 10-second collection intervals.
     /// </summary>
-    public SystemMetricsCollector(IOptions<AdaptiveSamplingOptions>? options = null)
+    public SystemMetricsCollector(
+        IOptions<AdaptiveSamplingOptions>? options = null,
+        ILogger<SystemMetricsCollector>? logger = null)
     {
+        _logger = logger ?? NullLogger<SystemMetricsCollector>.Instance;
         var windowMinutes = options?.Value.Error.ErrorWindowMinutes ?? 5;
         _errorWindow = TimeSpan.FromMinutes(Math.Max(1, windowMinutes));
         _metricsTimer = new Timer(CollectMetrics, null, TimeSpan.Zero, TimeSpan.FromSeconds(10));
@@ -151,10 +157,13 @@ public sealed class SystemMetricsCollector : ISystemMetricsCollector, IDisposabl
                 Timestamp = DateTime.UtcNow
             };
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Don't let metrics collection crash the application
-            // Keep the previous metrics if collection fails
+            // Don't let metrics collection crash the application (this runs on a Timer
+            // callback thread with no caller to observe an exception) — keep the previous
+            // metrics if collection fails, but log it: a silently-stuck metrics snapshot
+            // would otherwise degrade adaptive sampling with no operator-visible signal.
+            Log.MetricsCollectionFailed(_logger, ex);
         }
     }
 
@@ -295,6 +304,15 @@ public sealed class SystemMetricsCollector : ISystemMetricsCollector, IDisposabl
             _disposed = true;
             _collector.EndRequest();
         }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 8300,
+            Level = LogLevel.Warning,
+            Message = "System metrics collection failed; the previous metrics snapshot is retained.")]
+        public static partial void MetricsCollectionFailed(ILogger logger, Exception exception);
     }
 }
 

--- a/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
+++ b/src/Honua.Core/Features/Migration/Services/ArcGisRestClient.cs
@@ -161,7 +161,10 @@ internal sealed partial class ArcGisRestClient
                 cancellationToken);
             featureCount = countResponse.Count;
         }
-        catch (Exception ex)
+        // Best-effort enrichment only: a failed count query still surfaces the rest of the
+        // layer metadata. Cancellation must propagate rather than be swallowed as a
+        // "count unavailable" result.
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             Log.FeatureCountFailed(_logger, layerId, ex);
         }

--- a/src/Honua.Geometry/Features/FileImport/Services/FlatGeobufFormatReader.cs
+++ b/src/Honua.Geometry/Features/FileImport/Services/FlatGeobufFormatReader.cs
@@ -86,7 +86,7 @@ internal static class FlatGeobufFormatReader
             var count = header.FeaturesCount;
             return count > 0 ? (int)Math.Min(count, int.MaxValue) : null;
         }
-        catch (Exception) // Malformed or truncated header
+        catch (Exception ex) when (ex is not OperationCanceledException) // Malformed or truncated header
         {
             return null;
         }
@@ -110,7 +110,7 @@ internal static class FlatGeobufFormatReader
             var wkt = ExtractCrsWkt(header);
             return (null, wkt);
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return (null, null);
         }
@@ -132,7 +132,7 @@ internal static class FlatGeobufFormatReader
             var wkt = ExtractCrsWkt(header);
             return (null, wkt);
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return (null, null);
         }

--- a/src/Honua.Geometry/Queries/Filters/OData/ODataFilterParser.cs
+++ b/src/Honua.Geometry/Queries/Filters/OData/ODataFilterParser.cs
@@ -500,7 +500,7 @@ public sealed class ODataFilterParser
             var geometry = new WKBReader().Read(literal.Wkb);
             return IsGeographyCompatible(geometry);
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Unreadable literal: fall back to the planar path rather than reject.
             return false;

--- a/src/Honua.Geoprocessing.Cli/GpCli.cs
+++ b/src/Honua.Geoprocessing.Cli/GpCli.cs
@@ -866,7 +866,10 @@ public static class GpCli
             throw new GpCliUsageException($"Invalid --server URL: '{options.Server}'.");
         }
 
-        var http = new HttpClient { BaseAddress = baseAddress };
+        // Publishing a workflow package can involve a non-trivial upload; use a generous
+        // but bounded timeout rather than none (the CLI would otherwise hang indefinitely
+        // on an unresponsive/unreachable --server).
+        var http = new HttpClient { BaseAddress = baseAddress, Timeout = TimeSpan.FromMinutes(5) };
         return new WorkflowPackagePublishClient(http, options.ApiKey, options.BearerToken);
     }
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
@@ -272,7 +272,7 @@ internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
             cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task<(string? ConnectionString, string? Error)> ResolveConnectionStringAsync(
+    private async Task<(string? ConnectionString, string? Error)> ResolveConnectionStringAsync(
         ISecureConnectionResolver resolver,
         bool hasId,
         string? connectionName,
@@ -308,8 +308,13 @@ internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            // Previously swallowed with no trace, which left an operator staring at a
+            // generic "could not be resolved" job failure with no way to diagnose why
+            // (bad credentials, unreachable secret store, etc.). Log the real exception.
+            var connectionRef = hasId ? $"connectionId={connectionIdText}" : $"connectionName={connectionName}";
+            Log.ConnectionResolutionFailed(_logger, connectionRef, ex);
             return (null, "secure connection could not be resolved.");
         }
     }
@@ -501,5 +506,10 @@ internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
             "Sink executor failed job {OperationId} during {ProcessId} write")]
         public static partial void SinkWriteFailed(
             ILogger logger, string operationId, string processId, Exception exception);
+
+        [LoggerMessage(9261, LogLevel.Warning,
+            "Sink executor could not resolve the secure connection ({ConnectionRef})")]
+        public static partial void ConnectionResolutionFailed(
+            ILogger logger, string connectionRef, Exception exception);
     }
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
@@ -230,7 +230,13 @@ internal abstract partial class FeatureCollectionTransformExecutor : IProcessExe
 /// Signals a caller-supplied parameter error inside a transform body. Mapped by
 /// <see cref="FeatureCollectionTransformExecutor"/> to a classified job failure.
 /// </summary>
-internal sealed class TransformInputException(string message) : Exception(message)
+/// <remarks>
+/// <paramref name="innerException"/> is optional and never surfaced to the caller — only
+/// <see cref="PublicMessage"/> is — but it lets call sites attach the original failure for
+/// logging/diagnostics instead of discarding it (#2404 PA-211).
+/// </remarks>
+internal sealed class TransformInputException(string message, Exception? innerException = null)
+    : Exception(message, innerException)
 {
     public string PublicMessage { get; } = message;
 }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
@@ -115,7 +115,7 @@ internal sealed partial class RemoteSourceExecutor : IProcessExecutor
         }
         catch (TransformInputException ex)
         {
-            Log.InvalidInputs(_logger, job.OperationId, _processId, ex.PublicMessage);
+            Log.InvalidInputs(_logger, job.OperationId, _processId, ex.PublicMessage, ex.InnerException);
             return JobExecutionResult.Failed($"Invalid {_processId} inputs: {ex.PublicMessage}");
         }
 
@@ -332,9 +332,12 @@ internal sealed partial class RemoteSourceExecutor : IProcessExecutor
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            throw new TransformInputException("secure connection could not be resolved.");
+            // Preserve the original failure as InnerException (never surfaced to the
+            // caller — only PublicMessage is) so BuildRequestAsync's catch can log the
+            // real cause instead of a bare "could not be resolved" with no diagnostic.
+            throw new TransformInputException("secure connection could not be resolved.", ex);
         }
     }
 
@@ -375,7 +378,8 @@ internal sealed partial class RemoteSourceExecutor : IProcessExecutor
     {
         [LoggerMessage(9280, LogLevel.Warning,
             "Remote source executor rejected job {OperationId} for {ProcessId}: {Reason}")]
-        public static partial void InvalidInputs(ILogger logger, string operationId, string processId, string reason);
+        public static partial void InvalidInputs(
+            ILogger logger, string operationId, string processId, string reason, Exception? exception = null);
 
         [LoggerMessage(9281, LogLevel.Error,
             "Remote source executor failed job {OperationId} during {ProcessId} read")]

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunner.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/LocalRunner/GeoprocessingLocalRunner.cs
@@ -122,7 +122,10 @@ public sealed class GeoprocessingLocalRunner
         {
             throw;
         }
-        catch (Exception ex)
+        // Fatal CLR exceptions must keep unwinding rather than being converted into a
+        // "failed" run result — the process is not in a state where continuing to serve
+        // requests (or reporting a normal job failure) is meaningful.
+        catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             stopwatch.Stop();
             return new LocalRunResult

--- a/src/Honua.Postgres.Shared/Features/Infrastructure/SemaphoreReleasingConnection.cs
+++ b/src/Honua.Postgres.Shared/Features/Infrastructure/SemaphoreReleasingConnection.cs
@@ -85,13 +85,23 @@ internal sealed class SemaphoreReleasingConnection : DbConnection
             _disposed = true;
             if (disposing)
             {
-                // Dispose the inner connection FIRST so its final
-                // StateChange(Closed) event can relay through the wrapper,
-                // then unsubscribe to avoid rooting the wrapper from the
-                // pooled connection's event list.
-                _inner.Dispose();
-                _inner.StateChange -= OnInnerStateChange;
-                _releaseAction();
+                // The semaphore slot must be released even if disposing the inner
+                // connection (or unsubscribing) throws — otherwise a faulted
+                // Dispose() call permanently leaks a MaxConcurrentQueries slot and
+                // the pool silently shrinks over time. Dispose the inner connection
+                // FIRST so its final StateChange(Closed) event can relay through
+                // the wrapper, then unsubscribe to avoid rooting the wrapper from
+                // the pooled connection's event list — both wrapped in `finally` so
+                // the release action always runs last.
+                try
+                {
+                    _inner.Dispose();
+                }
+                finally
+                {
+                    _inner.StateChange -= OnInnerStateChange;
+                    _releaseAction();
+                }
             }
         }
 
@@ -103,9 +113,15 @@ internal sealed class SemaphoreReleasingConnection : DbConnection
         if (!_disposed)
         {
             _disposed = true;
-            await _inner.DisposeAsync().ConfigureAwait(false);
-            _inner.StateChange -= OnInnerStateChange;
-            _releaseAction();
+            try
+            {
+                await _inner.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _inner.StateChange -= OnInnerStateChange;
+                _releaseAction();
+            }
         }
 
         await base.DisposeAsync().ConfigureAwait(false);

--- a/src/Honua.Server/Features/Admin/ComplianceAdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ComplianceAdminEndpoints.cs
@@ -222,6 +222,7 @@ internal static partial class ComplianceAdminEndpoints
             NewVersion = outcome.NewVersion,
             RotatedAt = outcome.RotatedAt,
             Message = outcome.Message,
+            AuditRecorded = outcome.AuditRecorded,
         };
 
         return Results.Json(

--- a/src/Honua.Server/Features/Admin/Models/ComplianceAdminModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ComplianceAdminModels.cs
@@ -234,4 +234,12 @@ public sealed class ComplianceKeyRotationResponse
     /// <summary>Sanitized status message.</summary>
     [JsonPropertyName("message")]
     public required string Message { get; init; }
+
+    /// <summary>
+    /// Whether the rotation event was also persisted to the audit log. <c>false</c>
+    /// means the posture advanced (<see cref="Succeeded"/>) but the audit-trail write
+    /// failed — see <see cref="Message"/> and server logs to reconcile.
+    /// </summary>
+    [JsonPropertyName("auditRecorded")]
+    public required bool AuditRecorded { get; init; }
 }

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/AuditExportServiceCollectionExtensions.cs
@@ -86,11 +86,18 @@ internal static class AuditExportServiceCollectionExtensions
             return services;
         }
 
+        // Sinks resolve a fresh named HttpClient from IHttpClientFactory per send rather than
+        // capturing one at singleton construction (PA-081): calling CreateClient() once and
+        // holding the result forever bypasses the factory's primary-handler rotation, so a
+        // DNS change or broken pooled connection would wedge the sink for the process
+        // lifetime. Passing the factory + name keeps each sink long-lived while every send
+        // gets an up-to-date client.
         if (options.Splunk.Enabled)
         {
             services.AddHttpClient(SplunkClient);
             services.AddSingleton<IAuditSink>(sp => new SplunkHecAuditSink(
-                sp.GetRequiredService<IHttpClientFactory>().CreateClient(SplunkClient),
+                sp.GetRequiredService<IHttpClientFactory>(),
+                SplunkClient,
                 options.Splunk));
         }
 
@@ -98,7 +105,8 @@ internal static class AuditExportServiceCollectionExtensions
         {
             services.AddHttpClient(SentinelClient);
             services.AddSingleton<IAuditSink>(sp => new SentinelAuditSink(
-                sp.GetRequiredService<IHttpClientFactory>().CreateClient(SentinelClient),
+                sp.GetRequiredService<IHttpClientFactory>(),
+                SentinelClient,
                 options.Sentinel));
         }
 
@@ -106,7 +114,8 @@ internal static class AuditExportServiceCollectionExtensions
         {
             services.AddHttpClient(S3Client);
             services.AddSingleton<IAuditSink>(sp => new S3AuditSink(
-                sp.GetRequiredService<IHttpClientFactory>().CreateClient(S3Client),
+                sp.GetRequiredService<IHttpClientFactory>(),
+                S3Client,
                 options.S3));
         }
 

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/S3AuditSink.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/S3AuditSink.cs
@@ -21,19 +21,27 @@ namespace Honua.Server.Features.Infrastructure.AuditLog.Export;
 /// </remarks>
 internal sealed class S3AuditSink : IAuditSink
 {
-    private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly string _httpClientName;
     private readonly S3SinkOptions _options;
 
     /// <summary>
     /// Initializes a new S3 sink.
     /// </summary>
-    /// <param name="httpClient">The HTTP client (typically named, from <see cref="IHttpClientFactory"/>).</param>
+    /// <param name="httpClientFactory">
+    /// Factory used to resolve a fresh named <see cref="HttpClient"/> per send — see
+    /// <see cref="SplunkHecAuditSink"/> for why capturing a single client at construction
+    /// would bypass <see cref="IHttpClientFactory"/> handler rotation.
+    /// </param>
+    /// <param name="httpClientName">The named client to resolve on each send.</param>
     /// <param name="options">S3 configuration.</param>
-    public S3AuditSink(HttpClient httpClient, S3SinkOptions options)
+    public S3AuditSink(IHttpClientFactory httpClientFactory, string httpClientName, S3SinkOptions options)
     {
-        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(httpClientName);
         ArgumentNullException.ThrowIfNull(options);
-        _httpClient = httpClient;
+        _httpClientFactory = httpClientFactory;
+        _httpClientName = httpClientName;
         _options = options;
     }
 
@@ -60,7 +68,7 @@ internal sealed class S3AuditSink : IAuditSink
                 request.Headers.TryAddWithoutValidation("Authorization", _options.AuthHeaderValue);
             }
 
-            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            using var response = await _httpClientFactory.CreateClient(_httpClientName).SendAsync(request, ct).ConfigureAwait(false);
             return AuditHttpResultMapper.FromStatus(SinkType, response.StatusCode);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/SentinelAuditSink.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/SentinelAuditSink.cs
@@ -15,19 +15,27 @@ namespace Honua.Server.Features.Infrastructure.AuditLog.Export;
 /// </summary>
 internal sealed class SentinelAuditSink : IAuditSink
 {
-    private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly string _httpClientName;
     private readonly SentinelSinkOptions _options;
 
     /// <summary>
     /// Initializes a new Sentinel sink.
     /// </summary>
-    /// <param name="httpClient">The HTTP client (typically named, from <see cref="IHttpClientFactory"/>).</param>
+    /// <param name="httpClientFactory">
+    /// Factory used to resolve a fresh named <see cref="HttpClient"/> per send — see
+    /// <see cref="SplunkHecAuditSink"/> for why capturing a single client at construction
+    /// would bypass <see cref="IHttpClientFactory"/> handler rotation.
+    /// </param>
+    /// <param name="httpClientName">The named client to resolve on each send.</param>
     /// <param name="options">Sentinel configuration.</param>
-    public SentinelAuditSink(HttpClient httpClient, SentinelSinkOptions options)
+    public SentinelAuditSink(IHttpClientFactory httpClientFactory, string httpClientName, SentinelSinkOptions options)
     {
-        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(httpClientName);
         ArgumentNullException.ThrowIfNull(options);
-        _httpClient = httpClient;
+        _httpClientFactory = httpClientFactory;
+        _httpClientName = httpClientName;
         _options = options;
     }
 
@@ -51,7 +59,7 @@ internal sealed class SentinelAuditSink : IAuditSink
             request.Headers.TryAddWithoutValidation("Authorization", _options.AuthHeaderValue);
             request.Headers.TryAddWithoutValidation("Log-Type", _options.LogType);
 
-            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            using var response = await _httpClientFactory.CreateClient(_httpClientName).SendAsync(request, ct).ConfigureAwait(false);
             return AuditHttpResultMapper.FromStatus(SinkType, response.StatusCode);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/Honua.Server/Features/Infrastructure/AuditLog/Export/SplunkHecAuditSink.cs
+++ b/src/Honua.Server/Features/Infrastructure/AuditLog/Export/SplunkHecAuditSink.cs
@@ -17,19 +17,28 @@ namespace Honua.Server.Features.Infrastructure.AuditLog.Export;
 internal sealed class SplunkHecAuditSink : IAuditSink
 {
     private const string Path = "/services/collector/event";
-    private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly string _httpClientName;
     private readonly SplunkHecSinkOptions _options;
 
     /// <summary>
     /// Initializes a new Splunk HEC sink.
     /// </summary>
-    /// <param name="httpClient">The HTTP client (typically named, from <see cref="IHttpClientFactory"/>).</param>
+    /// <param name="httpClientFactory">
+    /// Factory used to resolve a fresh named <see cref="HttpClient"/> per send. A sink that
+    /// captured a single <see cref="HttpClient"/> at construction (a singleton) would never
+    /// observe <see cref="IHttpClientFactory"/>'s primary-handler rotation, so a DNS change
+    /// or a broken pooled connection would wedge this sink for the life of the process.
+    /// </param>
+    /// <param name="httpClientName">The named client to resolve on each send.</param>
     /// <param name="options">Splunk HEC configuration.</param>
-    public SplunkHecAuditSink(HttpClient httpClient, SplunkHecSinkOptions options)
+    public SplunkHecAuditSink(IHttpClientFactory httpClientFactory, string httpClientName, SplunkHecSinkOptions options)
     {
-        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(httpClientName);
         ArgumentNullException.ThrowIfNull(options);
-        _httpClient = httpClient;
+        _httpClientFactory = httpClientFactory;
+        _httpClientName = httpClientName;
         _options = options;
     }
 
@@ -45,6 +54,7 @@ internal sealed class SplunkHecAuditSink : IAuditSink
         ArgumentNullException.ThrowIfNull(events);
 
         var requestUri = BuildRequestUri();
+        var httpClient = _httpClientFactory.CreateClient(_httpClientName);
         foreach (var evt in events)
         {
             var payload = BuildEnvelope(evt);
@@ -55,7 +65,7 @@ internal sealed class SplunkHecAuditSink : IAuditSink
                 using var request = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
                 request.Headers.TryAddWithoutValidation("Authorization", $"Splunk {_options.Token}");
 
-                using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+                using var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
                 var result = AuditHttpResultMapper.FromStatus(SinkType, response.StatusCode);
                 if (!result.Succeeded)
                 {

--- a/tests/dotnet/Honua.Core.Tests/Features/Compliance/EncryptionPostureProviderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Compliance/EncryptionPostureProviderTests.cs
@@ -49,6 +49,7 @@ public sealed class EncryptionPostureProviderTests
             "the provider does not own encryption — that language belongs to IConnectionEncryptionService");
         outcome.Message.Should().NotContain("existing ciphertext remains decryptable",
             "no ciphertext is touched by this endpoint");
+        outcome.AuditRecorded.Should().BeTrue("the audit write succeeded");
 
         var posture = provider.GetPosture();
         posture.ActiveKeyVersion.Should().Be(2);
@@ -134,6 +135,25 @@ public sealed class EncryptionPostureProviderTests
     }
 
     [Fact]
+    public async Task Rotate_WhenAuditWriteFails_StillSucceedsButReportsAuditNotRecorded()
+    {
+        // PA-032: the in-memory posture must still advance (Succeeded = true) even when the
+        // audit trail write fails, but the outcome must distinguish "rotated" from "rotated
+        // AND auditable" instead of unconditionally claiming the audit event was recorded.
+        var audit = new ThrowingAuditLog();
+        var provider = CreateProvider(audit);
+
+        var outcome = await provider.RotateAsync("alice", CancellationToken.None);
+
+        outcome.Succeeded.Should().BeTrue("the in-memory posture always advances once committed");
+        outcome.AuditRecorded.Should().BeFalse("the audit-log write threw");
+        outcome.Message.Should().Contain("audit-log write failed");
+
+        var posture = provider.GetPosture();
+        posture.ActiveKeyVersion.Should().Be(2, "the posture advances independently of the audit write");
+    }
+
+    [Fact]
     public void OperatorAttestedFipsMode_IsHonoured()
     {
         var opts = new ComplianceOptions
@@ -191,4 +211,10 @@ internal sealed class TokenCapturingAuditLog : IAuditLog
         CapturedTokens.Add(cancellationToken);
         return Task.CompletedTask;
     }
+}
+
+internal sealed class ThrowingAuditLog : IAuditLog
+{
+    public Task RecordAsync(AuditEvent auditEvent, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException("Simulated audit sink outage.");
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/ArcGisRestClientSecurityTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/ArcGisRestClientSecurityTests.cs
@@ -209,6 +209,27 @@ public sealed class ArcGisRestClientSecurityTests
         (settledDescriptors - baselineDescriptors).Should().BeLessThan(96);
     }
 
+    [Fact]
+    public async Task GetLayerInfoAsync_FeatureCountQueryCanceled_PropagatesCancellation()
+    {
+        // PA-034: the feature-count query is best-effort enrichment and its failures are
+        // swallowed into a null count — but a genuine cancellation must still propagate to
+        // the caller instead of being reported as "count unavailable".
+        var handler = new CancelingSecondRequestHandler("""
+            { "id": 0, "name": "Layer 0" }
+            """);
+        var client = CreateClient(handler, (_, _) => Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") }));
+        using var cts = new CancellationTokenSource();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            client.GetLayerInfoAsync(
+                "https://example.com/arcgis/rest/services/Test/FeatureServer",
+                layerId: 0,
+                timeoutSeconds: 5,
+                maxRetries: 0,
+                cts.Token));
+    }
+
     private static ArcGisRestClient CreateClient(
         HttpMessageHandler handler,
         Func<string, CancellationToken, Task<IPAddress[]>> resolver,
@@ -331,6 +352,31 @@ public sealed class ArcGisRestClientSecurityTests
                     Encoding.UTF8,
                     "application/json")
             });
+        }
+    }
+
+    private sealed class CancelingSecondRequestHandler : HttpMessageHandler
+    {
+        private readonly string _firstResponse;
+        private int _requestCount;
+
+        public CancelingSecondRequestHandler(string firstResponse)
+        {
+            _firstResponse = firstResponse;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _requestCount) == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_firstResponse, Encoding.UTF8, "application/json")
+                });
+            }
+
+            // Simulate the feature-count query observing its own cancellation.
+            throw new OperationCanceledException("Simulated cancellation of the feature-count query.");
         }
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningAsyncReconcileTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FeatureStore/BranchVersioningAsyncReconcileTests.cs
@@ -161,6 +161,29 @@ public sealed class BranchVersioningAsyncReconcileTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task AsyncReconcileJob_HostShuttingDown_TerminatesAsFailedWithShutdownMessage()
+    {
+        // PA-030: the detached background job must observe IHostApplicationLifetime and
+        // record a clear terminal state (not sit unobserved past process teardown) when the
+        // host shuts down mid-run. A lifetime whose ApplicationStopping is already
+        // cancelled simulates the job starting just as shutdown begins.
+        var lifetime = new AlreadyStoppingApplicationLifetime();
+        await using var provider = BuildServiceProvider(lifetime);
+        var runner = provider.GetRequiredService<IVersionJobRunner>();
+
+        var versionManager = CreateVersionManager();
+        var version = await versionManager.CreateAsync(
+            new CreateVersionRequest("AsyncShutdown", "sde", VersionAccess.Public), CancellationToken.None);
+
+        var job = await runner.StartReconcileAsync(
+            "svc", version.VersionId, VersionReconcilePolicy.None, cancellationToken: CancellationToken.None);
+
+        var terminal = await PollJobAsync(runner, job.JobId);
+        terminal.Status.Should().Be(VersionJobStatus.Failed);
+        terminal.ErrorMessage.Should().Contain("shutting down");
+    }
+
+    [Fact]
     public async Task Reconcile_AfterRestart_IsIdempotentAndResumesPendingConflicts()
     {
         var store = CreateFeatureStore();
@@ -213,15 +236,40 @@ public sealed class BranchVersioningAsyncReconcileTests : IAsyncLifetime
         throw new TimeoutException($"Version job {jobId} did not reach a terminal state.");
     }
 
-    private ServiceProvider BuildServiceProvider()
+    private ServiceProvider BuildServiceProvider(Microsoft.Extensions.Hosting.IHostApplicationLifetime? lifetime = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IVersionLock>(_sharedLock);
         services.AddSingleton<IVersionJobStore, InMemoryVersionJobStore>();
         services.AddScoped<IVersionManager>(_ => CreateVersionManager());
+        if (lifetime is not null)
+        {
+            services.AddSingleton(lifetime);
+        }
+
         services.AddSingleton<IVersionJobRunner, VersionJobRunner>();
         return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Minimal <see cref="Microsoft.Extensions.Hosting.IHostApplicationLifetime"/> test double whose
+    /// <see cref="ApplicationStopping"/> is already cancelled, simulating a background job that starts
+    /// just as the host begins a graceful shutdown.
+    /// </summary>
+    private sealed class AlreadyStoppingApplicationLifetime : Microsoft.Extensions.Hosting.IHostApplicationLifetime
+    {
+        private readonly CancellationTokenSource _stoppingCts = new(0);
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+
+        public CancellationToken ApplicationStopping => _stoppingCts.Token;
+
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication()
+        {
+        }
     }
 
     private static Feature BuildFeature(string name, double x, double y, long id = 0)

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutorConnectionResolutionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutorConnectionResolutionTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using NSubstitute;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit coverage (no Testcontainers/Docker needed) for the secure-connection resolution
+/// failure path of <see cref="ExternalPostgisSinkExecutor"/> (#2404 PA-210): a resolver
+/// exception must be logged, not silently swallowed, while still returning a sanitized
+/// job failure to the caller.
+/// </summary>
+public sealed class ExternalPostgisSinkExecutorConnectionResolutionTests
+{
+    private const string DataUriPrefix = "data:application/geo+json;base64,";
+
+    [Fact]
+    public async Task ExecuteAsync_WhenResolverThrows_LogsFailureAndReturnsSanitizedError()
+    {
+        var resolver = Substitute.For<ISecureConnectionResolver>();
+        resolver
+            .ResolveConnectionStringAsync("external-target", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string>(new InvalidOperationException("secret store unreachable")));
+        var logger = new RecordingLogger<ExternalPostgisSinkExecutor>();
+        var executor = new ExternalPostgisSinkExecutor(Options(), resolver, logger);
+
+        var factory = new GeometryFactory(new PrecisionModel(), 4326);
+        var input = BuildInputUri(
+            new Feature(factory.CreatePoint(new Coordinate(13.405, 52.52)), new AttributesTable { { "name", "berlin" } }));
+
+        var record = Record(
+            ("input", input),
+            ("connectionName", "external-target"),
+            ("schema", "public"),
+            ("table", "external_out"),
+            ("targetSrid", "4326"));
+
+        var result = await executor.ExecuteAsync(record, Substitute.For<IJobExecutionContext>(), CancellationToken.None);
+
+        Assert.Equal(ExecutionJobStatus.Failed, result.Status);
+        Assert.Contains("secure connection could not be resolved", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret store unreachable", result.ErrorMessage ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains(logger.Entries, e => e.Exception is InvalidOperationException { Message: "secret store unreachable" });
+    }
+
+    private static IOptionsMonitor<GeoprocessingExecutorOptions> Options()
+    {
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+        return monitor;
+    }
+
+    private static string BuildInputUri(params IFeature[] features)
+    {
+        var collection = new FeatureCollection();
+        foreach (var feature in features)
+        {
+            collection.Add(feature);
+        }
+
+        var json = new GeoJsonWriter().Write(collection);
+        return DataUriPrefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+    }
+
+    private static ExecutionJobRecord Record(params (string Name, string Value)[] inputs)
+    {
+        const string processId = ExternalPostgisSinkExecutor.HandledProcessId;
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = processId,
+            ["protocolProcessId"] = processId,
+        };
+
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        foreach (var (name, value) in inputs)
+        {
+            parameters[prefix + name] = value;
+        }
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-ext",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:test",
+                Parameters = parameters
+            }
+        };
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, Exception? Exception, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, exception, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/RemoteSourceExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/RemoteSourceExecutorTests.cs
@@ -85,6 +85,44 @@ public sealed class RemoteSourceExecutorTests
         status.Should().Be(ExecutionJobStatus.Failed);
     }
 
+    [UnitTest]
+    public async Task RemoteSource_SecureConnectionResolverThrows_LogsInnerExceptionAndFailsCleanly()
+    {
+        // PA-211: the secure-connection resolution failure is wrapped in a
+        // TransformInputException with a sanitized PublicMessage, but the original
+        // exception must be preserved as InnerException and logged — not discarded —
+        // so an operator can diagnose why the connection could not be resolved.
+        var fake = new FakeDagFeatureSource("source.postgis", []);
+        var resolver = Substitute.For<Honua.Core.Features.Security.Abstractions.ISecureConnectionResolver>();
+        resolver
+            .ResolveConnectionStringAsync("broken-connection", Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string>(new InvalidOperationException("secret store unreachable")));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(fake as IDagFeatureSource);
+        services.AddSingleton(resolver);
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        var options = new GeoprocessingExecutorOptions
+        {
+            MaxArtifactBytes = 50L * 1024L * 1024L,
+            ResultRetention = TimeSpan.FromDays(7)
+        };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+
+        var logger = new RecordingLogger<RemoteSourceExecutor>();
+        var executor = RemoteSourceExecutor.ForProcess("source.postgis", scopeFactory, monitor, logger);
+
+        var (status, _, _) = await RunExecutorAsync(executor, "source.postgis", ("connectionName", "broken-connection"));
+
+        status.Should().Be(ExecutionJobStatus.Failed);
+        logger.Entries
+            .Any(e => e.Exception is InvalidOperationException { Message: "secret store unreachable" })
+            .Should().BeTrue("the original resolver exception must be logged, not discarded");
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -196,6 +234,36 @@ public sealed class RemoteSourceExecutorTests
             }
 
             await Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingLogger<T> : Microsoft.Extensions.Logging.ILogger<T>
+    {
+        public List<(Microsoft.Extensions.Logging.LogLevel Level, Exception? Exception, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => NullScope.Instance;
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, exception, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/AuditLog/Export/SplunkHecAuditSinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/AuditLog/Export/SplunkHecAuditSinkTests.cs
@@ -40,8 +40,7 @@ public sealed class SplunkHecAuditSinkTests
     public async Task SendAsync_Http200_ReturnsSuccess()
     {
         var handler = new StubHandler(HttpStatusCode.OK);
-        using var client = new HttpClient(handler);
-        var sink = new SplunkHecAuditSink(client, Options());
+        var sink = new SplunkHecAuditSink(new SingleHandlerHttpClientFactory(handler), "splunk", Options());
 
         var result = await sink.SendAsync(new[] { SampleEvent() }, CancellationToken.None);
 
@@ -54,8 +53,7 @@ public sealed class SplunkHecAuditSinkTests
     public async Task SendAsync_Http503_ReturnsRetryable()
     {
         var handler = new StubHandler(HttpStatusCode.ServiceUnavailable);
-        using var client = new HttpClient(handler);
-        var sink = new SplunkHecAuditSink(client, Options());
+        var sink = new SplunkHecAuditSink(new SingleHandlerHttpClientFactory(handler), "splunk", Options());
 
         var result = await sink.SendAsync(new[] { SampleEvent() }, CancellationToken.None);
 
@@ -67,13 +65,30 @@ public sealed class SplunkHecAuditSinkTests
     public async Task SendAsync_Http400_ReturnsPermanentFailure()
     {
         var handler = new StubHandler(HttpStatusCode.BadRequest);
-        using var client = new HttpClient(handler);
-        var sink = new SplunkHecAuditSink(client, Options());
+        var sink = new SplunkHecAuditSink(new SingleHandlerHttpClientFactory(handler), "splunk", Options());
 
         var result = await sink.SendAsync(new[] { SampleEvent() }, CancellationToken.None);
 
         result.Succeeded.Should().BeFalse();
         result.Retryable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendAsync_ResolvesClientFromFactoryOnEverySend()
+    {
+        // PA-081: the sink must not capture a single HttpClient at construction — it should
+        // resolve a fresh client from the factory on every send so a rotated/replaced
+        // primary handler (e.g. after a DNS change) is observed.
+        var handler = new StubHandler(HttpStatusCode.OK);
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var sink = new SplunkHecAuditSink(factory, "splunk", Options());
+
+        await sink.SendAsync(new[] { SampleEvent() }, CancellationToken.None);
+        await sink.SendAsync(new[] { SampleEvent() }, CancellationToken.None);
+
+        factory.CreateClientCallCount.Should().BeGreaterThanOrEqualTo(2,
+            "each send should resolve the named client from the factory rather than reusing one captured at construction");
+        factory.LastRequestedName.Should().Be("splunk");
     }
 
     private sealed class StubHandler : HttpMessageHandler
@@ -95,6 +110,32 @@ public sealed class SplunkHecAuditSinkTests
                 ? string.Join(' ', values)
                 : null;
             return Task.FromResult(new HttpResponseMessage(_status));
+        }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IHttpClientFactory"/> test double that hands back a client wired
+    /// to a fixed handler on every call, recording how many times (and with what name) it
+    /// was asked — used to assert sinks resolve a client per send instead of caching one.
+    /// </summary>
+    private sealed class SingleHandlerHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public SingleHandlerHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public int CreateClientCallCount { get; private set; }
+
+        public string? LastRequestedName { get; private set; }
+
+        public HttpClient CreateClient(string name)
+        {
+            CreateClientCallCount++;
+            LastRequestedName = name;
+            return new HttpClient(_handler, disposeHandler: false);
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2404

## Summary
Fixes the tractable, low-risk findings from the 2026-07 "Exceptions / Resilience" platform
cross-cut audit backlog (honua-server#2404, 17 findings total). Ships 15 targeted fixes and
documents 2 deferrals with rationale; does not close #2404 since it is a shared backlog
umbrella issue tracking multiple audit categories.

## Changes Made
- `VersionJobRunner` (PA-030): observe `IHostApplicationLifetime.ApplicationStopping` during
  the detached reconcile/post job and record a clear "shutting down" terminal `Failed` state
  instead of running unobserved past process teardown.
- `EditProcessor.ValidateEdit` / `OptimizeEdit` (PA-031, PA-035): narrow the broad
  `catch (Exception)` to the exception shapes that can genuinely arise from malformed input,
  so an unexpected bug propagates to the global exception middleware instead of being
  reported as a generic client validation failure.
- `InMemoryEncryptionPostureProvider.RotateAsync` (PA-032): add `KeyRotationOutcome.AuditRecorded`
  (and the compliance admin endpoint response field) so a failed audit-trail write is
  distinguishable from a fully-recorded rotation instead of an unconditional `Succeeded=true`.
- `SystemMetricsCollector.CollectMetrics` (PA-033): log the previously-silent bare
  `catch (Exception)`.
- `ArcGisRestClient.GetLayerInfoAsync` (PA-034): let `OperationCanceledException` propagate out
  of the best-effort feature-count query instead of being swallowed as "count unavailable".
- Audit export sinks — Splunk/Sentinel/S3 (PA-081): resolve a fresh named `HttpClient` from
  `IHttpClientFactory` on every send instead of capturing one at singleton construction, which
  bypassed `IHttpClientFactory`'s primary-handler rotation.
- `GeoprocessingLocalRunner` (PA-083): let `OutOfMemoryException` keep unwinding instead of
  being converted into a job failure result.
- ArcGIS REST federated `HttpClient` (PA-123): add an explicit per-request timeout and the
  existing shared retry/circuit-breaker resilience policy (`AddHttpResiliencePolicy`).
- `SemaphoreReleasingConnection` (PA-171): wrap inner `Dispose`/`DisposeAsync` in `try/finally`
  so the `MaxConcurrentQueries` semaphore slot is always released even if disposing the inner
  connection throws.
- `ExternalPostgisSinkExecutor` (PA-210) / `RemoteSourceExecutor` (PA-211): log the real
  exception (and thread it through a new `TransformInputException(message, innerException)`
  overload) when secure-connection resolution fails, instead of discarding it.
- `ODataFilterParser` (PA-215) / `FlatGeobufFormatReader` (PA-217): let
  `OperationCanceledException` pass through the malformed-input fallback catch blocks.
- Geoprocessing publish CLI (PA-218): set an explicit `HttpClient` timeout on the publish
  command's REST client.

**Deferred (documented, not changed):**
- PA-174 (GDAL runner wall-clock timeout): verified every call site already binds a
  timeout-linked `CancellationTokenSource` to `GdalWorkerOptions.ToolTimeout`
  (`GdalToolExecution.RunAndPublishAsync` and each executor). Moving the timeout into
  `IGdalCommandRunner` itself would touch ~19 call sites and two runner implementations for
  marginal additional defense-in-depth — left as a documented follow-up rather than done here.
- PA-216 (`GeoprocessingJobArtifactService` cancellation guard): verified the existing
  `catch (Exception ex) when (!cancellationToken.IsCancellationRequested)` guard is
  intentional, not inverted — it swallows third-party/foreign `OperationCanceledException` so
  the class's documented "store read/write failures are logged and swallowed" contract holds,
  while still letting the *caller's own* cancellation propagate uncaught. Applying the
  suggested `when (ex is not OperationCanceledException)` form would let foreign/internal
  timeouts escape uncaught, regressing that contract. No change made; noted as a false
  positive on the finding.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Added/extended tests for every behavior-affecting change: `VersionJobRunner` shutdown handling
(DB-backed), `RotateAsync` `AuditRecorded`, `ArcGisRestClient` cancellation propagation, the
audit sink per-send client resolution, and the two secure-connection-resolution logging paths
(one DB-free, one DB-backed via the existing Testcontainers fixture).

Verified locally: full solution build with `TreatWarningsAsErrors=true` (clean),
`dotnet format Honua.sln` (no changes), and targeted `dotnet test` runs for every touched area
(`Honua.Core.Tests` compliance/ArcGisRest suites, `Honua.Server.Tests` audit-sink/geoprocessing
unit tests, and the two Testcontainers-backed integration suites
`BranchVersioningAsyncReconcileTests` and `ExternalPostgisSinkExecutorTests`) — all green.
`scripts/ci/pre-pr-check.sh`'s affected-project computation errored on an unrelated stale
`.slnf` reference to a scripts-only project not in `Honua.sln`; this reproduces on a fresh
`origin/trunk` checkout too, so it is pre-existing tooling drift, not caused by this change.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact (the new `auditRecorded` response field is additive)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. `KeyRotationOutcome.AuditRecorded` and `ComplianceKeyRotationResponse.AuditRecorded` are
additive fields (default `true`); `TransformInputException` gained an optional
`innerException` constructor parameter; all sink/HTTP-client constructor signature changes are
internal/DI-only with no external callers.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
