### PR TITLE
fix(observability): close tractable audit findings from #2401

### DIFF
--- a/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationService.cs
+++ b/src/Honua.Ai/Features/AnalysisGeneration/AnalysisGenerationService.cs
@@ -9,6 +9,7 @@ using Honua.Ai.WorkflowGeneration.Models;
 using Honua.Core.Features.AnalysisContent.Domain;
 using Honua.Core.Features.Geoprocessing.Abstractions;
 using Honua.Core.Features.WorkflowPackages.Generation;
+using Honua.ServiceDefaults;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Ai.AnalysisGeneration;
@@ -48,12 +49,16 @@ public sealed class AnalysisGenerationService : IAnalysisGenerationService
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("honua.analysis_generation.generate");
+
         if (!_configuration.Enabled)
         {
             return Unsupported("AI analysis generation is disabled on this server.");
         }
 
         var providerId = string.IsNullOrWhiteSpace(request.Provider) ? _configuration.DefaultProvider : request.Provider!;
+        activity?.SetTag("honua.ai.provider", providerId);
+
         var options = _configuration.GetProvider(providerId);
         if (options is null || string.IsNullOrWhiteSpace(options.Endpoint) || string.IsNullOrWhiteSpace(options.Model))
         {

--- a/src/Honua.Ai/Features/Grounding/GroundingService.cs
+++ b/src/Honua.Ai/Features/Grounding/GroundingService.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.Grounding.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Geoprocessing;
+using Honua.ServiceDefaults;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -70,6 +71,8 @@ internal sealed class GroundingService : IGroundingService
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(principal);
+
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("honua.grounding.ground");
 
         if (string.IsNullOrWhiteSpace(request.Goal))
         {

--- a/src/Honua.ArcGisRest/Features/FeatureStore/ArcGisRestFeatureStore.cs
+++ b/src/Honua.ArcGisRest/Features/FeatureStore/ArcGisRestFeatureStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Text.Json;
 using Honua.ArcGisRest.Features.FeatureStore.Models;
 using Honua.ArcGisRest.Features.FeatureStore.Services;
@@ -10,6 +11,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Domain;
+using Microsoft.Extensions.Logging;
 
 namespace Honua.ArcGisRest.Features.FeatureStore;
 
@@ -31,6 +33,16 @@ namespace Honua.ArcGisRest.Features.FeatureStore;
 /// </remarks>
 internal sealed class ArcGisRestFeatureStore : IFeatureDataProvider, IFeatureReader, IBindableFeatureDataProvider
 {
+    /// <summary>
+    /// Dedicated ActivitySource for the federated ArcGIS REST provider (PA-108). One span
+    /// covers the entire paging loop in <see cref="QueryAsync"/> rather than per-page
+    /// spans, since a single query can issue up to <see cref="MaxPageIterations"/> outbound
+    /// HTTP calls and per-page spans would themselves become a cardinality problem. Must be
+    /// registered as <c>"Honua.ArcGisRest"</c> in <c>Honua.ServiceDefaults.Extensions._activitySourceNames</c>
+    /// or the spans are silently dropped by the tracer provider.
+    /// </summary>
+    private static readonly ActivitySource _activitySource = new("Honua.ArcGisRest");
+
     private static readonly FeatureProviderCapabilities _capabilities = new()
     {
         SupportsQuery = true,
@@ -68,16 +80,18 @@ internal sealed class ArcGisRestFeatureStore : IFeatureDataProvider, IFeatureRea
     private const int MaxPageIterations = 10_000;
 
     private readonly IArcGisRestFeatureClient _client;
+    private readonly ILogger<ArcGisRestFeatureStore> _logger;
     private readonly FeatureProviderBinding? _binding;
 
-    public ArcGisRestFeatureStore(IArcGisRestFeatureClient client)
-        : this(client, binding: null)
+    public ArcGisRestFeatureStore(IArcGisRestFeatureClient client, ILogger<ArcGisRestFeatureStore> logger)
+        : this(client, logger, binding: null)
     {
     }
 
-    private ArcGisRestFeatureStore(IArcGisRestFeatureClient client, FeatureProviderBinding? binding)
+    private ArcGisRestFeatureStore(IArcGisRestFeatureClient client, ILogger<ArcGisRestFeatureStore> logger, FeatureProviderBinding? binding)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _binding = binding;
     }
 
@@ -97,7 +111,7 @@ internal sealed class ArcGisRestFeatureStore : IFeatureDataProvider, IFeatureRea
     public IFeatureReader CreateReaderForBinding(FeatureProviderBinding binding)
     {
         ArgumentNullException.ThrowIfNull(binding);
-        return new ArcGisRestFeatureStore(_client, binding);
+        return new ArcGisRestFeatureStore(_client, _logger, binding);
     }
 
     /// <inheritdoc />
@@ -118,8 +132,16 @@ internal sealed class ArcGisRestFeatureStore : IFeatureDataProvider, IFeatureRea
         var context = ResolveBinding(layerId);
         var authHeader = ArcGisRestQueryParameters.BuildAuthorizationHeader(context.ServiceLocation.Token);
 
+        // One span for the whole federated query, not one per page: the loop below can
+        // issue up to MaxPageIterations outbound HTTP calls, and a child span per page
+        // would itself become a cardinality/performance problem (PA-108).
+        using var activity = _activitySource.StartActivity("honua.arcgisrest.query", ActivityKind.Client);
+        activity?.SetTag("honua.arcgisrest.service_url", context.ServiceLocation.ServiceUrl);
+        activity?.SetTag("honua.arcgisrest.layer_id", context.ArcGisLayerId);
+
         var geometryType = ResolveDeclaredGeometryType(context.Resource);
         var items = ImmutableArray.CreateBuilder<Feature>();
+        var pageCount = 0;
 
         // The caller-supplied paging window. The upstream service truncates each
         // /query response at its own maxRecordCount (commonly 1000–2000) and flags
@@ -161,6 +183,7 @@ internal sealed class ArcGisRestFeatureStore : IFeatureDataProvider, IFeatureRea
                 pageQuery);
 
             var response = await _client.QueryAsync(url, authHeader, cancellationToken).ConfigureAwait(false);
+            pageCount++;
             EnsureNoUpstreamError(response.Error);
 
             // The object-id field name only needs resolving once; later pages echo
@@ -215,6 +238,10 @@ internal sealed class ArcGisRestFeatureStore : IFeatureDataProvider, IFeatureRea
             EnsureNoUpstreamError(countResponse.Error);
             totalCount = countResponse.Count;
         }
+
+        activity?.SetTag("honua.arcgisrest.page_count", pageCount);
+        activity?.SetTag("honua.arcgisrest.feature_count", built.Length);
+        ArcGisRestFeatureStoreLog.QueryPagesFetched(_logger, context.ArcGisLayerId, pageCount, built.Length);
 
         return QueryResult<Feature>.Create(totalCount, built, exceededTransferLimit);
     }

--- a/src/Honua.ArcGisRest/Features/FeatureStore/ArcGisRestFeatureStoreLog.cs
+++ b/src/Honua.ArcGisRest/Features/FeatureStore/ArcGisRestFeatureStoreLog.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Logging;
+
+namespace Honua.ArcGisRest.Features.FeatureStore;
+
+/// <summary>
+/// Source-generated structured log messages for <see cref="ArcGisRestFeatureStore"/>.
+/// </summary>
+internal static partial class ArcGisRestFeatureStoreLog
+{
+    /// <summary>
+    /// Debug-level summary of a completed federated query's paging loop (PA-108): how many
+    /// upstream <c>/query</c> round-trips were issued and how many features were assembled.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 8100,
+        Level = LogLevel.Debug,
+        Message = "ArcGIS REST query for layer {ArcGisLayerId} fetched {PageCount} page(s) totaling {FeatureCount} feature(s).")]
+    public static partial void QueryPagesFetched(ILogger logger, int arcGisLayerId, int pageCount, int featureCount);
+}

--- a/src/Honua.Azure/Features/Alerts/AzureEventGridAlertDeliverySink.cs
+++ b/src/Honua.Azure/Features/Alerts/AzureEventGridAlertDeliverySink.cs
@@ -6,21 +6,25 @@ using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Alerts;
 
-internal sealed class AzureEventGridAlertDeliverySink : IAlertDeliverySink
+internal sealed partial class AzureEventGridAlertDeliverySink : IAlertDeliverySink
 {
     private readonly EventGridPublisherClient _client;
     private readonly AlertDeliveryOptions _options;
+    private readonly ILogger<AzureEventGridAlertDeliverySink> _logger;
 
     public AzureEventGridAlertDeliverySink(
         EventGridPublisherClient client,
-        IOptions<AlertDeliveryOptions> options)
+        IOptions<AlertDeliveryOptions> options,
+        ILogger<AzureEventGridAlertDeliverySink> logger)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public AlertChannelType ChannelType => AlertChannelType.AzureEventGrid;
@@ -97,8 +101,9 @@ internal sealed class AzureEventGridAlertDeliverySink : IAlertDeliverySink
                 Error = "Event Grid topic not found."
             };
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Log.DeliveryFailed(_logger, ex);
             return new AlertDeliveryResult
             {
                 Succeeded = false,
@@ -106,5 +111,11 @@ internal sealed class AzureEventGridAlertDeliverySink : IAlertDeliverySink
                 Error = "Event Grid alert delivery failed."
             };
         }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(10120, LogLevel.Warning, "Event Grid alert delivery failed with an unhandled exception.")]
+        public static partial void DeliveryFailed(ILogger logger, Exception ex);
     }
 }

--- a/src/Honua.Azure/Features/Alerts/AzureEventHubAlertDeliverySink.cs
+++ b/src/Honua.Azure/Features/Alerts/AzureEventHubAlertDeliverySink.cs
@@ -5,6 +5,7 @@ using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Alerts;
@@ -68,17 +69,20 @@ internal sealed class EventHubPublisher : IEventHubPublisher
     }
 }
 
-internal sealed class AzureEventHubAlertDeliverySink : IAlertDeliverySink
+internal sealed partial class AzureEventHubAlertDeliverySink : IAlertDeliverySink
 {
     private readonly IEventHubPublisher _publisher;
     private readonly AlertDeliveryOptions _options;
+    private readonly ILogger<AzureEventHubAlertDeliverySink> _logger;
 
     public AzureEventHubAlertDeliverySink(
         IEventHubPublisher publisher,
-        IOptions<AlertDeliveryOptions> options)
+        IOptions<AlertDeliveryOptions> options,
+        ILogger<AzureEventHubAlertDeliverySink> logger)
     {
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public AlertChannelType ChannelType => AlertChannelType.AzureEventHub;
@@ -117,8 +121,9 @@ internal sealed class AzureEventHubAlertDeliverySink : IAlertDeliverySink
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Log.DeliveryFailed(_logger, ex);
             return new AlertDeliveryResult
             {
                 Succeeded = false,
@@ -126,5 +131,11 @@ internal sealed class AzureEventHubAlertDeliverySink : IAlertDeliverySink
                 Error = "Event Hub alert delivery failed."
             };
         }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(10121, LogLevel.Warning, "Event Hub alert delivery failed with an unhandled exception.")]
+        public static partial void DeliveryFailed(ILogger logger, Exception ex);
     }
 }

--- a/src/Honua.Core/Features/AuditLog/Export/AuditExportDispatcher.cs
+++ b/src/Honua.Core/Features/AuditLog/Export/AuditExportDispatcher.cs
@@ -123,6 +123,7 @@ public sealed partial class AuditExportDispatcher
             {
                 // Sink contract is non-throwing; defensively treat an escaped
                 // exception as a transient failure so it follows the retry path.
+                LogSinkThrew(sink.SinkType, ex);
                 result = AuditSinkResult.TransientFailure(ex.Message);
             }
 
@@ -197,4 +198,10 @@ public sealed partial class AuditExportDispatcher
         Level = LogLevel.Error,
         Message = "Audit export to sink {SinkType} blocked by data residency (region {Region}); dead-lettered {EventCount} event(s).")]
     partial void LogResidencyViolation(string sinkType, string region, int eventCount);
+
+    [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Warning,
+        Message = "Audit export sink {SinkType} threw an unexpected exception; treating as a transient failure.")]
+    partial void LogSinkThrew(string sinkType, Exception exception);
 }

--- a/src/Honua.Core/Features/Edit/EditProcessor.cs
+++ b/src/Honua.Core/Features/Edit/EditProcessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -15,6 +16,13 @@ namespace Honua.Core.Features.Edit;
 /// </summary>
 public sealed class EditProcessor : IEditProcessor
 {
+    // PA-018: the feature-write pipeline (validate/optimize/convert) is called separately by
+    // every protocol adapter and previously emitted no telemetry at all. Honua.Core cannot
+    // depend on Honua.ServiceDefaults (see the dependency-direction rule), so this mirrors the
+    // local-ActivitySource convention already used elsewhere in this project (e.g.
+    // VersionJobRunner) rather than referencing HonuaTelemetry.ActivitySource.
+    private static readonly ActivitySource _activitySource = new("Honua.Core.Edit");
+
     private readonly ILogger<EditProcessor> _logger;
 
     /// <summary>
@@ -66,6 +74,9 @@ public sealed class EditProcessor : IEditProcessor
     {
         ArgumentNullException.ThrowIfNull(resource);
 
+        using var activity = _activitySource.StartActivity("edit.validate");
+        activity?.SetTag("honua.resource.id", resource.Metadata.Id);
+
         try
         {
             var warnings = new List<string>();
@@ -73,6 +84,7 @@ public sealed class EditProcessor : IEditProcessor
             // Check if edit request is empty
             if (editRequest.IsEmpty)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, "Edit request cannot be empty");
                 return EditValidationResult.Failure("Edit request cannot be empty");
             }
 
@@ -80,6 +92,7 @@ public sealed class EditProcessor : IEditProcessor
             var totalOperations = editRequest.TotalOperations;
             if (totalOperations > GetMaxOperationsForResource(resource))
             {
+                activity?.SetStatus(ActivityStatusCode.Error, "Too many operations");
                 return EditValidationResult.Failure(
                     $"Too many operations ({totalOperations}). Maximum allowed: {GetMaxOperationsForResource(resource)}");
             }
@@ -145,6 +158,7 @@ public sealed class EditProcessor : IEditProcessor
         // middleware instead of being disguised as "your edit request is invalid".
         catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             EditLog.ValidateEditFailed(_logger, resource.Metadata.Id, ex);
             return EditValidationResult.Failure("Failed to validate edit request");
         }
@@ -154,6 +168,9 @@ public sealed class EditProcessor : IEditProcessor
     public UnifiedEditRequest OptimizeEdit(UnifiedEditRequest editRequest, MetadataV2Resource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);
+
+        using var activity = _activitySource.StartActivity("edit.optimize");
+        activity?.SetTag("honua.resource.id", resource.Metadata.Id);
 
         try
         {
@@ -189,6 +206,7 @@ public sealed class EditProcessor : IEditProcessor
         // silently masked by falling back to the unoptimized request.
         catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             EditLog.OptimizeEditFailed(_logger, resource.Metadata.Id, ex);
             return editRequest;
         }
@@ -198,6 +216,9 @@ public sealed class EditProcessor : IEditProcessor
     public FeatureEditBatch ToFeatureEditBatch(UnifiedEditRequest editRequest, MetadataV2Resource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);
+
+        using var activity = _activitySource.StartActivity("edit.tofeaturebatch");
+        activity?.SetTag("honua.resource.id", resource.Metadata.Id);
 
         try
         {
@@ -230,6 +251,7 @@ public sealed class EditProcessor : IEditProcessor
         }
         catch (Exception ex)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             EditLog.FeatureEditBatchConversionFailed(_logger, resource.Metadata.Id, ex);
             throw;
         }
@@ -239,6 +261,9 @@ public sealed class EditProcessor : IEditProcessor
     public TransactionValidationResult ValidateTransaction(EditTransaction transaction, MetadataV2Resource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);
+
+        using var activity = _activitySource.StartActivity("edit.validatetransaction");
+        activity?.SetTag("honua.resource.id", resource.Metadata.Id);
 
         try
         {
@@ -304,6 +329,7 @@ public sealed class EditProcessor : IEditProcessor
         }
         catch (Exception ex)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             EditLog.ValidateTransactionFailed(_logger, transaction.TransactionId, resource.Metadata.Id, ex);
             return TransactionValidationResult.Failure("Failed to validate transaction");
         }

--- a/src/Honua.Core/Features/FeatureStore/Services/FeatureProviderQueryRouter.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/FeatureProviderQueryRouter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -14,6 +15,10 @@ namespace Honua.Core.Features.FeatureStore.Services;
 /// </summary>
 public sealed class FeatureProviderQueryRouter
 {
+    // PA-019: every query goes through this resolution hot path, and it previously emitted no
+    // telemetry at all (no span, no metrics, no logging).
+    private static readonly ActivitySource _activitySource = new("Honua.Core.FeatureStore");
+
     private readonly ISecureConnectionRegistry _connectionRegistry;
     private readonly IFeatureDataProviderRegistry _providerRegistry;
     private readonly string _defaultProviderName;
@@ -67,58 +72,73 @@ public sealed class FeatureProviderQueryRouter
         ArgumentNullException.ThrowIfNull(service);
         ArgumentNullException.ThrowIfNull(resource);
         ArgumentNullException.ThrowIfNull(publication);
-        var storageBinding = snapshot.ResolveStorageBinding(publication)
-            ?? throw new InvalidOperationException(
-                $"Publication '{publication.Metadata.Id}' on service '{service.Metadata.Id}' does not resolve to a storage binding.");
-        var resolvedStorageLayerId = storageBinding.StorageLayerId ?? storageLayerId;
-        var storageMapping = FeatureStorageMapping.FromMetadata(resource, storageBinding);
 
-        DataConnection? connection = null;
-        var providerName = _defaultProviderName;
+        using var activity = _activitySource.StartActivity("featurestore.resolve_reader");
+        activity?.SetTag("service.id", service.Metadata.Id);
+        activity?.SetTag("resource.id", resource.Metadata.Id);
+        activity?.SetTag("publication.id", publication.Metadata.Id);
 
-        var v2Connection = snapshot.ResolveConnection(storageBinding);
-        if (v2Connection != null)
+        try
         {
-            connection = await _connectionRegistry
-                .GetConnectionAsync(v2Connection.Metadata.Id, cancellationToken)
-                .ConfigureAwait(false);
+            var storageBinding = snapshot.ResolveStorageBinding(publication)
+                ?? throw new InvalidOperationException(
+                    $"Publication '{publication.Metadata.Id}' on service '{service.Metadata.Id}' does not resolve to a storage binding.");
+            var resolvedStorageLayerId = storageBinding.StorageLayerId ?? storageLayerId;
+            var storageMapping = FeatureStorageMapping.FromMetadata(resource, storageBinding);
 
-            if (connection != null)
+            DataConnection? connection = null;
+            var providerName = _defaultProviderName;
+
+            var v2Connection = snapshot.ResolveConnection(storageBinding);
+            if (v2Connection != null)
             {
-                providerName = connection.NormalizedProvider;
+                connection = await _connectionRegistry
+                    .GetConnectionAsync(v2Connection.Metadata.Id, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (connection != null)
+                {
+                    providerName = connection.NormalizedProvider;
+                }
+                else if (!string.IsNullOrWhiteSpace(v2Connection.Provider))
+                {
+                    providerName = DataProviderNames.Normalize(v2Connection.Provider!);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Connection '{v2Connection.Metadata.Id}' for publication '{publication.Metadata.Id}' on service '{service.Metadata.Id}' was not found.");
+                }
             }
-            else if (!string.IsNullOrWhiteSpace(v2Connection.Provider))
-            {
-                providerName = DataProviderNames.Normalize(v2Connection.Provider!);
-            }
-            else
+
+            if (!_providerRegistry.TryGetProvider(providerName, out var provider))
             {
                 throw new InvalidOperationException(
-                    $"Connection '{v2Connection.Metadata.Id}' for publication '{publication.Metadata.Id}' on service '{service.Metadata.Id}' was not found.");
+                    $"Feature provider '{providerName}' is not registered for publication '{publication.Metadata.Id}' on service '{service.Metadata.Id}'.");
             }
-        }
 
-        if (!_providerRegistry.TryGetProvider(providerName, out var provider))
+            activity?.SetTag("provider.name", providerName);
+            EnsureOperationSupported(provider, operation);
+
+            var providerBinding = new FeatureProviderBinding(
+                service,
+                resource,
+                publication,
+                storageBinding,
+                storageMapping,
+                resolvedStorageLayerId,
+                provider,
+                connection);
+
+            return provider is IBindableFeatureDataProvider bindable
+                ? bindable.CreateReaderForBinding(providerBinding)
+                : provider.Reader;
+        }
+        catch (InvalidOperationException ex)
         {
-            throw new InvalidOperationException(
-                $"Feature provider '{providerName}' is not registered for publication '{publication.Metadata.Id}' on service '{service.Metadata.Id}'.");
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
         }
-
-        EnsureOperationSupported(provider, operation);
-
-        var providerBinding = new FeatureProviderBinding(
-            service,
-            resource,
-            publication,
-            storageBinding,
-            storageMapping,
-            resolvedStorageLayerId,
-            provider,
-            connection);
-
-        return provider is IBindableFeatureDataProvider bindable
-            ? bindable.CreateReaderForBinding(providerBinding)
-            : provider.Reader;
     }
 
     private static void EnsureOperationSupported(

--- a/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/ReplicaSyncService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Microsoft.Extensions.Logging;
@@ -24,6 +25,10 @@ namespace Honua.Core.Features.FeatureStore.Services;
 /// </remarks>
 public sealed partial class ReplicaSyncService : IReplicaSyncService
 {
+    // PA-020: replica conflict detection / edit application is a hot path (every replica
+    // upload) and previously had no telemetry span.
+    private static readonly ActivitySource _activitySource = new("Honua.Core.FeatureStore");
+
     private readonly IChangeTracker _changeTracker;
     private readonly IReplicaConflictRepository _conflictRepository;
     private readonly ILogger<ReplicaSyncService> _logger;
@@ -53,6 +58,12 @@ public sealed partial class ReplicaSyncService : IReplicaSyncService
         ArgumentNullException.ThrowIfNull(editApplier);
 
         var layerEdits = request.LayerEdits;
+
+        using var activity = _activitySource.StartActivity("replicasync.apply_upload");
+        activity?.SetTag("replica.id", request.ReplicaId);
+        activity?.SetTag("service.id", request.ServiceId);
+        activity?.SetTag("replicasync.layer_count", layerEdits.IsDefault ? 0 : layerEdits.Length);
+
         if (layerEdits.IsDefaultOrEmpty)
         {
             var currentGen = await _changeTracker.GetCurrentGenerationAsync(cancellationToken).ConfigureAwait(false);
@@ -183,6 +194,12 @@ public sealed partial class ReplicaSyncService : IReplicaSyncService
         if (conflicts.Count > 0)
         {
             Log.ConflictsDetected(_logger, request.ReplicaId, request.ServiceId, conflicts.Count, applyConflicting);
+        }
+
+        activity?.SetTag("replicasync.conflict_count", conflicts.Count);
+        if (anyFailure)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, firstFailure);
         }
 
         // The server generation produced once the uploaded edits applied. A subsequent download delta

--- a/src/Honua.Core/Features/FeatureStore/Services/VersionJobRunner.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/VersionJobRunner.cs
@@ -107,7 +107,18 @@ public sealed partial class VersionJobRunner : IVersionJobRunner
 
     private async Task ExecuteAsync(VersionJob job)
     {
-        using var activity = ActivitySource.StartActivity($"VersionJob.{job.Kind}", ActivityKind.Internal);
+        // PA-021: Task.Run flows the ambient ExecutionContext by default, so Activity.Current
+        // here would still be the HTTP request's activity — which ends when the response
+        // returns, long before this detached background job finishes. Capture it as a link
+        // instead of letting StartActivity implicitly parent to it. Passing default(ActivityContext)
+        // is NOT enough to force a root span: when it is the all-zero/invalid context the
+        // ActivitySource falls back to Activity.Current as the implicit parent, so we must null
+        // out the ambient activity first so the job span starts a fresh trace of its own.
+        var callerContext = Activity.Current?.Context;
+        var links = callerContext is { } ctx ? new[] { new ActivityLink(ctx) } : null;
+        Activity.Current = null;
+        using var activity = ActivitySource.StartActivity(
+            $"VersionJob.{job.Kind}", ActivityKind.Internal, default(ActivityContext), links: links);
         activity?.SetTag("honua.version.job_id", job.JobId.ToString());
         activity?.SetTag("honua.version.id", job.VersionId.ToString());
         activity?.SetTag("honua.version.service", job.Service);

--- a/src/Honua.Core/Features/Federation/Services/FederatedQueryExecutor.cs
+++ b/src/Honua.Core/Features/Federation/Services/FederatedQueryExecutor.cs
@@ -23,6 +23,10 @@ namespace Honua.Core.Features.Federation.Services;
 /// </summary>
 internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
 {
+    // PA-017: remote federated source calls had metrics and structured logging but no
+    // distributed tracing span, so a slow/failing remote source was invisible in traces.
+    private static readonly ActivitySource _activitySource = new("Honua.Federation");
+
     private readonly IFederationQueryPlanner _planner;
     private readonly Dictionary<FederatedSourceKind, IFederatedSourceConnector> _connectors;
     private readonly ResiliencePolicyOptions _resilienceOptions;
@@ -67,9 +71,14 @@ internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
     {
         ArgumentNullException.ThrowIfNull(source);
 
+        using var activity = _activitySource.StartActivity("federation.execute", ActivityKind.Client);
+        activity?.SetTag("source.id", source.Id);
+        activity?.SetTag("source.kind", source.Kind.ToString());
+
         if (!_connectors.TryGetValue(source.Kind, out var connector))
         {
             _metrics.RecordUnavailable(source, FederatedSourceUnavailableReason.NoConnector, TimeSpan.Zero);
+            activity?.SetStatus(ActivityStatusCode.Error, "No connector registered for source kind.");
             throw new FederatedSourceUnavailableException(source.Id, FederatedSourceUnavailableReason.NoConnector);
         }
 
@@ -87,6 +96,7 @@ internal sealed class FederatedQueryExecutor : IFederatedQueryExecutor
         {
             stopwatch.Stop();
             _metrics.RecordUnavailable(source, ex.Reason, stopwatch.Elapsed);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }
 

--- a/src/Honua.Core/Features/FileImport/Services/InMemoryImportJobService.cs
+++ b/src/Honua.Core/Features/FileImport/Services/InMemoryImportJobService.cs
@@ -60,6 +60,11 @@ internal static class ImportFormatDispatchGuard
 /// </summary>
 internal sealed partial class InMemoryImportJobService : IImportJobService, IDisposable
 {
+    // PA-016: background import processing is fire-and-forget from the request handler
+    // (`_ = ProcessJobAsync(...)`), so it needs its own ActivitySource — see the
+    // detach-from-caller idiom at the top of ProcessJobAsync below.
+    private static readonly ActivitySource ActivitySource = new("Honua.Import.Jobs", "1.0.0");
+
     private const string SafeImportFailureMessage = "Import failed.";
     private readonly IFileImportService _importService;
     private readonly IPerformanceMonitor _performanceMonitor;
@@ -196,6 +201,21 @@ internal sealed partial class InMemoryImportJobService : IImportJobService, IDis
         string? tempFilePath,
         CancellationToken cancellationToken)
     {
+        // PA-016: this method runs fire-and-forget (`_ = ProcessJobAsync(...)`) off the request
+        // handler. Because the async continuation still flows the caller's ExecutionContext,
+        // Activity.Current here would be the HTTP request's activity — which ends when the
+        // response returns, long before this background job finishes. Capture it as a link
+        // instead of an implicit parent. Passing default(ActivityContext) alone does NOT force a
+        // root span — the ActivitySource falls back to Activity.Current when the context is the
+        // all-zero/invalid value — so null out the ambient activity first for a fresh trace.
+        var callerContext = Activity.Current?.Context;
+        var links = callerContext is { } ctx ? new[] { new ActivityLink(ctx) } : null;
+        Activity.Current = null;
+        using var activity = ActivitySource.StartActivity(
+            "ImportJob.Process", ActivityKind.Internal, default(ActivityContext), links: links);
+        activity?.SetTag("honua.import.job_id", jobId);
+        activity?.SetTag("honua.import.table_name", request.TableName);
+
         var stopwatch = Stopwatch.StartNew();
         var status = "failed";
         int? featureCount = null;
@@ -207,6 +227,7 @@ internal sealed partial class InMemoryImportJobService : IImportJobService, IDis
         {
             if (_jobs.TryGetValue(jobId, out var state))
             {
+                activity?.SetTag("honua.import.format", state.Format);
                 state.Progress = state.Progress with { Status = ImportStatus.Processing };
                 ImportJobLog.JobStarted(_logger, jobId, state.TableName, state.Format, state.FileSize);
             }
@@ -255,6 +276,7 @@ internal sealed partial class InMemoryImportJobService : IImportJobService, IDis
         }
         catch (OperationCanceledException)
         {
+            activity?.SetTag("honua.import.outcome", "cancelled");
             if (_jobs.TryGetValue(jobId, out var state))
             {
                 status = "cancelled";
@@ -270,6 +292,8 @@ internal sealed partial class InMemoryImportJobService : IImportJobService, IDis
         }
         catch (Exception ex)
         {
+            activity?.SetTag("honua.import.outcome", "failed");
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             if (_jobs.TryGetValue(jobId, out var state))
             {
                 status = "failed";

--- a/src/Honua.Core/Features/FileImport/Services/UniversalImportJobService.cs
+++ b/src/Honua.Core/Features/FileImport/Services/UniversalImportJobService.cs
@@ -20,6 +20,12 @@ namespace Honua.Core.Features.FileImport.Services;
 /// </summary>
 internal sealed partial class UniversalImportJobService : IImportJobService, IDisposable
 {
+    // PA-016: this is the DI-registered IImportJobService (see ServiceCollectionExtensions.cs) and
+    // its ProcessJobAsync is invoked fire-and-forget (`_ = ProcessJobAsync(...)`), so it needs its
+    // own ActivitySource plus the detach-from-caller idiom at the top of ProcessJobAsync. Registered
+    // as "Honua.Import.Jobs" in Honua.ServiceDefaults.Extensions._activitySourceNames.
+    private static readonly ActivitySource ActivitySource = new("Honua.Import.Jobs", "1.0.0");
+
     private const string SafeImportFailureMessage = "Import failed.";
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IUniversalProgressStore _progressStore;
@@ -184,6 +190,21 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
         string? tempFilePath,
         CancellationToken cancellationToken)
     {
+        // PA-016: fire-and-forget (`_ = ProcessJobAsync(...)`) off the request handler. The
+        // continuation still flows the caller's ExecutionContext, so Activity.Current here would
+        // otherwise be the HTTP request's activity — which ends when the response returns, long
+        // before this background job finishes. Capture it as a link instead of an implicit
+        // parent. Passing default(ActivityContext) alone does NOT force a root span — the
+        // ActivitySource falls back to Activity.Current when the context is the all-zero/invalid
+        // value — so null out the ambient activity first for a fresh trace.
+        var callerContext = Activity.Current?.Context;
+        var links = callerContext is { } ctx ? new[] { new ActivityLink(ctx) } : null;
+        Activity.Current = null;
+        using var activity = ActivitySource.StartActivity(
+            "ImportJob.Process", ActivityKind.Internal, default(ActivityContext), links: links);
+        activity?.SetTag("honua.import.job_id", jobId);
+        activity?.SetTag("honua.import.table_name", request.TableName);
+
         var stopwatch = Stopwatch.StartNew();
         var status = "failed";
         int? featureCount = null;
@@ -196,6 +217,7 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
         {
             if (_jobs.TryGetValue(jobId, out var state))
             {
+                activity?.SetTag("honua.import.format", state.Format);
                 var currentProgress = await _progressStore.GetProgressAsync<ImportProgress>(jobId, cancellationToken);
                 if (currentProgress != null)
                 {
@@ -252,6 +274,7 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
         }
         catch (OperationCanceledException)
         {
+            activity?.SetTag("honua.import.outcome", "cancelled");
             if (_jobs.TryGetValue(jobId, out var state))
             {
                 status = "cancelled";
@@ -278,6 +301,8 @@ internal sealed partial class UniversalImportJobService : IImportJobService, IDi
         }
         catch (Exception ex)
         {
+            activity?.SetTag("honua.import.outcome", "failed");
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             if (_jobs.TryGetValue(jobId, out var state))
             {
                 status = "failed";

--- a/src/Honua.Core/Features/Operations/Services/OperationCatalog.cs
+++ b/src/Honua.Core/Features/Operations/Services/OperationCatalog.cs
@@ -14,7 +14,7 @@ namespace Honua.Core.Features.Operations.Services;
 /// the workflow node registry's aggregation: providers are queried, descriptors are sorted
 /// for stable output, and a fingerprint version is computed over the descriptor ids.
 /// </summary>
-public sealed class OperationCatalog : IOperationCatalog
+public sealed class OperationCatalog : IOperationCatalog, IDisposable
 {
     // Every operation dispatch calls GetDescriptorAsync, which previously rebuilt the
     // whole catalog (querying every provider, re-sorting, re-hashing a version string)
@@ -149,4 +149,10 @@ public sealed class OperationCatalog : IOperationCatalog
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
         return "operation-catalog:" + Convert.ToHexString(hash)[..16].ToLowerInvariant();
     }
+
+    /// <summary>
+    /// Disposes the snapshot-cache lock. The catalog is registered as a singleton and owns the
+    /// <see cref="SemaphoreSlim"/> guarding its cached snapshot, so it must dispose it (CA1001).
+    /// </summary>
+    public void Dispose() => _snapshotLock.Dispose();
 }

--- a/src/Honua.Geocoding/Features/Geocoding/Abstractions/BaseGeocodeProvider.cs
+++ b/src/Honua.Geocoding/Features/Geocoding/Abstractions/BaseGeocodeProvider.cs
@@ -78,14 +78,18 @@ internal abstract class BaseGeocodeProvider : IGeocodeProvider
                 ResponseTimeMs = stopwatch.Elapsed.TotalMilliseconds
             };
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             stopwatch.Stop();
 
+            // No ILogger is threaded through this abstract base (none of the five
+            // concrete providers currently accept one; PA-067/PA-201), so the
+            // exception detail is surfaced in the returned health record itself —
+            // that is the only diagnostic signal available to callers here.
             return new GeocodeProviderHealth(
                 ProviderName: Name,
                 IsHealthy: false,
-                ErrorMessage: "Provider health check failed.",
+                ErrorMessage: $"Provider health check failed: {ex.GetType().Name}: {ex.Message}",
                 LastChecked: DateTime.UtcNow)
             {
                 ResponseTimeMs = stopwatch.Elapsed.TotalMilliseconds

--- a/src/Honua.Geocoding/Features/Geocoding/Services/GeocodeCoordinatorService.cs
+++ b/src/Honua.Geocoding/Features/Geocoding/Services/GeocodeCoordinatorService.cs
@@ -282,11 +282,18 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        using var activity = GeocodingTelemetry.Source.StartActivity("geocoding.suggest");
+        activity?.SetTag("honua.geocoding.operation", "suggest");
+        activity?.SetTag("honua.geocoding.preferred_provider", providerName);
+        // Length only — never tag the raw query text (PII).
+        activity?.SetTag("honua.geocoding.query_length", request.Text?.Length ?? 0);
+
         var providers = GetProvidersToTry(providerName);
 
         var throttled = EnforceRateLimit<IReadOnlyList<GeocodeSuggestion>>(providers, static p => p.Capabilities.SupportsSuggest);
         if (throttled is not null)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, throttled.ErrorMessage);
             return throttled;
         }
 
@@ -325,6 +332,9 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
                     stopwatch.Elapsed.TotalMilliseconds,
                     results.Count);
 
+                activity?.SetTag("honua.geocoding.provider", provider.Name);
+                activity?.SetTag("honua.geocoding.result_count", results.Count);
+
                 return GeocodeResults.Success<IReadOnlyList<GeocodeSuggestion>>(
                     results, provider.Name, stopwatch.Elapsed.TotalMilliseconds);
             }
@@ -360,6 +370,10 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             string.Join(", ", attemptedProviders),
             lastException);
 
+        activity?.SetTag("honua.geocoding.provider", failedProviderName);
+        activity?.SetTag("honua.geocoding.result_count", 0);
+        activity?.SetStatus(ActivityStatusCode.Error, errorMessage);
+
         return GeocodeResults.Failure<IReadOnlyList<GeocodeSuggestion>>(
             errorMessage, failedProviderName, attemptedProviders: attemptedProviders);
     }
@@ -370,6 +384,11 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+
+        using var activity = GeocodingTelemetry.Source.StartActivity("geocoding.batch");
+        activity?.SetTag("honua.geocoding.operation", "batch");
+        activity?.SetTag("honua.geocoding.preferred_provider", providerName);
+        activity?.SetTag("honua.geocoding.batch_size", request.Queries.Count);
 
         var providers = GetProvidersToTry(providerName);
 
@@ -383,8 +402,10 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             if (!batchDecision.Allowed)
             {
                 GeocodeCoordinatorLog.BatchSizeRejected(_logger, batchPrimary.Name, request.Queries.Count, batchDecision.EffectiveLimit ?? 0);
+                var rejection = batchDecision.Reason ?? "Batch size exceeds the maximum allowed batch size.";
+                activity?.SetStatus(ActivityStatusCode.Error, rejection);
                 return GeocodeResults.Failure<IReadOnlyList<GeocodeCandidate>>(
-                    batchDecision.Reason ?? "Batch size exceeds the maximum allowed batch size.",
+                    rejection,
                     batchPrimary.Name,
                     attemptedProviders: [batchPrimary.Name]);
             }
@@ -393,6 +414,7 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
         var throttled = EnforceRateLimit<IReadOnlyList<GeocodeCandidate>>(providers, static p => p.Capabilities.SupportsBatch);
         if (throttled is not null)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, throttled.ErrorMessage);
             return throttled;
         }
 
@@ -431,6 +453,9 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
                     stopwatch.Elapsed.TotalMilliseconds,
                     results.Count);
 
+                activity?.SetTag("honua.geocoding.provider", provider.Name);
+                activity?.SetTag("honua.geocoding.result_count", results.Count);
+
                 return GeocodeResults.Success<IReadOnlyList<GeocodeCandidate>>(
                     results, provider.Name, stopwatch.Elapsed.TotalMilliseconds);
             }
@@ -465,6 +490,10 @@ internal sealed class GeocodeCoordinatorService : IGeocodeCoordinatorService
             "batch geocoding",
             string.Join(", ", attemptedProviders),
             lastException);
+
+        activity?.SetTag("honua.geocoding.provider", failedProviderName);
+        activity?.SetTag("honua.geocoding.result_count", 0);
+        activity?.SetStatus(ActivityStatusCode.Error, errorMessage);
 
         return GeocodeResults.Failure<IReadOnlyList<GeocodeCandidate>>(
             errorMessage, failedProviderName, attemptedProviders: attemptedProviders);

--- a/src/Honua.Import/Features/Migration/MigrationRunAdminEndpoints.cs
+++ b/src/Honua.Import/Features/Migration/MigrationRunAdminEndpoints.cs
@@ -29,7 +29,7 @@ namespace Honua.Migration;
 /// adapter over <see cref="IMigrationRunCatalog"/>; all storage decisions
 /// (Postgres today, alternate backends tomorrow) live behind the catalog.
 /// </summary>
-internal static class MigrationRunAdminEndpoints
+internal static partial class MigrationRunAdminEndpoints
 {
     private const int DefaultPageLimit = 25;
     private const int MaxPageLimit = 100;
@@ -117,8 +117,9 @@ internal static class MigrationRunAdminEndpoints
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Log.RequestBodyReadFailed(GetLogger(context), "RecordMigrationRunStarted", ex);
             await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body.", StatusCodes.Status400BadRequest);
             return;
         }
@@ -291,8 +292,9 @@ internal static class MigrationRunAdminEndpoints
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Log.RequestBodyReadFailedForRun(GetLogger(context), "RecordMigrationRunCompleted", runId, ex);
             await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body.", StatusCodes.Status400BadRequest);
             return;
         }
@@ -365,8 +367,9 @@ internal static class MigrationRunAdminEndpoints
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Log.RequestBodyReadFailedForRun(GetLogger(context), "RecordMigrationRunScorecard", runId, ex);
             await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body.", StatusCodes.Status400BadRequest);
             return;
         }
@@ -439,8 +442,9 @@ internal static class MigrationRunAdminEndpoints
             {
                 throw;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Log.RequestBodyReadFailedForRun(GetLogger(context), "CancelMigrationRun", runId, ex);
                 await AdminResponseWriter.WriteErrorAsync(context, "Invalid request body.", StatusCodes.Status400BadRequest);
                 return;
             }
@@ -572,6 +576,25 @@ internal static class MigrationRunAdminEndpoints
 
         var trimmed = value.Trim();
         return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    // PA-164: this class is static (no constructor/DI-injected ILogger<T> field is
+    // possible), so each catch resolves a logger from the current request's
+    // service provider instead — the same pattern used by the sibling
+    // GeoServerImportEndpoints/GeoservicesImportEndpoints static endpoint classes.
+    private static ILogger<MigrationRunAdminEndpointsLog> GetLogger(HttpContext context) =>
+        context.RequestServices.GetRequiredService<ILogger<MigrationRunAdminEndpointsLog>>();
+
+    /// <summary>Log category marker for migration-run admin endpoint operations.</summary>
+    internal sealed class MigrationRunAdminEndpointsLog;
+
+    private static partial class Log
+    {
+        [LoggerMessage(7988, LogLevel.Warning, "Failed to read request body for {Operation}")]
+        public static partial void RequestBodyReadFailed(ILogger logger, string operation, Exception exception);
+
+        [LoggerMessage(7989, LogLevel.Warning, "Failed to read request body for {Operation} (run {RunId})")]
+        public static partial void RequestBodyReadFailedForRun(ILogger logger, string operation, string runId, Exception exception);
     }
 }
 

--- a/src/Honua.Io/Features/Export/ExportJobService.cs
+++ b/src/Honua.Io/Features/Export/ExportJobService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Threading.Channels;
 using Honua.Core.Features.FeatureStore.Abstractions;
@@ -11,6 +12,7 @@ using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Io.Export.Writers;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Progress;
+using Honua.ServiceDefaults;
 using Microsoft.Extensions.Caching.Distributed;
 using StackExchange.Redis;
 
@@ -202,6 +204,17 @@ internal sealed class ExportJobService(
             var scratchDir = Path.Combine(Path.GetTempPath(), "honua-export", job.JobId);
             Directory.CreateDirectory(scratchDir);
             var shouldRequeue = false;
+
+            // PA-161: the export processing hot path (queue -> stream -> write -> upload) had no
+            // OTel span. "Honua" is HonuaTelemetry's ActivitySource name, already registered with
+            // the TracerProvider and already used by the sibling ExportEndpoints.cs in this project.
+            using var activity = HonuaTelemetry.ActivitySource.StartActivity("Export.ProcessQueuedJob");
+            activity?.SetTag("export.job_id", job.JobId);
+            activity?.SetTag("export.format", job.Format);
+            activity?.SetTag("export.service_name", job.ServiceName);
+            activity?.SetTag("export.layer_id", job.LayerId);
+            activity?.SetTag("export.total_features", job.TotalFeatures);
+
             try
             {
                 await using var scope = _scopeFactory.CreateAsyncScope();
@@ -241,10 +254,13 @@ internal sealed class ExportJobService(
 
                 _jobRequests.TryRemove(job.JobId, out _);
                 await RemovePersistedJobRequestAsync(job.JobId, processingToken).ConfigureAwait(false);
+                activity?.SetTag("export.output_size_bytes", fileInfo.Length);
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 ExportLog.AsyncExportCompleted(_logger, job.JobId, job.TotalFeatures, fileInfo.Length);
             }
             catch (OperationCanceledException) when (leaseCoordinator?.LeaseLostToken.IsCancellationRequested == true && !cancellationToken.IsCancellationRequested)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, "Lease lost; requeued for retry.");
                 var requeued = progress with
                 {
                     Status = OperationStatus.Queued,
@@ -259,6 +275,7 @@ internal sealed class ExportJobService(
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 ExportLog.AsyncExportFailed(_logger, job.JobId, ex);
 
                 try
@@ -286,8 +303,10 @@ internal sealed class ExportJobService(
                 {
                     Directory.Delete(scratchDir, recursive: true);
                 }
-                catch
+                catch (Exception cleanupEx)
                 {
+                    // Cleanup failure must not fail the export job itself; log and continue.
+                    ExportJobServiceLog.ScratchDirCleanupFailed(_logger, job.JobId, scratchDir, cleanupEx);
                 }
             }
 

--- a/src/Honua.Io/Features/Export/ExportJobServiceLog.cs
+++ b/src/Honua.Io/Features/Export/ExportJobServiceLog.cs
@@ -29,4 +29,9 @@ internal static partial class ExportJobServiceLog
         Level = LogLevel.Warning,
         Message = "Export job lease renewal was lost while processing a background export.")]
     public static partial void LeaseRenewalLost(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Failed to delete scratch directory {ScratchDir} for export job {JobId}; leaking temp files.")]
+    public static partial void ScratchDirCleanupFailed(ILogger logger, string jobId, string scratchDir, Exception exception);
 }

--- a/src/Honua.Jobs/Features/ControlPlane/ControlPlaneTelemetry.cs
+++ b/src/Honua.Jobs/Features/ControlPlane/ControlPlaneTelemetry.cs
@@ -27,6 +27,8 @@ internal static class ControlPlaneTelemetry
         public const string ExecutionObserve = "honua.controlplane.execution.observe";
         public const string ExecutionCancel = "honua.controlplane.execution.cancel";
         public const string ExecutionReconcile = "honua.controlplane.execution.reconcile";
+        /// <summary>Activity name for the worker-side job execution loop (PA-159): claim through terminal finalize.</summary>
+        public const string ExecutionRun = "honua.controlplane.execution.run";
     }
 
     internal static class Tags
@@ -42,6 +44,13 @@ internal static class ControlPlaneTelemetry
         public const string ExecutionJobStatus = "honua.controlplane.execution.status";
         public const string ExecutionJobPreviousStatus = "honua.controlplane.execution.previous_status";
         public const string ExecutionResult = "honua.controlplane.execution.result";
+        /// <summary>
+        /// Outcome of a single <c>ExecutionReconcileCycles</c> tick (PA-165): one of
+        /// <c>changed</c>, <c>unchanged</c>, <c>not_found</c>, <c>terminal</c>,
+        /// <c>backend_missing</c>, <c>cas_conflict</c>, <c>lease_lost</c>, or <c>error</c>.
+        /// Lets the reconcile-cycle counter be sliced by outcome in addition to job kind.
+        /// </summary>
+        public const string ExecutionReconcileOutcome = "honua.controlplane.execution.reconcile_outcome";
     }
 
     // Instrument names as const strings so tests can subscribe to the same identifier

--- a/src/Honua.Jobs/Features/ControlPlane/ExecutionJobReconciler.cs
+++ b/src/Honua.Jobs/Features/ControlPlane/ExecutionJobReconciler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
@@ -46,8 +47,10 @@ internal sealed partial class ExecutionJobReconciler(
 
         // Count every reconciliation attempt that acquires the lease: the metric reflects
         // how often this job is actually processed by the reconciler, not merely how often
-        // the background service surfaces it in the active list.
-        ControlPlaneTelemetry.ExecutionReconcileCycles.Add(1);
+        // the background service surfaces it in the active list. Tagged with job kind and
+        // outcome (PA-165) so cycles can be sliced instead of only totaled.
+        var reconcileJobKind = "unknown";
+        var reconcileOutcome = "error";
 
         using var reconciliationCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var renewalTask = RenewLeaseUntilCancelledAsync(operationId, reconciliationCancellation);
@@ -55,14 +58,24 @@ internal sealed partial class ExecutionJobReconciler(
         try
         {
             var job = await jobStore.GetAsync(operationId, reconciliationCancellation.Token).ConfigureAwait(false);
-            if (job == null || IsTerminal(job.Status))
+            if (job == null)
             {
+                reconcileOutcome = "not_found";
+                return;
+            }
+
+            reconcileJobKind = job.Spec.Kind.ToString();
+
+            if (IsTerminal(job.Status))
+            {
+                reconcileOutcome = "terminal";
                 return;
             }
 
             var backend = _backends.Resolve(job.Spec.Backend, job.Spec.TargetKind);
             if (backend == null)
             {
+                reconcileOutcome = "backend_missing";
                 Log.BackendMissing(logger, operationId, job.Spec.Backend, job.Spec.TargetKind.ToString());
                 var failedAt = DateTimeOffset.UtcNow;
                 var missing = job with
@@ -117,22 +130,30 @@ internal sealed partial class ExecutionJobReconciler(
                 var persisted = await jobStore.TrySetAsync(updated, cancellationToken: reconciliationCancellation.Token).ConfigureAwait(false);
                 if (!persisted)
                 {
+                    reconcileOutcome = "cas_conflict";
                     Log.ExecutionJobCasConflict(logger, operationId);
                     return;
                 }
 
+                reconcileOutcome = "changed";
                 ControlPlaneTelemetry.RecordExecutionTransition(job, updated);
                 await BridgeProgressAsync(job, updated, reconciliationCancellation.Token).ConfigureAwait(false);
                 Log.ExecutionJobReconciled(logger, operationId, updated.Status.ToString(), updated.PercentComplete ?? double.NaN);
             }
+            else
+            {
+                reconcileOutcome = "unchanged";
+            }
         }
         catch (OperationCanceledException) when (reconciliationCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
+            reconcileOutcome = "lease_lost";
             Log.ExecutionJobLeaseLost(logger, operationId);
             return;
         }
         catch (Exception ex)
         {
+            reconcileOutcome = "error";
             var job = await jobStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
             if (job != null && !IsTerminal(job.Status))
             {
@@ -156,6 +177,12 @@ internal sealed partial class ExecutionJobReconciler(
         }
         finally
         {
+            ControlPlaneTelemetry.ExecutionReconcileCycles.Add(1, new TagList
+            {
+                { ControlPlaneTelemetry.Tags.ExecutionJobKind, reconcileJobKind },
+                { ControlPlaneTelemetry.Tags.ExecutionReconcileOutcome, reconcileOutcome }
+            });
+
             reconciliationCancellation.Cancel();
             try
             {

--- a/src/Honua.Jobs/Features/ControlPlane/JobExecutionService.cs
+++ b/src/Honua.Jobs/Features/ControlPlane/JobExecutionService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 
@@ -260,6 +261,13 @@ internal sealed partial class JobExecutionService(
 
         ControlPlaneTelemetry.RecordExecutionTransition(job, running);
 
+        // PA-159: the worker-side execution loop (claim -> executor dispatch -> terminal
+        // finalize) had metrics and logging but no trace span, leaving the actual job
+        // execution invisible in traces even though ControlPlaneTelemetry already provides
+        // a StartExecutionActivity helper used by the submission-side backend calls.
+        using var activity = ControlPlaneTelemetry.StartExecutionActivity(
+            ControlPlaneTelemetry.Activities.ExecutionRun, "run", running);
+
         Log.JobExecutionStarted(logger, operationId, executor.Kind.ToString());
 
         // Create execution context with heartbeat pump.
@@ -296,10 +304,12 @@ internal sealed partial class JobExecutionService(
 
             if (result.Status == ExecutionJobStatus.Succeeded)
             {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 await FinalizeJobAsync(operationId, workerId, result, CancellationToken.None).ConfigureAwait(false);
             }
             else
             {
+                activity?.SetStatus(ActivityStatusCode.Error, result.ErrorMessage);
                 // Executor returned failure — route through retry policy.
                 // Thread executor warnings so they are persisted on terminal
                 // failure and logged to structured execution logs on retry.
@@ -332,6 +342,7 @@ internal sealed partial class JobExecutionService(
             // fail terminally per ADR-0031, even when shutdown also fired.
             if (timeoutCts.IsCancellationRequested)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, "Execution timed out.");
                 Log.JobTimedOut(logger, operationId, timeoutPolicy.MaxDuration);
                 await TerminateJobAsync(operationId, workerId, ExecutionJobStatus.Failed,
                     $"Execution timed out after {timeoutPolicy.MaxDuration}.", CancellationToken.None)
@@ -339,6 +350,7 @@ internal sealed partial class JobExecutionService(
             }
             else
             {
+                activity?.SetStatus(ActivityStatusCode.Error, "Worker shutdown.");
                 // Worker is shutting down; always requeue regardless of retry budget
                 // because this is an infrastructure event, not an execution failure.
                 // Use CancellationToken.None so store/queue cleanup can complete
@@ -350,6 +362,7 @@ internal sealed partial class JobExecutionService(
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
+            activity?.SetStatus(ActivityStatusCode.Error, "Execution timed out.");
             Log.JobTimedOut(logger, operationId, timeoutPolicy.MaxDuration);
             // Timeout — terminal failure, do not retry.
             await TerminateJobAsync(operationId, workerId, ExecutionJobStatus.Failed,
@@ -359,6 +372,7 @@ internal sealed partial class JobExecutionService(
         catch (OperationCanceledException)
         {
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
+            activity?.SetStatus(ActivityStatusCode.Error, "Cancelled by operator.");
             Log.JobCancelledByOperator(logger, operationId);
             // Operator cancellation — terminal cancelled state.
             await TerminateJobAsync(operationId, workerId, ExecutionJobStatus.Cancelled,
@@ -367,6 +381,7 @@ internal sealed partial class JobExecutionService(
         catch (Exception ex)
         {
             await StopHeartbeatPumpAsync().ConfigureAwait(false);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             Log.JobExecutionFailed(logger, operationId, ex);
             // Execution exception — route through retry policy.
             await AbandonJobAsync(running, workerId, SafeExecutionFailureMessage, CancellationToken.None).ConfigureAwait(false);

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Data;
+using System.Diagnostics;
 using System.Text.Json;
 using NetTopologySuite.Features;
 using NetTopologySuite.IO;
@@ -29,7 +30,7 @@ internal sealed partial class StreamingFileImportService
         NpgsqlConnection connection,
         string schemaName,
         string tableName,
-        IReadOnlyList<IFeature> features,
+        List<IFeature> features,
         int sourceSrid,
         int targetSrid,
         WKBWriter wkbWriter,
@@ -39,6 +40,11 @@ internal sealed partial class StreamingFileImportService
     {
         var imported = 0;
         var failed = 0;
+
+        using var activity = _activitySource.StartActivity("Import.InsertBatch");
+        activity?.SetTag("import.table", tableName);
+        activity?.SetTag("import.feature_count", features.Count);
+        activity?.SetTag("import.load_mode", loadMode.ToString());
 
         // Continue-on-error can't run inside a single transaction because any statement error aborts it.
         var useTransaction = _limits.UseTransactions && !_limits.ContinueOnError;
@@ -88,14 +94,18 @@ internal sealed partial class StreamingFileImportService
                 await transaction.CommitAsync(cancellationToken);
             }
         }
-        catch
+        catch (Exception ex)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             if (transaction != null)
             {
                 await transaction.RollbackAsync(CancellationToken.None);
             }
             throw;
         }
+
+        activity?.SetTag("import.imported_count", imported);
+        activity?.SetTag("import.failed_count", failed);
 
         return (imported, failed);
     }
@@ -105,7 +115,7 @@ internal sealed partial class StreamingFileImportService
         NpgsqlTransaction? transaction,
         string schemaName,
         string tableName,
-        IReadOnlyList<IFeature> features,
+        List<IFeature> features,
         int sourceSrid,
         int targetSrid,
         WKBWriter wkbWriter,
@@ -251,7 +261,7 @@ internal sealed partial class StreamingFileImportService
         NpgsqlTransaction? transaction,
         string schemaName,
         string tableName,
-        IReadOnlyList<IFeature> features,
+        List<IFeature> features,
         int sourceSrid,
         int targetSrid,
         WKBWriter wkbWriter,

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.cs
@@ -32,6 +32,11 @@ namespace Honua.Postgres.Features.FileImport;
 /// </summary>
 internal sealed partial class StreamingFileImportService : IFileImportService
 {
+    // PA-161: the batch-insert hot path (InsertBatchAsync, StreamingFileImportService.Batch.cs)
+    // had no OTel span. Local ActivitySource named "Honua" for TracerProvider correlation,
+    // matching the convention already used by PostgresAnomalyAnalyzer in this project.
+    private static readonly ActivitySource _activitySource = new("Honua", "1.0.0");
+
     private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
     private readonly ICrsDetectionService _crsDetectionService;
     private readonly IFileFormatDetectionService _formatDetectionService;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
@@ -17,7 +17,7 @@ internal static partial class FeatureServerLog
     /// <param name="serviceId">The service identifier.</param>
     [LoggerMessage(
         EventId = 2001,
-        Level = LogLevel.Information,
+        Level = LogLevel.Debug,
         Message = "Service metadata requested: {ServiceId}")]
     public static partial void ServiceMetadataRequested(ILogger logger, string serviceId);
 
@@ -67,7 +67,7 @@ internal static partial class FeatureServerLog
     /// <param name="layerId">The layer identifier.</param>
     [LoggerMessage(
         EventId = 2101,
-        Level = LogLevel.Information,
+        Level = LogLevel.Debug,
         Message = "Layer metadata requested: {ServiceId}/FeatureServer/{LayerId}")]
     public static partial void LayerMetadataRequested(ILogger logger, string serviceId, int layerId);
 
@@ -121,7 +121,7 @@ internal static partial class FeatureServerLog
     /// <param name="hasWhereClause">Whether the request supplied a WHERE clause.</param>
     [LoggerMessage(
         EventId = 2201,
-        Level = LogLevel.Information,
+        Level = LogLevel.Debug,
         Message = "Query requested: {ServiceId}/FeatureServer/{LayerId}/query (WHERE clause present: {HasWhereClause})")]
     public static partial void QueryRequested(ILogger logger, string serviceId, int layerId, bool hasWhereClause);
 
@@ -229,7 +229,7 @@ internal static partial class FeatureServerLog
     /// <param name="addCount">The number of features to add.</param>
     /// <param name="updateCount">The number of features to update.</param>
     /// <param name="deleteCount">The number of features to delete.</param>
-    [LoggerMessage(Level = LogLevel.Information, Message = "ApplyEdits requested for service '{ServiceId}' layer {LayerId} with {AddCount} adds, {UpdateCount} updates, {DeleteCount} deletes")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "ApplyEdits requested for service '{ServiceId}' layer {LayerId} with {AddCount} adds, {UpdateCount} updates, {DeleteCount} deletes")]
     public static partial void ApplyEditsRequested(ILogger logger, string serviceId, int layerId, int addCount, int updateCount, int deleteCount);
 
     /// <summary>
@@ -344,7 +344,7 @@ internal static partial class FeatureServerLog
     /// <param name="relationshipId">The relationship identifier.</param>
     [LoggerMessage(
         EventId = 2401,
-        Level = LogLevel.Information,
+        Level = LogLevel.Debug,
         Message = "Related records query requested: {ServiceId}/FeatureServer/{LayerId}/queryRelatedRecords with objectIdCount: {ObjectIdCount}, objectIdSample: {ObjectIdSample}, relationshipId: {RelationshipId}")]
     public static partial void RelatedRecordsQueryRequested(
         ILogger logger,

--- a/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Coverages/Handlers/OgcCoveragesHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -211,6 +212,10 @@ internal sealed class OgcCoveragesHandler
         context.Items[RequestTelemetryClassifier.OperationItemKey] = "collections";
         OgcCoveragesLog.CollectionsRequested(_logger);
 
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("ogc.coverages.getcollections", ActivityKind.Internal);
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.OgcCoverages);
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "collections");
+
         try
         {
             if (!OgcCoreMetadataUtilities.TryPrepareMetadataResponse(
@@ -301,6 +306,7 @@ internal sealed class OgcCoveragesHandler
                 Links = links.ToImmutable()
             };
 
+            HonuaTelemetry.SetSuccess(activity, response.Collections.Length);
             return OgcCommonUtilities.FormatMetadataResponse(
                 response,
                 OgcCoveragesJsonContext.Default.OgcCoverageCollections,
@@ -314,6 +320,7 @@ internal sealed class OgcCoveragesHandler
         catch (Exception ex)
         {
             OgcCoveragesLog.RequestFailed(_logger, ex, "collections", null);
+            HonuaTelemetry.RecordException(activity, ex);
             return StandardErrorHelpers.CreateInternalServerError(context, "An error occurred while retrieving coverage collections.");
         }
     }

--- a/src/Honua.Protocols.OgcApi/Features/CollectionsEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Features/CollectionsEndpoints.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using Honua.Core.Exceptions;
 using Honua.Core.Features.FeatureStore.Abstractions;
@@ -16,6 +17,7 @@ using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.Ogc.Common;
 using Honua.Protocols.Ogc.Api.Features.Models;
+using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -264,6 +266,7 @@ internal static class CollectionsEndpoints
         catch (Exception ex)
         {
             CollectionsEndpointLogging.LogCollectionsQueryFailed(logger, ex);
+            HonuaTelemetry.RecordException(Activity.Current, ex);
             return StandardErrorHelpers.CreateInternalServerError(
                 context,
                 "An error occurred while retrieving collections.");
@@ -387,6 +390,7 @@ internal static class CollectionsEndpoints
         catch (Exception ex)
         {
             CollectionsEndpointLogging.LogCollectionQueryFailed(logger, collectionId, ex);
+            HonuaTelemetry.RecordException(Activity.Current, ex);
             return StandardErrorHelpers.CreateInternalServerError(
                 context,
                 "An error occurred while retrieving the collection.");
@@ -485,6 +489,7 @@ internal static class CollectionsEndpoints
         catch (Exception ex)
         {
             CollectionsEndpointLogging.LogCollectionQueryFailed(logger, collectionId, ex);
+            HonuaTelemetry.RecordException(Activity.Current, ex);
             return StandardErrorHelpers.CreateInternalServerError(
                 context,
                 "An error occurred while retrieving the queryables schema.");

--- a/src/Honua.Protocols.OgcApi/Processes/JobEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Processes/JobEndpoints.cs
@@ -78,7 +78,9 @@ internal static class JobEndpoints
         [FromQuery] int? limit = null,
         [FromServices] IExecutionJobStore? jobStore = null)
     {
-        EnrichActivity("GetJobList");
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("ogc.processes.getjoblist");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, "OGC-API-Processes");
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "GetJobList");
 
         var gate = context.RequestServices.GetRequiredService<OperatorApprovalGate>();
         var authDecision = await gate.CheckAuthorizationAsync(
@@ -168,7 +170,10 @@ internal static class JobEndpoints
         ILogger<OgcProcessesEndpointsLog> logger,
         [FromServices] IExecutionJobStore? jobStore = null)
     {
-        EnrichActivity("GetJobStatus");
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("ogc.processes.getjobstatus");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, "OGC-API-Processes");
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "GetJobStatus");
+        activity?.SetTag(HonuaTelemetry.Tags.JobId, jobId);
 
         var gate = context.RequestServices.GetRequiredService<OperatorApprovalGate>();
         var authDecision = await gate.CheckAuthorizationAsync(
@@ -229,7 +234,10 @@ internal static class JobEndpoints
         [FromServices] IGeoprocessingJobService jobService,
         [FromServices] IExecutionJobStore? jobStore = null)
     {
-        EnrichActivity("GetJobResults");
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("ogc.processes.getjobresults");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, "OGC-API-Processes");
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "GetJobResults");
+        activity?.SetTag(HonuaTelemetry.Tags.JobId, jobId);
 
         var gate = context.RequestServices.GetRequiredService<OperatorApprovalGate>();
         var authDecision = await gate.CheckAuthorizationAsync(
@@ -346,7 +354,10 @@ internal static class JobEndpoints
         [FromServices] IJobQueue? jobQueue = null,
         [FromServices] IEnumerable<IBatchComputeBackend>? backends = null)
     {
-        EnrichActivity("DismissJob");
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("ogc.processes.dismissjob");
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, "OGC-API-Processes");
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, "DismissJob");
+        activity?.SetTag(HonuaTelemetry.Tags.JobId, jobId);
 
         var gate = context.RequestServices.GetRequiredService<OperatorApprovalGate>();
 
@@ -856,14 +867,6 @@ internal static class JobEndpoints
             && !string.IsNullOrWhiteSpace(protocolProcessId)
                 ? protocolProcessId
                 : ProcessEndpoints.CanonicalProcessId;
-
-    private static void EnrichActivity(string operation)
-    {
-        var activity = Activity.Current;
-        if (activity == null) return;
-        activity.SetTag(HonuaTelemetry.Tags.Protocol, "OGC-API-Processes");
-        activity.SetTag(HonuaTelemetry.Tags.Operation, operation);
-    }
 
 }
 

--- a/src/Honua.Protocols.OgcApi/Tiles/CollectionsEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Tiles/CollectionsEndpoints.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -14,6 +15,7 @@ using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Validation;
 using Honua.Protocols.Ogc.Common;
 using Honua.Protocols.Ogc.Api.Features;
+using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Honua.Protocols.Ogc.Api.Tiles;
@@ -193,6 +195,7 @@ internal static class CollectionsEndpoints
         catch (Exception ex)
         {
             OgcTilesCollectionsEndpointLogging.LogCollectionsQueryFailed(logger, ex);
+            HonuaTelemetry.RecordException(Activity.Current, ex);
             return StandardErrorHelpers.CreateInternalServerError(
                 context,
                 "An error occurred while retrieving collections.");
@@ -275,6 +278,7 @@ internal static class CollectionsEndpoints
         catch (Exception ex)
         {
             OgcTilesCollectionsEndpointLogging.LogCollectionQueryFailed(logger, collectionId, ex);
+            HonuaTelemetry.RecordException(Activity.Current, ex);
             return StandardErrorHelpers.CreateInternalServerError(
                 context,
                 "An error occurred while retrieving the collection.");

--- a/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamModels.cs
+++ b/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamModels.cs
@@ -85,4 +85,7 @@ internal static partial class ObservationStreamLog
 
     [LoggerMessage(EventId = 5102, Level = LogLevel.Warning, Message = "Observation stream cluster publish failed.")]
     public static partial void ClusterPublishFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 5103, Level = LogLevel.Warning, Message = "Observation stream cluster unsubscribe failed during dispose; continuing shutdown.")]
+    public static partial void ClusterUnsubscribeFailed(ILogger logger, Exception exception);
 }

--- a/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamSessionManager.cs
+++ b/src/Honua.Protocols.SensorThings/Streaming/ObservationStreamSessionManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
 using System.Text.Json;
 using System.Threading.Channels;
 using Honua.Core.Features.SensorThings.Abstractions;
@@ -24,6 +25,13 @@ namespace Honua.Protocols.SensorThings.Streaming;
 /// </summary>
 internal sealed class ObservationStreamSessionManager : IObservationChangeEventPublisher, IDisposable
 {
+    /// <summary>
+    /// The <see cref="Meter"/> name emitted for OpenTelemetry. Must be registered in the
+    /// service defaults meter allow-list (<c>Honua.ServiceDefaults.Extensions._meterNames</c>)
+    /// or the drop counter below is silently excluded from export (PA-112).
+    /// </summary>
+    internal const string MeterName = "Honua.SensorThings";
+
     private static readonly RedisChannel BroadcastChannel =
         new("sta:observation:stream:broadcast", RedisChannel.PatternMode.Literal);
 
@@ -31,6 +39,8 @@ internal sealed class ObservationStreamSessionManager : IObservationChangeEventP
     private readonly ILogger<ObservationStreamSessionManager> _logger;
     private readonly IConnectionMultiplexer? _redis;
     private readonly ISubscriber? _subscriber;
+    private readonly Meter _meter;
+    private readonly Counter<long> _observationStreamDrops;
     private readonly string _instanceId = Guid.NewGuid().ToString("N");
     private readonly int _maxConcurrentSessions;
     private readonly int _maxBufferPerConnection;
@@ -48,6 +58,10 @@ internal sealed class ObservationStreamSessionManager : IObservationChangeEventP
         _redis = redis;
         _maxConcurrentSessions = maxConcurrentSessions;
         _maxBufferPerConnection = maxBufferPerConnection;
+        _meter = new Meter(MeterName);
+        _observationStreamDrops = _meter.CreateCounter<long>(
+            "honua_sensorthings_observation_stream_drops_total",
+            description: "Observation-stream frames dropped because a slow consumer's bounded channel was full.");
 
         if (_redis is null)
         {
@@ -69,6 +83,13 @@ internal sealed class ObservationStreamSessionManager : IObservationChangeEventP
 
     /// <summary>Number of slow-consumer disconnects since startup.</summary>
     public long SlowConsumerDrops => Interlocked.Read(ref _slowConsumerDrops);
+
+    /// <summary>
+    /// The underlying <see cref="Meter"/> instance. Exposed to tests so a per-instance
+    /// <see cref="MeterListener"/> can scope capture to this object rather than the shared
+    /// meter name, which prevents cross-test contamination under parallel execution.
+    /// </summary>
+    internal Meter Meter => _meter;
 
     /// <summary>Current active session count.</summary>
     public int SessionCount => Volatile.Read(ref _activeSessionCount);
@@ -207,9 +228,19 @@ internal sealed class ObservationStreamSessionManager : IObservationChangeEventP
 
             // DropWrite bounded channel: a full buffer drops the frame and the reader
             // observes the gap. Track the drop for slow-consumer visibility.
+            //
+            // NOTE (found while wiring PA-112's OTel export): ChannelWriter<T>.TryWrite
+            // returns true for BoundedChannelFullMode.DropWrite even when the item is
+            // silently discarded — it only returns false once the writer is completed,
+            // which this manager never does. That means this branch, and therefore both
+            // counters below, are effectively unreachable via the current code path. Fixing
+            // the drop-detection itself (e.g. checking channel occupancy around the write) is
+            // a separate, more invasive change and is out of scope here; the counter is wired
+            // correctly so it starts reporting real drops once that detection bug is fixed.
             if (!entry.Channel.Writer.TryWrite(frame))
             {
                 Interlocked.Increment(ref _slowConsumerDrops);
+                _observationStreamDrops.Add(1, new KeyValuePair<string, object?>("datastream.id", frame.DatastreamId));
             }
         }
     }
@@ -234,9 +265,10 @@ internal sealed class ObservationStreamSessionManager : IObservationChangeEventP
             {
                 _subscriber.Unsubscribe(BroadcastChannel, HandleClusterBroadcast);
             }
-            catch
+            catch (Exception ex)
             {
-                // Best-effort shutdown.
+                // Best-effort shutdown: Dispose() must not throw, so log and continue.
+                ObservationStreamLog.ClusterUnsubscribeFailed(_logger, ex);
             }
         }
 
@@ -248,6 +280,7 @@ internal sealed class ObservationStreamSessionManager : IObservationChangeEventP
 
         _sessions.Clear();
         Interlocked.Exchange(ref _activeSessionCount, 0);
+        _meter.Dispose();
     }
 
     private sealed class SessionEntry

--- a/src/Honua.Scene/Publishing/CityGmlScenePublishExecutor.cs
+++ b/src/Honua.Scene/Publishing/CityGmlScenePublishExecutor.cs
@@ -150,8 +150,9 @@ internal sealed partial class CityGmlScenePublishExecutor
                     outputDirectory,
                     stale => CityGmlIngestLog.PromotionOverwroteStaleFinalDir(_logger, stale));
             }
-            catch
+            catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 if (registeredDatasetId is { } datasetId)
                 {
                     await CompensateRegistrationAsync(datasetId, sceneId).ConfigureAwait(false);

--- a/src/Honua.Scene/Publishing/PointCloudScenePublishExecutor.cs
+++ b/src/Honua.Scene/Publishing/PointCloudScenePublishExecutor.cs
@@ -179,8 +179,9 @@ internal sealed partial class PointCloudScenePublishExecutor
                     outputDirectory,
                     stale => PointCloudIngestLog.PromotionOverwroteStaleFinalDir(_logger, stale));
             }
-            catch
+            catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 if (registeredDatasetId is { } datasetId)
                 {
                     await CompensateRegistrationAsync(datasetId, sceneId).ConfigureAwait(false);

--- a/src/Honua.Server/Features/HealthCheck/HealthEndpoints.cs
+++ b/src/Honua.Server/Features/HealthCheck/HealthEndpoints.cs
@@ -97,7 +97,7 @@ internal static class HealthEndpoints
             {
                 Timestamp = DateTimeOffset.UtcNow,
                 Status = readiness.IsReady ? "healthy" : "not_ready",
-                PerformanceScore = CalculateBasicPerformanceScore(totalMemory),
+                PerformanceScore = CalculateBasicPerformanceScore(totalMemory, loggerFactory.CreateLogger("Honua.HealthCheck")),
                 License = FileBackedLicenseService.ToHealthSummary(licenseEntitlementService.GetSnapshot()),
                 Metrics = new HealthPerformanceMetrics
                 {
@@ -153,7 +153,7 @@ internal static class HealthEndpoints
     /// <summary>
     /// Calculates overall performance score based on comprehensive metrics
     /// </summary>
-    private static double CalculateBasicPerformanceScore(long totalMemoryBytes)
+    private static double CalculateBasicPerformanceScore(long totalMemoryBytes, ILogger logger)
     {
         try
         {
@@ -182,8 +182,20 @@ internal static class HealthEndpoints
 
             return Math.Max(0, Math.Min(100, score));
         }
-        catch
+        catch (Exception ex)
         {
+            // Nothing in this method should realistically throw (arithmetic over
+            // an already-obtained memory reading plus GC.CollectionCount calls
+            // with fixed, valid generation numbers), so this is a defensive
+            // guard rather than an expected failure path. It previously used a
+            // parenthesis-free empty catch clause that both hid the exception
+            // entirely and slipped past the ErrorHandlingPolicyTests regex,
+            // which only matched a typed, empty "catch (Exception ...)"
+            // clause. 0 is kept as the fallback score (the response's Status
+            // field independently reports readiness, so a fallback score of 0
+            // here does not mislead about overall health), but the failure is
+            // now logged so it is diagnosable.
+            HealthEndpointsLog.PerformanceScoreCalculationFailed(logger, ex);
             return 0;
         }
     }

--- a/src/Honua.Server/Features/HealthCheck/HealthEndpointsLog.cs
+++ b/src/Honua.Server/Features/HealthCheck/HealthEndpointsLog.cs
@@ -7,4 +7,7 @@ internal static partial class HealthEndpointsLog
 {
     [LoggerMessage(Level = LogLevel.Error, Message = "Failed to retrieve performance metrics")]
     public static partial void PerformanceMetricsFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to calculate the basic performance score; reporting a fallback score of 0")]
+    public static partial void PerformanceScoreCalculationFailed(ILogger logger, Exception exception);
 }

--- a/src/Honua.Server/Features/HealthCheck/ProductionHealthChecks.cs
+++ b/src/Honua.Server/Features/HealthCheck/ProductionHealthChecks.cs
@@ -24,7 +24,6 @@ internal static class ProductionHealthChecks
     private static readonly string[] DatabaseTags = ["db", "sql", "postgres"];
     private static readonly string[] RedisTags = ["cache", "redis"];
     private static readonly string[] UploadTags = ["upload", "queue"];
-    private static readonly string[] ExternalServiceTags = ["external", "http"];
     private static readonly string[] MetricsTags = ["metrics", "monitoring"];
     private static readonly string[] OutboxTags = ["outbox", "events"];
     private static readonly string[] PluginTags = ["plugins", "extensibility"];
@@ -65,12 +64,6 @@ internal static class ProductionHealthChecks
             "file-upload",
             HealthStatus.Degraded,
             UploadTags);
-
-        // External service connectivity checks
-        healthChecksBuilder.AddCheck<ExternalServiceHealthCheck>(
-            "external-services",
-            HealthStatus.Degraded,
-            ExternalServiceTags);
 
         // Production metrics health check
         healthChecksBuilder.AddCheck<ProductionMetricsHealthCheck>(
@@ -396,50 +389,13 @@ internal sealed class FileUploadHealthCheck : IHealthCheck
         => maxQueueDepth > 0 ? (double)queueDepth / maxQueueDepth : 0.0;
 }
 
-/// <summary>
-/// Health check for external service connectivity.
-/// </summary>
-internal sealed class ExternalServiceHealthCheck : IHealthCheck
-{
-    private readonly ILogger<ExternalServiceHealthCheck> _logger;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ExternalServiceHealthCheck"/> class.
-    /// </summary>
-    /// <param name="logger">Logger instance.</param>
-    public ExternalServiceHealthCheck(
-        ILogger<ExternalServiceHealthCheck> logger)
-    {
-        _logger = logger;
-    }
-
-    /// <inheritdoc/>
-    public Task<HealthCheckResult> CheckHealthAsync(
-        HealthCheckContext context,
-        CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            return Task.FromResult(HealthCheckResult.Healthy(
-                "No external service probes are configured",
-                new Dictionary<string, object>
-                {
-                    ["configuredProbes"] = 0
-                }));
-        }
-        catch (Exception ex)
-        {
-            ProductionHealthChecksLog.ExternalServiceHealthCheckFailed(_logger, ex);
-            return Task.FromResult(HealthCheckResult.Degraded(
-                "External service connectivity check failed",
-                ex,
-                new Dictionary<string, object>
-                {
-                    ["errorType"] = ex.GetType().Name
-                }));
-        }
-    }
-}
+// PA-065 / PA-162: removed the ExternalServiceHealthCheck no-op stub, which was registered as a
+// real health gate ("external-services") but its CheckHealthAsync always returned
+// HealthCheckResult.Healthy("No external service probes are configured") — it never actually
+// probed anything, so it manufactured false confidence rather than reporting real external
+// dependency state. No external-service probe list/config exists to implement a real check
+// against, so removing the stub (rather than inventing new probing logic) is the lower-risk fix;
+// a follow-up issue should define what external dependencies, if any, need a real health probe.
 
 /// <summary>
 /// Health check for production metrics collection.

--- a/src/Honua.Server/Features/HealthCheck/ProductionHealthChecksLog.cs
+++ b/src/Honua.Server/Features/HealthCheck/ProductionHealthChecksLog.cs
@@ -14,9 +14,6 @@ internal static partial class ProductionHealthChecksLog
     [LoggerMessage(Level = LogLevel.Error, Message = "File upload health check failed")]
     public static partial void FileUploadHealthCheckFailed(ILogger logger, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "External service health check failed")]
-    public static partial void ExternalServiceHealthCheckFailed(ILogger logger, Exception exception);
-
     [LoggerMessage(Level = LogLevel.Error, Message = "Production metrics health check failed")]
     public static partial void ProductionMetricsHealthCheckFailed(ILogger logger, Exception exception);
 }

--- a/src/Honua.ServiceDefaults/Extensions.cs
+++ b/src/Honua.ServiceDefaults/Extensions.cs
@@ -38,7 +38,10 @@ public static partial class Extensions
         "Honua.Database.ConnectionPool",
         "Honua.Production.Metrics",
         FederationMetrics.MeterName,
-        LambdaTelemetry.MeterName
+        LambdaTelemetry.MeterName,
+        // PA-112: the SensorThings observation-stream slow-consumer drop counter was
+        // tracked in-memory but never exported as an OTel metric.
+        "Honua.SensorThings"
     ];
     private static readonly string[] _activitySourceNames =
     [
@@ -50,7 +53,26 @@ public static partial class Extensions
         StudioPackageLifecycleService.ActivitySourceName,
         "Honua.PackageReview",
         "Honua.Routing",
-        "Honua.Geocoding"
+        "Honua.Geocoding",
+        // PA-014 / PA-063: declared ActivitySources that were never registered with the
+        // OTel TracerProvider, so every span they emit was silently dropped.
+        "Honua.GeoServer.Import",
+        "Honua.Spec.Parse",
+        "Honua.Spec.Validation",
+        "Honua.Server.Reporting",
+        // PA-160: provider data-access ActivitySources (spans created but dropped).
+        "Honua.SqlServer.FeatureStore",
+        "Honua.Snowflake.FeatureStore",
+        "Honua.Redshift.FeatureStore",
+        "Honua.Oracle.FeatureStore",
+        // PA-016 / PA-017 / PA-018 / PA-019 / PA-020: hot-path ActivitySources added by the
+        // 2026-07 observability audit (#2401) that previously had no span coverage at all.
+        "Honua.Import.Jobs",
+        "Honua.Federation",
+        "Honua.Core.Edit",
+        "Honua.Core.FeatureStore",
+        // PA-108: federated ArcGIS REST provider query span (paging loop).
+        "Honua.ArcGisRest"
     ];
 
     /// <summary>

--- a/tests/dotnet/Honua.Ai.Tests/Source/AnalysisGenerationServiceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/AnalysisGenerationServiceTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -207,6 +208,34 @@ public sealed class AnalysisGenerationServiceTests
         result.Status.Should().Be("unsupported");
         result.Analysis.Should().BeNull();
         result.UnmappedRequests.Should().NotBeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint(GenerateContract)]
+    public async Task GenerateAsync_BufferRequest_StartsAnalysisGenerationSpanTaggedWithProvider()
+    {
+        // PA-202: the outbound AI provider call was previously untraced. GenerateAsync must
+        // start a "honua.analysis_generation.generate" span tagged with the provider id (not
+        // the prompt/response content) so the AI generation hot path is visible in traces.
+        var service = CreateService(enabled: true, ProposalJson(BufferProposal()));
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Honua",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await service.GenerateAsync(new AnalysisGenerationRequest
+        {
+            Prompt = "buffer all parcels by 100 meters"
+        });
+
+        var span = activities.Should().ContainSingle(a => a.OperationName == "honua.analysis_generation.generate").Which;
+        span.TagObjects.Should().Contain(t => t.Key == "honua.ai.provider" && Equals(t.Value, "local"));
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.ArcGisRest.Tests/ArcGisRestPaginationTests.cs
+++ b/tests/dotnet/Honua.ArcGisRest.Tests/ArcGisRestPaginationTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Honua.ArcGisRest.Features.FeatureStore;
@@ -11,6 +12,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.ArcGisRest.Tests;
 
@@ -23,6 +25,7 @@ public sealed class ArcGisRestPaginationTests
 {
     private const int LayerId = 1;
     private const string ServiceUrl = "https://services.arcgis.com/org/arcgis/rest/services/parcels/FeatureServer";
+    private const string TestSourceName = "Honua.ArcGisRest.Tests.Pagination";
 
     [Fact]
     public async Task QueryAsync_NoCallerLimit_PagesUntilUpstreamStopsFlaggingMore()
@@ -141,10 +144,51 @@ public sealed class ArcGisRestPaginationTests
         Assert.Contains("resultOffset=" + ArcGisRestFeatureStore.DefaultPageSize, client.Requests[1], StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task QueryAsync_MultiPageResult_EmitsOneSpanTaggedWithPageAndFeatureCounts()
+    {
+        // PA-108: a single QueryAsync call can page many times, but must record exactly
+        // one "honua.arcgisrest.query" span (not one per page) tagged with the remote
+        // service/layer plus the total page and feature counts observed across the loop.
+        var client = new PagingArcGisRestFeatureClient(upstreamMaxRecordCount: 2, totalFeatures: 5);
+        var reader = CreateReader(client, out _);
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Honua.ArcGisRest" || source.Name == TestSourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // The ActivityListener is process-global, so a sibling test class that also queries the
+        // ArcGIS REST provider can emit "honua.arcgisrest.query" spans concurrently. Anchor this
+        // call under a test-local parent activity and filter captured spans by its trace id so the
+        // assertion sees only the span this test produced.
+        using var testSource = new ActivitySource(TestSourceName);
+        using var parent = testSource.StartActivity("test.arcgisrest.query", ActivityKind.Internal)!;
+
+        var result = await reader.QueryAsync(LayerId, new FeatureQuery());
+
+        var span = Assert.Single(
+            activities,
+            a => a.OperationName == "honua.arcgisrest.query" && a.TraceId == parent.TraceId);
+        Assert.Equal("honua.arcgisrest.query", span.OperationName);
+        Assert.Equal(ActivityKind.Client, span.Kind);
+        Assert.Equal(ServiceUrl, span.TagObjects.First(t => t.Key == "honua.arcgisrest.service_url").Value);
+        Assert.Equal(LayerId, span.TagObjects.First(t => t.Key == "honua.arcgisrest.layer_id").Value);
+        Assert.Equal(3, span.TagObjects.First(t => t.Key == "honua.arcgisrest.page_count").Value);
+        Assert.Equal(result.Items.Length, span.TagObjects.First(t => t.Key == "honua.arcgisrest.feature_count").Value);
+    }
+
     private static IFeatureReader CreateReader(IArcGisRestFeatureClient client)
+        => CreateReader(client, out _);
+
+    private static IFeatureReader CreateReader(IArcGisRestFeatureClient client, out ArcGisRestFeatureStore provider)
     {
         var connection = CreateConnection();
-        var provider = new ArcGisRestFeatureStore(client);
+        provider = new ArcGisRestFeatureStore(client, NullLogger<ArcGisRestFeatureStore>.Instance);
         return ((IBindableFeatureDataProvider)provider).CreateReaderForBinding(CreateBinding(provider, connection));
     }
 

--- a/tests/dotnet/Honua.ArcGisRest.Tests/ArcGisRestProviderResolutionTests.cs
+++ b/tests/dotnet/Honua.ArcGisRest.Tests/ArcGisRestProviderResolutionTests.cs
@@ -13,6 +13,7 @@ using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Security.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.ArcGisRest.Tests;
 
@@ -93,7 +94,7 @@ public class ArcGisRestProviderResolutionTests
         {
             CountResponse = new ArcGisRestCountResponse { Count = 42 }
         };
-        var provider = new ArcGisRestFeatureStore(client);
+        var provider = new ArcGisRestFeatureStore(client, NullLogger<ArcGisRestFeatureStore>.Instance);
 
         var reader = ((IBindableFeatureDataProvider)provider)
             .CreateReaderForBinding(CreateBinding(provider, connection));
@@ -133,7 +134,7 @@ public class ArcGisRestProviderResolutionTests
             }
         };
 
-        var provider = new ArcGisRestFeatureStore(client);
+        var provider = new ArcGisRestFeatureStore(client, NullLogger<ArcGisRestFeatureStore>.Instance);
         var reader = ((IBindableFeatureDataProvider)provider).CreateReaderForBinding(CreateBinding(provider, connection));
 
         var result = await reader.QueryAsync(LayerId, new FeatureQuery { Limit = 2, OutputSrid = 3857 });
@@ -168,7 +169,7 @@ public class ArcGisRestProviderResolutionTests
                 }
             }
         };
-        var provider = new ArcGisRestFeatureStore(client);
+        var provider = new ArcGisRestFeatureStore(client, NullLogger<ArcGisRestFeatureStore>.Instance);
         var reader = ((IBindableFeatureDataProvider)provider).CreateReaderForBinding(CreateBinding(provider, connection));
 
         var extent = await reader.GetExtentAsync(LayerId);
@@ -190,7 +191,7 @@ public class ArcGisRestProviderResolutionTests
                 Error = new ArcGisRestError { Code = 400, Message = "Invalid where clause" }
             }
         };
-        var provider = new ArcGisRestFeatureStore(client);
+        var provider = new ArcGisRestFeatureStore(client, NullLogger<ArcGisRestFeatureStore>.Instance);
         var reader = ((IBindableFeatureDataProvider)provider).CreateReaderForBinding(CreateBinding(provider, connection));
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -208,7 +209,7 @@ public class ArcGisRestProviderResolutionTests
         {
             CountResponse = new ArcGisRestCountResponse { Count = 5 }
         };
-        var provider = new ArcGisRestFeatureStore(client);
+        var provider = new ArcGisRestFeatureStore(client, NullLogger<ArcGisRestFeatureStore>.Instance);
         var providerRegistry = new FeatureDataProviderRegistry([provider]);
         var router = new FeatureProviderQueryRouter(
             new FakeSecureConnectionRegistry(connection),
@@ -233,7 +234,7 @@ public class ArcGisRestProviderResolutionTests
     }
 
     private static ArcGisRestFeatureStore CreateProvider()
-        => new(new RecordingArcGisRestFeatureClient());
+        => new(new RecordingArcGisRestFeatureClient(), NullLogger<ArcGisRestFeatureStore>.Instance);
 
     private static DataConnection CreateConnection()
         => new()

--- a/tests/dotnet/Honua.Architecture.Tests/ErrorHandlingPolicyTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ErrorHandlingPolicyTests.cs
@@ -204,9 +204,14 @@ public sealed class ErrorHandlingPolicyTests
 
         // A pattern like `catch (Exception) { }` (optionally with `ex`) and a
         // body that holds nothing but whitespace is a smell — it silently
-        // swallows every failure mode.
+        // swallows every failure mode. A genuinely bare `catch { }` (no
+        // exception type in parens at all — valid C#, and functionally
+        // identical to `catch (Exception) { }`) is just as silent but does not
+        // match the typed-catch alternative, so it is matched as a second
+        // alternative below (PA-068 slipped past this test in exactly this
+        // form before it was hardened).
         var pattern = new Regex(
-            @"catch\s*\(\s*Exception(?:\s+\w+)?\s*\)\s*(?:when\s*\([^)]*\)\s*)?\{\s*\}",
+            @"catch\s*\(\s*Exception(?:\s+\w+)?\s*\)\s*(?:when\s*\([^)]*\)\s*)?\{\s*\}|catch\s*\{\s*\}",
             RegexOptions.CultureInvariant);
         var offenders = new List<string>();
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorPreconditionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorPreconditionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using FluentAssertions;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -125,5 +126,49 @@ public sealed class EditProcessorPreconditionTests
         var batch = CreateProcessor().ToFeatureEditBatch(request, Resource);
 
         batch.Preconditions.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void ToFeatureEditBatch_EmitsActivitySpan()
+    {
+        // PA-018: the feature-write pipeline (validate/optimize/convert) previously emitted no
+        // telemetry span at all.
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Honua.Core.Edit",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var request = UnifiedEditRequest.WithUpdates(
+            ImmutableArray.Create(EditFeature.ForUpdate(5, null, ImmutableDictionary<string, object?>.Empty)));
+
+        CreateProcessor().ToFeatureEditBatch(request, Resource);
+
+        activities.Should().ContainSingle(activity =>
+            activity.OperationName == "edit.tofeaturebatch" &&
+            activity.TagObjects.Any(tag => tag.Key == "honua.resource.id"));
+    }
+
+    [UnitTest]
+    public void ValidateEdit_EmptyRequest_EmitsErrorStatusOnSpan()
+    {
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Honua.Core.Edit",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var result = CreateProcessor().ValidateEdit(new UnifiedEditRequest(), Resource);
+
+        result.IsValid.Should().BeFalse();
+        activities.Should().ContainSingle(activity =>
+            activity.OperationName == "edit.validate" &&
+            activity.Status == ActivityStatusCode.Error);
     }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/FeatureProviderQueryRouterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/FeatureProviderQueryRouterTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.FeatureStore.Services;
@@ -32,6 +33,76 @@ public sealed class FeatureProviderQueryRouterTests
             FeatureProviderReadOperation.Query);
 
         resolved.Should().BeSameAs(reader);
+    }
+
+    [Fact]
+    public async Task ResolveReaderAsync_EmitsSpanTaggedWithServiceResourcePublicationAndProvider()
+    {
+        // PA-019: this hot path previously emitted no telemetry at all.
+        var connectionId = Guid.NewGuid();
+        var reader = new Mock<IFeatureReader>(MockBehavior.Strict).Object;
+        var provider = CreateProvider(DataProviderNames.DuckDb, FeatureProviderCapabilities.ReadOnlyAnalytical, reader);
+        var router = CreateRouter(connectionId, DataProviderNames.DuckDb, provider);
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Honua.Core.FeatureStore",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await router.ResolveReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            storageLayerId: 1,
+            FeatureProviderReadOperation.Query);
+
+        activities.Should().ContainSingle(activity =>
+            activity.OperationName == "featurestore.resolve_reader" &&
+            activity.Status != ActivityStatusCode.Error &&
+            activity.TagObjects.Any(tag => tag.Key == "service.id" && Equals(tag.Value, "svc-maps")) &&
+            activity.TagObjects.Any(tag => tag.Key == "resource.id" && Equals(tag.Value, "res-roads")) &&
+            activity.TagObjects.Any(tag => tag.Key == "publication.id" && Equals(tag.Value, "pub-roads")) &&
+            activity.TagObjects.Any(tag => tag.Key == "provider.name" && Equals(tag.Value, DataProviderNames.DuckDb)));
+    }
+
+    [Fact]
+    public async Task ResolveReaderAsync_UnsupportedStatisticsOperation_SetsErrorStatusOnSpan()
+    {
+        var connectionId = Guid.NewGuid();
+        var reader = new Mock<IFeatureReader>(MockBehavior.Strict).Object;
+        var capabilities = FeatureProviderCapabilities.ReadOnlyAnalytical with
+        {
+            SupportsStatistics = false
+        };
+        var provider = CreateProvider(DataProviderNames.DuckDb, capabilities, reader);
+        var router = CreateRouter(connectionId, DataProviderNames.DuckDb, provider);
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Honua.Core.FeatureStore",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var action = () => router.ResolveReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            storageLayerId: 1,
+            FeatureProviderReadOperation.Statistics);
+
+        await action.Should().ThrowAsync<InvalidOperationException>();
+        activities.Should().ContainSingle(activity => activity.Status == ActivityStatusCode.Error);
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/VersionJobRunnerTelemetryTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/FeatureStore/VersionJobRunnerTelemetryTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Core.Tests.Features.FeatureStore;
+
+/// <summary>
+/// PA-021: <see cref="VersionJobRunner"/> detaches reconcile/post execution onto
+/// <c>Task.Run</c>, which flows the ambient <see cref="ExecutionContext"/> by default. Without
+/// an explicit fix, the job's span would silently become a child of the HTTP request's activity
+/// — one that has already ended by the time the background job finishes. These tests assert the
+/// job's span is instead a root span carrying an <see cref="ActivityLink"/> back to the caller.
+/// </summary>
+public sealed class VersionJobRunnerTelemetryTests
+{
+    [UnitTest]
+    public async Task StartPostAsync_WithAmbientCallerActivity_EmitsRootSpanLinkedToCaller()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IVersionManager>(new FakeVersionManager());
+        await using var provider = services.BuildServiceProvider();
+
+        var runner = new VersionJobRunner(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            new InMemoryVersionJobStore(),
+            NullLogger<VersionJobRunner>.Instance);
+
+        var jobActivityStopped = new TaskCompletionSource<Activity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var jobListener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Honua",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activity =>
+            {
+                if (activity.OperationName.StartsWith("VersionJob.", StringComparison.Ordinal))
+                {
+                    jobActivityStopped.TrySetResult(activity);
+                }
+            },
+        };
+        ActivitySource.AddActivityListener(jobListener);
+
+        using var callerSource = new ActivitySource("Test.VersionJobRunner.Caller");
+        using var callerListener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == "Test.VersionJobRunner.Caller",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(callerListener);
+
+        ActivityContext callerContext;
+        using (var callerActivity = callerSource.StartActivity("http.request"))
+        {
+            callerActivity.Should().NotBeNull();
+            callerContext = callerActivity!.Context;
+
+            // Simulate the HTTP request completing (and its activity ending) while the
+            // fire-and-forget job keeps running in the background.
+            await runner.StartPostAsync("svc", Guid.NewGuid());
+        }
+
+        var jobActivity = await jobActivityStopped.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        jobActivity.Parent.Should().BeNull(
+            "the job runs after the caller's request activity ends and must not be an implicit child of it");
+        jobActivity.ParentSpanId.Should().NotBe(callerContext.SpanId);
+        jobActivity.Links.Should().ContainSingle(link =>
+            link.Context.TraceId == callerContext.TraceId && link.Context.SpanId == callerContext.SpanId);
+    }
+
+    private sealed class FakeVersionManager : IVersionManager
+    {
+        public bool SupportsVersioning => true;
+
+        public Task<GdbVersion> CreateAsync(CreateVersionRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<bool> DeleteAsync(Guid versionId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<GdbVersion?> AlterAsync(AlterVersionRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<GdbVersion>> ListAsync(CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<VersionContext?> ResolveAsync(string? gdbVersion, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<VersionReconcileResult> ReconcileAsync(
+            Guid versionId,
+            VersionReconcilePolicy policy = VersionReconcilePolicy.None,
+            VersionConflictDetection detection = VersionConflictDetection.ByAttribute,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<VersionReconcileConflict>> GetPendingConflictsAsync(
+            Guid versionId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<VersionConflictResolutionResult> ResolveConflictsAsync(
+            Guid versionId,
+            IReadOnlyList<VersionConflictResolution> resolutions,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<VersionPostResult> PostAsync(Guid versionId, CancellationToken cancellationToken = default)
+            => Task.FromResult(new VersionPostResult(Posted: true, AppliedChanges: 3, ServerGeneration: 1, BlockedByConflicts: false));
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Federation/FederatedQueryExecutorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Federation/FederatedQueryExecutorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -81,6 +82,54 @@ public sealed class FederatedQueryExecutorTests
             () => executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), new FeatureQuery()));
 
         Assert.Equal(FederatedSourceUnavailableReason.NoConnector, ex.Reason);
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_EmitsSpanTaggedWithSourceIdAndKind()
+    {
+        // PA-017: remote federated source calls had metrics and structured logging but no
+        // distributed tracing span.
+        var rows = ImmutableArray.Create(Feature(1));
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.HonuaGrpc, rows));
+        var source = Source(FederatedSourceKind.HonuaGrpc);
+
+        var activities = new System.Collections.Generic.List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static s => s.Name == "Honua.Federation",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await executor.ExecuteAsync(source, new FeatureQuery());
+
+        Assert.Contains(activities, activity =>
+            activity.OperationName == "federation.execute" &&
+            activity.Kind == ActivityKind.Client &&
+            activity.Status != ActivityStatusCode.Error &&
+            activity.TagObjects.Any(t => t.Key == "source.id" && Equals(t.Value, source.Id)) &&
+            activity.TagObjects.Any(t => t.Key == "source.kind" && Equals(t.Value, source.Kind.ToString())));
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_NoConnector_SetsErrorStatusOnSpan()
+    {
+        var executor = BuildExecutor(new StubConnector(FederatedSourceKind.HonuaGrpc, ImmutableArray<Feature>.Empty));
+
+        var activities = new System.Collections.Generic.List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = static s => s.Name == "Honua.Federation",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await Assert.ThrowsAsync<FederatedSourceUnavailableException>(
+            () => executor.ExecuteAsync(Source(FederatedSourceKind.EsriRest), new FeatureQuery()));
+
+        Assert.Contains(activities, activity => activity.Status == ActivityStatusCode.Error);
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Core.Tests/Features/Geocoding/BaseGeocodeProviderHealthTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Geocoding/BaseGeocodeProviderHealthTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Geocoding.Features.Geocoding.Abstractions;
+using Honua.Geocoding.Features.Geocoding.Domain;
+
+namespace Honua.Core.Tests.Features.Geocoding;
+
+/// <summary>
+/// Covers <see cref="BaseGeocodeProvider.CheckHealthAsync"/>'s exception path
+/// (PA-067/PA-201): the previous bare <c>catch (Exception)</c> swallowed the
+/// failure entirely, returning a fixed "Provider health check failed." string
+/// with no way to tell what actually broke. The fix surfaces the exception's
+/// type and message in <see cref="GeocodeProviderHealth.ErrorMessage"/>.
+/// </summary>
+public sealed class BaseGeocodeProviderHealthTests
+{
+    [Fact]
+    public async Task CheckHealthAsync_WhenCoreThrows_ReturnsUnhealthyWithExceptionDetail()
+    {
+        var provider = new ThrowingHealthProvider(new InvalidOperationException("upstream timed out"));
+
+        var health = await provider.CheckHealthAsync(CancellationToken.None);
+
+        Assert.False(health.IsHealthy);
+        Assert.NotNull(health.ErrorMessage);
+        Assert.Contains(nameof(InvalidOperationException), health.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("upstream timed out", health.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenCoreSucceeds_ReturnsHealthyWithNoErrorMessage()
+    {
+        var provider = new ThrowingHealthProvider(exception: null);
+
+        var health = await provider.CheckHealthAsync(CancellationToken.None);
+
+        Assert.True(health.IsHealthy);
+        Assert.Null(health.ErrorMessage);
+    }
+
+    private sealed class ThrowingHealthProvider : BaseGeocodeProvider
+    {
+        private readonly Exception? _exception;
+
+        public ThrowingHealthProvider(Exception? exception)
+        {
+            _exception = exception;
+        }
+
+        public override string Name => "throwing-health";
+
+        public override GeocodeProviderCapabilities Capabilities => new(SupportsForwardGeocode: true);
+
+        public override Task<IReadOnlyList<GeocodeCandidate>> ForwardGeocodeAsync(
+            ForwardGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<GeocodeCandidate>>([]);
+
+        public override Task<ReverseGeocodeMatch?> ReverseGeocodeAsync(
+            ReverseGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<ReverseGeocodeMatch?>(null);
+
+        protected override Task CheckHealthCoreAsync(CancellationToken cancellationToken = default)
+        {
+            if (_exception is not null)
+            {
+                throw _exception;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Geocoding/GeocodeCoordinatorTelemetryTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Geocoding/GeocodeCoordinatorTelemetryTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using Honua.Geocoding.Features.Geocoding.Abstractions;
+using Honua.Geocoding.Features.Geocoding.Domain;
+using Honua.Geocoding.Features.Geocoding.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Tests.Features.Geocoding;
+
+/// <summary>
+/// Verifies PA-200: <see cref="GeocodeCoordinatorService.SuggestAsync"/> and
+/// <see cref="GeocodeCoordinatorService.BatchGeocodeAsync"/> emit
+/// "Honua.Geocoding" spans (mirroring the existing Forward/Reverse geocode
+/// telemetry) tagged with query length / batch size rather than raw
+/// address/query text.
+/// </summary>
+public sealed class GeocodeCoordinatorTelemetryTests
+{
+    [Fact]
+    public async Task SuggestAsync_Success_EmitsSpanTaggedWithQueryLengthNotRawText()
+    {
+        var provider = new FakeGeocodeProvider(
+            "capable",
+            new GeocodeProviderCapabilities(SupportsSuggest: true))
+        {
+            SuggestResult = [new GeocodeSuggestion("123 Main St", "magic-1")]
+        };
+
+        var coordinator = CreateCoordinator([provider], "capable", maxFailoverAttempts: 1);
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == GeocodingTelemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        const string queryText = "123 Main St, Anytown";
+        var result = await coordinator.SuggestAsync(
+            new SuggestGeocodeRequest(queryText),
+            providerName: null,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var span = Assert.Single(activities);
+        Assert.Equal("geocoding.suggest", span.OperationName);
+        Assert.Equal(queryText.Length, span.TagObjects.First(t => t.Key == "honua.geocoding.query_length").Value);
+        Assert.DoesNotContain(activities, a => a.TagObjects.Any(t => Equals(t.Value, queryText)));
+    }
+
+    [Fact]
+    public async Task BatchGeocodeAsync_Success_EmitsSpanTaggedWithBatchSize()
+    {
+        var provider = new FakeGeocodeProvider(
+            "capable",
+            new GeocodeProviderCapabilities(SupportsBatch: true))
+        {
+            BatchResult = [new GeocodeCandidate("1 Test St", 1.0, 2.0, 99.0, new Dictionary<string, string?>())]
+        };
+
+        var coordinator = CreateCoordinator([provider], "capable", maxFailoverAttempts: 1);
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == GeocodingTelemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var request = new BatchGeocodeRequest(["1 Test St", "2 Test Ave"]);
+        var result = await coordinator.BatchGeocodeAsync(request, providerName: null, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var span = Assert.Single(activities);
+        Assert.Equal("geocoding.batch", span.OperationName);
+        Assert.Equal(2, span.TagObjects.First(t => t.Key == "honua.geocoding.batch_size").Value);
+    }
+
+    private static GeocodeCoordinatorService CreateCoordinator(
+        IReadOnlyList<IGeocodeProvider> providers,
+        string defaultProvider,
+        int maxFailoverAttempts)
+    {
+        var configuration = new GeocodingConfiguration
+        {
+            DefaultProvider = defaultProvider,
+            EnableFailover = true,
+            MaxFailoverAttempts = maxFailoverAttempts
+        };
+
+        var registry = new GeocodeProviderRegistry(
+            new EmptyServiceProvider(),
+            providers,
+            Options.Create(configuration));
+
+        var limitEnforcer = new GeocodeLimitEnforcer(Options.Create(configuration));
+
+        return new GeocodeCoordinatorService(
+            registry,
+            Options.Create(configuration),
+            limitEnforcer,
+            NullLogger<GeocodeCoordinatorService>.Instance);
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class FakeGeocodeProvider : IGeocodeProvider
+    {
+        public FakeGeocodeProvider(string name, GeocodeProviderCapabilities capabilities)
+        {
+            Name = name;
+            Capabilities = capabilities;
+        }
+
+        public string Name { get; }
+
+        public GeocodeProviderCapabilities Capabilities { get; }
+
+        public IReadOnlyList<GeocodeSuggestion> SuggestResult { get; init; } = [];
+
+        public IReadOnlyList<GeocodeCandidate> BatchResult { get; init; } = [];
+
+        public Task<IReadOnlyList<GeocodeCandidate>> ForwardGeocodeAsync(
+            ForwardGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<GeocodeCandidate>>([]);
+
+        public Task<ReverseGeocodeMatch?> ReverseGeocodeAsync(
+            ReverseGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<ReverseGeocodeMatch?>(null);
+
+        public Task<IReadOnlyList<GeocodeSuggestion>> SuggestAsync(
+            SuggestGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(SuggestResult);
+
+        public Task<IReadOnlyList<GeocodeCandidate>> BatchGeocodeAsync(
+            BatchGeocodeRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(BatchResult);
+
+        public Task<GeocodeProviderHealth> CheckHealthAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new GeocodeProviderHealth(Name, true, LastChecked: DateTime.UtcNow));
+    }
+}

--- a/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/ObservationStreamSessionManagerDisposeTests.cs
+++ b/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/ObservationStreamSessionManagerDisposeTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Generic;
+using Honua.Protocols.SensorThings.Streaming;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Protocols.SensorThings;
+
+/// <summary>
+/// Covers <see cref="ObservationStreamSessionManager.Dispose"/>'s Redis-unsubscribe
+/// cleanup path (PA-115): it previously used a bare <c>catch { }</c> that hid any
+/// exception thrown by <c>ISubscriber.Unsubscribe</c>. The fix logs a warning (with
+/// the exception attached) and still swallows it, since <c>Dispose()</c> must not
+/// throw.
+/// </summary>
+public sealed class ObservationStreamSessionManagerDisposeTests
+{
+    [UnitTest]
+    public void Dispose_WhenUnsubscribeThrows_LogsAndDoesNotThrow()
+    {
+        var subscriber = Substitute.For<ISubscriber>();
+        var redis = Substitute.For<IConnectionMultiplexer>();
+        redis.GetSubscriber().Returns(subscriber);
+
+        var thrown = new RedisConnectionException(ConnectionFailureType.SocketFailure, "unsubscribe failed");
+        subscriber
+            .When(x => x.Unsubscribe(Arg.Any<RedisChannel>(), Arg.Any<Action<RedisChannel, RedisValue>>(), Arg.Any<CommandFlags>()))
+            .Do(_ => throw thrown);
+
+        var logger = new CapturingLogger<ObservationStreamSessionManager>();
+        var manager = new ObservationStreamSessionManager(logger, redis);
+
+        var caught = Record.Exception(manager.Dispose);
+
+        Assert.Null(caught);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.LogLevel);
+        Assert.Same(thrown, entry.Exception);
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel LogLevel, EventId EventId, string Message, Exception? Exception)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, eventId, formatter(state, exception), exception));
+        }
+    }
+}

--- a/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/ObservationStreamSessionManagerMetricsTests.cs
+++ b/tests/dotnet/Honua.Protocols.SensorThings.Tests/Source/ObservationStreamSessionManagerMetricsTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.Metrics;
+using Honua.Protocols.SensorThings.Streaming;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Protocols.SensorThings;
+
+/// <summary>
+/// Unit tests for the SensorThings observation-stream slow-consumer drop counter (PA-112): the
+/// in-memory <c>SlowConsumerDrops</c> counter must also be published as an OTel instrument on a
+/// named <see cref="Meter"/> so it can be registered with the shared MeterProvider. A
+/// <see cref="MeterListener"/> observes instrument publication directly, so the test needs
+/// neither a live host nor a way to actually force a slow-consumer drop.
+/// </summary>
+/// <remarks>
+/// Forcing an end-to-end "drop happens, counter increments" test is not meaningfully possible
+/// here: <c>ObservationStreamSessionManager</c> uses <see cref="BoundedChannelFullMode.DropWrite"/>,
+/// and <c>ChannelWriter&lt;T&gt;.TryWrite</c> returns <see langword="true"/> for that mode even
+/// when the item is silently discarded (it only returns <see langword="false"/> once the writer
+/// has been completed). The manager's drop-counting branch (<c>if (!TryWrite(...))</c>) is
+/// therefore effectively unreachable via the public API today — a separate, pre-existing bug
+/// this pass does not fix (see the PA-112 write-up). This test instead verifies the metric is
+/// wired up correctly so it is ready to report real drops once that separate bug is fixed.
+/// </remarks>
+public sealed class ObservationStreamSessionManagerMetricsTests
+{
+    [UnitTest]
+    public void Constructor_PublishesObservationStreamDropsCounter()
+    {
+        using var listener = new MeterListener();
+        Instrument? published = null;
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == ObservationStreamSessionManager.MeterName
+                && instrument.Name == "honua_sensorthings_observation_stream_drops_total")
+            {
+                published = instrument;
+            }
+        };
+        listener.Start();
+
+        using var manager = new ObservationStreamSessionManager(
+            NullLogger<ObservationStreamSessionManager>.Instance,
+            redis: null);
+
+        Assert.NotNull(published);
+        Assert.Equal(ObservationStreamSessionManager.MeterName, published!.Meter.Name);
+        Assert.IsType<Counter<long>>(published);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Alerts/AzureEventGridAlertDeliverySinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Alerts/AzureEventGridAlertDeliverySinkTests.cs
@@ -5,6 +5,7 @@ using Azure.Messaging.EventGrid;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Alerts;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Tests.Features.Alerts;
@@ -19,7 +20,8 @@ public sealed class AzureEventGridAlertDeliverySinkTests
         var client = CreateDummyClient();
         var sink = new AzureEventGridAlertDeliverySink(
             client,
-            Options.Create(new AlertDeliveryOptions()));
+            Options.Create(new AlertDeliveryOptions()),
+            NullLogger<AzureEventGridAlertDeliverySink>.Instance);
 
         var result = await sink.DeliverAsync(
             AlertTestFixtures.CreateDispatchItem(AlertChannelType.AzureEventGrid),
@@ -34,7 +36,10 @@ public sealed class AzureEventGridAlertDeliverySinkTests
     public void ChannelType_ReturnsAzureEventGrid()
     {
         var client = CreateDummyClient();
-        var sink = new AzureEventGridAlertDeliverySink(client, Options.Create(new AlertDeliveryOptions()));
+        var sink = new AzureEventGridAlertDeliverySink(
+            client,
+            Options.Create(new AlertDeliveryOptions()),
+            NullLogger<AzureEventGridAlertDeliverySink>.Instance);
 
         Assert.Equal(AlertChannelType.AzureEventGrid, sink.ChannelType);
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Alerts/AzureEventHubAlertDeliverySinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Alerts/AzureEventHubAlertDeliverySinkTests.cs
@@ -4,6 +4,8 @@
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Alerts;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Server.Tests.Features.Alerts;
@@ -27,7 +29,10 @@ public sealed class AzureEventHubAlertDeliverySinkTests
     public async Task DeliverAsync_WithNoConnectionStringConfigured_ReturnsNonRetryableFailure()
     {
         var publisher = new FakeEventHubPublisher();
-        var sink = new AzureEventHubAlertDeliverySink(publisher, Options.Create(new AlertDeliveryOptions()));
+        var sink = new AzureEventHubAlertDeliverySink(
+            publisher,
+            Options.Create(new AlertDeliveryOptions()),
+            NullLogger<AzureEventHubAlertDeliverySink>.Instance);
 
         var result = await sink.DeliverAsync(
             AlertTestFixtures.CreateDispatchItem(AlertChannelType.AzureEventHub),
@@ -46,7 +51,10 @@ public sealed class AzureEventHubAlertDeliverySinkTests
             SendAsyncHandler = static (_, _, _) => Task.FromResult(new EventHubPublishResult(true, false, null))
         };
 
-        var sink = new AzureEventHubAlertDeliverySink(publisher, Options.Create(CreateOptionsWithEventHub()));
+        var sink = new AzureEventHubAlertDeliverySink(
+            publisher,
+            Options.Create(CreateOptionsWithEventHub()),
+            NullLogger<AzureEventHubAlertDeliverySink>.Instance);
         var result = await sink.DeliverAsync(
             AlertTestFixtures.CreateDispatchItem(AlertChannelType.AzureEventHub),
             AlertTestFixtures.CreateAlertEvent());
@@ -63,13 +71,43 @@ public sealed class AzureEventHubAlertDeliverySinkTests
             SendAsyncHandler = static (_, _, _) => Task.FromResult(new EventHubPublishResult(false, true, "Event Hub transient error: test"))
         };
 
-        var sink = new AzureEventHubAlertDeliverySink(publisher, Options.Create(CreateOptionsWithEventHub()));
+        var sink = new AzureEventHubAlertDeliverySink(
+            publisher,
+            Options.Create(CreateOptionsWithEventHub()),
+            NullLogger<AzureEventHubAlertDeliverySink>.Instance);
         var result = await sink.DeliverAsync(
             AlertTestFixtures.CreateDispatchItem(AlertChannelType.AzureEventHub),
             AlertTestFixtures.CreateAlertEvent());
 
         Assert.False(result.Succeeded);
         Assert.True(result.Retryable);
+    }
+
+    [UnitTest]
+    public async Task DeliverAsync_WithUnhandledException_LogsAndReturnsRetryableFailure()
+    {
+        var publisher = new FakeEventHubPublisher
+        {
+            SendAsyncHandler = static (_, _, _) => throw new InvalidOperationException("boom")
+        };
+        var logger = new CapturingLogger<AzureEventHubAlertDeliverySink>();
+
+        var sink = new AzureEventHubAlertDeliverySink(
+            publisher,
+            Options.Create(CreateOptionsWithEventHub()),
+            logger);
+
+        var result = await sink.DeliverAsync(
+            AlertTestFixtures.CreateDispatchItem(AlertChannelType.AzureEventHub),
+            AlertTestFixtures.CreateAlertEvent());
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.Retryable);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.LogLevel);
+        Assert.IsType<InvalidOperationException>(entry.Exception);
+        Assert.Equal("boom", entry.Exception!.Message);
     }
 
     [UnitTest]
@@ -80,7 +118,10 @@ public sealed class AzureEventHubAlertDeliverySinkTests
             SendAsyncHandler = static (_, _, _) => Task.FromResult(new EventHubPublishResult(false, false, "Event Hub not found: test"))
         };
 
-        var sink = new AzureEventHubAlertDeliverySink(publisher, Options.Create(CreateOptionsWithEventHub()));
+        var sink = new AzureEventHubAlertDeliverySink(
+            publisher,
+            Options.Create(CreateOptionsWithEventHub()),
+            NullLogger<AzureEventHubAlertDeliverySink>.Instance);
         var result = await sink.DeliverAsync(
             AlertTestFixtures.CreateDispatchItem(AlertChannelType.AzureEventHub),
             AlertTestFixtures.CreateAlertEvent());
@@ -95,7 +136,10 @@ public sealed class AzureEventHubAlertDeliverySinkTests
     {
         var publisher = new FakeEventHubPublisher();
 
-        var sink = new AzureEventHubAlertDeliverySink(publisher, Options.Create(CreateOptionsWithEventHub()));
+        var sink = new AzureEventHubAlertDeliverySink(
+            publisher,
+            Options.Create(CreateOptionsWithEventHub()),
+            NullLogger<AzureEventHubAlertDeliverySink>.Instance);
         await sink.DeliverAsync(
             AlertTestFixtures.CreateDispatchItem(AlertChannelType.AzureEventHub),
             AlertTestFixtures.CreateAlertEvent());
@@ -112,7 +156,34 @@ public sealed class AzureEventHubAlertDeliverySinkTests
     public void ChannelType_ReturnsAzureEventHub()
     {
         var publisher = new FakeEventHubPublisher();
-        var sink = new AzureEventHubAlertDeliverySink(publisher, Options.Create(new AlertDeliveryOptions()));
+        var sink = new AzureEventHubAlertDeliverySink(
+            publisher,
+            Options.Create(new AlertDeliveryOptions()),
+            NullLogger<AzureEventHubAlertDeliverySink>.Instance);
         Assert.Equal(AlertChannelType.AzureEventHub, sink.ChannelType);
+    }
+}
+
+/// <summary>
+/// Captures log entries emitted to it for assertions; used to verify the
+/// previously-silent unhandled-exception path (PA-062) now emits a warning
+/// with the original exception attached.
+/// </summary>
+internal sealed class CapturingLogger<T> : ILogger<T>
+{
+    public List<(LogLevel LogLevel, EventId EventId, string Message, Exception? Exception)> Entries { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add((logLevel, eventId, formatter(state, exception), exception));
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Grounding/GroundingServiceTelemetryTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Grounding/GroundingServiceTelemetryTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Security.Claims;
+using Honua.Ai.Grounding;
+using Honua.Core.Features.Grounding.Abstractions;
+using Honua.Core.Features.Grounding.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Geoprocessing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Grounding;
+
+/// <summary>
+/// Verifies PA-199: <see cref="GroundingService.GroundAsync"/> starts a
+/// "honua.grounding.ground" span on the MCP/AI grounding hot path so a pass
+/// through the deterministic engine, authorization filter, and drafting is
+/// visible in traces.
+/// </summary>
+public sealed class GroundingServiceTelemetryTests
+{
+    [Fact]
+    public async Task GroundAsync_SuccessfulPass_StartsGroundingSpan()
+    {
+        var service = BuildService();
+        var request = new GroundingRequest { Goal = "buffer the parcels layer by 100 meters" };
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Honua",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await service.GroundAsync(request, BuildPrincipal(), CancellationToken.None);
+
+        Assert.Contains(activities, activity => activity.OperationName == "honua.grounding.ground");
+    }
+
+    private static GroundingService BuildService()
+    {
+        var engine = new DeterministicGroundingEngine();
+        var catalog = new BuiltInProcessCatalog();
+        var authFilter = Substitute.For<IGroundingAuthorizationFilter>();
+        authFilter
+            .FilterAsync(
+                Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<IReadOnlyList<GroundingCandidate>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(call.ArgAt<IReadOnlyList<GroundingCandidate>>(1)));
+
+        var options = Options.Create(new GroundingOptions());
+        return new GroundingService(
+            engine,
+            catalog,
+            authFilter,
+            options,
+            NullLogger<GroundingService>.Instance,
+            serviceScopeFactory: null,
+            metadataGraphProvider: new EmptyMetadataV2GraphProvider());
+    }
+
+    private static ClaimsPrincipal BuildPrincipal()
+    {
+        var identity = new ClaimsIdentity(authenticationType: "test");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private sealed class EmptyMetadataV2GraphProvider : Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider
+    {
+        private static readonly MetadataV2GraphSnapshot Snapshot = new(
+            new MetadataV2Graph(),
+            "\"test\"",
+            DateTimeOffset.UtcNow);
+
+        public ValueTask<MetadataV2GraphSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
+            => new(Snapshot);
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(
+            long revision,
+            CancellationToken cancellationToken = default)
+            => new((MetadataV2GraphSnapshot?)null);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/HealthCheck/ProductionHealthChecksRegistrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/HealthCheck/ProductionHealthChecksRegistrationTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Linq;
+using FluentAssertions;
+using Honua.Server.Features.HealthCheck;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.HealthCheck;
+
+/// <summary>
+/// Unit tests for <see cref="ProductionHealthChecks.AddProductionHealthChecks"/>. Covers PA-065 /
+/// PA-162: the <c>ExternalServiceHealthCheck</c> no-op stub (always returned <c>Healthy</c>
+/// regardless of real external-service state) was removed rather than registered as a real
+/// health gate, since it manufactured false confidence.
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class ProductionHealthChecksRegistrationTests
+{
+    [UnitTest]
+    public void AddProductionHealthChecks_DoesNotRegisterExternalServiceStub()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddProductionHealthChecks(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var registrationNames = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>()
+            .Value.Registrations
+            .Select(registration => registration.Name)
+            .ToArray();
+
+        registrationNames.Should().NotContain("external-services");
+        registrationNames.Should().Contain(new[]
+        {
+            "file-upload",
+            "production-metrics",
+            "feature-change-outbox",
+            "plugins",
+        });
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ExecutionJobReconcilerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ExecutionJobReconcilerTests.cs
@@ -1829,6 +1829,7 @@ public sealed class ExecutionJobReconcilerTests
         // execution-job lifecycle. Reconcile-cycle counts every accepted lease; transition
         // counts each persisted status change (e.g., Queued -> Failed for missing backend).
         var cycles = new List<long>();
+        var cycleTags = new List<(string? JobKind, string? Outcome)>();
         var transitions = new List<(long Value, string? Status, string? PreviousStatus)>();
         using var listener = new MeterListener
         {
@@ -1853,6 +1854,25 @@ public sealed class ExecutionJobReconcilerTests
                 lock (cycles)
                 {
                     cycles.Add(measurement);
+                }
+
+                string? jobKind = null;
+                string? outcome = null;
+                foreach (var tag in tags)
+                {
+                    if (tag.Key == ControlPlaneTelemetry.Tags.ExecutionJobKind)
+                    {
+                        jobKind = tag.Value as string;
+                    }
+                    else if (tag.Key == ControlPlaneTelemetry.Tags.ExecutionReconcileOutcome)
+                    {
+                        outcome = tag.Value as string;
+                    }
+                }
+
+                lock (cycleTags)
+                {
+                    cycleTags.Add((jobKind, outcome));
                 }
             }
             else if (instrument.Name == ControlPlaneTelemetry.Metrics.ExecutionJobTransitions)
@@ -1898,6 +1918,12 @@ public sealed class ExecutionJobReconcilerTests
         transitions.Should().Contain(t =>
             t.Value == 1 && t.PreviousStatus == nameof(ExecutionJobStatus.Queued) && t.Status == nameof(ExecutionJobStatus.Failed),
             "missing-backend path persists Queued -> Failed and must emit a transition sample");
+
+        // PA-165: the reconcile-cycle counter must carry job-kind and outcome tags so it
+        // can be sliced instead of only totaled. This run hits the missing-backend branch.
+        cycleTags.Should().Contain(
+            t => t.JobKind == nameof(ExecutionJobKind.Geoprocessing) && t.Outcome == "backend_missing",
+            "the missing-backend reconcile path must be tagged with the job kind and a backend_missing outcome");
     }
 
     private static ExecutionJobRecord CreateJobRecord(

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/ProductionMonitoringEndpointSecurityTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/ProductionMonitoringEndpointSecurityTests.cs
@@ -56,24 +56,6 @@ public sealed class ProductionMonitoringEndpointSecurityTests
         data.GetProperty("safe").GetInt32().Should().Be(7);
     }
 
-    [IntegrationTest]
-    [Operation(Operations.HealthCheck)]
-    [Endpoint("GET /monitoring/health/comprehensive")]
-    public async Task ComprehensiveHealth_ExternalServicesEntryDoesNotDependOnPublicInternet()
-    {
-        using var factory = CreateFactory();
-        using var client = CreateAdminClient(factory);
-
-        var response = await client.GetAsync("/monitoring/health/comprehensive");
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-        var entry = document.RootElement.GetProperty("entries").GetProperty("external-services");
-        entry.GetProperty("status").GetString().Should().Be("Healthy");
-        entry.GetProperty("description").GetString().Should().Be("No external service probes are configured");
-        entry.GetProperty("data").GetProperty("configuredProbes").GetInt32().Should().Be(0);
-    }
-
     private static WebApplicationFactory<Program> CreateFactory(Action<IServiceCollection>? configureServices = null)
     {
         return new TestWebApplicationFactory()

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/CityGmlScenePublishExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/CityGmlScenePublishExecutorTests.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using FluentAssertions;
 using Honua.Core.Exceptions;
 using Honua.Core.Features.Scene.Domain;
 using Honua.Infrastructure.Scene;
+using Honua.ServiceDefaults;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -165,5 +167,39 @@ public sealed class CityGmlScenePublishExecutorTests : IDisposable
 
         var ex = await act.Should().ThrowAsync<ValidationException>();
         ex.Which.Message.Should().StartWith(SceneGenerationErrorCodes.OptionsInvalid);
+    }
+
+    [UnitTest]
+    public async Task Ingest_PromotionFails_MarksActivityAsErrorAndRethrows()
+    {
+        // PA-203: IngestAsync already starts a span but never marked it failed when the
+        // stage -> register -> promote pipeline's final promote step throws. Force
+        // Directory.Move to fail by pre-occupying the final path with a plain file (not a
+        // directory), which is exactly what the promotion catch/compensation branch guards
+        // against, and assert the span now carries ActivityStatusCode.Error.
+        const string sceneId = "bim-promote-fail";
+        Directory.CreateDirectory(_outputRoot);
+        var finalDirectory = Path.Combine(_outputRoot, sceneId);
+        await File.WriteAllTextAsync(finalDirectory, "blocks Directory.Move");
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == HonuaTelemetry.ServiceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var act = async () => await _executor.IngestAsync(
+            new CityGmlSceneIngestRequest(CityGmlSceneFixtures.SingleBuildingGeographic(), SceneId: sceneId),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<IOException>();
+
+        var span = activities.Should().ContainSingle(a =>
+            a.OperationName == HonuaTelemetry.Activities.TileGeneration &&
+            (string?)a.GetTagItem("honua.scene.source_kind") == "citygml").Which;
+        span.Status.Should().Be(ActivityStatusCode.Error);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/PointCloudScenePublishExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Scene/PointCloudScenePublishExecutorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
@@ -8,6 +9,7 @@ using Honua.Core.Exceptions;
 using Honua.Core.Features.Scene.Domain;
 using Honua.Core.Features.Scene.PointCloud;
 using Honua.Infrastructure.Scene;
+using Honua.ServiceDefaults;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -216,6 +218,40 @@ public sealed class PointCloudScenePublishExecutorTests : IDisposable
 
         var ex = await act.Should().ThrowAsync<ValidationException>();
         ex.Which.Message.Should().StartWith(SceneGenerationErrorCodes.OptionsInvalid);
+    }
+
+    [UnitTest]
+    public async Task Ingest_PromotionFails_MarksActivityAsErrorAndRethrows()
+    {
+        // PA-203: IngestAsync already starts a span but never marked it failed when the
+        // stage -> register -> promote pipeline's final promote step throws. Force
+        // Directory.Move to fail by pre-occupying the final path with a plain file (not a
+        // directory), which is exactly what the promotion catch/compensation branch guards
+        // against, and assert the span now carries ActivityStatusCode.Error.
+        const string sceneId = "pcloud-promote-fail";
+        Directory.CreateDirectory(_outputRoot);
+        var finalDirectory = Path.Combine(_outputRoot, sceneId);
+        await File.WriteAllTextAsync(finalDirectory, "blocks Directory.Move");
+
+        var activities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == HonuaTelemetry.ServiceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = activities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var act = async () => await _executor.IngestAsync(
+            new PointCloudSceneIngestRequest(PointCloudSceneFixtures.SinglePointGeographic(), SceneId: sceneId),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<IOException>();
+
+        var span = activities.Should().ContainSingle(a =>
+            a.OperationName == HonuaTelemetry.Activities.TileGeneration &&
+            (string?)a.GetTagItem("honua.scene.source_kind") == "pointcloud").Which;
+        span.Status.Should().Be(ActivityStatusCode.Error);
     }
 
     private static string FindFirstPnts(string assetRoot)


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2401

## Summary
Works the observability findings from the 2026-07 platform cross-cut audit (#2401). Each of the 35 candidate findings was re-verified against current `trunk` before any change — several were stale/already-fixed or larger than a small correct change, and those are deferred with reasons (left open in the issue). This PR lands the tractable, low-risk fixes: unregistered ActivitySources, missing spans on key hot paths, mis-parented background-job spans, silently-swallowed exceptions, a false-confidence health stub, over-noisy per-request logs, and thin/untagged metrics. Behavior-affecting changes get ActivityListener/LoggerMessage unit tests.

## Changes Made
- Register 9 declared-but-unregistered ActivitySources (and the new SensorThings meter) in `Honua.ServiceDefaults` so their spans/metrics stop being silently dropped by the OTel SDK — the core bug class of this audit (PA-014/063/160 + Federation/Edit/FeatureStore/ArcGisRest).
- Add Activity spans to untraced hot paths: FederatedQueryExecutor, EditProcessor, FeatureProviderQueryRouter, ReplicaSyncService, JobExecutionService, streaming import (`InsertBatchAsync`) + export, ArcGIS REST paging loop (one span, not per-page), OGC Coverages, OGC Processes jobs, AI Grounding/AnalysisGeneration, geocode suggest/batch (PA-017/018/019/020/108/110/114/159/161/199/200/202).
- Detach background-job spans from already-ended HTTP request spans and link the caller context instead — VersionJobRunner and import `ProcessJobAsync` (PA-016/021).
- Record exceptions on `Activity.Current` in OGC Features/Tiles and scene-ingest catch paths (PA-111/203).
- Log previously-swallowed exceptions via source-gen LoggerMessage: AuditExportDispatcher, Azure EventHub/EventGrid alert sinks, BaseGeocodeProvider health, ExportJobService scratch cleanup, MigrationRunAdminEndpoints, SensorThings `Dispose`, HealthEndpoints score (PA-015/062/067/115/163/164/068). Also surface the exception type/message in the geocode health result detail.
- Harden the `ErrorHandlingPolicy` architecture test regex to also catch a bare `catch{}` (no parens), which previously slipped through.
- Tag `ExecutionReconcileCycles` by job kind + outcome (PA-165); export the SensorThings slow-consumer drop counter as an OTel metric (PA-112).
- Remove the always-`Healthy` `ExternalServiceHealthCheck` stub that probed nothing but registered as a real gate (PA-065/162).
- Demote per-request start-of-request FeatureServer logs from Information to Debug (PA-113).

Deferred (kept open in #2401, with reasons): PA-064 (folding production checks into `/healthz/ready` is a readiness/product decision, not a predicate tweak), PA-066 (Lambda control-plane carries no OTel/Activity by design — header injection would be dead code), PA-067 logging half (threading an ILogger through the geocode provider base ripples across ~15 call sites), PA-109 (already instrumented on trunk).

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
