### PR TITLE
fix: resolve 5 test-shard regressions from platform-audit train (run 28691230771)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5719,7 +5719,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithInvalidBboxValues_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithJsonAcceptHeader_ReturnsJsonResponse",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithJsonFormat_ReturnsJsonResponse",
-        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithLimitExceedingMax_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithLimitExceedingMax_ClampsToMaximum",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithOutOfRangeBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithPagination_ReturnsNextAndPrevLinks",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.OgcFeaturesEnhancementsTests.GetItems_WithQueryableParameter_FiltersResults",

--- a/src/Honua.Core/Features/Validation/Abstractions/PaginationValidationOptions.cs
+++ b/src/Honua.Core/Features/Validation/Abstractions/PaginationValidationOptions.cs
@@ -16,10 +16,12 @@ public sealed record PaginationValidationOptions(
     /// When <see langword="true"/>, a limit above the configured maximum record count is clamped
     /// to the maximum instead of failing validation. When <see langword="false"/> (the default for
     /// every preset, including <see cref="Default"/>), an over-maximum limit fails validation and
-    /// the adapter surfaces a 400. Honua's protocol surfaces — GeoServices, OData, gRPC, and OGC
-    /// API - Features — all reject over-maximum limits with a 400 rather than silently clamping, so
-    /// that callers learn their page size was not honored. Values below <see cref="MinLimit"/>
-    /// always fail validation regardless of this flag.
+    /// the adapter surfaces a 400. Honua's GeoServices, OData, and gRPC surfaces reject
+    /// over-maximum limits with a 400 rather than silently clamping, so that callers learn their
+    /// page size was not honored. OGC API - Features is the exception: OGC API - Features Part 1
+    /// requirement /req/core/fc-limit-definition (d) mandates clamping to the server maximum, so
+    /// its preset sets this flag. Values below <see cref="MinLimit"/> always fail validation
+    /// regardless of this flag.
     /// </summary>
     public bool ClampLimitToMaximum { get; init; }
 

--- a/src/Honua.Core/Queries/Filters/GeoServicesSql/GeoServicesSqlParser.cs
+++ b/src/Honua.Core/Queries/Filters/GeoServicesSql/GeoServicesSqlParser.cs
@@ -65,6 +65,11 @@ public sealed class GeoServicesSqlParser
         // and POSITION(needle IN haystack) — the comma form doesn't match the keyword-path
         // guard so it falls through here.  Both are safe, well-understood string functions.
         "SUBSTRING", "POSITION",
+        // CQL2 case-insensitive / accent-insensitive comparison functions. The FeatureServer
+        // where parameter accepts CQL2-Text, so CASEI(...) / ACCENTI(...) reach this parser as
+        // generic function calls; every ISqlFilterTranslator understands them (e.g. Postgres
+        // maps CASEI -> LOWER and ACCENTI -> UNACCENT(LOWER(...))).
+        "CASEI", "ACCENTI",
         // Null / conditional
         "COALESCE", "NULLIF", "IIF",
         // Numeric / math

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataEndpointTests.cs
@@ -79,7 +79,7 @@ public sealed class ODataEndpointTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
         response.Content.Headers.ContentType?.Parameters.Should()
-            .Contain(p => p.Name == "metadata" && string.Equals(p.Value, "none", StringComparison.OrdinalIgnoreCase));
+            .Contain(p => p.Name == "odata.metadata" && string.Equals(p.Value, "none", StringComparison.OrdinalIgnoreCase));
 
         var content = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(content);
@@ -483,7 +483,7 @@ public sealed class ODataEndpointTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.Parameters.Should()
-            .Contain(p => p.Name == "metadata" && string.Equals(p.Value, "none", StringComparison.OrdinalIgnoreCase));
+            .Contain(p => p.Name == "odata.metadata" && string.Equals(p.Value, "none", StringComparison.OrdinalIgnoreCase));
 
         var content = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(content);
@@ -517,7 +517,7 @@ public sealed class ODataEndpointTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, content);
         response.Content.Headers.ContentType?.Parameters.Should()
-            .Contain(p => p.Name == "metadata" && string.Equals(p.Value, "minimal", StringComparison.OrdinalIgnoreCase));
+            .Contain(p => p.Name == "odata.metadata" && string.Equals(p.Value, "minimal", StringComparison.OrdinalIgnoreCase));
     }
 
     [IntegrationTest]
@@ -533,7 +533,7 @@ public sealed class ODataEndpointTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.Parameters.Should()
-            .Contain(p => p.Name == "metadata" && string.Equals(p.Value, "minimal", StringComparison.OrdinalIgnoreCase));
+            .Contain(p => p.Name == "odata.metadata" && string.Equals(p.Value, "minimal", StringComparison.OrdinalIgnoreCase));
 
         var content = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(content);
@@ -553,7 +553,7 @@ public sealed class ODataEndpointTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.Parameters.Should()
-            .Contain(p => p.Name == "metadata" && string.Equals(p.Value, "minimal", StringComparison.OrdinalIgnoreCase));
+            .Contain(p => p.Name == "odata.metadata" && string.Equals(p.Value, "minimal", StringComparison.OrdinalIgnoreCase));
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
@@ -636,16 +636,24 @@ public sealed class OgcFeaturesEnhancementsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
-    public async Task GetItems_WithLimitExceedingMax_ReturnsBadRequest()
+    public async Task GetItems_WithLimitExceedingMax_ClampsToMaximum()
     {
-        // Arrange - Limit exceeding maximum allowed
-        var excessiveLimit = new Honua.Core.Configuration.LimitsOptions().Query.MaxRecordCount + 1;
+        // Arrange - Limit exceeding maximum allowed. Per OGC API - Features Part 1
+        // requirement /req/core/fc-limit-definition (d), an over-maximum limit is clamped
+        // to the server maximum rather than rejected with a 400.
+        var queryLimits = new Honua.Core.Configuration.LimitsOptions().Query;
+        var excessiveLimit = queryLimits.MaxRecordCount + 1;
 
         // Act
         var response = await _fixture.Client.GetAsync($"/ogc/features/collections/{TestCollectionId}/items?limit={excessiveLimit}");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var numberReturned = json.RootElement.GetProperty("numberReturned").GetInt32();
+        numberReturned.Should().BeLessThanOrEqualTo(queryLimits.MaxRecordCount);
     }
 
     #endregion

--- a/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
@@ -200,7 +200,9 @@ public class ApiSurfaceComplianceTests : IAsyncLifetime
             ("/rest/services/test/FeatureServer/0/query?where=invalid sql syntax", HttpStatusCode.BadRequest, "Invalid SQL where clause"),
             ("/ogc/features/collections/0/items?bbox=invalid", HttpStatusCode.BadRequest, "Invalid bbox format"),
             ("/ogc/features/collections/0/items?limit=-1", HttpStatusCode.BadRequest, "Negative limit"),
-            ("/ogc/features/collections/0/items?limit=999999", HttpStatusCode.BadRequest, "Limit too large"),
+            // OGC API - Features Part 1 /req/core/fc-limit-definition (d): an over-maximum
+            // limit is clamped to the server maximum, not rejected with a 400.
+            ("/ogc/features/collections/0/items?limit=999999", HttpStatusCode.OK, "Limit too large (clamped)"),
         };
 
         foreach (var (endpoint, expectedStatus, description) in errorTestCases)

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/PlatformAdminEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/PlatformAdminEndpointsTests.cs
@@ -226,7 +226,11 @@ public sealed class PlatformAdminEndpointsTests : IAsyncLifetime
                     Generic = new GenericOidcProviderOptions
                     {
                         Enabled = true,
-                        Authority = "https://auth.example.com",
+                        // Use a publicly-resolvable authority so the SSRF pre-check
+                        // (added with the platform-audit hardening) passes and the
+                        // discovery HTTP call is actually reached; the throwing
+                        // client factory then exercises the sanitized-error path.
+                        Authority = "https://example.com",
                         ClientId = "generic-client-id",
                         ClientSecret = "generic-secret-value-minimum-length",
                         DisplayName = "External Provider"


### PR DESCRIPTION
Fixes the 5 failing shards on consolidated verification run 28691230771 (trunk b6ebd7ea), all traced to the platform-audit sweep (security/protocol-conformance PR #2405 / commit 51a3d065b) admin-merged past per-PR CI.

| Shard | Root cause (audit PR) | Real regression? | Fix |
|---|---|---|---|
| Python Integration (CQL2 CASEI) | PA-013 function allowlist omitted CQL2 CASEI/ACCENTI | **Yes, product** | restore CASEI/ACCENTI in GeoServicesSqlParser allowlist |
| OGC API Features (limit) | PA-025 OGC over-max limit clamps per OGC spec /req/core/fc-limit-definition (d) | No (correct behavior) | update stale test to assert clamp + regen catalog |
| Server Tests Comprehensive (limit) | PA-025 (same) | No (correct) | update stale 'Limit too large' case to expect 200 |
| OData Core (5 tests) | PA-072 Content-Type 'metadata=' -> 'odata.metadata=' (OData v4 standard) | No (correct) | update 5 stale response-param assertions |
| .NET Foundation (TestIdentityProvider) | PA-061 SSRF guard before OIDC discovery | No (correct) | point test at resolvable authority so sanitize-path is exercised |

Also fixes the self-contradictory ClampLimitToMaximum XML doc and regenerates feature-catalog.json for the renamed OGC limit test.