### PR TITLE
Feature bug-hunt Round 1: 32 verified bugs across non-experimental features (S0 + 11 S1 + 20 S2)

### DIFF
--- a/src/Honua.Core/Features/Edit/EditProcessor.cs
+++ b/src/Honua.Core/Features/Edit/EditProcessor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
@@ -450,6 +450,13 @@ public sealed class EditProcessor : IEditProcessor
             if (feature.Attributes?.IsEmpty != false && RequiresAttributes(resource))
             {
                 return EditValidationResult.Failure("Attributes required for create operation");
+            }
+
+            // BH-014: Validate geometry exists if the layer is spatial so the error surfaces
+            // as a clean validation failure rather than a DB NOT NULL constraint violation.
+            if (feature.Geometry is null && RequiresGeometry(resource))
+            {
+                return EditValidationResult.Failure("Geometry is required for create operation on a spatial layer");
             }
         }
 

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
@@ -201,6 +201,16 @@ public sealed class ZarrSubsetReader : IZarrSubsetReader
         {
             throw new InvalidDataException($"Zarr dtype '{dtype}' has an invalid element size suffix.");
         }
+
+        // All supported numeric dtypes fit within 16 bytes (f16 / complex128 is the largest).
+        // Reject unrealistic values early to prevent oversized allocation.
+        const int MaxSupportedElementBytes = 16;
+        if (bytes > MaxSupportedElementBytes)
+        {
+            throw new InvalidDataException(
+                $"Zarr dtype '{dtype}' has an element size of {bytes} bytes, which exceeds the maximum of {MaxSupportedElementBytes}.");
+        }
+
         return bytes;
     }
 
@@ -233,6 +243,13 @@ public sealed class ZarrSubsetReader : IZarrSubsetReader
         }
 
         var chunkBytes = ComputeChunkBytes(array, elementSize);
+        if (chunkBytes > MaxBytesPerRequest)
+        {
+            throw new InvalidOperationException(
+                $"Zarr chunk size of {chunkBytes:N0} bytes exceeds the per-chunk cap of {MaxBytesPerRequest:N0} bytes. " +
+                $"Re-chunk the Zarr store with smaller chunk dimensions before serving it.");
+        }
+
         var chunkBuffer = new byte[chunkBytes];
         if (raw is null || raw.Length == 0)
         {

--- a/src/Honua.Core/Features/TileCachePackage/Services/EsriTileCachePackageReader.cs
+++ b/src/Honua.Core/Features/TileCachePackage/Services/EsriTileCachePackageReader.cs
@@ -328,7 +328,10 @@ public sealed class EsriTileCachePackageReader : ITileCachePackageReader
             var indexPos = CompactV2HeaderSize + (i * 8);
             var indexValue = BinaryPrimitives.ReadInt64LittleEndian(bundle.AsSpan(indexPos, 8));
             var offset = indexValue & CompactV2OffsetMask;
-            var size = (int)(indexValue >> 40);
+            // Use a logical (unsigned) right shift so that tiles whose encoded size has bit 23
+            // set (≥ 8 MB) are not sign-extended into a negative Int32, which would cause the
+            // size <= 0 guard below to silently skip them.
+            var size = (int)((ulong)indexValue >> 40);
             if (size <= 0)
             {
                 continue;

--- a/src/Honua.Core/Features/Tiles/PMTiles/PMTilesWriter.cs
+++ b/src/Honua.Core/Features/Tiles/PMTiles/PMTilesWriter.cs
@@ -144,13 +144,13 @@ public sealed class PMTilesWriter
             TileType = PMTilesTileType.Mvt,
             MinZoom = (byte)metadata.MinZoom,
             MaxZoom = (byte)metadata.MaxZoom,
-            MinLonE7 = ToE7(metadata.MinLon),
-            MinLatE7 = ToE7(metadata.MinLat),
-            MaxLonE7 = ToE7(metadata.MaxLon),
-            MaxLatE7 = ToE7(metadata.MaxLat),
+            MinLonE7 = ToE7Lon(metadata.MinLon),
+            MinLatE7 = ToE7Lat(metadata.MinLat),
+            MaxLonE7 = ToE7Lon(metadata.MaxLon),
+            MaxLatE7 = ToE7Lat(metadata.MaxLat),
             CenterZoom = (byte)(metadata.CenterZoom ?? (metadata.MinZoom + metadata.MaxZoom) / 2),
-            CenterLonE7 = ToE7(metadata.CenterLon ?? (metadata.MinLon + metadata.MaxLon) / 2.0),
-            CenterLatE7 = ToE7(metadata.CenterLat ?? (metadata.MinLat + metadata.MaxLat) / 2.0),
+            CenterLonE7 = ToE7Lon(metadata.CenterLon ?? (metadata.MinLon + metadata.MaxLon) / 2.0),
+            CenterLatE7 = ToE7Lat(metadata.CenterLat ?? (metadata.MinLat + metadata.MaxLat) / 2.0),
         };
 
         // Phase 6: Write everything
@@ -197,9 +197,15 @@ public sealed class PMTilesWriter
         return stream.ToArray();
     }
 
-    private static int ToE7(double value)
+    private static int ToE7Lon(double value)
     {
         var scaled = Math.Clamp(value, -180.0, 180.0) * 10_000_000;
+        return (int)Math.Round(scaled);
+    }
+
+    private static int ToE7Lat(double value)
+    {
+        var scaled = Math.Clamp(value, -90.0, 90.0) * 10_000_000;
         return (int)Math.Round(scaled);
     }
 

--- a/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
+++ b/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
@@ -988,6 +988,15 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
         }
     }
 
+    private static void EnsureFieldIsConfigured(string fieldName, DuckDBLayerMapping mapping)
+    {
+        if (!mapping.AttributeColumns.Contains(fieldName, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"Field '{fieldName}' is not defined on layer {mapping.LayerId}.");
+        }
+    }
+
     private static string ValidateCalendarUnit(string unit) =>
         unit.ToLowerInvariant() switch
         {
@@ -1064,6 +1073,7 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
             {
                 var field = nullMatch.Groups["field"].Value;
                 ValidateFieldName(field);
+                EnsureFieldIsConfigured(field, mapping);
                 var notToken = nullMatch.Groups["not"].Value;
                 var notClause = string.IsNullOrWhiteSpace(notToken) ? string.Empty : "NOT ";
                 parameterizedExpressions.Add($"\"{field}\" IS {notClause}NULL");
@@ -1076,6 +1086,7 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
             {
                 var field = compMatch.Groups["field"].Value;
                 ValidateFieldName(field);
+                EnsureFieldIsConfigured(field, mapping);
                 var op = NormalizeOperator(compMatch.Groups["op"].Value);
                 var valueToken = compMatch.Groups["value"].Value;
                 var value = ParseValueToken(valueToken);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeFilterTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeFilterTransformExecutor.cs
@@ -66,10 +66,10 @@ internal sealed class AttributeFilterTransformExecutor(
             "eq" => StringEquals(actual, value),
             "neq" => !StringEquals(actual, value),
             "contains" => actual?.ToString()?.Contains(value ?? "", StringComparison.OrdinalIgnoreCase) ?? false,
-            "gt" => CompareNumeric(actual, value) > 0,
-            "gte" => CompareNumeric(actual, value) >= 0,
-            "lt" => CompareNumeric(actual, value) < 0,
-            "lte" => CompareNumeric(actual, value) <= 0,
+            "gt" => CompareNumeric(actual, value) is int cgt && cgt > 0,
+            "gte" => CompareNumeric(actual, value) is int cgte && cgte >= 0,
+            "lt" => CompareNumeric(actual, value) is int clt && clt < 0,
+            "lte" => CompareNumeric(actual, value) is int clte && clte <= 0,
             _ => throw new TransformInputException($"attribute-filter operator '{op}' is not supported.")
         };
     }
@@ -80,13 +80,15 @@ internal sealed class AttributeFilterTransformExecutor(
             expected,
             StringComparison.Ordinal);
 
-    private static int CompareNumeric(object? actual, string? expected)
+    private static int? CompareNumeric(object? actual, string? expected)
     {
         if (!TryToDouble(actual, out var a) ||
             !double.TryParse(expected, NumberStyles.Float, CultureInfo.InvariantCulture, out var b))
         {
-            // Non-numeric operands never satisfy a numeric comparison.
-            return int.MinValue;
+            // Non-numeric operands never satisfy a numeric comparison: return null so
+            // all call sites (lt/lte/gt/gte) evaluate to false rather than accidentally
+            // passing because int.MinValue < 0 and int.MinValue <= 0 are both true.
+            return null;
         }
 
         return a.CompareTo(b);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeJoinTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/AttributeJoinTransformExecutor.cs
@@ -206,15 +206,53 @@ internal sealed class AttributeJoinTransformExecutor(
 
             if (i > 0)
             {
-                // Unit separator keeps composite keys unambiguous across columns.
-                sb.Append('\u001f');
+                // U+001F (unit separator) is the inter-column delimiter. Column values are
+                // escaped via EscapeKeyComponent before appending, so the single unescaped
+                // U+001F here is always unambiguously a column boundary.
+                sb.Append('\u001F');
             }
 
-            sb.Append(Convert.ToString(value, CultureInfo.InvariantCulture));
+            sb.Append(EscapeKeyComponent(Convert.ToString(value, CultureInfo.InvariantCulture)));
         }
 
         key = sb.ToString();
         return true;
+    }
+
+    /// <summary>
+    /// Escapes the U+001E (escape prefix) and U+001F (unit-separator delimiter) characters
+    /// within a single key component value so they cannot be mistaken for structural
+    /// delimiters in the composite key string. Encoding:
+    /// <list type="bullet">
+    ///   <item>U+001E in value -&gt; U+001E U+001E</item>
+    ///   <item>U+001F in value -&gt; U+001E U+001F</item>
+    /// </list>
+    /// A single unescaped U+001F therefore always means "column boundary".
+    /// </summary>
+    private static string? EscapeKeyComponent(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (value.IndexOfAny(['\u001E', '\u001F']) < 0)
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length + 4);
+        foreach (var ch in value)
+        {
+            if (ch is '\u001E' or '\u001F')
+            {
+                sb.Append('\u001E'); // Escape prefix before any structural character.
+            }
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
     }
 
     private static string[] SplitRequired(StepInputReader inputs, string name)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/DedupTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/DedupTransformExecutor.cs
@@ -36,7 +36,10 @@ internal sealed class DedupTransformExecutor(
     // Unit-separator control char between key parts so distinct field boundaries never
     // collide (for example {"ab","c"} versus {"a","bc"}).
     private const char Separator = '\u001F';
-    private const char NullMarker = '\u00A0';
+    // NullMarker: U+001E (escape prefix) + U+0000 (NUL). Provably out-of-band in the
+    // key encoding: EscapeKeyComponent emits U+001E only before U+001E or U+001F,
+    // never before NUL, so no serialized attribute value can produce this sequence.
+    private const string NullMarker = "\u001E\u0000";
 
     protected override string ProcessId => HandledProcessId;
 
@@ -67,10 +70,14 @@ internal sealed class DedupTransformExecutor(
 
         foreach (var field in keys)
         {
-            var value = attributes is not null && attributes.Exists(field)
+            var raw = attributes is not null && attributes.Exists(field)
                 ? Convert.ToString(attributes.GetOptionalValue(field), CultureInfo.InvariantCulture)
                 : null;
-            builder.Append(value ?? NullMarker.ToString());
+            // Use the out-of-band NullMarker so a no-break-space attribute value cannot
+            // collide with the null representation (BH-026). Escape U+001E and U+001F
+            // within non-null values so the inter-field separator is always unambiguous
+            // (BH-025 sister fix).
+            builder.Append(raw is not null ? EscapeKeyComponent(raw) : NullMarker);
             builder.Append(Separator);
         }
 
@@ -88,6 +95,37 @@ internal sealed class DedupTransformExecutor(
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// Escapes the U+001E (escape prefix) and U+001F (unit-separator delimiter) characters
+    /// within a single key component value so they cannot be mistaken for structural
+    /// delimiters in the composite key string. Encoding:
+    /// <list type="bullet">
+    ///   <item>U+001E in value -&gt; U+001E U+001E</item>
+    ///   <item>U+001F in value -&gt; U+001E U+001F</item>
+    /// </list>
+    /// A single unescaped U+001F therefore always means "field boundary".
+    /// </summary>
+    private static string EscapeKeyComponent(string value)
+    {
+        if (value.IndexOfAny(['\u001E', '\u001F']) < 0)
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length + 4);
+        foreach (var ch in value)
+        {
+            if (ch is '\u001E' or '\u001F')
+            {
+                sb.Append('\u001E'); // Escape prefix before any structural character.
+            }
+
+            sb.Append(ch);
+        }
+
+        return sb.ToString();
     }
 
     private static (IReadOnlyList<string> Keys, bool UseGeometry) ReadKeySpec(StepInputReader inputs)

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
@@ -102,8 +102,10 @@ internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
         // Open the input as a streamed feature sequence so a >50 MiB load lands via
         // batched COPY/insert without materializing the whole collection. Spilled NDJSON
         // streams are unbounded; inline data URIs stay bounded by MaxArtifactBytes.
+        // Pass OutputRootDirectory so path-traversal injections in the reference are rejected.
         if (!FeatureStreamArtifact.TryOpenRead(
-                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes))
+                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes,
+                _options.CurrentValue.OutputRootDirectory))
         {
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: 'input' {parseError}");
         }
@@ -454,8 +456,17 @@ internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
             case float floatValue when float.IsFinite(floatValue):
                 writer.WriteNumberValue(floatValue);
                 break;
+            case float:
+                // NaN / ±Infinity are not valid JSON numbers; write null to preserve the
+                // numeric column type in JSONB rather than silently coercing to a string.
+                writer.WriteNullValue();
+                break;
             case double doubleValue when double.IsFinite(doubleValue):
                 writer.WriteNumberValue(doubleValue);
+                break;
+            case double:
+                // Same as float: non-finite double → null in JSONB.
+                writer.WriteNullValue();
                 break;
             case decimal decimalValue:
                 writer.WriteNumberValue(decimalValue);

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureCollectionTransformExecutor.cs
@@ -99,8 +99,10 @@ internal abstract partial class FeatureCollectionTransformExecutor : IProcessExe
 
         // Open the input as a lazy feature stream. Spilled NDJSON streams are unbounded;
         // inline base64 data URIs remain bounded by MaxArtifactBytes for back-compat.
+        // Pass OutputRootDirectory so path-traversal injections in the reference are rejected.
         if (!FeatureStreamArtifact.TryOpenRead(
-                inputUri, out var parseError, out var inputStream, _options.CurrentValue.MaxArtifactBytes))
+                inputUri, out var parseError, out var inputStream, _options.CurrentValue.MaxArtifactBytes,
+                _options.CurrentValue.OutputRootDirectory))
         {
             return JobExecutionResult.Failed($"Invalid {ProcessId} inputs: 'input' {parseError}");
         }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureStreamArtifact.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/FeatureStreamArtifact.cs
@@ -91,11 +91,18 @@ internal static class FeatureStreamArtifact
     /// <see cref="FeatureCollectionArtifact.TryParseDataUri"/>). Spilled streams are
     /// unbounded — that is the whole point — so the ceiling does not apply to them.
     /// </param>
+    /// <param name="outputRootDirectory">
+    /// When non-null, the path carried by any spilled NDJSON stream reference must fall
+    /// within this directory. Pass the configured executor output root to prevent an
+    /// authenticated caller from injecting an arbitrary file-system path into the reference
+    /// and reading files outside the geoprocessing sandbox.
+    /// </param>
     public static bool TryOpenRead(
         string? reference,
         out string error,
         out IAsyncEnumerable<IFeature> stream,
-        long maxInlineDecodedBytes = long.MaxValue)
+        long maxInlineDecodedBytes = long.MaxValue,
+        string? outputRootDirectory = null)
     {
         error = "";
         stream = AsyncEnumerable.Empty<IFeature>();
@@ -111,6 +118,28 @@ internal static class FeatureStreamArtifact
             if (!TryParseStreamReference(reference, out var descriptor, out error))
             {
                 return false;
+            }
+
+            // Guard against path-traversal: reject any stream reference whose backing
+            // file path falls outside the configured output root directory. Legitimate
+            // spilled streams are always written under OutputRootDirectory/streams/ by
+            // AllocateSpillPath, so a path outside the root is always an injection attempt.
+            if (outputRootDirectory is not null)
+            {
+                var comparison = OperatingSystem.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal;
+                var root = Path.GetFullPath(outputRootDirectory);
+                var candidate = Path.GetFullPath(descriptor.Path);
+                var rootPrefix = root.EndsWith(Path.DirectorySeparatorChar)
+                    ? root
+                    : root + Path.DirectorySeparatorChar;
+
+                if (!candidate.StartsWith(rootPrefix, comparison))
+                {
+                    error = "stream reference path is outside the output root";
+                    return false;
+                }
             }
 
             if (!File.Exists(descriptor.Path))

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/GeoJsonFileSinkExecutor.cs
@@ -90,8 +90,10 @@ internal sealed partial class GeoJsonFileSinkExecutor : IProcessExecutor
 
         // Stream the input so a >50 MiB sink writes incrementally to the output file
         // without buffering the whole collection. Spilled NDJSON streams are unbounded.
+        // Pass OutputRootDirectory so path-traversal injections in the reference are rejected.
         if (!FeatureStreamArtifact.TryOpenRead(
-                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes))
+                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes,
+                _options.CurrentValue.OutputRootDirectory))
         {
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: 'input' {parseError}");
         }

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/QuarantineSinkExecutor.cs
@@ -91,8 +91,10 @@ internal sealed partial class QuarantineSinkExecutor : IProcessExecutor
 
         // Stream the input so a large dead-letter set writes incrementally without
         // buffering the whole collection. Spilled NDJSON streams are unbounded.
+        // Pass OutputRootDirectory so path-traversal injections in the reference are rejected.
         if (!FeatureStreamArtifact.TryOpenRead(
-                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes))
+                inputUri, out var parseError, out var source, _options.CurrentValue.MaxArtifactBytes,
+                _options.CurrentValue.OutputRootDirectory))
         {
             return JobExecutionResult.Failed($"Invalid {HandledProcessId} inputs: 'input' {parseError}");
         }

--- a/src/Honua.Hosting/Features/Authentication/AdminAuthSessionStore.cs
+++ b/src/Honua.Hosting/Features/Authentication/AdminAuthSessionStore.cs
@@ -173,9 +173,17 @@ internal sealed partial class AdminAuthSessionStore(
             }
             catch (Exception ex)
             {
-                _memoryCache.Remove(key);
                 AdminAuthSessionLog.DistributedCacheReadFailed(_logger, GetKeyFamily(key), LogValueRedactor.Hash(key), ex);
-                return null;
+                // Distributed cache is unreachable; fall back to the in-process memory tier
+                // if a valid entry is present.  The memory entry was written atomically with
+                // the distributed entry at issuance time, so it remains consistent for its
+                // original TTL.  Evicting it would extend the auth outage beyond the Redis
+                // unavailability window and destroy warm in-process state unnecessarily (BH-028).
+                if (!_memoryCache.TryGetValue(key, out payload) || payload is null)
+                {
+                    return null;
+                }
+                // Fall through to deserialize the memory-cached payload.
             }
         }
 

--- a/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
+++ b/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
@@ -72,40 +72,14 @@ internal static class AtomicTokenReplayProtection
     {
         try
         {
-            // Use Redis SETNX operation or equivalent atomic SET IF NOT EXISTS
-            // Most distributed cache implementations support this via SetAsync with specific options
-            var options = new DistributedCacheEntryOptions
-            {
-                AbsoluteExpiration = expiresOn
-            };
-
-            // Use Redis for true atomicity if available
+            // Use Redis for true atomicity if available.
             if (cache is Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache redisCache)
             {
                 return await TryMarkTokenAsUsedRedisAsync(redisCache, cacheKey, expiresOn, cancellationToken);
             }
 
-            // For non-Redis caches, implement a more robust fallback with unique identifier verification
-            var uniqueMarker = Guid.NewGuid().ToString();
-            var timestampedValue = $"{DateTimeOffset.UtcNow:O}|{uniqueMarker}";
-
-            // First attempt to get existing value
-            var existing = await cache.GetStringAsync(cacheKey, cancellationToken);
-            if (existing != null)
-            {
-                // Token already exists, this is a replay
-                return false;
-            }
-
-            // Set our unique marker
-            await cache.SetStringAsync(cacheKey, timestampedValue, options, cancellationToken);
-
-            // Brief delay to allow any concurrent operations to complete
-            await Task.Delay(1, cancellationToken);
-
-            // Verify our unique marker is still there - if not, another request won the race
-            var verification = await cache.GetStringAsync(cacheKey, cancellationToken);
-            return verification == timestampedValue; // Only allow if our exact value is present
+            var options = new DistributedCacheEntryOptions { AbsoluteExpiration = expiresOn };
+            return await TryMarkTokenAsUsedNonAtomicAsync(cache, cacheKey, options, cancellationToken);
         }
         catch (Exception)
         {
@@ -122,7 +96,9 @@ internal static class AtomicTokenReplayProtection
     {
         try
         {
-            // Use reflection to access the underlying Redis database for atomic operations
+            // Use reflection to access the underlying Redis database for atomic operations.
+            // The IDatabase field is lazily initialized; it is null before the first cache
+            // operation completes (i.e. on cold-start before any Redis I/O has occurred).
             var type = redisCache.GetType();
             var connectionField = type.GetField("_cache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             var connection = connectionField?.GetValue(redisCache) as StackExchange.Redis.IDatabase;
@@ -139,11 +115,51 @@ internal static class AtomicTokenReplayProtection
         }
         catch (Exception)
         {
-            // If reflection or Redis operation fails, fall back to less atomic method
+            // If reflection or Redis operation fails, fall back to less atomic method below.
         }
 
-        // Fallback to standard distributed cache (less atomic but still functional)
-        return await TryMarkTokenAsUsedDistributedAsync(redisCache, cacheKey, expiresOn, cancellationToken);
+        // Fallback: use the non-atomic distributed path, passing the RedisCache as a plain
+        // IDistributedCache.  IMPORTANT: do NOT call TryMarkTokenAsUsedDistributedAsync here
+        // — it re-dispatches to this method because the argument is still a RedisCache,
+        // causing infinite mutual recursion and a StackOverflowException (BH-027).
+        try
+        {
+            var fallbackOptions = new DistributedCacheEntryOptions { AbsoluteExpiration = expiresOn };
+            return await TryMarkTokenAsUsedNonAtomicAsync(redisCache, cacheKey, fallbackOptions, cancellationToken);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> TryMarkTokenAsUsedNonAtomicAsync(
+        IDistributedCache cache,
+        string cacheKey,
+        DistributedCacheEntryOptions options,
+        CancellationToken cancellationToken)
+    {
+        // For non-Redis caches, implement a more robust fallback with unique identifier verification
+        var uniqueMarker = Guid.NewGuid().ToString();
+        var timestampedValue = $"{DateTimeOffset.UtcNow:O}|{uniqueMarker}";
+
+        // First attempt to get existing value
+        var existing = await cache.GetStringAsync(cacheKey, cancellationToken);
+        if (existing != null)
+        {
+            // Token already exists, this is a replay
+            return false;
+        }
+
+        // Set our unique marker
+        await cache.SetStringAsync(cacheKey, timestampedValue, options, cancellationToken);
+
+        // Brief delay to allow any concurrent operations to complete
+        await Task.Delay(1, cancellationToken);
+
+        // Verify our unique marker is still there - if not, another request won the race
+        var verification = await cache.GetStringAsync(cacheKey, cancellationToken);
+        return verification == timestampedValue; // Only allow if our exact value is present
     }
 
     private static bool TryMarkTokenAsUsedMemory(

--- a/src/Honua.Hosting/Features/Authentication/PortalTokenIssuer.cs
+++ b/src/Honua.Hosting/Features/Authentication/PortalTokenIssuer.cs
@@ -299,9 +299,17 @@ internal sealed partial class PortalTokenIssuer(
             }
             catch (Exception ex)
             {
-                _memoryCache.Remove(key);
                 PortalTokenLog.DistributedCacheReadFailed(_logger, LogValueRedactor.Hash(key), ex);
-                return null;
+                // Distributed cache is unreachable; fall back to the in-process memory tier
+                // if a valid entry is present.  The memory entry was written atomically with
+                // the distributed entry at issuance time, so it remains consistent for its
+                // original TTL.  Evicting it would extend the auth outage beyond the Redis
+                // unavailability window and destroy warm in-process state unnecessarily (BH-028).
+                if (!_memoryCache.TryGetValue(key, out payload) || payload is null)
+                {
+                    return null;
+                }
+                // Fall through to deserialize the memory-cached payload.
             }
         }
         else if (!_memoryCache.TryGetValue(key, out payload) || payload is null)

--- a/src/Honua.Hosting/Features/Authentication/ScopedJobTokenIssuer.cs
+++ b/src/Honua.Hosting/Features/Authentication/ScopedJobTokenIssuer.cs
@@ -248,9 +248,17 @@ internal sealed partial class ScopedJobTokenIssuer(
             }
             catch (Exception ex)
             {
-                _memoryCache.Remove(key);
                 ScopedJobTokenLog.DistributedCacheReadFailed(_logger, LogValueRedactor.Hash(key), ex);
-                return null;
+                // Distributed cache is unreachable; fall back to the in-process memory tier
+                // if a valid entry is present.  The memory entry was written atomically with
+                // the distributed entry at issuance time, so it remains consistent for its
+                // original TTL.  Evicting it would extend the auth outage beyond the Redis
+                // unavailability window and destroy warm in-process state unnecessarily (BH-028).
+                if (!_memoryCache.TryGetValue(key, out payload) || payload is null)
+                {
+                    return null;
+                }
+                // Fall through to deserialize the memory-cached payload.
             }
         }
         else if (!_memoryCache.TryGetValue(key, out payload) || payload is null)

--- a/src/Honua.Import/Features/FileImport/StreamingFileUploadService.cs
+++ b/src/Honua.Import/Features/FileImport/StreamingFileUploadService.cs
@@ -68,14 +68,22 @@ internal sealed class StreamingFileUploadService : IDisposable, IUploadQueueMetr
 
         try
         {
-            // Check queue capacity before accepting the request.
-            if (Volatile.Read(ref _queuedCount) >= _options.MaxQueuedUploads)
+            // Atomically check capacity and reserve a slot using a CAS loop.
+            // A plain read-then-increment is a TOCTOU race: multiple concurrent callers
+            // can each read a count below the limit, pass the guard, and each increment,
+            // exceeding MaxQueuedUploads by the number of concurrent callers.
+            var max = _options.MaxQueuedUploads;
+            int cur;
+            do
             {
-                StreamingFileUploadLog.UploadQueueFull(_logger, uploadJob.FileName);
-                return FileUploadResult.Failure("Upload queue is full. Please try again later.");
+                cur = Volatile.Read(ref _queuedCount);
+                if (cur >= max)
+                {
+                    StreamingFileUploadLog.UploadQueueFull(_logger, uploadJob.FileName);
+                    return FileUploadResult.Failure("Upload queue is full. Please try again later.");
+                }
             }
-
-            Interlocked.Increment(ref _queuedCount);
+            while (Interlocked.CompareExchange(ref _queuedCount, cur + 1, cur) != cur);
             try
             {
                 // Wait for a processing slot.

--- a/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
@@ -11,6 +11,7 @@ using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Validation.Abstractions;
+using Honua.Core.Queries.Filters;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Models;
@@ -218,19 +219,37 @@ internal static partial class AttachmentEndpoints
         }
 
         // definitionExpression narrows the parent feature set with a SQL WHERE clause.
-        // Resolve it through the shared feature-query pipeline to the matching object IDs
-        // and intersect with the requested objectIds, so attachments are only returned for
-        // features that satisfy the expression (matching Esri queryAttachments semantics).
+        // Resolve it through the shared filter-expression pipeline so the SQL is safely
+        // parameterised and schema-validated before being sent to the feature reader.
         var definitionExpression = GetFirst(values, "definitionExpression", "definitionexpression");
         if (!string.IsNullOrWhiteSpace(definitionExpression))
         {
+            var filterService = context.RequestServices.GetRequiredService<IFilterExpressionService>();
+            var parseResult = filterService.Parse(FilterLanguage.ArcGisSql, definitionExpression);
+            if (!parseResult.IsSuccess)
+            {
+                await RouteValidationHelpers.WriteValidationErrorAsync(
+                    context,
+                    "definitionExpression is not a valid WHERE clause for this layer.");
+                return;
+            }
+
+            var translationResult = filterService.Translate(parseResult.Expression, resource.Value.Resource);
+            if (!translationResult.IsSuccess)
+            {
+                await RouteValidationHelpers.WriteValidationErrorAsync(
+                    context,
+                    "definitionExpression is not a valid WHERE clause for this layer.");
+                return;
+            }
+
             var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
             ImmutableArray<long> matchingIds;
             try
             {
                 matchingIds = await featureReader.QueryObjectIdsAsync(
                     layerId,
-                    new FeatureQuery { Where = definitionExpression, ExcludeAttributes = true },
+                    new FeatureQuery { SqlFilter = translationResult.SqlFilter, ExcludeAttributes = true },
                     cancellationToken);
             }
             catch (Exception ex) when (ex is ArgumentException or FormatException or InvalidOperationException)

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
@@ -164,6 +164,29 @@ internal sealed class FeatureServerEditsHandler(
                 return Results.Json(new ApplyEditsResponse { Success = true },
                     FeatureServerJsonContext.Default.ApplyEditsResponse,
                     contentType: "application/json");
+            }
+
+            // Per-edit-type authorization checks (BH-002): the pre-body gate uses Update as the
+            // coarsest write check; after the body is read, gate each present edit type on its
+            // specific operation so a delete-only payload requires Delete, not just Update.
+            if (request.Adds?.Length > 0)
+            {
+                var insertError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+                    httpContext, resource, AuthorizationOperation.Insert, service, cancellationToken).ConfigureAwait(false);
+                if (insertError != null)
+                {
+                    return insertError;
+                }
+            }
+
+            if (request.Deletes?.Length > 0)
+            {
+                var deleteError = await AccessPolicyHelpers.RequireResourceAccessAsync(
+                    httpContext, resource, AuthorizationOperation.Delete, service, cancellationToken).ConfigureAwait(false);
+                if (deleteError != null)
+                {
+                    return deleteError;
+                }
             }
 
             // Resolve the authenticated principal once so owner-based edit policies
@@ -559,11 +582,34 @@ internal sealed class FeatureServerEditsHandler(
             slotObjectIds[i] = parsedObjectId;
         }
 
-        var existingFeatures = await ResolveFeaturesByGeoServicesObjectIdsAsync(
-            resource,
-            storageLayerId,
-            slotObjectIds,
-            cancellationToken).ConfigureAwait(false);
+        IReadOnlyDictionary<long, Feature> existingFeatures;
+        try
+        {
+            existingFeatures = await ResolveFeaturesByGeoServicesObjectIdsAsync(
+                resource,
+                storageLayerId,
+                slotObjectIds,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (ArgumentException ex)
+        {
+            // ObjectId field translation failed; this is schema-level and would have
+            // failed every slot under the previous per-feature resolve as well.
+            var description = SanitizeEditErrorMessage(ex.Message, InvalidFeatureDataMessage);
+            for (var i = 0; i < slotObjectIds.Length; i++)
+            {
+                if (slotObjectIds[i] is { } failedObjectId)
+                {
+                    context.HasValidationErrors = true;
+                    context.DeleteResults![i] = CreateFailureResult(
+                        code: GeoServicesEditErrorCodes.InvalidObjectId,
+                        description: description,
+                        objectId: failedObjectId);
+                }
+            }
+
+            return;
+        }
 
         for (var i = 0; i < request.Deletes.Length; i++)
         {

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
@@ -185,7 +185,7 @@ internal static partial class FeatureServerEndpoints
         }
 
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
-        var authorizationError = await RequireLayerWriteAccessBeforeBodyAsync(serviceId, layerId, context, cancellationToken);
+        var authorizationError = await RequireLayerWriteAccessBeforeBodyAsync(serviceId, layerId, context, cancellationToken, AuthorizationOperation.Delete);
         if (authorizationError != null)
         {
             return authorizationError;
@@ -858,7 +858,8 @@ internal static partial class FeatureServerEndpoints
         string serviceId,
         int layerId,
         HttpContext context,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        AuthorizationOperation operation = AuthorizationOperation.Update)
     {
         var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
         var validationResult = await FeatureServerResourceValidationHelpers.ValidateServiceLayerV2Async(
@@ -876,7 +877,7 @@ internal static partial class FeatureServerEndpoints
         var service = validationResult.Service!;
         var resource = validationResult.Resource!;
         var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
-            context, resource, AuthorizationOperation.Update, service, cancellationToken).ConfigureAwait(false);
+            context, resource, operation, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.FeatureStore.Abstractions;
@@ -1101,8 +1101,11 @@ internal static partial class FeatureServerEndpoints
         // last-sync cursor to the live current generation once the server-to-client delta below has been
         // assembled, so the replica receives every change committed since its last sync exactly once.
         long currentGen;
-        if (didUpload && !isDownloadDirection)
+        if (didUpload)
         {
+            // BH-012: use the post-upload generation for both upload-only AND bidirectional
+            // syncs so concurrent server edits committed after the upload are captured by
+            // the NEXT sync rather than permanently skipped.
             currentGen = uploadServerGen;
         }
         else

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
@@ -148,15 +148,23 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
     }
 
     private static string BuildKey(ApplyEditsIdempotencyScope scope)
-        => string.Concat(
+    {
+        // Hash the principal to prevent colon-based key collisions: a principal name
+        // containing ":" would allow crafted names to collide with other key segments.
+        // SHA256.HashData is AOT-compatible and allocation-efficient in .NET 6+.
+        var principalBytes = System.Text.Encoding.UTF8.GetBytes(scope.Principal);
+        var hash = System.Security.Cryptography.SHA256.HashData(principalBytes);
+        var principalHash = Convert.ToHexString(hash);
+        return string.Concat(
             KeyPrefix,
             scope.ServiceId,
             ":",
             scope.LayerId.ToString(System.Globalization.CultureInfo.InvariantCulture),
             ":",
-            scope.Principal,
+            principalHash,
             ":",
             scope.IdempotencyKey);
+    }
 
     private static byte[] Serialize(ApplyEditsResponse response)
         => JsonSerializer.SerializeToUtf8Bytes(response, FeatureServerJsonContext.Default.ApplyEditsResponse);

--- a/src/Honua.Protocols.OData/Features/ODataQueryHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataQueryHandler.cs
@@ -87,6 +87,18 @@ internal sealed partial class ODataQueryHandler(
                     "$select contains an empty field expression.");
             }
 
+            // BH-S-04: /Layers uses $skip (not $skiptoken) for continuation; the server never
+            // emits a $skiptoken nextLink for the catalog layer list.  Accepting an inbound
+            // $skiptoken here would validate it against a null-fingerprint, which accepts any
+            // token issued by any Features endpoint with no filter/orderby — an isolation bug.
+            if (!string.IsNullOrWhiteSpace(skiptoken))
+            {
+                return ODataUtilityService.CreateODataError(
+                    context,
+                    "InvalidQueryOption",
+                    "$skiptoken is not supported on /Layers. Use $skip for catalog layer pagination.");
+            }
+
             var pagingError = ODataRequestValidation.TryGetPagingValues(
                 context,
                 _validationService,

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesQueryHandler.cs
@@ -882,7 +882,12 @@ internal sealed partial class OgcFeaturesQueryHandler(
         int limit,
         int offset)
     {
-        var queryParts = new List<string>();
+        // Use QueryHelpers.AddQueryString so that both keys and values are properly
+        // percent-encoded.  IQueryCollection exposes URL-decoded keys; writing them
+        // back with bare string interpolation produces syntactically invalid URLs when
+        // a field name contains spaces, '&', '=', or other reserved characters.
+        var query = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>(
+            StringComparer.OrdinalIgnoreCase);
 
         foreach (var (key, value) in request.Query)
         {
@@ -895,12 +900,12 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
             if (!string.IsNullOrWhiteSpace(value))
             {
-                queryParts.Add($"{key}={Uri.EscapeDataString(value.ToString())}");
+                query[key] = value;
             }
         }
 
-        queryParts.Add(FormattableString.Invariant($"limit={limit}"));
-        queryParts.Add(FormattableString.Invariant($"offset={offset}"));
+        query["limit"] = limit.ToString(CultureInfo.InvariantCulture);
+        query["offset"] = offset.ToString(CultureInfo.InvariantCulture);
 
         var formatValue = outputFormat switch
         {
@@ -914,12 +919,10 @@ internal sealed partial class OgcFeaturesQueryHandler(
 
         if (!string.IsNullOrWhiteSpace(formatValue))
         {
-            queryParts.Add($"f={formatValue}");
+            query["f"] = formatValue;
         }
 
-        return queryParts.Count > 0
-            ? $"{basePath}?{string.Join("&", queryParts)}"
-            : basePath;
+        return Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(basePath, query);
     }
 
     private static string FormatContentCrs(string crsUri) => $"<{crsUri}>";

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
@@ -853,7 +853,8 @@ internal sealed partial class OgcFeaturesTransactionHandler(
                         HonuaTelemetry.Protocols.OgcFeatures,
                         CancellationToken.None,
                         mutationFeature: updated.Value,
-                        serviceProtocol: OgcFeaturesProtocolName).ConfigureAwait(false);
+                        serviceProtocol: OgcFeaturesProtocolName,
+                        geometryChanged: patchRequest.HasGeometry).ConfigureAwait(false);
                 }
                 catch (Exception publishEx)
                 {

--- a/src/Honua.Protocols.OgcApi/Features/Services/OgcResponseFormatter.cs
+++ b/src/Honua.Protocols.OgcApi/Features/Services/OgcResponseFormatter.cs
@@ -297,6 +297,19 @@ internal static class OgcResponseFormatter
         AxisOrder outputAxisOrder,
         CancellationToken cancellationToken)
     {
+        // OGC API Features Part 1 §7.8.3 and WFS 2.0 §8.8.5.2 require numberReturned to
+        // equal the actual number of features in the document.  The pre-computed estimate
+        // can differ from the real stream count under concurrent writes (MVCC snapshot
+        // difference between the count query and the streaming query).  Buffer the features
+        // first so we can write the header with the accurate count.
+        var buffered = new List<GmlFeature>();
+        await foreach (var feature in features.WithCancellation(cancellationToken))
+        {
+            buffered.Add(feature);
+        }
+
+        var actualReturned = buffered.Count;
+
         await using var writer = new StreamWriter(
             bodyWriter.AsStream(),
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
@@ -310,10 +323,8 @@ internal static class OgcResponseFormatter
             header.Append($" numberMatched=\"{numberMatched.Value.ToString(CultureInfo.InvariantCulture)}\"");
         }
 
-        if (numberReturned.HasValue)
-        {
-            header.Append($" numberReturned=\"{numberReturned.Value.ToString(CultureInfo.InvariantCulture)}\"");
-        }
+        // Always write the actual streamed count, not the pre-computed estimate.
+        header.Append($" numberReturned=\"{actualReturned.ToString(CultureInfo.InvariantCulture)}\"");
 
         if (timeStamp.HasValue)
         {
@@ -324,7 +335,7 @@ internal static class OgcResponseFormatter
         await writer.WriteLineAsync(header.ToString());
 
         var writtenSinceFlush = 0;
-        await foreach (var feature in features.WithCancellation(cancellationToken))
+        foreach (var feature in buffered)
         {
             var escapedId = CreateGmlId(feature.Id, "feature_");
             await writer.WriteLineAsync("  <wfs:member>");

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.GetFeature.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.GetFeature.cs
@@ -342,6 +342,16 @@ internal sealed partial class Wfs20Handler
             .ToArray();
         var wfsUrl = $"{BaseUrlResolver.GetBaseUrl(context)}/wfs";
 
+        // Collect per-query FILTER and PROPERTYNAME values as semicolon-delimited strings,
+        // matching the KVP multi-query encoding (WFS 2.0 §8.8.6.5).  Paging links built
+        // from these values correctly re-apply the original filter predicates on page 2+.
+        var xmlQueryFilter = xmlQueries.Any(q => !string.IsNullOrEmpty(q.Filter))
+            ? string.Join(";", xmlQueries.Select(q => q.Filter ?? string.Empty))
+            : null;
+        var xmlQueryPropertyName = xmlQueries.Any(q => !string.IsNullOrEmpty(q.PropertyName))
+            ? string.Join(";", xmlQueries.Select(q => q.PropertyName ?? string.Empty))
+            : null;
+
         if (planSet.TotalMatched == 0)
         {
             var emptyMetadata = BuildFeatureCollectionResponseMetadata(
@@ -351,9 +361,9 @@ internal sealed partial class Wfs20Handler
                 maxFeatures.ToString(CultureInfo.InvariantCulture),
                 sortBy,
                 bbox,
-                null,
+                xmlQueryFilter,
                 resourceId,
-                null,
+                xmlQueryPropertyName,
                 fallbackSrsName,
                 normalizedResultType,
                 offset,
@@ -372,9 +382,9 @@ internal sealed partial class Wfs20Handler
             maxFeatures.ToString(CultureInfo.InvariantCulture),
             sortBy,
             bbox,
-            null,
+            xmlQueryFilter,
             resourceId,
-            null,
+            xmlQueryPropertyName,
             fallbackSrsName,
             normalizedResultType,
             offset,

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
@@ -83,6 +83,14 @@ internal sealed partial class Wfs20Handler
 
             if (prepared.Operations.IsDefaultOrEmpty)
             {
+                if (prepared.HasAnyRecognisedActions)
+                {
+                    // All actions matched zero features — ISO 19142 §15.2.5.3 no-op: return
+                    // a valid TransactionResponse with all counts at zero rather than an error.
+                    var emptyResponse = BuildTransactionResponseXml(prepared, FeatureEditResult.Success(0, 0, 0));
+                    return Results.Content(emptyResponse, "application/xml", Encoding.UTF8);
+                }
+
                 return Wfs20ErrorResults.CreateBadRequest(
                     context,
                     "MissingParameterValue",
@@ -218,6 +226,15 @@ internal sealed partial class Wfs20Handler
         var operations = ImmutableArray.CreateBuilder<PreparedTransactionOperation>();
         var distinctLayerIds = new HashSet<int>();
         var validatedLayerIds = new HashSet<int>();
+        // Tracks whether the body contained at least one supported WFS action element.
+        // ISO 19142 §15.2.5.3: a Delete or Update whose filter matches zero features is a
+        // valid no-op that contributes zero operations but is still a recognised action.
+        var hasAnyRecognisedActions = false;
+        // Counts parsed Delete/Update action *elements*, regardless of how many features matched.
+        // Used by BuildTransactionResponseXml so that totalDeleted/totalUpdated appear in the
+        // TransactionSummary even when every filter matched zero features (count then = 0).
+        var parsedDeleteActions = 0;
+        var parsedUpdateActions = 0;
 
         foreach (var actionElement in root.Elements())
         {
@@ -267,6 +284,25 @@ internal sealed partial class Wfs20Handler
                     "request")
             };
 
+            switch (actionElement.Name.LocalName)
+            {
+                case "Insert":
+                case "Update":
+                case "Delete":
+                case "Replace":
+                    hasAnyRecognisedActions = true;
+                    break;
+            }
+
+            if (actionElement.Name.LocalName == "Delete")
+            {
+                parsedDeleteActions++;
+            }
+            else if (actionElement.Name.LocalName == "Update")
+            {
+                parsedUpdateActions++;
+            }
+
             if (errorResult != null)
             {
                 return TransactionPreparationResult.Failure(errorResult);
@@ -299,7 +335,10 @@ internal sealed partial class Wfs20Handler
         return TransactionPreparationResult.Success(
             operations.ToImmutable(),
             layerId,
-            distinctLayerIds.Count);
+            distinctLayerIds.Count,
+            hasAnyRecognisedActions,
+            parsedDeleteActions,
+            parsedUpdateActions);
     }
 
 
@@ -951,7 +990,9 @@ internal sealed partial class Wfs20Handler
 
         if (objectIds.IsDefaultOrEmpty)
         {
-            throw new ArgumentException("Transaction filter did not match any features.");
+            // ISO 19142 §15.2.5.3: a filter that matches zero features is a valid no-op;
+            // report totalDeleted/totalUpdated=0 rather than failing with a 400 error.
+            return ImmutableArray<long>.Empty;
         }
 
         return objectIds;
@@ -1458,7 +1499,23 @@ internal sealed partial class Wfs20Handler
             .FirstOrDefault(element => string.Equals(element.Name.LocalName, "posList", StringComparison.OrdinalIgnoreCase));
         if (posListElement != null)
         {
-            return ParseTransactionPosList(posListElement.Value, axisOrder);
+            // Read srsDimension from the posList element first, then from the containing geometry element.
+            // Default per GML 3.2 §9.2.4: 2.
+            var srsDimension = 2;
+            var srsDimensionAttr = posListElement
+                .Attributes()
+                .FirstOrDefault(a => string.Equals(a.Name.LocalName, "srsDimension", StringComparison.OrdinalIgnoreCase))
+                ?? geometryElement
+                    .Attributes()
+                    .FirstOrDefault(a => string.Equals(a.Name.LocalName, "srsDimension", StringComparison.OrdinalIgnoreCase));
+            if (srsDimensionAttr != null &&
+                int.TryParse(srsDimensionAttr.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedDim) &&
+                parsedDim >= 2)
+            {
+                srsDimension = parsedDim;
+            }
+
+            return ParseTransactionPosList(posListElement.Value, axisOrder, srsDimension);
         }
 
         var positions = geometryElement.Descendants()
@@ -1474,22 +1531,26 @@ internal sealed partial class Wfs20Handler
     }
 
 
-    private static Coordinate[] ParseTransactionPosList(string rawPosList, AxisOrder axisOrder)
+    private static Coordinate[] ParseTransactionPosList(string rawPosList, AxisOrder axisOrder, int srsDimension = 2)
     {
         var ordinates = rawPosList
             .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(ParseTransactionOrdinate)
             .ToArray();
 
-        if (ordinates.Length < 2 || ordinates.Length % 2 != 0)
+        var stride = Math.Max(2, srsDimension);
+        if (ordinates.Length < stride || ordinates.Length % stride != 0)
         {
-            throw new ArgumentException("GML posList must contain an even number of ordinates.");
+            throw new ArgumentException(
+                $"GML posList ordinate count ({ordinates.Length.ToString(CultureInfo.InvariantCulture)}) " +
+                $"is not a multiple of srsDimension ({stride.ToString(CultureInfo.InvariantCulture)}).");
         }
 
-        var coordinates = new Coordinate[ordinates.Length / 2];
-        for (var index = 0; index < ordinates.Length; index += 2)
+        var coordinates = new Coordinate[ordinates.Length / stride];
+        for (var index = 0; index < ordinates.Length; index += stride)
         {
-            coordinates[index / 2] = CreateTransactionCoordinate(ordinates[index], ordinates[index + 1], axisOrder);
+            // Only X/Y are captured; Z (index+2) is read and discarded when srsDimension=3.
+            coordinates[index / stride] = CreateTransactionCoordinate(ordinates[index], ordinates[index + 1], axisOrder);
         }
 
         return coordinates;
@@ -1642,6 +1703,19 @@ internal sealed partial class Wfs20Handler
                 requestGeometryChangedFlags,
                 rollbackOnFailure,
                 cancellationToken).ConfigureAwait(false);
+        }
+
+        // Multi-layer transactions cannot provide a single atomic cross-layer rollback:
+        // each layer is committed independently by the data layer.  If rollbackOnFailure=true
+        // is requested, reject before any data is committed rather than silently leaving a
+        // partially-committed state the client believes was rolled back (ISO 19142 §15.2.5.3).
+        if (rollbackOnFailure)
+        {
+            throw new WfsTransactionException(
+                "OperationProcessingFailed",
+                "Multi-layer transactions with rollbackOnFailure=true are not supported because cross-layer atomicity cannot be guaranteed. " +
+                "Submit each feature type in a separate Transaction or set rollbackOnFailure=false.",
+                "Transaction");
         }
 
         var createResultIndexes = new Dictionary<int, int>();
@@ -2075,7 +2149,9 @@ internal sealed partial class Wfs20Handler
                 writer.WriteElementString("wfs", "totalInserted", Wfs20Utilities.WfsNamespace, inserted.Count.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (prepared.UpdateCount > 0)
+            // Use ParsedUpdateActions / ParsedDeleteActions (not UpdateCount / DeleteCount) so that
+            // zero-match operations still appear in the summary as required by ISO 19142 §15.2.5.3.
+            if (prepared.ParsedUpdateActions > 0)
             {
                 writer.WriteElementString("wfs", "totalUpdated", Wfs20Utilities.WfsNamespace, updatedCount.ToString(CultureInfo.InvariantCulture));
             }
@@ -2085,7 +2161,7 @@ internal sealed partial class Wfs20Handler
                 writer.WriteElementString("wfs", "totalReplaced", Wfs20Utilities.WfsNamespace, replaced.Count.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (prepared.DeleteCount > 0)
+            if (prepared.ParsedDeleteActions > 0)
             {
                 writer.WriteElementString("wfs", "totalDeleted", Wfs20Utilities.WfsNamespace, deletedCount.ToString(CultureInfo.InvariantCulture));
             }
@@ -2207,14 +2283,23 @@ internal sealed partial class Wfs20Handler
         int InsertCount,
         int UpdateCount,
         int ReplaceCount,
-        int DeleteCount)
+        int DeleteCount,
+        bool HasAnyRecognisedActions,
+        // Count of parsed Delete/Update *action elements* in the XML body regardless of how many
+        // features matched.  Used by BuildTransactionResponseXml to decide whether to emit
+        // totalDeleted/totalUpdated even when the filter matched zero features (ISO 19142 §15.2.5.3).
+        int ParsedDeleteActions,
+        int ParsedUpdateActions)
     {
         public bool IsValid => ErrorResult is null;
 
         public static TransactionPreparationResult Success(
             ImmutableArray<PreparedTransactionOperation> operations,
             int layerId,
-            int layerIdCount)
+            int layerIdCount,
+            bool hasAnyRecognisedActions,
+            int parsedDeleteActions,
+            int parsedUpdateActions)
         {
             var insertCount = 0;
             var updateCount = 0;
@@ -2248,7 +2333,10 @@ internal sealed partial class Wfs20Handler
                 insertCount,
                 updateCount,
                 replaceCount,
-                deleteCount);
+                deleteCount,
+                hasAnyRecognisedActions,
+                parsedDeleteActions,
+                parsedUpdateActions);
         }
 
         public static TransactionPreparationResult Failure(IResult errorResult)
@@ -2259,6 +2347,9 @@ internal sealed partial class Wfs20Handler
                 errorResult,
                 0,
                 0,
+                0,
+                0,
+                false,
                 0,
                 0);
     }

--- a/src/Honua.Protocols.Stac/CollectionEndpoints.cs
+++ b/src/Honua.Protocols.Stac/CollectionEndpoints.cs
@@ -261,6 +261,15 @@ internal static class CollectionEndpoints
                 return StandardErrorHelpers.CreateNotFound(context, $"Collection '{collectionId}' not found.");
             }
 
+            // BH-S-01: mirror HandleGetCollection's access check so the field schema of a
+            // private collection is not visible to unauthenticated / unauthorised callers.
+            var accessError = Honua.Infrastructure.Authentication.AccessPolicyHelpers
+                .RequireResourceAccess(context, resolved.Value.Resource, resolved.Value.Service);
+            if (accessError != null)
+            {
+                return accessError;
+            }
+
             var baseUrl = BaseUrlResolver.GetBaseUrl(context);
             var escapedCollectionId = Uri.EscapeDataString(collectionId);
             var queryablesId = $"{baseUrl}/stac/collections/{escapedCollectionId}/queryables";

--- a/src/Honua.Protocols.Stac/Services/StacFilterHelpers.cs
+++ b/src/Honua.Protocols.Stac/Services/StacFilterHelpers.cs
@@ -331,7 +331,19 @@ internal static class StacFilterHelpers
 
         if (start is null && end is null)
         {
-            return null;
+            // BH-S-02: datetime=../.. (doubly-open interval) is syntactically valid per
+            // the OGC STAC spec — it means "no temporal constraint". Return a TemporalFilter
+            // with null Start/End so IsValidDatetimeSyntax accepts it and the query pipeline
+            // treats it as a no-op temporal filter (the Postgres temporal builder skips the
+            // WHERE clause when both bounds are null).
+            return new TemporalFilter
+            {
+                PropertyName = timeField,
+                PropertyType = TemporalPropertyType.DateTime,
+                EndPropertyName = endTimeField,
+                Start = null,
+                End = null,
+            };
         }
         if (start > end)
         {

--- a/src/Honua.Scene/Conversion/I3sAttributeBufferBuilder.cs
+++ b/src/Honua.Scene/Conversion/I3sAttributeBufferBuilder.cs
@@ -154,9 +154,18 @@ public static class I3sAttributeBufferBuilder
             var ids = new int[features.Count];
             for (var i = 0; i < features.Count; i++)
             {
-                // Oid32 narrows the 64-bit feature id to the 32-bit object-id
-                // space Esri identify uses (hosted scene object ids fit in 32 bits).
-                ids[i] = unchecked((int)features[i].Id);
+                var rawId = features[i].Id;
+                // BH-S-03: guard against silent truncation — Oid32 only holds values in
+                // [0, Int32.MaxValue]. A feature ID that exceeds this range (e.g. OSM building
+                // IDs) would previously silently wrap to a negative/wrong value, causing ArcGIS
+                // identify to return wrong attributes. Fail loudly so the caller can remap IDs.
+                if (rawId < 0 || rawId > int.MaxValue)
+                {
+                    throw new InvalidOperationException(
+                        $"Feature ID {rawId} exceeds the I3S Oid32 range (0–{int.MaxValue}). " +
+                        "Publish the scene with a remapped integer ID field to serve it via I3S.");
+                }
+                ids[i] = (int)rawId;
             }
 
             return PackOid32(ids);
@@ -202,9 +211,16 @@ public static class I3sAttributeBufferBuilder
         {
             var recordOffset = featureSectionOffset + (i * I3sGeometryTranscoder.FeatureRecordBytes);
             var id = BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(recordOffset, 8));
-            // Oid32 narrows the 64-bit feature id to the 32-bit object-id space
-            // Esri identify uses; hosted scene object ids fit in 32 bits.
-            ids[i] = unchecked((int)id);
+            // BH-S-03: guard against silent truncation — Oid32 only holds values up to
+            // Int32.MaxValue. Fail loudly if a geometry transcoded with a large ID was
+            // somehow persisted so the caller can diagnose the mismatch.
+            if (id > (ulong)int.MaxValue)
+            {
+                throw new InvalidOperationException(
+                    $"Feature ID {id} exceeds the I3S Oid32 range (0–{int.MaxValue}). " +
+                    "Publish the scene with a remapped integer ID field to serve it via I3S.");
+            }
+            ids[i] = (int)id;
         }
 
         return ids;

--- a/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
+++ b/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
@@ -275,12 +275,16 @@ internal static partial class SqlServerFeatureQueryBuilder
         // query to silently return zero rows. The MySQL provider throws NotSupportedException for
         // cross-SRID filters. Mirror that contract here so callers receive a clear error instead
         // of an empty result set.
-        if (filter.Srid is > 0 && mapping.Srid.HasValue && filter.Srid.Value != mapping.Srid.Value)
+        if ((filter.Srid is > 0 && mapping.Srid.HasValue && filter.Srid.Value != mapping.Srid.Value)
+            || (filter.Srid is > 0 && !mapping.Srid.HasValue))
         {
+            var layerSridDescription = mapping.Srid.HasValue
+                ? mapping.Srid.Value.ToString(CultureInfo.InvariantCulture)
+                : "unset (null)";
             throw new NotSupportedException(
                 $"Cross-SRID spatial filter is not supported by the SQL Server provider: " +
-                $"filter SRID {filter.Srid.Value} differs from layer SRID {mapping.Srid.Value}. " +
-                $"Pre-project the filter geometry to SRID {mapping.Srid.Value} before submitting the request.");
+                $"filter SRID {filter.Srid.Value} differs from layer SRID {layerSridDescription}. " +
+                $"Pre-project the filter geometry to the layer's SRID before submitting the request.");
         }
 
         var wkbParam = "@p" + parameters.Count.ToString(CultureInfo.InvariantCulture);

--- a/src/Honua.Worker.Gdal/Execution/MapAlgebraExpression.cs
+++ b/src/Honua.Worker.Gdal/Execution/MapAlgebraExpression.cs
@@ -74,11 +74,31 @@ internal static class MapAlgebraExpression
 
             if (char.IsDigit(c) || c == '.')
             {
-                // Skip a numeric literal (digits, decimal point, exponent sign).
-                while (i < expr.Length && (char.IsDigit(expr[i]) || expr[i] == '.' || expr[i] == 'e' || expr[i] == 'E'))
+                // Skip a numeric literal (digits, decimal point, optional exponent).
+                while (i < expr.Length && (char.IsDigit(expr[i]) || expr[i] == '.'))
                 {
                     i++;
                 }
+
+                // Consume an optional exponent ('e' or 'E') only when immediately followed
+                // by at least one digit. A bare 'e' (e.g. "1e" or "1eA") is not a valid
+                // Python literal and would produce a SyntaxError in gdal_calc.py.
+                if (i < expr.Length && (expr[i] == 'e' || expr[i] == 'E'))
+                {
+                    var exponentStart = i;
+                    i++; // advance past 'e'/'E'
+                    if (i >= expr.Length || !char.IsDigit(expr[i]))
+                    {
+                        // No digit follows the exponent character — reject the expression.
+                        error = $"'expression' contains an incomplete numeric exponent near position {exponentStart}";
+                        return false;
+                    }
+                    while (i < expr.Length && char.IsDigit(expr[i]))
+                    {
+                        i++;
+                    }
+                }
+
                 continue;
             }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorPreconditionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorPreconditionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
@@ -152,6 +152,60 @@ public sealed class EditProcessorPreconditionTests
             activity.TagObjects.Any(tag => tag.Key == "honua.resource.id"));
     }
 
+
+    [UnitTest]
+    public void ValidateCreate_SpatialLayerWithNullGeometry_ReturnsFailure()
+    {
+        // BH-014: Adding a feature to a spatial layer without geometry must return a
+        // clean validation failure rather than hitting a DB NOT NULL constraint.
+        var processor = CreateProcessor();
+
+        var resource = new MetadataV2Resource
+        {
+            Spatial = new Honua.Core.Features.Metadata.Domain.V2.MetadataV2ResourceSpatial
+            {
+                GeometryType = Honua.Core.Features.Metadata.Domain.V2.MetadataV2GeometryType.Point
+            }
+        };
+
+        var feature = EditFeature.ForCreate(
+            geometry: null,
+            ImmutableDictionary<string, object?>.Empty);
+
+        var request = UnifiedEditRequest.WithCreates(ImmutableArray.Create(feature));
+
+        var result = processor.ValidateEdit(request, resource);
+
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Geometry is required");
+    }
+
+    [UnitTest]
+    public void ValidateCreate_SpatialLayerWithGeometry_Succeeds()
+    {
+        // BH-014 complement: a create with geometry on a spatial layer must still pass.
+        var processor = CreateProcessor();
+
+        var resource = new MetadataV2Resource
+        {
+            Spatial = new Honua.Core.Features.Metadata.Domain.V2.MetadataV2ResourceSpatial
+            {
+                GeometryType = Honua.Core.Features.Metadata.Domain.V2.MetadataV2GeometryType.Point
+            }
+        };
+
+        // Minimal WKB for a point (not validated in this test path)
+        var wkb = new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+        var feature = EditFeature.ForCreate(
+            geometry: wkb,
+            ImmutableDictionary<string, object?>.Empty);
+
+        var request = UnifiedEditRequest.WithCreates(ImmutableArray.Create(feature));
+
+        var result = processor.ValidateEdit(request, resource);
+
+        result.IsValid.Should().BeTrue();
+    }
     [UnitTest]
     public void ValidateEdit_EmptyRequest_EmitsErrorStatusOnSpan()
     {

--- a/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeBufferBuilderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Scene/Conversion/I3sAttributeBufferBuilderTests.cs
@@ -158,6 +158,48 @@ public sealed class I3sAttributeBufferBuilderTests
         I3sAttributeBufferBuilder.Build(features, field).Should().BeNull();
     }
 
+    // BH-S-03 regression: feature IDs > Int32.MaxValue (e.g. OSM building IDs) must not
+    // silently truncate to negative/wrong values. Both Build overloads must throw before
+    // packing any Oid32 value that does not fit in the 32-bit signed space.
+
+    [UnitTest]
+    public void Build_FromFeatures_ObjectIdExceedsInt32Max_Throws()
+    {
+        const ulong largeId = (ulong)int.MaxValue + 1;
+        var features = new List<SceneFeature>
+        {
+            FeatureWith((long)largeId, new Dictionary<string, object?>()),
+        };
+
+        var act = () => I3sAttributeBufferBuilder.Build(features, I3sAttributeSchemaBuilder.BuildObjectIdField());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Oid32*");
+    }
+
+    [UnitTest]
+    public void Build_FromGeometry_ObjectIdExceedsInt32Max_Throws()
+    {
+        // Transcode a feature whose ID encodes into the geometry buffer, then
+        // attempt to read it back as an Oid32 attribute file.
+        const long largeId = (long)int.MaxValue + 1;
+        var features = new[]
+        {
+            new SceneFeature
+            {
+                Id = largeId,
+                Geometry = Square(largeId, -122.42, 37.77).Geometry,
+                Attributes = new Dictionary<string, object?>(),
+            },
+        };
+        var geometry = I3sGeometryTranscoder.Transcode(features);
+
+        var act = () => I3sAttributeBufferBuilder.Build(geometry, ObjectIdField());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Oid32*");
+    }
+
     private static IReadOnlyList<SceneFeature> ThreeFeaturesWithAttributes() =>
     [
         FeatureWith(11, new Dictionary<string, object?> { ["HEIGHT"] = 12.5, ["NAME"] = "alpha" }),

--- a/tests/dotnet/Honua.Core.Tests/Features/TileCachePackage/EsriTileCachePackageReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/TileCachePackage/EsriTileCachePackageReaderTests.cs
@@ -141,6 +141,40 @@ public sealed class EsriTileCachePackageReaderTests
         read.Should().ContainSingle(t => t.Z == 2 && t.Y == 10 && t.X == 20);
     }
 
+    /// <summary>
+    /// Regression test for BH-020: tiles whose encoded byte-size has bit 23 set
+    /// (≥ 8,388,608 bytes = 8 MB) must not be silently dropped.  The previous code
+    /// used an arithmetic right-shift on the signed Int64 index value, which sign-
+    /// extended negative Int64s into negative Int32 sizes, triggering the size-&lt;=0
+    /// guard and skipping the tile.
+    /// </summary>
+    [Fact]
+    public async Task ReadTiles_CompactV2_TilesLargerThan8MB_AreNotSilentlyDropped()
+    {
+        // 8,388,608 bytes (8 MiB exactly) sets bit 23 of the 24-bit size field.
+        // Combined with a typical offset, bit 63 of the Int64 index entry is set,
+        // making it negative — the arithmetic-shift bug produces a negative size.
+        var tileContent = new byte[8_388_608];
+        tileContent[0] = 0xAB;
+        tileContent[^1] = 0xCD;
+
+        var tiles = new (int Row, int Col, byte[] Bytes)[] { (0, 0, tileContent) };
+        using var package = BuildCompactV2Package(prefix: string.Empty, format: "PNG", wkid: 3857, name: "large", level: 0, tiles: tiles);
+        var reader = new EsriTileCachePackageReader();
+        var descriptor = await reader.ReadDescriptorAsync(package);
+
+        var read = new List<TileCachePackageTile>();
+        await foreach (var tile in reader.ReadTilesAsync(package, descriptor, 0, 24))
+        {
+            read.Add(tile);
+        }
+
+        read.Should().HaveCount(1, "a tile with size ≥ 8 MiB must not be silently skipped");
+        read[0].Content.Length.Should().Be(8_388_608);
+        read[0].Content[0].Should().Be(0xAB);
+        read[0].Content[^1].Should().Be(0xCD);
+    }
+
     [Fact]
     public async Task ReadDescriptor_MissingDescriptor_Throws()
     {

--- a/tests/dotnet/Honua.Core.Tests/Features/Tiles/PMTiles/PMTilesWriterTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Tiles/PMTiles/PMTilesWriterTests.cs
@@ -251,6 +251,76 @@ public class PMTilesWriterTests
         writer.TileCount.Should().Be(2);
     }
 
+    /// <summary>
+    /// Regression test for BH-018: latitude header fields must be clamped to [-90, 90],
+    /// not to the longitude range [-180, 180].  A swapped or out-of-range latitude (e.g.
+    /// 91°) must be clamped to 90° before being encoded as an E7 integer.
+    /// </summary>
+    [Fact]
+    public async Task WriteAsync_OutOfRangeLatitude_ClampsToLatitudeBounds()
+    {
+        var metadata = new PMTilesArchiveMetadata
+        {
+            MinLon = -180,
+            MinLat = -91,   // out of range — must be clamped to -90
+            MaxLon = 180,
+            MaxLat = 91,    // out of range — must be clamped to 90
+            MinZoom = 0,
+            MaxZoom = 1
+        };
+
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(50));
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, metadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        // Latitudes must be clamped to ±90 × 10^7.
+        header.MinLatE7.Should().Be(-900_000_000, "MinLat=-91 must be clamped to -90");
+        header.MaxLatE7.Should().Be(900_000_000, "MaxLat=91 must be clamped to 90");
+
+        // Longitudes must remain at their full ±180 × 10^7 encoding.
+        header.MinLonE7.Should().Be(-1_800_000_000);
+        header.MaxLonE7.Should().Be(1_800_000_000);
+    }
+
+    /// <summary>
+    /// Regression test for BH-018 (negative case): a longitude of 181 must be clamped
+    /// to 180, ensuring the longitude helper also enforces its own bounds.
+    /// </summary>
+    [Fact]
+    public async Task WriteAsync_OutOfRangeLongitude_ClampsToLongitudeBounds()
+    {
+        var metadata = new PMTilesArchiveMetadata
+        {
+            MinLon = -181,   // out of range — must be clamped to -180
+            MinLat = -85,
+            MaxLon = 181,    // out of range — must be clamped to 180
+            MaxLat = 85,
+            MinZoom = 0,
+            MaxZoom = 1
+        };
+
+        var writer = new PMTilesWriter(PMTilesCompression.None, PMTilesCompression.None);
+        writer.AddTile(0, 0, 0, CreateFakeTileData(50));
+
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(stream, metadata);
+
+        stream.Position = 0;
+        var headerBytes = new byte[PMTilesHeader.HeaderSize];
+        await stream.ReadExactlyAsync(headerBytes);
+        var header = PMTilesHeader.ReadFrom(headerBytes);
+
+        header.MinLonE7.Should().Be(-1_800_000_000, "MinLon=-181 must be clamped to -180");
+        header.MaxLonE7.Should().Be(1_800_000_000, "MaxLon=181 must be clamped to 180");
+    }
+
     private static byte[] CreateFakeTileData(int size)
     {
         var data = new byte[size];

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrSubsetReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrSubsetReaderTests.cs
@@ -187,4 +187,52 @@ public class ZarrSubsetReaderTests
 
         await act.Should().ThrowAsync<ArgumentException>();
     }
+
+    /// <summary>
+    /// Regression test for BH-017: a Zarr store that declares chunk dimensions whose
+    /// product × element-size exceeds MaxBytesPerRequest must be rejected before any
+    /// per-chunk heap allocation is attempted.  With MaxDegreeOfParallelism=8, reading
+    /// 8 such chunks would otherwise allocate ~2 GB of heap before the caller receives
+    /// any error.
+    /// </summary>
+    [Fact]
+    public async Task ReadSubsetAsync_OversizedChunkDimensions_ThrowsBeforeAllocatingChunkBuffer()
+    {
+        // shape=[4,4] but chunks=[8200,8200] with dtype=<f4:
+        //   chunkBytes = 8200 * 8200 * 4 = 268,960,000 > MaxBytesPerRequest (256 MiB)
+        // The array total (4*4*4=64 bytes) is well under the total-bytes cap so
+        // only the per-chunk guard added by BH-017 stops the allocation.
+        var objects = new System.Collections.Generic.Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            ["datasets/huge/.zarray"] = System.Text.Encoding.UTF8.GetBytes(
+                """{"chunks":[8200,8200],"compressor":null,"dtype":"<f4","fill_value":0,"filters":null,"order":"C","shape":[4,4],"zarr_format":2}""")
+        };
+        var reader = new InMemoryZarrRangeReader(objects);
+        var metadata = await new ZarrMetadataExtractor().ReadMetadataAsync(reader, "bucket", "datasets/huge");
+
+        var request = new ZarrSubsetRequest
+        {
+            Variable = "huge",
+            Start = new[] { 0, 0 },
+            Stop = new[] { 4, 4 }
+        };
+
+        var act = () => new ZarrSubsetReader().ReadSubsetAsync(reader, "bucket", "datasets/huge", metadata, request);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*chunk size*exceeds*");
+    }
+
+    /// <summary>
+    /// Regression test for BH-017: ResolveElementSize must reject unrealistically
+    /// large element-size suffixes (> 16) before any array-wide computation occurs.
+    /// </summary>
+    [Fact]
+    public void ResolveElementSize_ElementSizeExceedsMaxSupported_Throws()
+    {
+        var act = () => ZarrSubsetReader.ResolveElementSize("<f32");
+
+        act.Should().Throw<InvalidDataException>()
+            .WithMessage("*element size*exceeds*");
+    }
 }

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureQueryBuilderTests.cs
@@ -354,6 +354,40 @@ public class DuckDBFeatureQueryBuilderTests
             _builder.BuildSelectQuery(999, new FeatureQuery()));
     }
 
+    /// <summary>
+    /// Regression test for BH-016: a WHERE clause that references a field not in the
+    /// layer mapping must produce ArgumentException (HTTP 400), not let the unknown
+    /// column reach DuckDB where it causes a DbException (HTTP 500).
+    /// </summary>
+    [Theory]
+    [InlineData("populaton > 1000")]          // misspelled — not in mapping
+    [InlineData("nonexistent = 'foo'")]        // entirely unknown field
+    [InlineData("nonexistent IS NULL")]        // null-check form
+    [InlineData("nonexistent IS NOT NULL")]    // null-check with NOT
+    public void BuildSelectQuery_WhereReferencesUnknownField_ThrowsArgumentException(string where)
+    {
+        var query = new FeatureQuery { Where = where };
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            _builder.BuildSelectQuery(TestLayerId, query));
+
+        Assert.Contains("not defined on layer", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("name = 'foo'")]       // name is in mapping
+    [InlineData("area > 100")]         // area is in mapping
+    [InlineData("type IS NULL")]       // type is in mapping
+    [InlineData("NAME = 'foo'")]       // case-insensitive match
+    public void BuildSelectQuery_WhereReferencesKnownField_Succeeds(string where)
+    {
+        var query = new FeatureQuery { Where = where };
+
+        // Should not throw — known fields must pass the layer-membership check.
+        var result = _builder.BuildSelectQuery(TestLayerId, query);
+        Assert.NotEmpty(result.Sql);
+    }
+
     [Fact]
     public void BuildSelectQuery_WithOrderBy_GeneratesOrderClause()
     {

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataSkipTokenTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataSkipTokenTests.cs
@@ -182,4 +182,23 @@ public sealed class ODataSkipTokenTests : IAsyncLifetime
         allFeatures.Should().HaveCount(15);
         pageCount.Should().Be(3); // 15 features / 5 per page = 3 pages
     }
+
+    // BH-S-04 regression: /Layers must reject inbound $skiptoken with 400. The server
+    // never emits a $skiptoken nextLink on the catalog layer list ($skip is the
+    // continuation mechanism there). Accepting a $skiptoken against a null fingerprint
+    // would allow a token minted by any Features endpoint with no filter/orderby to jump
+    // the Layers list to an arbitrary offset — an OData skiptoken isolation violation.
+
+    [IntegrationTest]
+    [Operation(Operations.Pagination)]
+    [Endpoint("GET /odata/Layers")]
+    public async Task GetLayers_WithSkipToken_ReturnsBadRequest()
+    {
+        // A legacy bare-integer token is the easiest crafted token with a null fingerprint.
+        var response = await _fixture.Client.GetAsync("/odata/Layers?$skiptoken=0");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("skiptoken");
+    }
 }

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20EndpointsTests.cs
@@ -2002,6 +2002,244 @@ public sealed class Wfs20EndpointsTests : IAsyncLifetime
         allowedValues.Should().Contain("FALSE");
     }
 
+    // ---- Regression tests for BH-008, BH-009, BH-010, BH-011 ----
+
+    /// <summary>
+    /// BH-008 regression: ISO 19142 §15.2.5.3 requires a zero-match Delete to succeed and
+    /// report totalDeleted=0, not return a 400 error.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_Delete_ZeroMatchFilter_ReturnsSuccessWithZeroDeleted()
+    {
+        const string requestBody = """
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0">
+              <wfs:Delete typeName="test_layer">
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.999999999" />
+                </fes:Filter>
+              </wfs:Delete>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        // Must be 200, not 400 — zero-match is a valid no-op per ISO 19142 §15.2.5.3.
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("TransactionResponse");
+        content.Should().Contain("<wfs:totalDeleted>0</wfs:totalDeleted>");
+    }
+
+    /// <summary>
+    /// BH-008 regression: a zero-match Update filter must also succeed with totalUpdated=0.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_Update_ZeroMatchFilter_ReturnsSuccessWithZeroUpdated()
+    {
+        const string requestBody = """
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0">
+              <wfs:Update typeName="test_layer">
+                <wfs:Property>
+                  <wfs:ValueReference>name</wfs:ValueReference>
+                  <wfs:Value>should-not-be-written</wfs:Value>
+                </wfs:Property>
+                <fes:Filter>
+                  <fes:ResourceId rid="test_layer.999999999" />
+                </fes:Filter>
+              </wfs:Update>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("TransactionResponse");
+        content.Should().Contain("<wfs:totalUpdated>0</wfs:totalUpdated>");
+    }
+
+    /// <summary>
+    /// BH-009 regression: a multi-layer WFS Transaction with rollbackOnFailure=true (the
+    /// default) must be rejected before any data is committed because cross-layer atomicity
+    /// cannot be guaranteed.  Using rollbackOnFailure=false must still succeed (see the
+    /// existing Wfs_Transaction_MultiLayer_Insert test).
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_MultiLayer_DefaultRollbackOnFailure_ReturnsOperationProcessingFailed()
+    {
+        // rollbackOnFailure defaults to true when the attribute is omitted (ISO 19142 §15.2.5.2).
+        // A multi-layer transaction cannot provide cross-layer atomicity, so it must be rejected
+        // before committing anything to avoid partial-commit state.
+        const string requestBody = """
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="http://honua.io/wfs">
+              <wfs:Insert handle="insert-primary">
+                <honua:test_layer>
+                  <honua:name>BH009 Primary Layer Feature</honua:name>
+                  <honua:shape>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                      <gml:pos>37.150 -122.450</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:test_layer>
+              </wfs:Insert>
+              <wfs:Insert handle="insert-related">
+                <honua:related_test_layer_1>
+                  <honua:name>BH009 Related Layer Feature</honua:name>
+                  <honua:related_id>1</honua:related_id>
+                  <honua:shape>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                      <gml:pos>37.250 -122.550</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:related_test_layer_1>
+              </wfs:Insert>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        content.Should().Contain("exceptionCode=\"OperationProcessingFailed\"");
+        content.Should().ContainAny(
+            "cross-layer atomicity",
+            "rollbackOnFailure",
+            "Multi-layer");
+    }
+
+    /// <summary>
+    /// BH-010 regression: a WFS GetFeature POST request with an XML query containing a
+    /// fes:Filter must carry that filter through into the 'next' paging link.  Before the
+    /// fix, following page 2 fetched the unfiltered result set.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "GetFeature")]
+    public async Task Wfs_GetFeature_XmlQueryWithFilter_PagingNextLinkPreservesFilter()
+    {
+        // Insert two features with the same distinctive name so both match the filter and
+        // COUNT=1 forces a next-page link.
+        const string marker = "BH010PagingFilter";
+        await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, $"{marker} A");
+        await _fixture.InsertFeatureAsync(WebAppFixture.TestLayerId, $"{marker} B");
+
+        var requestBody = $"""
+            <wfs:GetFeature service="WFS" version="2.0.0" count="1"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:fes="http://www.opengis.net/fes/2.0">
+              <wfs:Query typeNames="test_layer">
+                <fes:Filter>
+                  <fes:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\\">
+                    <fes:ValueReference>name</fes:ValueReference>
+                    <fes:Literal>{marker}%</fes:Literal>
+                  </fes:PropertyIsLike>
+                </fes:Filter>
+              </wfs:Query>
+            </wfs:GetFeature>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        // Parse the XML response; wfs:FeatureCollection must have a 'next' attribute that
+        // includes the FILTER parameter so page 2 still applies the same predicate.
+        var doc = XDocument.Parse(content);
+        var featureCollection = doc.Root;
+        featureCollection.Should().NotBeNull();
+
+        var nextAttribute = featureCollection!
+            .Attributes()
+            .FirstOrDefault(a => string.Equals(a.Name.LocalName, "next", StringComparison.OrdinalIgnoreCase));
+        nextAttribute.Should().NotBeNull("a second page exists so a 'next' paging link must be present");
+
+        var nextHref = nextAttribute!.Value;
+        nextHref.Should().Contain("FILTER", "the paging link must carry the original per-query filter");
+    }
+
+    /// <summary>
+    /// BH-011 regression: a WFS Transaction inserting a 3D LineString (srsDimension=3) with
+    /// an even vertex count must succeed and store the correct 2-point geometry.  Before the
+    /// fix, 6 ordinates (2 vertices × 3) were mis-parsed as 3 2D coordinates.
+    /// </summary>
+    [IntegrationTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task Wfs_Transaction_Insert_3dGmlPosList_EvenVertexCount_StoresCorrectGeometry()
+    {
+        // 2-vertex 3D LineString: x1 y1 z1 x2 y2 z2 → 6 ordinates.
+        // Before the fix these were mis-parsed as 3 2D points with the wrong coordinates.
+        const string requestBody = """
+            <wfs:Transaction service="WFS" version="2.0.0"
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="http://honua.io/wfs">
+              <wfs:Insert handle="insert-3d-line">
+                <honua:test_layer>
+                  <honua:name>BH011 3D LineString</honua:name>
+                  <honua:shape>
+                    <gml:LineString srsName="urn:ogc:def:crs:EPSG::4326" srsDimension="3">
+                      <gml:posList srsDimension="3">37.1 -122.1 10.0 37.2 -122.2 20.0</gml:posList>
+                    </gml:LineString>
+                  </honua:shape>
+                </honua:test_layer>
+              </wfs:Insert>
+            </wfs:Transaction>
+            """;
+
+        using var requestContent = new StringContent(requestBody, Encoding.UTF8, "application/xml");
+        var response = await _fixture.Client.PostAsync("/wfs", requestContent);
+
+        var content = await response.Content.ReadAsStringAsync();
+        // Before the fix this returned 400 or stored wrong geometry; now it must succeed.
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+        content.Should().Contain("TransactionResponse");
+        content.Should().Contain("<wfs:totalInserted>1</wfs:totalInserted>");
+
+        // Retrieve the feature and verify the geometry is a 2-vertex LineString, not 3.
+        var ridMatch = Regex.Match(content, "rid=\"(?<rid>test_layer\\.\\d+)\"", RegexOptions.CultureInvariant);
+        ridMatch.Success.Should().BeTrue(content);
+        var rid = ridMatch.Groups["rid"].Value;
+
+        var queryResponse = await _fixture.Client.GetAsync(
+            $"/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=test_layer&RESOURCEID={rid}&OUTPUTFORMAT=application%2Fjson");
+        var queryContent = await queryResponse.Content.ReadAsStringAsync();
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK, queryContent);
+
+        using var json = JsonDocument.Parse(queryContent);
+        var coordinates = json.RootElement
+            .GetProperty("features")[0]
+            .GetProperty("geometry")
+            .GetProperty("coordinates");
+
+        // A correct 2-point LineString has exactly 2 coordinate pairs.
+        coordinates.GetArrayLength().Should().Be(2,
+            "a 3D GML posList with 2 vertices must produce a 2-point LineString, not 3");
+    }
+
     private static string?[] ReadGeoJsonFeatureNames(string responseBody)
     {
         using var document = JsonDocument.Parse(responseBody);

--- a/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacFilterHelpersTests.cs
+++ b/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacFilterHelpersTests.cs
@@ -242,6 +242,36 @@ public sealed class StacFilterHelpersTests
         return await StacV2Lookups.ResolveVisibleStacPublicationsAsync(context, CancellationToken.None);
     }
 
+    // BH-S-02 regression: datetime=../.. (doubly-open interval) is syntactically valid
+    // per OGC STAC spec and must not return 400. IsValidDatetimeSyntax must accept it;
+    // ParseDatetime must return a no-op TemporalFilter (Start/End both null) rather than
+    // null (which would have triggered a 400 from the caller's syntax guard).
+
+    [UnitTest]
+    public void IsValidDatetimeSyntax_WithDoublyOpenInterval_ReturnsTrue()
+    {
+        StacFilterHelpers.IsValidDatetimeSyntax("../..").Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void ParseDatetime_WithDoublyOpenInterval_ReturnsNoOpFilter()
+    {
+        var resource = CreateResource(
+            [
+                new MetadataV2Field { Name = "objectid", Type = MetadataV2FieldType.Integer, Nullable = false },
+                new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime }
+            ]);
+
+        const string openInterval = "../..";
+        var filter = StacFilterHelpers.ParseDatetime(openInterval, resource);
+
+        // The filter must be non-null so the syntax guard does not return 400 …
+        filter.Should().NotBeNull();
+        // … but both temporal bounds must be null so the query pipeline applies no predicate.
+        filter!.Value.Start.Should().BeNull();
+        filter!.Value.End.Should().BeNull();
+    }
+
     private static MetadataV2Resource CreateResource(MetadataV2Field[] fields)
     {
         return new MetadataV2Resource

--- a/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacQueryablesTests.cs
+++ b/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacQueryablesTests.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
@@ -102,5 +104,50 @@ public sealed class StacQueryablesTests : IClassFixture<WebAppFixture>
         var response = await _fixture.Client.GetAsync("/stac/collections/99999/queryables");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}
+
+/// <summary>
+/// BH-S-01 regression: GET /stac/collections/{id}/queryables must enforce the same
+/// resource access policy as GET /stac/collections/{id}. An unauthenticated caller
+/// must not be able to read the field schema (names/types) of a private collection.
+/// </summary>
+[Protocol(TestProtocols.Stac)]
+[Collection("Database")]
+public sealed class StacQueryablesAuthorizationTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .ConfigureWebHost(builder =>
+        {
+            // Disable the dev-auth passthrough so unauthenticated requests are truly
+            // anonymous (no implicit super-user identity).
+            builder.UseSetting("HONUA_DEV_AUTH", "false");
+        });
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+
+        // Make the test collection private — only authenticated principals may access it.
+        _fixture.UpdateV2ResourceMetadata(
+            WebAppFixture.TestLayerId,
+            accessPolicy: new AccessPolicy { AllowAnonymous = false });
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /stac/collections/{collectionId}/queryables")]
+    public async Task GetCollectionQueryables_Unauthenticated_PrivateCollection_ReturnsUnauthorized()
+    {
+        var collectionId = WebAppFixture.TestLayerId.ToString(CultureInfo.InvariantCulture);
+
+        // Unauthenticated request (no API key, no bearer token).
+        var response = await _fixture.Client.GetAsync($"/stac/collections/{collectionId}/queryables");
+
+        // The server must deny the request — 401 (unauthenticated) or 403 (forbidden).
+        // Before fix BH-S-01 the handler skipped the access check and returned 200.
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/AttributeTransformExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/AttributeTransformExecutorTests.cs
@@ -177,6 +177,56 @@ public sealed class AttributeTransformExecutorTests
         ReadFeatures(uri!).Should().HaveCount(1);
     }
 
+    // ----- BH-022 regression: non-numeric values must FAIL all numeric comparisons -----
+
+    [UnitTest]
+    public async Task AttributeFilter_Lt_WithNonNumericField_ExcludesNonNumericRows()
+    {
+        // BH-022: int.MinValue was returned for non-numeric operands; because
+        // int.MinValue < 0 is true, every non-numeric row falsely passed 'lt'.
+        var executor = new AttributeFilterTransformExecutor(Options());
+        var input = BuildInputUri(
+            Feature(Point(0, 0), ("population", 500)),
+            Feature(Point(1, 1), ("population", "unknown")),    // non-numeric string
+            Feature(Point(2, 2), ("population", "null-like"))); // another non-numeric string
+
+        var (status, uri) = await RunAsync(
+            executor,
+            AttributeFilterTransformExecutor.HandledProcessId,
+            ("input", input),
+            ("field", "population"),
+            ("op", "lt"),
+            ("value", "1000"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().HaveCount(1, "only the numeric row 500 < 1000 should pass; non-numeric rows must be dropped");
+        Convert.ToDouble(features[0].Attributes.GetOptionalValue("population"), CultureInfo.InvariantCulture)
+            .Should().Be(500d);
+    }
+
+    [UnitTest]
+    public async Task AttributeFilter_Lte_WithNonNumericField_ExcludesNonNumericRows()
+    {
+        // BH-022: lte also used int.MinValue comparison and falsely admitted non-numeric rows.
+        var executor = new AttributeFilterTransformExecutor(Options());
+        var input = BuildInputUri(
+            Feature(Point(0, 0), ("score", 10.0)),
+            Feature(Point(1, 1), ("score", "N/A")));
+
+        var (status, uri) = await RunAsync(
+            executor,
+            AttributeFilterTransformExecutor.HandledProcessId,
+            ("input", input),
+            ("field", "score"),
+            ("op", "lte"),
+            ("value", "10"));
+
+        status.Should().Be(ExecutionJobStatus.Succeeded);
+        var features = ReadFeatures(uri!);
+        features.Should().HaveCount(1, "the string 'N/A' is non-numeric and must not pass lte");
+    }
+
     [UnitTest]
     public async Task Transform_UnsupportedProcessId_FailsCleanly()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/StreamingTransformExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/StreamingTransformExecutorTests.cs
@@ -268,6 +268,56 @@ public sealed class StreamingTransformExecutorTests : IDisposable
         (await CountAsync(inlineStream)).Should().Be(1);
     }
 
+    // ----- BH-023 regression: path traversal in stream reference is rejected -----
+
+    [UnitTest]
+    public void TryOpenRead_WithPathOutsideRoot_RejectsWithError()
+    {
+        // BH-023: TryOpenRead accepted any path in the stream reference without
+        // validating it falls within the configured output root. An authenticated
+        // caller could craft a reference pointing at e.g. /etc/passwd or server
+        // config files. The outputRootDirectory parameter must reject such references.
+        var root = Path.Combine(Path.GetTempPath(), "honua-traversal-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            // Build a crafted reference with a path that escapes the root via "..".
+            var traversalPath = Path.GetFullPath(Path.Combine(root, "..", "etc", "passwd"));
+            var craftedRef = FeatureStreamArtifact.BuildStreamReference(traversalPath, count: 0, bytes: 0);
+
+            var accepted = FeatureStreamArtifact.TryOpenRead(
+                craftedRef,
+                out var error,
+                out _,
+                outputRootDirectory: root);
+
+            accepted.Should().BeFalse("a path outside the output root must be rejected");
+            error.Should().NotBeNullOrEmpty("a descriptive error must be returned");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch (IOException) { }
+        }
+    }
+
+    [UnitTest]
+    public async Task TryOpenRead_WithPathInsideRoot_Succeeds()
+    {
+        // BH-023: A legitimate stream reference whose path falls within the root must
+        // still be accepted — the guard must not over-reject.
+        var sourceRef = await BuildSpilledSourceAsync(10, includeDuplicates: false);
+
+        var accepted = FeatureStreamArtifact.TryOpenRead(
+            sourceRef,
+            out var openError,
+            out var stream,
+            outputRootDirectory: _outputRoot);
+
+        accepted.Should().BeTrue(openError);
+        (await CountAsync(stream)).Should().Be(10);
+    }
+
     [UnitTest]
     public async Task LargeOutput_SpillFileStaysBounded_RelativeToFeatureCount()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
@@ -435,7 +435,60 @@ public sealed class CrossProtocolPermissionMatrixTests
         await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
     }
 
-    // ---- WFS GetFeature + Transaction ----
+    // ---- FeatureServer deleteFeatures (BH-001 regression) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.Delete)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/deleteFeatures")]
+    public async Task DeleteFeatures_DeleteGrantOverridesCoarseDenyForObjectIdsPath()
+    {
+        // BH-001: the deleteFeatures pre-body gate must gate on AuthorizationOperation.Delete,
+        // not Update. A principal with only a "delete" grant must pass the gate.
+        using var factory = CreateWriteFactory(Grant("delete"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var content = new StringContent(
+            "objectIds=1&f=json",
+            System.Text.Encoding.UTF8,
+            "application/x-www-form-urlencoded");
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/deleteFeatures",
+            content);
+
+        // 200 OK (no matching features) or 404; not 401/403 which would mean
+        // the wrong authorization operation was checked.
+        response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Forbidden);
+    }
+
+    // ---- FeatureServer applyEdits delete payload (BH-002 regression) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_DeletePayload_DeleteGrantAllowsDeletesWhenUpdateGrantDoesNot()
+    {
+        // BH-002: the applyEdits handler must check AuthorizationOperation.Delete for a
+        // deletes-only payload. A principal with only a "delete" grant (no "update") must
+        // pass; if Update were the only check this would incorrectly deny.
+        using var factory = CreateWriteFactory(Grant("delete"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var applyEditsContent = new StringContent(
+            @"{""deletes"":[1,2]}",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
+            applyEditsContent);
+
+        response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Forbidden);
+    }
+
+        // ---- WFS GetFeature + Transaction ----
     //
     // WFS read (GetFeature / capabilities feature-type list) flows through the
     // shared GetPublishedFeatureTypesAsync filter, now resolver-aware via

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AdminAuthSessionStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AdminAuthSessionStoreTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for <see cref="AdminAuthSessionStore"/> covering session lifecycle
+/// and the BH-028 distributed-cache exception fallback regression.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Security)]
+public sealed class AdminAuthSessionStoreTests
+{
+    // ─── BH-028 regression ──────────────────────────────────────────────────────
+
+    [UnitTest]
+    public async Task GetPendingSessionAsync_DistributedCacheThrows_FallsBackToMemoryCache()
+    {
+        // Regression test for BH-028: when distributedCache.GetAsync throws (e.g. Redis
+        // cluster failover), the store previously evicted the in-process memory entry and
+        // returned null.  Admin login flows in progress during the outage returned 401.
+        // After the fix, the memory tier is preserved as a fallback.
+        var mockDistCache = Substitute.For<IDistributedCache>();
+        // SetAsync succeeds by default (NSubstitute returns Task.CompletedTask) so the
+        // pending session is committed to both distributed and memory caches on creation.
+        mockDistCache
+            .GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<byte[]?>(new InvalidOperationException("Redis cluster failover")));
+
+        var memCache = new MemoryCache(new MemoryCacheOptions());
+        var store = new AdminAuthSessionStore(memCache, NullLogger<AdminAuthSessionStore>.Instance, mockDistCache);
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(10);
+
+        var sessionId = await store.CreatePendingSessionAsync(
+            providerKey: "oidc-test",
+            state: "random-state-value",
+            codeVerifier: "pkce-verifier",
+            expiresAt: expiresAt,
+            cancellationToken: CancellationToken.None);
+
+        // Distributed cache throws → before the fix: memory entry evicted, null returned.
+        // After the fix: falls back to the memory tier; pending session is returned.
+        var session = await store.GetPendingSessionAsync(sessionId, CancellationToken.None);
+
+        session.Should().NotBeNull(
+            "the pending session must be retrievable from memory cache during a Redis outage (BH-028)");
+        session!.ProviderKey.Should().Be("oidc-test");
+        session.State.Should().Be("random-state-value");
+    }
+
+    [UnitTest]
+    public async Task GetAuthenticatedSessionAsync_DistributedCacheThrows_FallsBackToMemoryCache()
+    {
+        // Same BH-028 regression but for authenticated sessions: an admin console page
+        // load during a Redis outage must not evict the session and return 401.
+        var mockDistCache = Substitute.For<IDistributedCache>();
+        mockDistCache
+            .GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<byte[]?>(new InvalidOperationException("Redis cluster failover")));
+
+        var memCache = new MemoryCache(new MemoryCacheOptions());
+        var store = new AdminAuthSessionStore(memCache, NullLogger<AdminAuthSessionStore>.Instance, mockDistCache);
+        var expiresAt = DateTimeOffset.UtcNow.AddHours(1);
+
+        var sessionId = await store.CreateAuthenticatedSessionAsync(
+            providerKey: "oidc-test",
+            accessToken: "at-test-value",
+            idToken: null,
+            claims: [new AdminAuthSessionClaim { Type = "sub", Value = "user-1" }],
+            expiresAt: expiresAt,
+            cancellationToken: CancellationToken.None);
+
+        var session = await store.GetAuthenticatedSessionAsync(sessionId, CancellationToken.None);
+
+        session.Should().NotBeNull(
+            "the authenticated session must be retrievable from memory cache during a Redis outage (BH-028)");
+        session!.ProviderKey.Should().Be("oidc-test");
+        session.AccessToken.Should().Be("at-test-value");
+    }
+
+    [UnitTest]
+    public async Task GetPendingSessionAsync_DistributedCacheReturnsNull_ReturnsNull()
+    {
+        // When distributedCache.GetAsync returns null (key genuinely absent / expired),
+        // the correct behavior is to evict the memory entry and return null.
+        // The BH-028 fix must not affect this path.
+        var mockDistCache = Substitute.For<IDistributedCache>();
+        mockDistCache
+            .GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<byte[]?>(null));
+
+        var memCache = new MemoryCache(new MemoryCacheOptions());
+        var store = new AdminAuthSessionStore(memCache, NullLogger<AdminAuthSessionStore>.Instance, mockDistCache);
+
+        var sessionId = await store.CreatePendingSessionAsync(
+            providerKey: "oidc-test",
+            state: "state-val",
+            codeVerifier: "verifier-val",
+            expiresAt: DateTimeOffset.UtcNow.AddMinutes(5),
+            cancellationToken: CancellationToken.None);
+
+        var session = await store.GetPendingSessionAsync(sessionId, CancellationToken.None);
+
+        session.Should().BeNull(
+            "a null distributed cache result means key-not-found; the store must return null");
+    }
+
+    // ─── Basic session lifecycle ────────────────────────────────────────────────
+
+    [UnitTest]
+    public async Task CreateAndGetPendingSession_RoundTrips()
+    {
+        var store = CreateStore();
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        var sessionId = await store.CreatePendingSessionAsync(
+            "provider-1", "state-abc", "verifier-xyz", expiresAt, CancellationToken.None);
+
+        sessionId.Should().NotBeNullOrWhiteSpace();
+
+        var session = await store.GetPendingSessionAsync(sessionId, CancellationToken.None);
+
+        session.Should().NotBeNull();
+        session!.ProviderKey.Should().Be("provider-1");
+        session.State.Should().Be("state-abc");
+        session.CodeVerifier.Should().Be("verifier-xyz");
+    }
+
+    [UnitTest]
+    public async Task RemovePendingSession_SubsequentGetReturnsNull()
+    {
+        var store = CreateStore();
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        var sessionId = await store.CreatePendingSessionAsync(
+            "provider-2", "state-def", "verifier-abc", expiresAt, CancellationToken.None);
+
+        (await store.GetPendingSessionAsync(sessionId, CancellationToken.None)).Should().NotBeNull();
+
+        await store.RemovePendingSessionAsync(sessionId, CancellationToken.None);
+
+        (await store.GetPendingSessionAsync(sessionId, CancellationToken.None)).Should().BeNull();
+    }
+
+    [UnitTest]
+    public async Task CreateAndGetAuthenticatedSession_RoundTrips()
+    {
+        var store = CreateStore();
+        var expiresAt = DateTimeOffset.UtcNow.AddHours(1);
+
+        var sessionId = await store.CreateAuthenticatedSessionAsync(
+            "provider-1",
+            accessToken: "at-value",
+            idToken: "id-token-value",
+            claims: [new AdminAuthSessionClaim { Type = "email", Value = "admin@honua.io" }],
+            expiresAt: expiresAt,
+            cancellationToken: CancellationToken.None);
+
+        sessionId.Should().NotBeNullOrWhiteSpace();
+
+        var session = await store.GetAuthenticatedSessionAsync(sessionId, CancellationToken.None);
+
+        session.Should().NotBeNull();
+        session!.AccessToken.Should().Be("at-value");
+        session.IdToken.Should().Be("id-token-value");
+        session.Claims.Should().ContainSingle(c => c.Type == "email" && c.Value == "admin@honua.io");
+    }
+
+    [UnitTest]
+    public async Task GetPendingSession_UnknownId_ReturnsNull()
+    {
+        var store = CreateStore();
+        var session = await store.GetPendingSessionAsync("unknown-session-id", CancellationToken.None);
+        session.Should().BeNull();
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
+    private static AdminAuthSessionStore CreateStore()
+    {
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        return new AdminAuthSessionStore(memoryCache, NullLogger<AdminAuthSessionStore>.Instance);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for <see cref="AtomicTokenReplayProtection"/> covering replay detection,
+/// distributed-cache fallback paths, and the BH-027 mutual-recursion regression.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.Security)]
+public sealed class AtomicTokenReplayProtectionTests
+{
+    // ─── BH-027 regression ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Regression test for BH-027: when the Redis IDatabase has not yet been initialized
+    /// (lazy connect, _cache == null), the old fallback re-entered
+    /// TryMarkTokenAsUsedDistributedAsync with the same RedisCache argument, which
+    /// re-dispatched back to TryMarkTokenAsUsedRedisAsync — infinite mutual recursion
+    /// → StackOverflowException on the very first JWT validation request.
+    ///
+    /// After the fix the fallback calls TryMarkTokenAsUsedNonAtomicAsync directly,
+    /// breaking the cycle.  If the old code is restored, this test causes the test
+    /// runner process to crash with a StackOverflowException instead of completing.
+    /// </summary>
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_RedisCacheWithNullDatabase_TerminatesWithoutRecursion()
+    {
+        // Port 65530 on loopback is almost certainly closed; a closed port returns
+        // ECONNREFUSED immediately, so the connection fails in < 1 ms.
+        var configOptions = new StackExchange.Redis.ConfigurationOptions
+        {
+            EndPoints = { "127.0.0.1:65530" },
+            ConnectTimeout = 100,
+            SyncTimeout = 100,
+            AbortOnConnectFail = true,
+            ConnectRetry = 0
+        };
+        using var redisCache = new Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache(
+            Microsoft.Extensions.Options.Options.Create(
+                new Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions
+                {
+                    ConfigurationOptions = configOptions
+                }));
+
+        // Precondition: _cache is null before any Redis operation (lazy initialization).
+        // This is the exact state that triggered the StackOverflow: reflection returns null,
+        // connection == null, the old code fell back into TryMarkTokenAsUsedDistributedAsync,
+        // which re-dispatched to TryMarkTokenAsUsedRedisAsync, causing infinite recursion.
+        var cacheField = redisCache.GetType().GetField(
+            "_cache",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        cacheField.Should().NotBeNull("the private _cache field must be resolvable via reflection");
+        cacheField!.GetValue(redisCache).Should().BeNull(
+            "IDatabase is lazily initialized and must be null before the first Redis operation");
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IDistributedCache>(redisCache);
+        using var sp = services.BuildServiceProvider();
+
+        var token = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        // Before the fix: StackOverflowException kills the test runner (no assertion reached).
+        // After the fix: returns false because Redis is unreachable; the exception from the
+        // non-atomic fallback path is caught and mapped to false (fail-secure).
+        var result = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+
+        result.Should().BeFalse(
+            "the atomic Redis path failed (null IDatabase) and the non-atomic fallback also " +
+            "failed (unreachable Redis); the method must degrade to false without recursing");
+    }
+
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_DistributedCacheAlwaysThrows_ReturnsFalseWithoutThrowing()
+    {
+        // When every distributed cache operation throws, the method must return false
+        // (err on the side of security) and must NOT propagate the exception to the caller.
+        var throwingCache = Substitute.For<IDistributedCache>();
+        throwingCache
+            .GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<byte[]?>(new InvalidOperationException("simulated Redis failure")));
+        throwingCache
+            .SetAsync(
+                Arg.Any<string>(),
+                Arg.Any<byte[]>(),
+                Arg.Any<DistributedCacheEntryOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("simulated Redis failure")));
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IDistributedCache>(throwingCache);
+        using var sp = services.BuildServiceProvider();
+
+        var token = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        var act = () => AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+
+        var result = await act.Should().NotThrowAsync();
+        result.Subject.Should().BeFalse(
+            "a distributed cache failure is treated as a replay signal to fail-secure");
+    }
+
+    // ─── Happy-path replay detection ────────────────────────────────────────────
+
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_MemoryDistributedCache_FirstUseTrueThenReplayFalse()
+    {
+        // Non-Redis IDistributedCache: first use accepted, replay rejected.
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        using var sp = services.BuildServiceProvider();
+
+        var token = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        var firstResult = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+        var replayResult = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+
+        firstResult.Should().BeTrue("first use of a valid token must be accepted");
+        replayResult.Should().BeFalse("a replayed token must be rejected");
+    }
+
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_MemoryCacheOnly_FirstUseTrueThenReplayFalse()
+    {
+        // In-memory-only path (no distributed cache): first use accepted, replay rejected.
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        using var sp = services.BuildServiceProvider();
+
+        var token = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        var firstResult = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+        var replayResult = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+
+        firstResult.Should().BeTrue("first use must be accepted");
+        replayResult.Should().BeFalse("replay must be rejected even in the in-memory path");
+    }
+
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_NoCacheAvailable_AllowsThrough()
+    {
+        // When no cache is registered, the method allows the token through (graceful
+        // degradation; replay protection is best-effort when no cache is configured).
+        var services = new ServiceCollection();
+        using var sp = services.BuildServiceProvider();
+
+        var token = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        var result = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+
+        result.Should().BeTrue("with no cache, the method must degrade gracefully and allow the token");
+    }
+
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_DistinctTokens_EachAcceptedOnFirstUse()
+    {
+        // Two distinct tokens (different JTIs) are each accepted on first use.
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        using var sp = services.BuildServiceProvider();
+
+        var tokenA = CreateTestJwtToken();
+        var tokenB = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        var resultA = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            tokenA, options, sp, CancellationToken.None);
+        var resultB = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            tokenB, options, sp, CancellationToken.None);
+
+        resultA.Should().BeTrue("token A must be accepted on first use");
+        resultB.Should().BeTrue("token B is a distinct token and must be accepted independently");
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static JwtSecurityToken CreateTestJwtToken()
+    {
+        var payload = new JwtPayload(
+            issuer: "test-issuer",
+            audience: "test-audience",
+            claims: [new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())],
+            notBefore: null,
+            expires: DateTime.UtcNow.AddHours(1));
+        return new JwtSecurityToken(new JwtHeader(), payload);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/PortalTokenIssuerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/PortalTokenIssuerTests.cs
@@ -7,8 +7,10 @@ using Honua.Core.Features.Authorization.Abstractions;
 using Honua.Infrastructure.Authentication;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace Honua.Server.Tests.Infrastructure.Authentication;
 
@@ -140,9 +142,94 @@ public sealed class PortalTokenIssuerTests
         validation.Should().BeNull();
     }
 
+    // ─── BH-028 regression ──────────────────────────────────────────────────────
+
+    [UnitTest]
+    public async Task ValidateAsync_DistributedCacheThrows_FallsBackToMemoryCache()
+    {
+        // Regression test for BH-028: when distributedCache.GetAsync throws, the issuer
+        // previously evicted the in-process memory cache entry and returned null, conflating
+        // a transient Redis outage with key-not-found.  During a Redis cluster failover
+        // (typically 15-60 s) this invalidated all portal sessions simultaneously.
+        //
+        // After the fix, a distributed cache read exception falls back to the memory tier,
+        // preserving auth continuity for the duration of the outage.
+        var mockDistCache = NSubstitute.Substitute.For<IDistributedCache>();
+        // SetAsync returns Task.CompletedTask by default (NSubstitute) so issuance succeeds
+        // and the record is committed to both the distributed cache (mock) and memory cache.
+        mockDistCache
+            .GetAsync(NSubstitute.Arg.Any<string>(), NSubstitute.Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<byte[]?>(new InvalidOperationException("Redis cluster failover")));
+
+        var memCache = new MemoryCache(new MemoryCacheOptions());
+        var issuer = new PortalTokenIssuer(memCache, NullLogger<PortalTokenIssuer>.Instance, mockDistCache);
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(30);
+
+        var issuance = await issuer.IssueAsync(
+            new PortalTokenIssueRequest(
+                PrincipalId: "alice",
+                DisplayName: null,
+                TenantId: "tenant-A",
+                Roles: ["viewer"],
+                ClientType: PortalTokenClientType.Ip,
+                BindingValue: "10.0.0.1",
+                ExpiresAt: expiresAt),
+            CancellationToken.None);
+
+        // Distributed cache throws → before the fix: memory entry evicted, null returned.
+        // After the fix: falls back to the memory tier and validation succeeds.
+        var validation = await issuer.ValidateAsync(
+            issuance.Token,
+            new PortalTokenBinding(Referer: null, ClientIp: "10.0.0.1"),
+            CancellationToken.None);
+
+        validation.Should().NotBeNull(
+            "the token must validate from memory cache during a Redis outage (BH-028)");
+        validation!.Principal.Identity!.IsAuthenticated.Should().BeTrue();
+        validation.Principal.FindFirstValue(TenantClaimType).Should().Be("tenant-A");
+    }
+
+    [UnitTest]
+    public async Task ValidateAsync_DistributedCacheReturnsNull_EvictsMemory_ReturnsNull()
+    {
+        // When distributedCache.GetAsync returns null (key genuinely expired / absent),
+        // the memory entry must be evicted and null returned — the correct
+        // key-not-found semantics that the BH-028 fix must not regress.
+        var mockDistCache = NSubstitute.Substitute.For<IDistributedCache>();
+        mockDistCache
+            .GetAsync(NSubstitute.Arg.Any<string>(), NSubstitute.Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<byte[]?>(null));
+
+        var memCache = new MemoryCache(new MemoryCacheOptions());
+        var issuer = new PortalTokenIssuer(memCache, NullLogger<PortalTokenIssuer>.Instance, mockDistCache);
+
+        var issuance = await issuer.IssueAsync(
+            new PortalTokenIssueRequest(
+                PrincipalId: "bob",
+                DisplayName: null,
+                TenantId: null,
+                Roles: [],
+                ClientType: PortalTokenClientType.Ip,
+                BindingValue: "10.0.0.2",
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(30)),
+            CancellationToken.None);
+
+        var validation = await issuer.ValidateAsync(
+            issuance.Token,
+            new PortalTokenBinding(Referer: null, ClientIp: "10.0.0.2"),
+            CancellationToken.None);
+
+        validation.Should().BeNull(
+            "a null distributed cache result means key-not-found; the memory entry should be evicted");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
+
     private static PortalTokenIssuer CreateIssuer()
     {
         var memoryCache = new MemoryCache(new MemoryCacheOptions());
         return new PortalTokenIssuer(memoryCache, NullLogger<PortalTokenIssuer>.Instance);
     }
+
+    private const string TenantClaimType = PortalTokenIssuer.TenantClaimType;
 }

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobTokenIssuerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ScopedJobTokenIssuerTests.cs
@@ -8,8 +8,10 @@ using Honua.Core.Features.Authorization.Domain;
 using Honua.Infrastructure.Authentication;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 
 namespace Honua.Server.Tests.Infrastructure.Authentication;
 
@@ -418,6 +420,47 @@ public sealed class ScopedJobTokenIssuerTests
             CancellationToken.None))
             .Should().ThrowAsync<ArgumentException>();
     }
+
+    // ─── BH-028 regression ──────────────────────────────────────────────────────
+
+    [UnitTest]
+    public async Task ValidateAsync_DistributedCacheThrows_FallsBackToMemoryCache()
+    {
+        // Regression test for BH-028: when distributedCache.GetAsync throws (Redis outage),
+        // the store previously evicted the memory cache entry and returned null, causing
+        // every in-flight geoprocessing job callback to be rejected for the duration of
+        // the outage.  After the fix, the memory tier is preserved as a fallback.
+        var mockDistCache = NSubstitute.Substitute.For<IDistributedCache>();
+        mockDistCache
+            .GetAsync(NSubstitute.Arg.Any<string>(), NSubstitute.Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<byte[]?>(new InvalidOperationException("Redis cluster failover")));
+
+        var memCache = new MemoryCache(new MemoryCacheOptions());
+        var issuer = new ScopedJobTokenIssuer(memCache, NullLogger<ScopedJobTokenIssuer>.Instance, mockDistCache);
+
+        var issuance = await issuer.IssueAsync(
+            new ScopedJobTokenRequest(
+                PrincipalId: "alice",
+                TenantId: "tenant-A",
+                Roles: ["data-editor:parcels"],
+                Grants: [],
+                JobId: "gp-bh028-1",
+                ResourceScope: [new JobResourceScopeEntry("parcels", null, JobResourceAccess.Read)],
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(30)),
+            CancellationToken.None);
+
+        // Distributed cache throws → before the fix: memory entry evicted, null returned.
+        // After the fix: falls back to the memory tier.
+        var validation = await issuer.ValidateAsync(
+            issuance.Token, "gp-bh028-1", CancellationToken.None);
+
+        validation.Should().NotBeNull(
+            "the token must validate from memory cache during a Redis outage (BH-028)");
+        validation!.JobId.Should().Be("gp-bh028-1");
+        validation.Principal.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────
 
     private static List<string> PermissionsOf(ClaimsPrincipal principal)
         => principal.FindAll(PermissionClaimType).Select(c => c.Value).ToList();

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMapAlgebraExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterMapAlgebraExecutorTests.cs
@@ -7,6 +7,7 @@ using Honua.Core.Features.ControlPlane.Domain;
 using Honua.TestKit.Attributes;
 using Honua.Worker.Gdal.Execution;
 using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
 
 namespace Honua.Worker.Gdal.Tests;
 
@@ -53,7 +54,9 @@ public sealed class GdalRasterMapAlgebraExecutorTests
             context.Artifacts.Should().ContainSingle();
             context.Artifacts[0].Should().StartWith("data:image/tiff");
 
-            var invocation = runner.Invocations.Single();
+            // GdalNoData.TryReadSourceNoDataAsync adds a gdalinfo invocation before gdal_calc.py;
+            // filter to the actual gdal_calc.py call.
+            var invocation = runner.Invocations.Single(i => i.Tool == "gdal_calc.py");
             invocation.Tool.Should().Be("gdal_calc.py");
             invocation.Arguments.Should().Contain(a => a.StartsWith("-A"));
             invocation.Arguments.Should().Contain(a => a.StartsWith("-B"));
@@ -83,7 +86,8 @@ public sealed class GdalRasterMapAlgebraExecutorTests
 
             result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
 
-            var args = runner.Invocations.Single().Arguments;
+            // GdalNoData.TryReadSourceNoDataAsync adds a gdalinfo invocation before gdal_calc.py.
+            var args = runner.Invocations.Single(i => i.Tool == "gdal_calc.py").Arguments;
             // The expression is a single "--calc=-A" token so argparse cannot mistake
             // the leading minus for a separate option. (The band-variable flag "-A" is
             // a separate, expected argument.)
@@ -112,7 +116,8 @@ public sealed class GdalRasterMapAlgebraExecutorTests
             var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
 
             result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
-            runner.Invocations.Single().Arguments.Should().ContainInOrder("--type", "Float32");
+            // GdalNoData.TryReadSourceNoDataAsync adds a gdalinfo invocation before gdal_calc.py.
+            runner.Invocations.Single(i => i.Tool == "gdal_calc.py").Arguments.Should().ContainInOrder("--type", "Float32");
         }
         finally
         {
@@ -212,6 +217,68 @@ public sealed class GdalRasterMapAlgebraExecutorTests
             result.Status.Should().Be(ExecutionJobStatus.Failed);
             result.ErrorMessage.Should().Contain("total");
             runner.Invocations.Should().BeEmpty();
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    /// <summary>
+    /// Regression tests for BH-021: a bare exponent character ('e'/'E') with no
+    /// following digits is not a valid Python literal and must be rejected by the
+    /// allow-list validator before reaching gdal_calc.py.  Previously "1e" passed
+    /// the scanner and produced a Python SyntaxError at runtime.
+    /// </summary>
+    [Theory]
+    [InlineData("A + 1e")]       // trailing bare exponent
+    [InlineData("1E + A")]       // leading bare exponent (not a valid numeric start)
+    [InlineData("A * 2e")]       // bare exponent at end of expression
+    public async Task MapAlgebra_ExpressionWithOrphanedExponent_FailsBeforeReachingTheCli(string expression)
+    {
+        var runner = FakeGdalCommandRunner.Failing(1, "n/a");
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a")),
+                ("expression", expression));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().NotBeNullOrEmpty();
+            runner.Invocations.Should().BeEmpty("the CLI must never be reached for an invalid expression");
+        }
+        finally
+        {
+            CleanupScratch(scratch);
+        }
+    }
+
+    /// <summary>
+    /// Regression test for BH-021 (positive case): valid scientific notation with a
+    /// digit after the exponent character must be accepted.
+    /// </summary>
+    [Theory]
+    [InlineData("A * 1e3")]      // valid: 1000
+    [InlineData("A + 2E6")]      // valid: 2,000,000
+    [InlineData("A * 1e10")]     // valid: multi-digit exponent
+    public async Task MapAlgebra_ExpressionWithValidSciNotation_Succeeds(string expression)
+    {
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes("ok"));
+        var executor = NewExecutor(runner, out var scratch);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterMapAlgebraJobExecutor.HandledProcessId,
+                ("sources", Sources("raster-a")),
+                ("expression", expression));
+
+            var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
         }
         finally
         {

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterReclassifyExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterReclassifyExecutorTests.cs
@@ -49,7 +49,7 @@ public sealed class GdalRasterReclassifyExecutorTests
             result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
             context.Artifacts.Single().Should().StartWith("data:image/tiff");
 
-            var args = runner.Invocations.Single().Arguments;
+            var args = runner.Invocations.Single(i => i.Tool == "gdal_calc.py").Arguments;
             args.Should().Contain("-A");
             var calcIndex = args.ToList().IndexOf("--calc");
             var calc = args[calcIndex + 1];
@@ -79,7 +79,7 @@ public sealed class GdalRasterReclassifyExecutorTests
             var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
 
             result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
-            var args = runner.Invocations.Single().Arguments;
+            var args = runner.Invocations.Single(i => i.Tool == "gdal_calc.py").Arguments;
             var calc = args[args.ToList().IndexOf("--calc") + 1];
             calc.Should().Contain("(A==1)");
             calc.Should().Contain("(A==2)");

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterSpectralIndexExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalRasterSpectralIndexExecutorTests.cs
@@ -50,7 +50,7 @@ public sealed class GdalRasterSpectralIndexExecutorTests
             result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
             context.Artifacts.Single().Should().StartWith("data:image/tiff");
 
-            var args = runner.Invocations.Single().Arguments;
+            var args = runner.Invocations.Single(i => i.Tool == "gdal_calc.py").Arguments;
             args.Should().Contain(a => a.StartsWith("-A")).And.Contain(a => a.StartsWith("-B"));
             args.Should().ContainInOrder("--calc", "(1.0*A-B)/(1.0*A+B)");
             args.Should().ContainInOrder("--type", "Float32");
@@ -78,7 +78,7 @@ public sealed class GdalRasterSpectralIndexExecutorTests
             var result = await executor.ExecuteAsync(job, new RecordingJobExecutionContext(job.OperationId), default);
 
             result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
-            var args = runner.Invocations.Single().Arguments;
+            var args = runner.Invocations.Single(i => i.Tool == "gdal_calc.py").Arguments;
             var calcIndex = args.ToList().IndexOf("--calc");
             args[calcIndex + 1].Should().Contain("0.25");
         }


### PR DESCRIPTION
Round 1 of the feature-area bug-bounty of non-experimental honua-server features. 44 raw findings → 32 survived double adversarial verification (each confirmed by 2 independent refuters) + my line-by-line validation of the S0/S1s. All fixed with regression tests; consolidated for one CI run. Experimental features (SensorThings, Federated Query, Redshift/Snowflake/Databricks, mTLS, alerts/geofence, realtime, sync, temporal.*) were out of scope.

## S0
- **JWT replay-protection infinite recursion** (`AtomicTokenReplayProtection`): the Redis atomic-path fallback called back into the dispatcher which re-dispatched to Redis → StackOverflow on auth. Fixed: fallback now goes to a terminal non-atomic path; SOE regression test.

## S1 (11)
- **applyEdits/deleteFeatures authz bypass** (×2): a principal with Update-but-not-Delete could delete/insert features (only Update was checked). Now gates deletes on Delete and adds on Insert, per-payload + pre-body.
- **WFS Transaction cluster** (×4): partial-commit despite `rollbackOnFailure=true` (now fail-safe rejects the un-atomic multi-layer case), paging links dropping all filters (page 2 wrong set), zero-match → 400 instead of no-op, 3D `gml:posList` flattening coords.
- **STAC /queryables authz bypass**: leaked the field schema of access-protected collections without a credential — now enforces RequireResourceAccess.
- **Bidirectional replica sync** dropping concurrent server edits.
- **GP numeric filter** (`CompareNumeric`): `int.MinValue < 0` made `lt`/`lte` pass every non-numeric row — now returns `int?`/null so non-numeric fails all comparisons.
- **GP path-traversal**: arbitrary server file read via a user-injected stream-reference path — now containment-checked against the output root.
- **Zarr unbounded per-chunk buffer** (OOM) — now capped.

## S2 (20)
Across GeoServices (idempotency key collision, queryAttachments filter bypass, null-geometry create), OGC API (GML numberReturned, paging key encoding, PATCH geometryChanged), providers (SqlServer cross-SRID, DuckDB unknown-column), raster/tiles (PMTiles lon/lat clamp, ESRI tile-size logical shift, MapAlgebra exponent), STAC (open-interval datetime, I3S Oid32 truncation), OData (Layers skiptoken fingerprint), auth (session-store Redis-failover 401s), and a TOCTOU upload race. Each fixed per its finding; regression tests where practical.

Also fixed 5 pre-existing GDAL raster test failures (stale `gdalinfo` invocation assertion). Register: ~/honua-io/_bughunt/register/round1-survivors.jsonl.