### PR TITLE
fix(edit): stop rejecting attribute-only creates on nullable-geometry layers

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5389,6 +5389,7 @@
         "Honua.Server.Tests.Features.Protocols.OData.ODataClientCertificationTests.CertDisc02_SingleEntitySetQuery",
         "Honua.Server.Tests.Features.Protocols.OData.ODataClientIntegrationTests.LayersQuery_ReturnsExpectedLayer_ViaODataClient",
         "Honua.Server.Tests.Features.Protocols.OData.ODataEndpointTests.Layers_ReturnsCollection",
+        "Honua.Server.Tests.Features.Protocols.OData.ODataSkipTokenTests.GetLayers_WithSkipToken_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Security.ODataServiceBoundaryTests.GetLayers_WithSharedLayerInSecondaryService_DoesNotLeakCanonicalBoundary"
       ],
       "proof_ledger_surface": "odata-v4",
@@ -10569,6 +10570,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Stac.StacQueryablesAuthorizationTests.GetCollectionQueryables_Unauthenticated_PrivateCollection_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Protocols.Stac.StacQueryablesTests.GetCollectionQueryables_ById_ReturnsJsonSchemaDocument",
         "Honua.Server.Tests.Features.Protocols.Stac.StacQueryablesTests.GetCollectionQueryables_NotFound_Returns404"
       ],
@@ -15929,6 +15931,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.GeometryValidationTests.ApplyEdits_WithValidPointGeometry_Succeeds",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.GeometryValidationTests.ApplyEdits_WithZCoordinates_Succeeds",
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.FeatureServerGdbVersionFlowTests.GdbVersionFlow_EditQueryReconcilePost_IsolatesThenMerges",
+        "Honua.Server.Tests.Features.Security.CrossProtocolPermissionMatrixTests.ApplyEdits_DeletePayload_DeleteGrantAllowsDeletesWhenUpdateGrantDoesNot",
         "Honua.Server.Tests.Features.Security.CrossProtocolPermissionMatrixTests.FeatureServerApplyEdits_NoGrant_FallsBackToCoarseDeny",
         "Honua.Server.Tests.Features.Security.CrossProtocolPermissionMatrixTests.FeatureServerApplyEdits_QueryOnlyGrant_DeniesWrite",
         "Honua.Server.Tests.Features.Security.CrossProtocolPermissionMatrixTests.FeatureServerApplyEdits_UpdateGrant_OverridesCoarseDeny",
@@ -15974,7 +15977,8 @@
         "Honua.Server.Tests.FeatureServerEndpointTests.DeleteFeatures_WithMalformedObjectIdsDelimiter_ReturnsBadRequest",
         "Honua.Server.Tests.FeatureServerEndpointTests.DeleteFeatures_WithObjectIdsPayload_ReturnsDeleteResults",
         "Honua.Server.Tests.FeatureServerEndpointTests.DeleteFeatures_WithWhereClauseInBody_DeletesMatchingFeatures",
-        "Honua.Server.Tests.Features.Admin.RowLevelSecurityEndpointsTests.RlsPolicy_BlocksEditAndDeleteOfHiddenRow_OnDefaultObjectIdLayer"
+        "Honua.Server.Tests.Features.Admin.RowLevelSecurityEndpointsTests.RlsPolicy_BlocksEditAndDeleteOfHiddenRow_OnDefaultObjectIdLayer",
+        "Honua.Server.Tests.Features.Security.CrossProtocolPermissionMatrixTests.DeleteFeatures_DeleteGrantOverridesCoarseDenyForObjectIdsPath"
       ],
       "proof_ledger_surface": "feature-server",
       "maturity": "implemented"
@@ -17593,6 +17597,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_CreateStoredQuery_WithDuplicateId_ReturnsDuplicateIdLocator",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_CreateStoredQuery_WithSupportedQueryLanguage_ReturnsOk",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_GetCapabilities_ReturnsXmlWithTransactionOperation",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_GetFeature_XmlQueryWithFilter_PagingNextLinkPreservesFilter",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Post_GetCapabilities_ReturnsXml",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Post_GetCapabilities_XmlBody_ReturnsXml",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Post_GetFeature_AfterTimePeriodWithUtcZ_ReturnsLaterFeatures",
@@ -17607,11 +17612,15 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Post_XmlBodyWithDtd_ReturnsSanitizedExceptionReport",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_AnonymousWrite_AllowsInsertWithoutRbac",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_Delete_DeletedFeatureStoredQueryReturns404ExceptionReport",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_Delete_ZeroMatchFilter_ReturnsSuccessWithZeroDeleted",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_Insert_3dGmlPosList_EvenVertexCount_StoresCorrectGeometry",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_MultiLayerWithoutRollback_ReturnsTransactionResponseAndCreatesFeatures",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_MultiLayer_DefaultRollbackOnFailure_ReturnsOperationProcessingFailed",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_Replace_ReturnsReplaceSummaryAndUpdatesFeature",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_Replace_RoundTripsGmlDescriptionAndIdentifierCodeSpace",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_UpdateBoundedBy_WithInvalidValue_ReturnsInvalidValueException",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_UpdateGmlNameXPathReference_UpdatesStoredQueryResult",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_Update_ZeroMatchFilter_ReturnsSuccessWithZeroUpdated",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_WithExplicitlyRejectedXmlAccept_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_WithInsertUpdateAndDelete_ReturnsTransactionSummary",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_Transaction_WithXmlLockId_ReturnsExceptionReport",

--- a/src/Honua.Core/Features/Edit/EditProcessor.cs
+++ b/src/Honua.Core/Features/Edit/EditProcessor.cs
@@ -452,12 +452,14 @@ public sealed class EditProcessor : IEditProcessor
                 return EditValidationResult.Failure("Attributes required for create operation");
             }
 
-            // BH-014: Validate geometry exists if the layer is spatial so the error surfaces
-            // as a clean validation failure rather than a DB NOT NULL constraint violation.
-            if (feature.Geometry is null && RequiresGeometry(resource))
-            {
-                return EditValidationResult.Failure("Geometry is required for create operation on a spatial layer");
-            }
+            // A spatial layer does not universally require geometry: a nullable geometry
+            // column legitimately accepts attribute-only ("null geometry") creates, which
+            // ArcGIS FeatureServer and the OGC/OData edit paths all support (see
+            // GeometryValidationTests.ApplyEdits_WithNullGeometry_SucceedsWhenAllowed and
+            // Issue #45). The prior blanket "geometry required on a spatial layer" gate
+            // (BH-014, #2423) rejected those valid attribute-only creates; NOT NULL geometry
+            // columns are enforced by the database constraint, mapped through the shared
+            // error helpers rather than a client-side pre-check.
         }
 
         return EditValidationResult.Success(warnings.Count > 0 ? warnings : null);
@@ -758,11 +760,6 @@ public sealed class EditProcessor : IEditProcessor
         next:;
         }
         return false;
-    }
-
-    private static bool RequiresGeometry(MetadataV2Resource resource)
-    {
-        return resource.Spatial?.GeometryType is { } gt && gt != MetadataV2GeometryType.None;
     }
 
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorPreconditionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorPreconditionTests.cs
@@ -154,10 +154,14 @@ public sealed class EditProcessorPreconditionTests
 
 
     [UnitTest]
-    public void ValidateCreate_SpatialLayerWithNullGeometry_ReturnsFailure()
+    public void ValidateCreate_SpatialLayerWithNullGeometry_Succeeds()
     {
-        // BH-014: Adding a feature to a spatial layer without geometry must return a
-        // clean validation failure rather than hitting a DB NOT NULL constraint.
+        // A spatial layer does not universally require geometry: a nullable geometry
+        // column legitimately accepts attribute-only ("null geometry") creates, which the
+        // GeoServices/OGC/OData edit paths all support (Issue #45). The edit-validation
+        // layer must not blanket-reject null geometry on a spatial layer; a NOT NULL
+        // geometry column is enforced by the database constraint instead. (Reverts the
+        // over-broad BH-014 gate from #2423 that regressed attribute-only creates.)
         var processor = CreateProcessor();
 
         var resource = new MetadataV2Resource
@@ -176,8 +180,7 @@ public sealed class EditProcessorPreconditionTests
 
         var result = processor.ValidateEdit(request, resource);
 
-        result.IsValid.Should().BeFalse();
-        result.ErrorMessage.Should().Contain("Geometry is required");
+        result.IsValid.Should().BeTrue();
     }
 
     [UnitTest]


### PR DESCRIPTION
## Related Issue
Related to #2423

## Summary
#2423 (BH-014) added a blanket "geometry required on a spatial layer" precondition to `EditProcessor.ValidateCreateOperations`. A spatial layer does **not** universally require geometry: a nullable geometry column legitimately accepts attribute-only ("null geometry") creates, which the GeoServices / OGC / OData edit paths all support (Issue #45; e.g. `GeometryValidationTests.ApplyEdits_WithNullGeometry_SucceedsWhenAllowed`). Because almost every write test — and many read/RBAC/sync/versioning tests — creates an attribute-only feature as setup, the over-broad gate regressed ~10 CI shards after #2423 landed on trunk (`13351eb`): they fail with `400 "Geometry is required for create operation on a spatial layer"`, `500`, or a test-side `NullReferenceException` when the setup add is rejected.

Diagnosis of run `28713814705`: **0** shards failed on capability/experimental gating; **all** failures are this genuine #2423 regression (plus a stale feature-catalog).

## Changes Made
- Remove the `RequiresGeometry` precondition (and the now-unused helper) from `EditProcessor`. NOT NULL geometry columns are enforced by the database constraint through the shared error helpers, matching pre-#2423 behavior.
- Update `EditProcessorPreconditionTests`: null geometry on a spatial layer now validates successfully (`ValidateCreate_SpatialLayerWithNullGeometry_Succeeds`).
- Regenerate `docs/gis/data/feature-catalog.json` to include the proving tests #2423 added (ODataSkipToken, StacQueryablesAuthorization, CrossProtocolPermissionMatrix, Wfs20 paging), fixing `FeatureCatalogDriftTests` in the `.NET Foundation Tests` (Architecture) shard.

## Breaking Changes
None. Restores pre-#2423 edit behavior.

## Gate Impact
- [x] Fixes failing CI shards (FeatureServer/OData/GeoServices/Replication/Core Endpoints, .NET Foundation, Python/JS integration)

## Testing
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- Built `Honua.Core.Tests` (Release, warnings-as-errors) and ran `EditProcessorPreconditionTests`: 10/10 pass.
- Regenerated the feature catalog; `FeatureCatalogEmitter`/`FeatureCatalogDriftTests` pass.
