### PR TITLE
fix(stac): reject doubly-open datetime intervals with 400 (STAC conformance)

### DIFF
--- a/src/Honua.Protocols.Stac/Services/StacFilterHelpers.cs
+++ b/src/Honua.Protocols.Stac/Services/StacFilterHelpers.cs
@@ -331,19 +331,13 @@ internal static class StacFilterHelpers
 
         if (start is null && end is null)
         {
-            // BH-S-02: datetime=../.. (doubly-open interval) is syntactically valid per
-            // the OGC STAC spec — it means "no temporal constraint". Return a TemporalFilter
-            // with null Start/End so IsValidDatetimeSyntax accepts it and the query pipeline
-            // treats it as a no-op temporal filter (the Postgres temporal builder skips the
-            // WHERE clause when both bounds are null).
-            return new TemporalFilter
-            {
-                PropertyName = timeField,
-                PropertyType = TemporalPropertyType.DateTime,
-                EndPropertyName = endTimeField,
-                Start = null,
-                End = null,
-            };
+            // A doubly-open / empty interval (datetime=../.., /, /.., ../) is not a valid
+            // OGC API-Features / STAC datetime value: an interval must have at least one
+            // bounded (closed) end. The STAC API conformance validator requires these to be
+            // rejected with 400, so return null here to fail the caller's syntax guard.
+            // (The earlier BH-S-02 no-op-filter behavior from #2423 accepted them with 200
+            // and regressed STAC item-search conformance.)
+            return null;
         }
         if (start > end)
         {

--- a/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacFilterHelpersTests.cs
+++ b/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacFilterHelpersTests.cs
@@ -242,19 +242,24 @@ public sealed class StacFilterHelpersTests
         return await StacV2Lookups.ResolveVisibleStacPublicationsAsync(context, CancellationToken.None);
     }
 
-    // BH-S-02 regression: datetime=../.. (doubly-open interval) is syntactically valid
-    // per OGC STAC spec and must not return 400. IsValidDatetimeSyntax must accept it;
-    // ParseDatetime must return a no-op TemporalFilter (Start/End both null) rather than
-    // null (which would have triggered a 400 from the caller's syntax guard).
+    // A doubly-open / empty datetime interval (datetime=../.., /, /..) is NOT a valid
+    // OGC API-Features / STAC value — an interval must have at least one bounded end. The
+    // STAC API conformance validator requires these to be rejected with 400, so the syntax
+    // check must fail and ParseDatetime must return null. (Reverts BH-S-02 from #2423, which
+    // accepted them as a no-op filter and regressed STAC item-search conformance.)
 
     [UnitTest]
-    public void IsValidDatetimeSyntax_WithDoublyOpenInterval_ReturnsTrue()
+    public void IsValidDatetimeSyntax_WithDoublyOpenInterval_ReturnsFalse()
     {
-        StacFilterHelpers.IsValidDatetimeSyntax("../..").Should().BeTrue();
+        foreach (var datetime in new[] { "../..", "/", "/..", "../" })
+        {
+            StacFilterHelpers.IsValidDatetimeSyntax(datetime)
+                .Should().BeFalse("'{0}' is a doubly-open interval and must be rejected", datetime);
+        }
     }
 
     [UnitTest]
-    public void ParseDatetime_WithDoublyOpenInterval_ReturnsNoOpFilter()
+    public void ParseDatetime_WithDoublyOpenInterval_ReturnsNull()
     {
         var resource = CreateResource(
             [
@@ -265,11 +270,7 @@ public sealed class StacFilterHelpersTests
         const string openInterval = "../..";
         var filter = StacFilterHelpers.ParseDatetime(openInterval, resource);
 
-        // The filter must be non-null so the syntax guard does not return 400 …
-        filter.Should().NotBeNull();
-        // … but both temporal bounds must be null so the query pipeline applies no predicate.
-        filter!.Value.Start.Should().BeNull();
-        filter!.Value.End.Should().BeNull();
+        filter.Should().BeNull();
     }
 
     private static MetadataV2Resource CreateResource(MetadataV2Field[] fields)


### PR DESCRIPTION
## Related Issue
Related to #2423

## Summary
Second genuine #2423 regression surfaced by run `28717459927` (the first fix, #2433, greened every Server/JS shard and the .NET Foundation catalog test). The `Python Integration Tests` shard still failed on `test_stac_api_validator_conformance`:

```
[Item Search] datetime='/'  had status 200 instead of 400: invalid datetime returned non-400 status code
[Item Search] datetime='/..' had status 200 instead of 400: invalid datetime returned non-400 status code
```

#2423's BH-S-02 changed `StacFilterHelpers.ParseDatetimeWithField` to return a no-op `TemporalFilter` (Start/End both null) for a doubly-open/empty datetime interval instead of `null`, so `datetime=../..`, `/`, and `/..` began returning `200` instead of `400`. That regressed the STAC API item-search conformance suite (stac-api-validator). Python was green on trunk right up to #2423, then failed — this is a #2423 regression, not a flake.

An OGC API-Features / STAC datetime interval must have at least one bounded end; only half-bounded intervals (`../date`, `date/..`) are valid. This restores pre-#2423 behavior.

## Changes Made
- `StacFilterHelpers.ParseDatetimeWithField`: return `null` when both interval bounds are open/empty, so the caller's syntax guard emits `400`.
- `StacFilterHelpersTests`: assert `IsValidDatetimeSyntax` is `false` and `ParseDatetime` returns `null` for `../..`, `/`, `/..`, `../` (updates the BH-S-02 unit tests).

## Breaking Changes
None. Restores pre-#2423 STAC conformance behavior.

## Gate Impact
- [x] Fixes the failing `Python Integration Tests` shard (STAC API conformance)

## Testing
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- Built `Honua.Protocols.Stac.Tests` (Release, warnings-as-errors) and ran `StacFilterHelpersTests`: 12/12 pass.
- `dotnet format --verify-no-changes` clean on both changed files.
