### PR TITLE
fix(edit,stac): fix-forward BH-014 geometry gate and BH-S-02 datetime interval

### DIFF
--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
@@ -30,8 +30,64 @@ internal sealed class FeatureEditPreconditionFailedException : Exception
     public long ObjectId { get; }
 }
 
+/// <summary>
+/// Internal signal that a create was rejected because the layer's geometry column is
+/// non-nullable (a database NOT NULL constraint fired) and the feature supplied no
+/// geometry. The edit paths translate this into a clean, actionable validation error
+/// ("Geometry is required for create operation on a spatial layer") instead of leaking a
+/// raw provider constraint violation.
+/// </summary>
+/// <remarks>
+/// BH-014 fix-forward (#2423 / reverted by #2433): the original fix added a blanket
+/// client-side pre-check that rejected null geometry on ANY spatial layer, which wrongly
+/// failed valid attribute-only creates on nullable geometry columns (Issue #45) and
+/// regressed ~10 CI shards. Mapping the actual database NOT NULL violation preserves the
+/// clean-error UX for genuinely non-nullable geometry columns while never rejecting a
+/// legitimate null-geometry create on a nullable column.
+/// </remarks>
+internal sealed class GeometryRequiredForCreateException : Exception
+{
+    public GeometryRequiredForCreateException(Exception innerException)
+        : base(FeatureDataAccess.GeometryRequiredForCreateMessage, innerException)
+    {
+    }
+}
+
 internal sealed partial class FeatureDataAccess
 {
+    /// <summary>
+    /// Client-safe validation message surfaced when a create supplies no geometry for a
+    /// layer whose geometry column is non-nullable (database NOT NULL constraint).
+    /// </summary>
+    internal const string GeometryRequiredForCreateMessage =
+        "Geometry is required for create operation on a spatial layer";
+
+    /// <summary>
+    /// Recognizes the common PostGIS geometry column names so a NOT NULL constraint
+    /// violation on the geometry column can be mapped to a clean validation error.
+    /// </summary>
+    internal static bool IsGeometryColumn(string? columnName)
+    {
+        if (string.IsNullOrEmpty(columnName))
+        {
+            return false;
+        }
+
+        return columnName.Equals("geometry", StringComparison.OrdinalIgnoreCase)
+            || columnName.Equals("geom", StringComparison.OrdinalIgnoreCase)
+            || columnName.Equals("shape", StringComparison.OrdinalIgnoreCase)
+            || columnName.Equals("the_geom", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// True when a provider exception is a database NOT NULL constraint violation on the
+    /// geometry column, i.e. the layer's geometry column is non-nullable and the create
+    /// supplied no geometry. Used to map the raw provider error to a clean validation
+    /// message without a client-side pre-check (BH-014 fix-forward).
+    /// </summary>
+    internal static bool IsGeometryNotNullViolation(PostgresException ex)
+        => ex.SqlState == PostgresErrorCodes.NotNullViolation && IsGeometryColumn(ex.ColumnName);
+
     public async Task<Feature> CreateFeatureAsync(int layerId, Feature feature, CancellationToken cancellationToken)
     {
         // When an outbox scope is active and the provider supports transactional outbox,
@@ -728,6 +784,15 @@ internal sealed partial class FeatureDataAccess
         {
             throw new ResourceConflictException("Feature creation conflicted with existing data.", ex);
         }
+        catch (PostgresException ex) when (IsGeometryNotNullViolation(ex))
+        {
+            // BH-014 fix-forward: a null-geometry create against a non-nullable geometry
+            // column surfaces as a clean validation error rather than a raw provider
+            // constraint violation. This maps only the database's own decision (the
+            // NOT NULL constraint actually fired), so nullable geometry columns still
+            // accept valid attribute-only creates (Issue #45) with no client-side gate.
+            throw new GeometryRequiredForCreateException(ex);
+        }
     }
 
     private async Task<Feature> UpdateWithConnectionAsync(
@@ -1308,13 +1373,16 @@ internal sealed partial class FeatureDataAccess
         return result;
     }
 
-    private static string GetSafeEditOperationError(Exception ex, string operation)
+    internal static string GetSafeEditOperationError(Exception ex, string operation)
     {
         return ex switch
         {
             ResourceNotFoundException => "Feature not found.",
             FeatureEditPreconditionFailedException => "The feature was modified by another writer; the supplied precondition no longer matches.",
             ResourceConflictException => "The operation conflicted with existing data.",
+            // GeometryRequiredForCreateException carries a fixed, client-safe message
+            // (no provider internals) so it is surfaced verbatim.
+            GeometryRequiredForCreateException => GeometryRequiredForCreateMessage,
             ValidationException => "Invalid feature data.",
             ArgumentException or InvalidOperationException => "Invalid feature data.",
             _ => $"{operation} failed."

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureDataAccessGeometryRequiredMappingTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureDataAccessGeometryRequiredMappingTests.cs
@@ -1,0 +1,121 @@
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Postgres.Features.FeatureStore.Services;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.FeatureStore;
+
+/// <summary>
+/// Unit coverage for the BH-014 fix-forward (#2423, reverted by #2433): a create with no
+/// geometry on a layer whose geometry column is non-nullable must surface a clean
+/// validation message ("Geometry is required...") instead of a raw provider NOT NULL
+/// constraint violation. The mapping is driven by the database's own decision (the
+/// constraint actually fired), so it can never wrongly reject a valid attribute-only
+/// create on a nullable geometry column (Issue #45).
+/// </summary>
+public sealed class FeatureDataAccessGeometryRequiredMappingTests
+{
+    private static PostgresException NotNullViolation(string columnName) =>
+        new(
+            messageText: $"null value in column \"{columnName}\" violates not-null constraint",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: PostgresErrorCodes.NotNullViolation,
+            detail: null,
+            hint: null,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null,
+            where: null,
+            schemaName: null,
+            tableName: "features",
+            columnName: columnName,
+            dataTypeName: null,
+            constraintName: null,
+            file: null,
+            line: null,
+            routine: null);
+
+    [Theory]
+    [InlineData("geometry")]
+    [InlineData("GEOMETRY")]
+    [InlineData("geom")]
+    [InlineData("shape")]
+    [InlineData("the_geom")]
+    public void IsGeometryColumn_RecognizesCommonGeometryColumnNames(string columnName)
+    {
+        FeatureDataAccess.IsGeometryColumn(columnName).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("name")]
+    [InlineData("attributes")]
+    [InlineData("layer_id")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsGeometryColumn_RejectsNonGeometryColumns(string? columnName)
+    {
+        FeatureDataAccess.IsGeometryColumn(columnName).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsGeometryNotNullViolation_GeometryColumnNotNull_MapsToClean400()
+    {
+        // Non-nullable geometry column + null geometry create -> the database raises a
+        // NOT NULL violation on the geometry column, which we surface as a clean 400.
+        FeatureDataAccess.IsGeometryNotNullViolation(NotNullViolation("geometry")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsGeometryNotNullViolation_NonGeometryColumnNotNull_IsNotMapped()
+    {
+        // A NOT NULL violation on some other required column is unrelated to geometry and
+        // must not be reported as a missing-geometry error.
+        FeatureDataAccess.IsGeometryNotNullViolation(NotNullViolation("name")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsGeometryNotNullViolation_UniqueViolationOnGeometry_IsNotMapped()
+    {
+        var unique = new PostgresException(
+            messageText: "duplicate key value violates unique constraint",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: PostgresErrorCodes.UniqueViolation,
+            detail: null,
+            hint: null,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null,
+            where: null,
+            schemaName: null,
+            tableName: "features",
+            columnName: "geometry",
+            dataTypeName: null,
+            constraintName: null,
+            file: null,
+            line: null,
+            routine: null);
+
+        FeatureDataAccess.IsGeometryNotNullViolation(unique).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetSafeEditOperationError_GeometryRequired_SurfacesActionableMessage()
+    {
+        var mapped = new GeometryRequiredForCreateException(NotNullViolation("geometry"));
+
+        FeatureDataAccess.GetSafeEditOperationError(mapped, "Create")
+            .Should().Be("Geometry is required for create operation on a spatial layer");
+    }
+
+    [Fact]
+    public void GetSafeEditOperationError_OtherProviderError_StaysGeneric()
+    {
+        // A generic NOT NULL violation on an unrelated column is not mapped to the
+        // geometry message; it stays a safe generic error (no provider internals leak).
+        FeatureDataAccess.GetSafeEditOperationError(NotNullViolation("name"), "Create")
+            .Should().Be("Create failed.");
+    }
+}

--- a/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacFilterHelpersTests.cs
+++ b/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacFilterHelpersTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using FluentAssertions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -271,6 +272,53 @@ public sealed class StacFilterHelpersTests
         var filter = StacFilterHelpers.ParseDatetime(openInterval, resource);
 
         filter.Should().BeNull();
+    }
+
+    // Boundary complement to the doubly-open rejection: a HALF-bounded (single-open)
+    // interval is valid per OGC API-Features / STAC and must still be accepted. Rejection
+    // is scoped strictly to the doubly-open/empty case; the revert must not over-reject
+    // '../date' or 'date/..'.
+
+    [UnitTest]
+    public void IsValidDatetimeSyntax_WithSingleOpenInterval_ReturnsTrue()
+    {
+        foreach (var datetime in new[] { "../2023-01-02T00:00:00Z", "2023-01-02T00:00:00Z/.." })
+        {
+            StacFilterHelpers.IsValidDatetimeSyntax(datetime)
+                .Should().BeTrue("'{0}' is a valid half-bounded interval", datetime);
+        }
+    }
+
+    [UnitTest]
+    public void ParseDatetime_WithOpenStartInterval_ReturnsUpperBoundedFilter()
+    {
+        var resource = CreateResource(
+            [
+                new MetadataV2Field { Name = "objectid", Type = MetadataV2FieldType.Integer, Nullable = false },
+                new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime }
+            ]);
+
+        var filter = StacFilterHelpers.ParseDatetime("../2023-01-02T00:00:00Z", resource);
+
+        filter.Should().NotBeNull();
+        filter!.Value.Start.Should().BeNull();
+        filter.Value.End.Should().Be(DateTimeOffset.Parse("2023-01-02T00:00:00Z", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+    }
+
+    [UnitTest]
+    public void ParseDatetime_WithOpenEndInterval_ReturnsLowerBoundedFilter()
+    {
+        var resource = CreateResource(
+            [
+                new MetadataV2Field { Name = "objectid", Type = MetadataV2FieldType.Integer, Nullable = false },
+                new MetadataV2Field { Name = "timestamp", Type = MetadataV2FieldType.DateTime }
+            ]);
+
+        var filter = StacFilterHelpers.ParseDatetime("2023-01-02T00:00:00Z/..", resource);
+
+        filter.Should().NotBeNull();
+        filter!.Value.Start.Should().Be(DateTimeOffset.Parse("2023-01-02T00:00:00Z", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+        filter.Value.End.Should().BeNull();
     }
 
     private static MetadataV2Resource CreateResource(MetadataV2Field[] fields)


### PR DESCRIPTION
## Summary

Fix-forwards two of #2423's bug-fixes that were reverted (#2433 → BH-014, #2454 → BH-S-02) to green ~10 regressed shards. Each is now reinstated correctly so the shards stay green AND the original intent/UX value is preserved. Standing rule: fix-forward, never revert.

## Changes Made

- **BH-014 geometry gate (approach a — DB-constraint mapping):** replaced the reverted client-side pre-check with a mapping of the database's own NOT NULL constraint violation on the geometry column to a clean validation error. Nullable geometry columns still accept valid attribute-only creates (Issue #45, no gate); a non-nullable geometry column now surfaces the actionable "Geometry is required for create operation on a spatial layer" message instead of a raw provider error. The managed `features` table has a nullable geometry column, so the ~10 previously-regressed shards never trigger the mapping and stay green. Chosen over a nullability-aware pre-check because `MetadataV2Field.Nullable` is unreliable under source-gen deserialization.
- `FeatureDataAccess.CreateWithConnectionAsync` catches the geometry NOT NULL violation → `GeometryRequiredForCreateException`; `GetSafeEditOperationError` surfaces its client-safe message verbatim. Adds `FeatureDataAccessGeometryRequiredMappingTests` (column recognition, violation classification, message passthrough).
- **BH-S-02 STAC datetime interval — keep reverted 400 as the correct behavior:** BH-S-02 made doubly-open/empty intervals (`../..`, `/`, `/..`, `../`) return 200 on the false premise they are spec-valid. Per OGC API-Features / STAC an interval must have at least one bounded end, and the STAC API conformance validator requires the doubly-open case be rejected with 400. BH-S-02 had no separate valid case it was fixing, so the reverted 400 IS the standards-correct fix-forward — kept as-is. Adds boundary tests proving valid single-open intervals (`../date`, `date/..`) are still accepted.

## Breaking Changes

None.

## Gate Impact

- [x] No gate impact / green-keeping (restores intent without re-regressing shards)

## Testing

- [x] Ran affected unit suites locally: `FeatureDataAccessGeometryRequiredMappingTests` (15 passed), `StacFilterHelpersTests` (15 passed). `dotnet format --verify-no-changes` clean on changed files. Release build (warnings-as-errors) of the affected test projects succeeded.

Related to #2423
