### PR TITLE
Feature bug-hunt Round 3: systemic class-kills for 14 S1s (+ build-failing analyzer)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -80,6 +80,19 @@
   </ItemGroup>
 
   <!--
+    HN0001 (CommitAsyncWithLiveToken): fails the build on any call to
+    DbTransaction.CommitAsync() with a live CancellationToken. Use
+    DbTransactionExtensions.CommitSafelyAsync(ct) instead to guard against the
+    phantom-commit race. Excluded from the analyzer project itself (IsRoslynComponent)
+    to avoid a self-reference bootstrap cycle.
+  -->
+  <ItemGroup Condition="'$(HonuaSkipRepoAnalyzers)' != 'true' AND '$(MSBuildProjectName)' != 'package-test' AND '$(IsRoslynComponent)' != 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)src/Honua.Analyzers/Honua.Analyzers.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!--
     Roslynator initial-rollout suppressions: a handful of rules fire en masse
     across the existing codebase and would block the warnings-as-errors build.
     They are suppressed (NOT silenced via Severity=None) so they still surface

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,6 +111,7 @@
     <PackageVersion Include="Parquet.Net" Version="5.6.0" />
     <PackageVersion Include="ParquetSharp" Version="23.0.0.1" />
     <PackageVersion Include="Polly" Version="8.6.6" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.1" />
     <!-- Transitive of WireMock.Net (test-only HTTP mocking); pinned directly to clear GHSA-24c8-4792-22hx (NU1903). -->

--- a/Honua.sln
+++ b/Honua.sln
@@ -165,6 +165,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.ControlPlane.Lambda",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.ControlPlane.Lambda.Tests", "tests\dotnet\Honua.ControlPlane.Lambda.Tests\Honua.ControlPlane.Lambda.Tests.csproj", "{014DB146-0395-4086-BD8C-155FFF3AA9EB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Analyzers", "src\Honua.Analyzers\Honua.Analyzers.csproj", "{E2716F67-388F-4D07-B3BF-E1D78293F214}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1075,6 +1077,18 @@ Global
 		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|x64.Build.0 = Release|Any CPU
 		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|x86.ActiveCfg = Release|Any CPU
 		{014DB146-0395-4086-BD8C-155FFF3AA9EB}.Release|x86.Build.0 = Release|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Debug|x64.Build.0 = Debug|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Debug|x86.Build.0 = Debug|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|x64.ActiveCfg = Release|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|x64.Build.0 = Release|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|x86.ActiveCfg = Release|Any CPU
+		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1150,5 +1164,6 @@ Global
 		{B6D2F1A4-3C7E-4F0A-9E21-7A5C8D4B1E60} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 		{C6BCF7FB-E329-4820-BC94-7D3939F747A7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{014DB146-0395-4086-BD8C-155FFF3AA9EB} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
+		{E2716F67-388F-4D07-B3BF-E1D78293F214} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/Honua.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Honua.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Honua.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Honua.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+HN0001 | Honua.DataIntegrity | Error | CommitAsync called with a live CancellationToken

--- a/src/Honua.Analyzers/CommitAsyncWithLiveTokenAnalyzer.cs
+++ b/src/Honua.Analyzers/CommitAsyncWithLiveTokenAnalyzer.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Honua.Analyzers;
+
+/// <summary>
+/// HN0001 — Detects calls to <c>DbTransaction.CommitAsync(CancellationToken)</c>
+/// where the argument is not <c>CancellationToken.None</c>.
+/// </summary>
+/// <remarks>
+/// Passing a live <see cref="System.Threading.CancellationToken"/> to
+/// <c>DbTransaction.CommitAsync(CancellationToken)</c> creates a
+/// phantom-commit race condition: if the token fires after the database server
+/// accepts COMMIT but before the network ACK arrives, the driver throws
+/// <see cref="System.OperationCanceledException"/> yet the transaction is
+/// durably committed server-side. Callers that observe the exception as failure
+/// and retry will insert duplicates.
+///
+/// Use <c>DbTransactionExtensions.CommitSafelyAsync(cancellationToken)</c>
+/// instead: it pre-checks the token (failing cleanly if already cancelled) then
+/// commits with <see cref="System.Threading.CancellationToken.None"/> so the
+/// in-flight COMMIT round-trip is never interrupted.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CommitAsyncWithLiveTokenAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>Diagnostic identifier.</summary>
+    public const string DiagnosticId = "HN0001";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "CommitAsync called with a live CancellationToken",
+        messageFormat: "'{0}' passes a live CancellationToken to CommitAsync. Use CommitSafelyAsync(cancellationToken) to prevent phantom commits.",
+        category: "Honua.DataIntegrity",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description:
+            "Passing a live CancellationToken to DbTransaction.CommitAsync creates a phantom-commit race: " +
+            "if the token fires after the server accepts COMMIT but before the ACK arrives, the driver throws " +
+            "OperationCanceledException yet the transaction is durably committed. Use CommitSafelyAsync(ct) instead.");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Must be a member-access call
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return;
+        }
+
+        // Must be named CommitAsync
+        if (!string.Equals(memberAccess.Name.Identifier.Text, "CommitAsync", System.StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Must have exactly one argument
+        var args = invocation.ArgumentList.Arguments;
+        if (args.Count != 1)
+        {
+            return;
+        }
+
+        // If the argument is CancellationToken.None, it is already the safe form
+        if (IsCancellationTokenNone(args[0].Expression))
+        {
+            return;
+        }
+
+        // Resolve the method symbol and verify it is DbTransaction.CommitAsync
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation);
+        if (symbolInfo.Symbol is not IMethodSymbol method)
+        {
+            return;
+        }
+
+        if (!IsDbTransactionCommitAsync(method))
+        {
+            return;
+        }
+
+        var containingType = context.ContainingSymbol?.ContainingType?.ToDisplayString() ?? "(unknown)";
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), containingType));
+    }
+
+    private static bool IsCancellationTokenNone(ExpressionSyntax expression)
+    {
+        // Matches: CancellationToken.None
+        return expression is MemberAccessExpressionSyntax { Name.Identifier.Text: "None" } ma
+               && string.Equals(ma.Expression.ToString(), "CancellationToken", System.StringComparison.Ordinal);
+    }
+
+    private static bool IsDbTransactionCommitAsync(IMethodSymbol method)
+    {
+        var containingType = method.ContainingType;
+        while (containingType is not null)
+        {
+            if (string.Equals(
+                    containingType.ToDisplayString(),
+                    "System.Data.Common.DbTransaction",
+                    System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            containingType = containingType.BaseType;
+        }
+
+        return false;
+    }
+}

--- a/src/Honua.Analyzers/Honua.Analyzers.csproj
+++ b/src/Honua.Analyzers/Honua.Analyzers.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!--
+      Roslyn components target netstandard2.0 to work in both MSBuild and dotnet compilation
+      hosts; suppress XML-doc requirement (CS1591) since this is not a published library.
+    -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- Analyzers are compile-time tools only; do not pack or publish as a runtime assembly. -->
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/Honua.Core/Features/Infrastructure/Session/AdoNetDatabaseSession.cs
+++ b/src/Honua.Core/Features/Infrastructure/Session/AdoNetDatabaseSession.cs
@@ -167,7 +167,11 @@ public class AdoNetDatabaseSession : IDatabaseSession
             throw new InvalidOperationException("Cannot commit: session is not transactional.");
         }
 
-        await _transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        // Guard against phantom commits: check the token before the COMMIT round-trip
+        // so we fail cleanly if already cancelled; then commit with None so the in-flight
+        // COMMIT can never be interrupted once it starts (see HN0001).
+        cancellationToken.ThrowIfCancellationRequested();
+        await _transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
         _committed = true;
     }
 

--- a/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
+++ b/src/Honua.Core/Features/Raster/ZarrParser/ZarrSubsetReader.cs
@@ -229,10 +229,28 @@ public sealed class ZarrSubsetReader : IZarrSubsetReader
     {
         var rank = array.Shape.Length;
         var chunkPath = JoinKey(arrayPath, BuildChunkKey(chunkIndex, array.ChunkKeyEncoding));
+
+        // BH3-022: Validate the declared chunk size against the per-request cap BEFORE issuing
+        // any cloud read. The old code passed int.MaxValue/4 (~512 MB) as the read ceiling and
+        // only checked the metadata-declared size after the read had already allocated raw buffers.
+        // An attacker-controlled Zarr store can write chunk objects much larger than the declared
+        // chunk dimensions; with MaxDegreeOfParallelism=8, that yielded up to 4.3 GB of temporary
+        // allocation per request. By computing chunkBytes first and using it as the read ceiling,
+        // the network read is bounded to the expected uncompressed size (compressed data is always
+        // smaller than its uncompressed form, so this ceiling is safe for both codecs).
+        var chunkBytes = ComputeChunkBytes(array, elementSize);
+        if (chunkBytes > MaxBytesPerRequest)
+        {
+            throw new InvalidOperationException(
+                $"Zarr chunk size of {chunkBytes:N0} bytes exceeds the per-chunk cap of {MaxBytesPerRequest:N0} bytes. " +
+                $"Re-chunk the Zarr store with smaller chunk dimensions before serving it.");
+        }
+
         byte[]? raw;
         try
         {
-            raw = await reader.ReadRangeAsync(bucket, chunkPath, 0, int.MaxValue / 4, cancellationToken).ConfigureAwait(false);
+            // chunkBytes <= MaxBytesPerRequest (256 MiB), so the cast to int is safe.
+            raw = await reader.ReadRangeAsync(bucket, chunkPath, 0, (int)chunkBytes, cancellationToken).ConfigureAwait(false);
         }
         catch (FileNotFoundException)
         {
@@ -241,14 +259,6 @@ public sealed class ZarrSubsetReader : IZarrSubsetReader
         catch (DirectoryNotFoundException)
         {
             raw = null;
-        }
-
-        var chunkBytes = ComputeChunkBytes(array, elementSize);
-        if (chunkBytes > MaxBytesPerRequest)
-        {
-            throw new InvalidOperationException(
-                $"Zarr chunk size of {chunkBytes:N0} bytes exceeds the per-chunk cap of {MaxBytesPerRequest:N0} bytes. " +
-                $"Re-chunk the Zarr store with smaller chunk dimensions before serving it.");
         }
 
         var chunkBuffer = new byte[chunkBytes];

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ExternalPostgisSinkExecutor.cs
@@ -189,7 +189,8 @@ internal sealed partial class ExternalPostgisSinkExecutor : IProcessExecutor
                         .ConfigureAwait(false);
                 }
 
-                await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                await tx.CommitAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/ImportDatasetJobExecutor.cs
@@ -16,6 +16,7 @@ using Honua.Core.Features.Security.Abstractions;
 using Honua.ControlPlane;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Geoprocessing.Execution;
 
@@ -76,13 +77,16 @@ internal sealed partial class ImportDatasetJobExecutor : IProcessExecutor
 
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly ILogger<ImportDatasetJobExecutor> _logger;
+    private readonly IOptionsMonitor<GeoprocessingExecutorOptions> _executorOptions;
 
     public ImportDatasetJobExecutor(
         IServiceScopeFactory serviceScopeFactory,
-        ILogger<ImportDatasetJobExecutor> logger)
+        ILogger<ImportDatasetJobExecutor> logger,
+        IOptionsMonitor<GeoprocessingExecutorOptions> executorOptions)
     {
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
+        _executorOptions = executorOptions;
     }
 
     /// <summary>
@@ -125,7 +129,23 @@ internal sealed partial class ImportDatasetJobExecutor : IProcessExecutor
         cancellationToken.ThrowIfCancellationRequested();
         await context.ReportProgressAsync(5, "Staging source", cancellationToken).ConfigureAwait(false);
 
-        if (!File.Exists(request.SourcePath))
+        // BH3-027: Validate that the caller-supplied sourcePath is contained within the
+        // configured staging root before any filesystem access. Path.GetFullPath resolves
+        // ".." segments and symlink-style escapes; the StartsWith check on the canonical
+        // form then prevents traversal to arbitrary server paths (e.g. /etc/shadow).
+        var stagingRoot = Path.GetFullPath(_executorOptions.CurrentValue.ImportStagingDirectory);
+        var resolvedSourcePath = Path.GetFullPath(request.SourcePath);
+        var stagingRootWithSep = stagingRoot.EndsWith(Path.DirectorySeparatorChar)
+            ? stagingRoot
+            : stagingRoot + Path.DirectorySeparatorChar;
+        if (!resolvedSourcePath.StartsWith(stagingRootWithSep, StringComparison.OrdinalIgnoreCase))
+        {
+            Log.PathTraversalRejected(_logger, job.OperationId, request.SourcePath);
+            return JobExecutionResult.Failed(
+                $"Invalid {HandledProcessId} inputs: source path is not within the permitted staging directory.");
+        }
+
+        if (!File.Exists(resolvedSourcePath))
         {
             return JobExecutionResult.Failed(
                 $"Invalid {HandledProcessId} inputs: staged source file was not found.");
@@ -175,7 +195,7 @@ internal sealed partial class ImportDatasetJobExecutor : IProcessExecutor
             // source under overwrite idempotency, which is the resume contract.
             var importRequest = new ImportRequest
             {
-                LocalFilePath = request.SourcePath,
+                LocalFilePath = resolvedSourcePath,
                 FileName = request.FileName,
                 TableName = request.TableName,
                 TargetSchema = request.TargetSchema,
@@ -305,7 +325,7 @@ internal sealed partial class ImportDatasetJobExecutor : IProcessExecutor
                                 LayerId = rasterLayerId,
                                 Name = request.LayerName,
                                 Description = request.Description,
-                                FilePath = request.SourcePath,
+                                FilePath = resolvedSourcePath,
                                 FileName = request.FileName,
                                 Format = rasterFormat.Value,
                                 Srid = request.SourceSrid
@@ -575,6 +595,10 @@ internal sealed partial class ImportDatasetJobExecutor : IProcessExecutor
         [LoggerMessage(9200, LogLevel.Warning,
             "Import dataset executor refused job {OperationId}: unsupported process id '{ProcessId}'")]
         public static partial void UnsupportedProcessId(ILogger logger, string operationId, string processId);
+
+        [LoggerMessage(9207, LogLevel.Warning,
+            "Import dataset executor rejected job {OperationId}: source path '{SourcePath}' is outside the permitted staging directory (BH3-027)")]
+        public static partial void PathTraversalRejected(ILogger logger, string operationId, string sourcePath);
 
         [LoggerMessage(9201, LogLevel.Warning,
             "Import dataset executor rejected job {OperationId}: {Reason}")]

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingExecutorOptions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingExecutorOptions.cs
@@ -34,6 +34,16 @@ internal sealed class GeoprocessingExecutorOptions
         Path.Combine(Path.GetTempPath(), "honua-geoprocessing-outputs");
 
     /// <summary>
+    /// Root directory that the <c>import.dataset</c> executor accepts as the staging area
+    /// for source files. The caller-supplied <c>sourcePath</c> job input must resolve to a
+    /// canonical path that starts with this prefix; paths outside the staging root are
+    /// rejected with a job failure to prevent path-traversal attacks (BH3-027).
+    /// Defaults to the same staging directory used by the upload pipeline.
+    /// </summary>
+    public string ImportStagingDirectory { get; set; } =
+        Path.Combine(Path.GetTempPath(), "honua-import-staging");
+
+    /// <summary>
     /// Retention TTL applied to durable geoprocessing result packages produced
     /// by built-in executors. Mirrors the default Redis store retention so
     /// configuration here is authoritative for both reads and writes.

--- a/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
+++ b/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
@@ -20,6 +20,13 @@ internal static class AtomicTokenReplayProtection
     private static readonly object _memoryLock = new();
     private static readonly HashSet<string> _processedTokens = new();
 
+    // BH3-033: SemaphoreSlim(1,1) serialises the non-Redis check-then-set window so that
+    // two concurrent requests carrying the same token cannot both observe "not present" and
+    // both return true. This gate only protects the non-Redis fallback path (MemoryDistributed-
+    // Cache and other non-Redis IDistributedCache impls); the production Redis path uses SET NX
+    // which is natively atomic and never reaches this semaphore.
+    private static readonly SemaphoreSlim _nonAtomicGate = new(1, 1);
+
     /// <summary>
     /// Atomically checks and marks a JWT token as used to prevent replay attacks.
     /// Returns true if the token is valid and this is the first use, false if it's a replay.
@@ -139,27 +146,32 @@ internal static class AtomicTokenReplayProtection
         DistributedCacheEntryOptions options,
         CancellationToken cancellationToken)
     {
-        // For non-Redis caches, implement a more robust fallback with unique identifier verification
-        var uniqueMarker = Guid.NewGuid().ToString();
-        var timestampedValue = $"{DateTimeOffset.UtcNow:O}|{uniqueMarker}";
-
-        // First attempt to get existing value
-        var existing = await cache.GetStringAsync(cacheKey, cancellationToken);
-        if (existing != null)
+        // BH3-033: The previous read-delay-verify pattern had a TOCTOU race: two concurrent
+        // requests could both observe "not present" at T1, write their unique markers, and
+        // each verify their own write before the other's write arrived — both returning true.
+        // The 1 ms Task.Delay was not a distributed barrier and did not close the window.
+        //
+        // Fix: _nonAtomicGate serialises the check-then-set pair within this process.
+        // For MemoryDistributedCache (which is process-local) this is fully race-free.
+        // For cross-process distributed caches that are not Redis, the gate prevents same-
+        // process races but cannot prevent cross-process replays; operators should prefer
+        // Redis for true distributed replay protection.
+        await _nonAtomicGate.WaitAsync(cancellationToken);
+        try
         {
-            // Token already exists, this is a replay
-            return false;
+            var existing = await cache.GetStringAsync(cacheKey, cancellationToken);
+            if (existing != null)
+            {
+                return false;
+            }
+
+            await cache.SetStringAsync(cacheKey, "1", options, cancellationToken);
+            return true;
         }
-
-        // Set our unique marker
-        await cache.SetStringAsync(cacheKey, timestampedValue, options, cancellationToken);
-
-        // Brief delay to allow any concurrent operations to complete
-        await Task.Delay(1, cancellationToken);
-
-        // Verify our unique marker is still there - if not, another request won the race
-        var verification = await cache.GetStringAsync(cacheKey, cancellationToken);
-        return verification == timestampedValue; // Only allow if our exact value is present
+        finally
+        {
+            _nonAtomicGate.Release();
+        }
     }
 
     private static bool TryMarkTokenAsUsedMemory(

--- a/src/Honua.Hosting/Features/Authentication/ServiceDataEditorAuthorization.cs
+++ b/src/Honua.Hosting/Features/Authentication/ServiceDataEditorAuthorization.cs
@@ -71,6 +71,38 @@ internal static class ServiceDataEditorAuthorization
         MetadataV2Service? service = null,
         CancellationToken cancellationToken = default)
     {
+        return await RequireResourceDataEditorCoreAsync(context, resource, service, specificOperation: null, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Per-edit-type variant of <see cref="RequireResourceDataEditorAsync(HttpContext, MetadataV2Resource, MetadataV2Service?, CancellationToken)"/>
+    /// (BH3-001/BH3-014). The RBAC data-editor gate bypass is narrowed to the
+    /// specified <paramref name="operation"/> so a caller with only an Insert grant
+    /// is denied an Update-only payload and vice-versa.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The target resource.</param>
+    /// <param name="service">The owning service, or <see langword="null"/>.</param>
+    /// <param name="operation">The specific write operation being authorized.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An error result when denied; otherwise <see langword="null"/>.</returns>
+    public static async Task<IResult?> RequireResourceDataEditorAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        AuthorizationOperation operation,
+        CancellationToken cancellationToken = default)
+    {
+        return await RequireResourceDataEditorCoreAsync(context, resource, service, operation, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IResult?> RequireResourceDataEditorCoreAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        AuthorizationOperation? specificOperation,
+        CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(resource);
 
         // Layer-scoped write keys (#1637) are enforced here in the shared pipeline.
@@ -93,9 +125,12 @@ internal static class ServiceDataEditorAuthorization
 
         // No explicit write policy: a per-operation RBAC write grant (#1376) on
         // the (service, layer) authorizes the mutation, bypassing the coarse
-        // data-editor role gate. Absent any grant, behavior is unchanged.
+        // data-editor role gate. When specificOperation is set (per-type edit checks
+        // — BH3-001/BH3-014) the bypass is narrowed to that exact operation so a
+        // caller with only an Insert grant cannot bypass the gate for an Update-only
+        // payload and vice-versa.
         if (service is not null &&
-            await HasWriteGrantAsync(context, service.Metadata.Name, resource.Metadata.Name, cancellationToken).ConfigureAwait(false))
+            await HasWriteGrantAsync(context, service.Metadata.Name, resource.Metadata.Name, cancellationToken, specificOperation).ConfigureAwait(false))
         {
             return null;
         }
@@ -220,7 +255,8 @@ internal static class ServiceDataEditorAuthorization
         HttpContext context,
         string serviceName,
         string? layerName,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        AuthorizationOperation? specificOperation = null)
     {
         if (string.IsNullOrWhiteSpace(serviceName))
         {
@@ -246,7 +282,14 @@ internal static class ServiceDataEditorAuthorization
             ?? string.Empty;
         var isAuthenticated = principal.Identity?.IsAuthenticated == true;
 
-        foreach (var operation in WriteOperations)
+        // When specificOperation is set (per-type edit check), only that operation
+        // can bypass the data-editor role gate.  Without it, any write op suffices
+        // (coarse caller check — BH3-001/BH3-014 narrowing is done at the call site).
+        IEnumerable<AuthorizationOperation> operations = specificOperation.HasValue
+            ? [specificOperation.Value]
+            : WriteOperations;
+
+        foreach (var operation in operations)
         {
             var decision = await resolver.AuthorizeAsync(
                 userId,

--- a/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
@@ -644,10 +644,16 @@ internal static class LayerValidationHelpers
     /// <param name="requiredProtocol">Optional protocol gate. Defaults to
     /// <c>OgcFeatures</c> protocol constant to mirror the v1 method.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="operation">Per-operation authorization narrowing (BH3-001/BH3-014):
+    /// when supplied (POST=Insert, PUT/PATCH/Replace=Update, DELETE=Delete), the RBAC
+    /// data-editor gate bypass is limited to that operation so a grant for one operation
+    /// cannot authorize another. Null preserves the coarse any-write behavior (e.g. a mixed
+    /// batch that runs its own per-operation-kind checks after parsing the body).</param>
     public static async Task<MetadataV2ValidationResult> ValidateCollectionWriteAccessV2Async(
         HttpContext context,
         string collectionId,
         string? requiredProtocol = MetadataV2ServiceProtocols.OgcFeatures,
+        AuthorizationOperation? operation = null,
         CancellationToken cancellationToken = default)
     {
         var validation = await ValidateCollectionWithAccessV2Async(
@@ -661,11 +667,18 @@ internal static class LayerValidationHelpers
             return validation;
         }
 
-        var rbacError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
-            context,
-            validation.Resource!,
-            validation.Service,
-            cancellationToken).ConfigureAwait(false);
+        var rbacError = operation is { } op
+            ? await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                validation.Resource!,
+                validation.Service,
+                op,
+                cancellationToken).ConfigureAwait(false)
+            : await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                validation.Resource!,
+                validation.Service,
+                cancellationToken).ConfigureAwait(false);
         if (rbacError != null)
         {
             return new MetadataV2ValidationResult(
@@ -683,7 +696,7 @@ internal static class LayerValidationHelpers
         var canonicalError = await EnforceCanonicalServiceWriteAccessAsync(
             context,
             validation,
-            operation: null,
+            operation,
             cancellationToken).ConfigureAwait(false);
         if (canonicalError != null)
         {

--- a/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Domain;
@@ -682,6 +683,7 @@ internal static class LayerValidationHelpers
         var canonicalError = await EnforceCanonicalServiceWriteAccessAsync(
             context,
             validation,
+            operation: null,
             cancellationToken).ConfigureAwait(false);
         if (canonicalError != null)
         {
@@ -705,6 +707,7 @@ internal static class LayerValidationHelpers
     private static async Task<IResult?> EnforceCanonicalServiceWriteAccessAsync(
         HttpContext context,
         MetadataV2ValidationResult validation,
+        AuthorizationOperation? operation,
         CancellationToken cancellationToken)
     {
         if (!validation.IsValid || validation.Resource is null || validation.Publication is null)
@@ -749,12 +752,20 @@ internal static class LayerValidationHelpers
             ? cs
             : null;
 
-        // Re-evaluate data-editor authorization against the canonical service.
-        return await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
-            context,
-            validation.Resource,
-            canonicalService,
-            cancellationToken).ConfigureAwait(false);
+        // Re-evaluate data-editor authorization against the canonical service, preserving
+        // the per-operation narrowing (BH3-001/BH3-014) when the caller supplied an operation.
+        return operation is { } op
+            ? await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                validation.Resource,
+                canonicalService,
+                op,
+                cancellationToken).ConfigureAwait(false)
+            : await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                validation.Resource,
+                canonicalService,
+                cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -766,6 +777,7 @@ internal static class LayerValidationHelpers
         int layerId,
         ValidationProtocol protocol,
         string? requiredProtocol = null,
+        AuthorizationOperation? operation = null,
         CancellationToken cancellationToken = default)
     {
         var validation = await ValidateLayerWithAccessV2Async(
@@ -780,11 +792,22 @@ internal static class LayerValidationHelpers
             return validation;
         }
 
-        var rbacError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
-            context,
-            validation.Resource!,
-            validation.Service,
-            cancellationToken).ConfigureAwait(false);
+        // Per-operation authorization (BH3-001/BH3-014): when the caller supplies the specific
+        // CRUD operation (OData POST=Insert / PATCH/PUT=Update / DELETE=Delete), the RBAC
+        // data-editor gate bypass is narrowed to that operation so an insert-only grantee cannot
+        // Update or Delete and vice-versa. Absent an operation, any write grant satisfies the gate.
+        var rbacError = operation is { } op
+            ? await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                validation.Resource!,
+                validation.Service,
+                op,
+                cancellationToken).ConfigureAwait(false)
+            : await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                validation.Resource!,
+                validation.Service,
+                cancellationToken).ConfigureAwait(false);
         if (rbacError != null)
         {
             return new MetadataV2ValidationResult(
@@ -798,6 +821,7 @@ internal static class LayerValidationHelpers
         var canonicalError = await EnforceCanonicalServiceWriteAccessAsync(
             context,
             validation,
+            operation,
             cancellationToken).ConfigureAwait(false);
         if (canonicalError != null)
         {

--- a/src/Honua.Io/Features/Export/Writers/GeoPackageExportWriter.cs
+++ b/src/Honua.Io/Features/Export/Writers/GeoPackageExportWriter.cs
@@ -275,7 +275,8 @@ internal static class GeoPackageExportWriter
 
                 if (batchCount >= BatchSize)
                 {
-                    await transaction.CommitAsync(ct).ConfigureAwait(false);
+                    ct.ThrowIfCancellationRequested();
+                    await transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
                     transaction.Dispose();
                     transaction = (SqliteTransaction)await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
                     cmd.Transaction = transaction;
@@ -289,7 +290,7 @@ internal static class GeoPackageExportWriter
                 // not persist a partial batch whose in-flight features may have been
                 // truncated by the async source.
                 ct.ThrowIfCancellationRequested();
-                await transaction.CommitAsync(ct).ConfigureAwait(false);
+                await transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
             }
         }
         finally

--- a/src/Honua.Postgres.Shared/Features/Infrastructure/DbTransactionExtensions.cs
+++ b/src/Honua.Postgres.Shared/Features/Infrastructure/DbTransactionExtensions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data.Common;
+
+namespace Honua.Postgres.Features.Infrastructure;
+
+/// <summary>
+/// Extension methods for <see cref="DbTransaction"/> that guard against the
+/// phantom-commit race: if a <see cref="CancellationToken"/> fires after the
+/// server accepts COMMIT but before the network ACK arrives, the ADO.NET driver
+/// throws <see cref="OperationCanceledException"/> yet the transaction is
+/// durably committed server-side. Callers that observe the exception and retry
+/// produce duplicate mutations.
+/// </summary>
+/// <remarks>
+/// Always call <see cref="CommitSafelyAsync"/> instead of
+/// <see cref="DbTransaction.CommitAsync(CancellationToken)"/> when a live
+/// cancellation token is in scope. The Roslyn analyzer HN0001 (CommitAsyncWithLiveToken)
+/// enforces this at build time.
+/// </remarks>
+internal static class DbTransactionExtensions
+{
+    /// <summary>
+    /// Checks <paramref name="cancellationToken"/> before the COMMIT round-trip
+    /// begins, then commits with <see cref="CancellationToken.None"/> so the
+    /// in-flight COMMIT is never interrupted mid-flight.
+    /// </summary>
+    /// <param name="transaction">The transaction to commit.</param>
+    /// <param name="cancellationToken">
+    /// Token checked before committing. If it is already cancelled the method
+    /// throws <see cref="OperationCanceledException"/> without touching the
+    /// database. Once the commit begins it always runs to completion.
+    /// </param>
+    public static Task CommitSafelyAsync(this DbTransaction transaction, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return transaction.CommitAsync(CancellationToken.None);
+    }
+}

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.FeatureRefresh.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.FeatureRefresh.cs
@@ -6,8 +6,8 @@
 // Rebuilds a published layer's rows in the canonical `features` table from its live source
 // table. Publishing materializes a one-time snapshot (MaterializeLayerFeaturesAsync) that the
 // server-side MVT/tile path reads, while the feature-query paths read the live source table.
-// Re-importing or updating the source therefore leaves the snapshot — and the tiles built from
-// it — silently stale (honua-server#1628). These helpers delete the layer's stale snapshot rows
+// Re-importing or updating the source therefore leaves the snapshot â€” and the tiles built from
+// it â€” silently stale (honua-server#1628). These helpers delete the layer's stale snapshot rows
 // and re-insert them from the live source within a single transaction so tiles stay consistent
 // with the live data the query paths serve.
 
@@ -15,6 +15,7 @@ using System.Globalization;
 using Honua.Core.Features.Admin.Domain;
 using Npgsql;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Admin;
 
 internal sealed partial class PostgreSqlLayerPublishingService
@@ -120,7 +121,7 @@ internal sealed partial class PostgreSqlLayerPublishingService
                 cancellationToken)
             .ConfigureAwait(false);
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
         Log.LayerSnapshotRefreshed(_logger, metadata.LayerId, materializedCount);
 
@@ -295,7 +296,7 @@ internal sealed partial class PostgreSqlLayerPublishingService
 
         if (reader.IsDBNull(4))
         {
-            // No geometry column recorded — not a materializable spatial layer.
+            // No geometry column recorded â€” not a materializable spatial layer.
             return null;
         }
 

--- a/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgreSqlLayerPublishingService.cs
@@ -5,12 +5,12 @@
 // shared constants/fields, the LoggerMessage Log class, and the nested DTO records
 // (LayerFieldInsert, LayerExtentInsert, LayerExtentRefreshMetadata, GeometryHealth,
 // ResolvedPublishValidation) used across partials. Implementation helpers live in:
-//   * PostgreSqlLayerPublishingService.MetadataV2Graph.cs   — V2 graph projection
-//   * PostgreSqlLayerPublishingService.Validation.cs        — publish validation pipeline
-//   * PostgreSqlLayerPublishingService.TableIntrospection.cs — source-table discovery
-//   * PostgreSqlLayerPublishingService.LayerPersistence.cs  — honua.* catalog writes
-//   * PostgreSqlLayerPublishingService.ExtentRefresh.cs     — extent recomputation SQL
-//   * PostgreSqlLayerPublishingService.SqlHelpers.cs        — shared quoting / expression helpers
+//   * PostgreSqlLayerPublishingService.MetadataV2Graph.cs   â€” V2 graph projection
+//   * PostgreSqlLayerPublishingService.Validation.cs        â€” publish validation pipeline
+//   * PostgreSqlLayerPublishingService.TableIntrospection.cs â€” source-table discovery
+//   * PostgreSqlLayerPublishingService.LayerPersistence.cs  â€” honua.* catalog writes
+//   * PostgreSqlLayerPublishingService.ExtentRefresh.cs     â€” extent recomputation SQL
+//   * PostgreSqlLayerPublishingService.SqlHelpers.cs        â€” shared quoting / expression helpers
 
 using Honua.Core.Features.Admin.Abstractions;
 using Honua.Core.Features.Admin.Domain;
@@ -19,6 +19,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Admin;
 
 /// <summary>
@@ -334,7 +335,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         // Project into the Metadata v2 graph BEFORE committing the layer transaction. The graph store uses
         // its own connection/transaction, so it only needs the computed publish values (not the uncommitted
         // layer row). Doing it first means a projection failure leaves the layer transaction uncommitted and
-        // rolled back on dispose — instead of committing an orphaned layer that then blocks re-publish with
+        // rolled back on dispose â€” instead of committing an orphaned layer that then blocks re-publish with
         // "Layer already exists". (Publish is atomic from the caller's perspective.)
         await UpsertPublishedLayerMetadataV2Async(
                 serviceName,
@@ -352,7 +353,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
                 cancellationToken)
             .ConfigureAwait(false);
 
-        await transaction.CommitAsync(cancellationToken);
+        await transaction.CommitSafelyAsync(cancellationToken);
 
         return new PublishedLayerSummary
         {
@@ -408,7 +409,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         var linkedLayer = await GetLayerSummaryAsync(connection, transaction, layerId, normalizedService, cancellationToken)
             .ConfigureAwait(false);
 
-        await transaction.CommitAsync(cancellationToken);
+        await transaction.CommitSafelyAsync(cancellationToken);
         return linkedLayer;
     }
 
@@ -531,7 +532,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         layer = CloneWithEnabled(layer, enabled);
 
         await UpdateServiceExtentAsync(connection, transaction, normalizedService, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
+        await transaction.CommitSafelyAsync(cancellationToken);
         return layer;
     }
 
@@ -565,7 +566,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
         await updateCommand.ExecuteNonQueryAsync(cancellationToken);
 
         await UpdateServiceExtentAsync(connection, transaction, normalizedService, cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
+        await transaction.CommitSafelyAsync(cancellationToken);
 
         return await ListPublishedLayersAsync(connectionString, normalizedService, cancellationToken);
     }
@@ -616,7 +617,7 @@ internal sealed partial class PostgreSqlLayerPublishingService(
 
         await UpdateServiceExtentAsync(connection, transaction, normalizedService, cancellationToken)
             .ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
         // Mirror the recomputed extents into the canonical Metadata v2 graph so the
         // FeatureServer / OGC API Features / OData metadata endpoints (which read

--- a/src/Honua.Postgres/Features/Admin/PostgresLayerFieldConfigurationStore.cs
+++ b/src/Honua.Postgres/Features/Admin/PostgresLayerFieldConfigurationStore.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Admin;
 
 /// <summary>
@@ -76,7 +77,7 @@ internal sealed class PostgresLayerFieldConfigurationStore : ILayerFieldConfigur
         }
 
         var fields = await GetFieldConfigurationsAsync(connection, layerId, transaction, cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return fields;
     }
 

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Alerts;
 
 internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
@@ -139,7 +140,7 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
             }
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         AlertLog.DispatchClaimed(_logger, rows.Count);
         return rows;
     }

--- a/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
+++ b/src/Honua.Postgres/Features/AnalysisContent/PostgresAnalysisContentStore.cs
@@ -48,7 +48,7 @@ internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
             {
                 await InsertItemAsync(connection, transaction, item, cancellationToken).ConfigureAwait(false);
                 await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
-                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
                 return item;
             }
             catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
@@ -107,7 +107,7 @@ internal sealed class PostgresAnalysisContentStore : IAnalysisContentStore
             {
                 await InsertVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
                 await UpdateCurrentVersionAsync(connection, transaction, version, cancellationToken).ConfigureAwait(false);
-                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
                 return version;
             }
             catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)

--- a/src/Honua.Postgres/Features/AuditLog/PostgresAuditLog.cs
+++ b/src/Honua.Postgres/Features/AuditLog/PostgresAuditLog.cs
@@ -11,7 +11,7 @@ namespace Honua.Postgres.Features.AuditLog;
 
 /// <summary>
 /// PostgreSQL-backed <see cref="IAuditLog"/> writing to <c>honua.audit_log</c>.
-/// Append-only by design (see migration 033) — only INSERTs are issued, and
+/// Append-only by design (see migration 033) â€” only INSERTs are issued, and
 /// transient failures are swallowed (logged) so that an audit-write hiccup
 /// never blocks the security-relevant action being audited.
 /// </summary>
@@ -28,7 +28,7 @@ internal sealed class PostgresAuditLog : IAuditLog
     private const int MaxCorrelationIdLength = 64;
     private const int MaxRemoteIpLength = 64;
     private const int MaxUserAgentLength = 512;
-    private const string TruncationMarker = "…";
+    private const string TruncationMarker = "â€¦";
 
     // Stable, table-scoped key for the transaction advisory lock that serializes
     // hash-chain construction (#350). Concurrent audit inserts briefly contend on
@@ -57,7 +57,7 @@ internal sealed class PostgresAuditLog : IAuditLog
         ArgumentNullException.ThrowIfNull(auditEvent);
 
         // Compute the stored (truncated) field values up front so the hash chain
-        // is built over exactly what is persisted — the verifier replays the same
+        // is built over exactly what is persisted â€” the verifier replays the same
         // stored values, so the two hashes must agree.
         var actor = Truncate(auditEvent.Actor, MaxActorLength);
         var resourceType = Truncate(auditEvent.ResourceType, MaxResourceTypeLength);
@@ -143,11 +143,11 @@ internal sealed class PostgresAuditLog : IAuditLog
                 await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
-            // Honour cooperative cancellation — do not log; the caller is shutting down.
+            // Honour cooperative cancellation â€” do not log; the caller is shutting down.
             throw;
         }
         catch (Exception ex)

--- a/src/Honua.Postgres/Features/AuditLog/PostgresAuditLogRetentionPruner.cs
+++ b/src/Honua.Postgres/Features/AuditLog/PostgresAuditLogRetentionPruner.cs
@@ -22,7 +22,7 @@ namespace Honua.Postgres.Features.AuditLog;
 /// deletes, and migration 069 builds a hash chain over the rows. Retention is the
 /// sanctioned, privileged maintenance path the migration explicitly allows
 /// ("rotate / archive via partition swap or explicit DROP RULE in a maintenance
-/// window"). This pruner performs that rotation safely and — critically —
+/// window"). This pruner performs that rotation safely and â€” critically â€”
 /// <em>without holding a long-lived lock</em>:
 /// </para>
 /// <list type="number">
@@ -30,7 +30,7 @@ namespace Honua.Postgres.Features.AuditLog;
 /// (<c>MIN(audit_id)</c> among still-retained rows). Everything below that
 /// boundary is, by construction, an expired contiguous prefix of the chain.
 /// Because the integrity verifier treats the first surviving hashed row as the
-/// chain genesis, pruning a head prefix never breaks verification — unlike a
+/// chain genesis, pruning a head prefix never breaks verification â€” unlike a
 /// mid-chain delete. Concurrent inserts only ever add rows <em>above</em> the
 /// boundary (higher <c>audit_id</c>, newer timestamps), so they can never be
 /// caught by the prune and the boundary stays valid for the whole sweep.</item>
@@ -79,7 +79,7 @@ internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
     {
         ArgumentNullException.ThrowIfNull(policy);
 
-        // Unbounded retention means "retain forever" — never remove anything.
+        // Unbounded retention means "retain forever" â€” never remove anything.
         if (!policy.IsBounded)
         {
             return 0;
@@ -139,7 +139,7 @@ internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
     {
         // Each batch runs in its own short transaction so the ACCESS EXCLUSIVE lock
         // taken by DISABLE/ENABLE RULE is held only for the few milliseconds this
-        // small delete takes, then released — letting inline audit inserts proceed
+        // small delete takes, then released â€” letting inline audit inserts proceed
         // between batches instead of stalling for the whole sweep.
         await using var transaction = await connection.BeginTransactionAsync(ct).ConfigureAwait(false);
 
@@ -193,7 +193,7 @@ internal sealed class PostgresAuditLogRetentionPruner : IAuditRetentionPruner
             $"ALTER TABLE {_table} ENABLE RULE {NoDeleteRule}",
             ct).ConfigureAwait(false);
 
-        await transaction.CommitAsync(ct).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(ct).ConfigureAwait(false);
 
         return deleted;
     }

--- a/src/Honua.Postgres/Features/Authorization/PostgresRoleStore.cs
+++ b/src/Honua.Postgres/Features/Authorization/PostgresRoleStore.cs
@@ -80,7 +80,7 @@ internal sealed class PostgresRoleStore : IRoleStore
             }
 
             await ReplacePermissionsAsync(connection.Connection, transaction, role.RoleId, role.Permissions, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
         {
@@ -132,7 +132,7 @@ internal sealed class PostgresRoleStore : IRoleStore
             }
 
             await ReplacePermissionsAsync(connection.Connection, transaction, role.RoleId, role.Permissions, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
         {
@@ -202,7 +202,7 @@ internal sealed class PostgresRoleStore : IRoleStore
         }
 
         await ReplacePermissionsAsync(connection.Connection, transaction, roleId, permissions, cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return permissions;
     }
 

--- a/src/Honua.Postgres/Features/Console/Collaboration/PostgresStudioMapCollaborationStore.cs
+++ b/src/Honua.Postgres/Features/Console/Collaboration/PostgresStudioMapCollaborationStore.cs
@@ -124,7 +124,7 @@ internal sealed class PostgresStudioMapCollaborationStore : IStudioMapCollaborat
             await InsertActivityAsync(connection, transaction, mapId, "thread-opened", authorName, authorId,
                 $"opened a comment on {featureLabel}", threadId, now, cancellationToken).ConfigureAwait(false);
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
         }
         catch
@@ -167,7 +167,7 @@ internal sealed class PostgresStudioMapCollaborationStore : IStudioMapCollaborat
             await InsertActivityAsync(connection, transaction, mapId, "comment-posted", authorName, authorId,
                 $"replied on {featureLabel}", threadId, now, cancellationToken).ConfigureAwait(false);
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
         }
         catch
@@ -227,7 +227,7 @@ internal sealed class PostgresStudioMapCollaborationStore : IStudioMapCollaborat
             await InsertActivityAsync(connection, transaction, mapId, kind, actorName, actorId,
                 $"{verb} the comment on {featureLabel}", threadId, now, cancellationToken).ConfigureAwait(false);
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
         }
         catch

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
@@ -12,6 +12,7 @@ using NetTopologySuite.IO;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.FeatureStore.Services;
 
 /// <summary>
@@ -156,7 +157,7 @@ internal sealed partial class FeatureDataAccess
                     cancellationToken).ConfigureAwait(false);
             }
 
-            await Transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await Transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             return deleted.Deleted;
         }
 
@@ -176,7 +177,7 @@ internal sealed partial class FeatureDataAccess
         // A scope without a registered outbox repository is a wiring error: the protocol
         // layer opened a scope expecting durable CDC intent, so falling through to the
         // autocommit fast path would silently drop the envelope the scope was set up to
-        // record — the exact gap the transactional outbox is meant to close. Fail loud
+        // record â€” the exact gap the transactional outbox is meant to close. Fail loud
         // instead so the misconfiguration surfaces as a mutation failure rather than as
         // silent CDC loss. Capability provider and repository must be registered together.
         if (_outboxRepository is null)
@@ -214,7 +215,7 @@ internal sealed partial class FeatureDataAccess
             snapshot,
             cancellationToken).ConfigureAwait(false);
 
-        await Transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await Transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return snapshot ?? throw new InvalidOperationException("Mutation returned no snapshot.");
     }
 
@@ -507,7 +508,7 @@ internal sealed partial class FeatureDataAccess
 
         if (transaction != null)
         {
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
 
         var immutableCreatedIds = createdIds.ToImmutable();
@@ -960,7 +961,7 @@ internal sealed partial class FeatureDataAccess
         // When an outbox scope is active we serialize creates so the per-row snapshot
         // returned by CreateWithConnectionAsync can drive the outbox factory. The fast
         // bulk INSERT path returns ids only and would force a second projection just to
-        // satisfy the outbox payload — single-row inserts give us the snapshot directly
+        // satisfy the outbox payload â€” single-row inserts give us the snapshot directly
         // and remain inside the same connection/transaction so atomicity is preserved.
         // TryUseTransactionalOutbox throws when scope is active but the repository is
         // missing so the wiring error surfaces here instead of silently picking the bulk
@@ -1134,10 +1135,19 @@ internal sealed partial class FeatureDataAccess
                 FROM payload
                 ORDER BY payload.ordinality
                 RETURNING objectid
+            ),
+            numbered AS (
+                -- BH3-020: ORDER BY ctid diverges from insertion order on tables with
+                -- free pages from prior deletes. Use ROW_NUMBER() OVER () instead:
+                -- PostgreSQL returns RETURNING rows in insertion order, which we control
+                -- via ORDER BY payload.ordinality above, so row numbers map 1:1 to input
+                -- feature array indices.
+                SELECT objectid, ROW_NUMBER() OVER () AS rn
+                FROM inserted
             )
             SELECT objectid
-            FROM inserted
-            ORDER BY ctid";
+            FROM numbered
+            ORDER BY rn";
 
         await using var command = new NpgsqlCommand(sql, connection)
         {
@@ -1376,7 +1386,7 @@ internal sealed partial class FeatureDataAccess
 
         await using var rowTransaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken).ConfigureAwait(false);
         var result = await mutateAndAppendOutbox(connection, (NpgsqlTransaction)rowTransaction, cancellationToken).ConfigureAwait(false);
-        await rowTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await rowTransaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return result;
     }
 

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.VersionEdits.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.VersionEdits.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.FeatureStore.Services;
 
 internal sealed partial class FeatureDataAccess
@@ -121,7 +122,7 @@ internal sealed partial class FeatureDataAccess
                     createResults.ToImmutable(), updateResults.ToImmutable(), deleteResults.ToImmutable());
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
             var immutableCreateResults = createResults.ToImmutable();
             var immutableUpdateResults = updateResults.ToImmutable();

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresVersionManager.ReconcilePost.cs
@@ -297,7 +297,7 @@ internal sealed partial class PostgresVersionManager
         // DEFAULT writer cannot slip a committed edit between the drift check below and the replay. This is
         // a separate INNER-JOIN lock because Postgres rejects FOR UPDATE on the nullable side of an outer
         // join: the drift detection needs a LEFT JOIN (to spot an update target whose DEFAULT row vanished),
-        // but only rows that actually exist in DEFAULT can be — and need to be — locked. Locking these rows
+        // but only rows that actually exist in DEFAULT can be â€” and need to be â€” locked. Locking these rows
         // first holds them for the remainder of the transaction, so the subsequent LEFT-JOIN drift query
         // observes a stable snapshot of every target that still exists.
         await using (var lockCommand = new NpgsqlCommand(
@@ -331,7 +331,7 @@ internal sealed partial class PostgresVersionManager
             WHERE ve.version_id = @version
               AND ve.operation IN (2, 3)
               -- A branch delete whose DEFAULT row is already gone is a convergent no-op (DEFAULT
-              -- reached the desired end state), not drift — exclude it so it does not spuriously
+              -- reached the desired end state), not drift â€” exclude it so it does not spuriously
               -- block the post. Every other update/delete target must still match its captured base.
               AND NOT (ve.operation = 3 AND f.objectid IS NULL)
               AND NOT (
@@ -415,7 +415,7 @@ internal sealed partial class PostgresVersionManager
             serverGeneration = result is long gen ? gen : 0;
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return new OverlayReplayResult(applied, serverGeneration, Conflicted: false, ConflictingKeys: conflictingKeys);
     }
 
@@ -543,7 +543,7 @@ internal sealed partial class PostgresVersionManager
 
             // By-attribute detection auto-merges disjoint edits and only flags genuinely-overlapping
             // edits (overlapping fields or geometry-vs-geometry). By-object detection flags ANY feature
-            // edited on both sides since the merge base as a conflict, with no field-level auto-merge —
+            // edited on both sides since the merge base as a conflict, with no field-level auto-merge â€”
             // this is the documented Esri esriReconcileByObject behavior (#2135).
             var autoMergeable = detection == VersionConflictDetection.ByAttribute
                 && overlappingFields.Length == 0
@@ -591,13 +591,13 @@ internal sealed partial class PostgresVersionManager
         await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
 
         // Build the JSON patch of DEFAULT's changed fields and merge it onto the overlay attributes with
-        // the JSONB concat operator (||) — overlay keys win for any non-changed field, DEFAULT's changed
+        // the JSONB concat operator (||) â€” overlay keys win for any non-changed field, DEFAULT's changed
         // fields are layered in. A field DEFAULT removed is rendered as a JSON null. A DEFAULT-only
         // geometry change is copied from the live row.
         //
         // Rebase the overlay's captured base image onto the live DEFAULT row in the SAME statement. An
         // auto-merge accepts DEFAULT's current state (its disjoint field/geometry edits are layered in),
-        // so the merged overlay row's new base MUST be the live DEFAULT — otherwise the post-time drift
+        // so the merged overlay row's new base MUST be the live DEFAULT â€” otherwise the post-time drift
         // guard (f.* IS NOT DISTINCT FROM ve.base_*, #2063) still sees the stale common-ancestor base,
         // treats DEFAULT's now-merged divergence as drift, and blocks the post even though reconcile
         // reported CanPost. This mirrors the "take version" rebase in ApplyResolutionToOverlayAsync and
@@ -737,7 +737,7 @@ internal sealed partial class PostgresVersionManager
             // replay and DEFAULT would keep its own value. Resolving "take version" means the operator
             // accepts the current DEFAULT as the new base to overwrite: rebase the overlay's base image onto
             // the live DEFAULT row so the drift check passes and the version's value lands on DEFAULT. If
-            // DEFAULT deleted the row, leave the base untouched — the drift guard already treats a vanished
+            // DEFAULT deleted the row, leave the base untouched â€” the drift guard already treats a vanished
             // update target as a conflict, which is the correct outcome for "take version" over a deletion.
             await using var rebaseCommand = new NpgsqlCommand($"""
                 UPDATE honua.version_edits ve
@@ -761,7 +761,7 @@ internal sealed partial class PostgresVersionManager
             // branch no longer shadows/posts the feature. Rebase the overlay's base image onto DEFAULT too
             // (base_geometry/base_attributes = DEFAULT's): the resolution accepts the live DEFAULT as the
             // new base, so the post-time drift guard (f.* IS NOT DISTINCT FROM ve.base_*, #2063) sees no
-            // drift and the post proceeds — without this the stale common-ancestor base still differs from
+            // drift and the post proceeds â€” without this the stale common-ancestor base still differs from
             // the diverged DEFAULT and the post is wrongly blocked even though reconcile reported CanPost.
             await using var command = new NpgsqlCommand($"""
                 WITH d AS (
@@ -802,7 +802,7 @@ internal sealed partial class PostgresVersionManager
 
     /// <summary>
     /// Replaces the version's persisted pending conflict set with the supplied unresolved conflicts and,
-    /// when the reconcile is clean, advances the common-ancestor cursor — all in one transaction (#1553).
+    /// when the reconcile is clean, advances the common-ancestor cursor â€” all in one transaction (#1553).
     /// Clearing stale pending rows (auto-merged / auto-resolved this run), inserting the current set, and
     /// advancing the merge base commit atomically, so a crash cannot leave the durable conflict set and
     /// the cursor disagreeing. The operation is naturally idempotent: a re-run recomputes the same set
@@ -873,7 +873,7 @@ internal sealed partial class PostgresVersionManager
             await advance.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<int> CountPendingConflictsAsync(Guid versionId, CancellationToken cancellationToken)

--- a/src/Honua.Postgres/Features/FieldWorkflows/PostgresFieldReviewStore.cs
+++ b/src/Honua.Postgres/Features/FieldWorkflows/PostgresFieldReviewStore.cs
@@ -204,7 +204,7 @@ internal sealed class PostgresFieldReviewStore : IFieldReviewStore
             state = ReadReviewState(reader);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return state;
     }
 
@@ -267,7 +267,7 @@ internal sealed class PostgresFieldReviewStore : IFieldReviewStore
             state = ReadReviewState(reader);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return state;
     }
 
@@ -331,7 +331,7 @@ internal sealed class PostgresFieldReviewStore : IFieldReviewStore
             _ = await statusCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return comment;
     }
 

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Batch.cs
@@ -19,6 +19,7 @@ using Honua.Core.Features.FileImport.Services;
 using Honua.Postgres.Features.Migration;
 using Honua.Postgres.Features.FileImport;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.FileImport;
 
 internal sealed partial class StreamingFileImportService
@@ -91,7 +92,7 @@ internal sealed partial class StreamingFileImportService
 
             if (transaction != null)
             {
-                await transaction.CommitAsync(cancellationToken);
+                await transaction.CommitSafelyAsync(cancellationToken);
             }
         }
         catch (Exception ex)

--- a/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Sql.cs
+++ b/src/Honua.Postgres/Features/FileImport/StreamingFileImportService.Sql.cs
@@ -103,7 +103,7 @@ internal sealed partial class StreamingFileImportService
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }
 
-            await transaction.CommitAsync(cancellationToken);
+            await transaction.CommitSafelyAsync(cancellationToken);
         }
         catch
         {

--- a/src/Honua.Postgres/Features/Forms/PostgresFormPackageStore.cs
+++ b/src/Honua.Postgres/Features/Forms/PostgresFormPackageStore.cs
@@ -171,7 +171,7 @@ internal sealed class PostgresFormPackageStore : IFormPackageStore
             reopenedFromVersion: null,
             cancellationToken).ConfigureAwait(false);
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return await GetVersionAsync(formId, version, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException("Saved form package version could not be read back.");
     }
@@ -229,7 +229,7 @@ internal sealed class PostgresFormPackageStore : IFormPackageStore
         }
 
         await UpsertPackageFamilyAsync(connection, transaction, normalized, currentDraftVersion: version, cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return await GetVersionAsync(formId, version, cancellationToken).ConfigureAwait(false);
     }
 
@@ -321,7 +321,7 @@ internal sealed class PostgresFormPackageStore : IFormPackageStore
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return await GetVersionAsync(formId, version, cancellationToken).ConfigureAwait(false);
     }
 
@@ -367,7 +367,7 @@ internal sealed class PostgresFormPackageStore : IFormPackageStore
             reopenedFromVersion: publishedVersion,
             cancellationToken).ConfigureAwait(false);
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return await GetVersionAsync(formId, version, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Honua.Postgres/Features/Geoprocessing/PostgresHonuaLayerSink.cs
+++ b/src/Honua.Postgres/Features/Geoprocessing/PostgresHonuaLayerSink.cs
@@ -9,12 +9,13 @@ using Honua.Core.Features.Geoprocessing.Abstractions;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Geoprocessing;
 
 /// <summary>
 /// Catalog-database implementation of <see cref="IHonuaLayerSink"/>. Loads pre-encoded
 /// feature rows into a named layer table in the Honua catalog using the catalog's own
-/// <see cref="NpgsqlDataSource"/>. This type — not the geoprocessing dispatcher — owns the
+/// <see cref="NpgsqlDataSource"/>. This type â€” not the geoprocessing dispatcher â€” owns the
 /// dependency on the catalog data source, so it is registered only by the Postgres provider
 /// and is simply absent in lean deployments (#2210).
 /// </summary>
@@ -83,7 +84,7 @@ internal sealed partial class PostgresHonuaLayerSink(NpgsqlDataSource dataSource
                 .ConfigureAwait(false);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
         return new HonuaLayerSinkOutcome(written, schema, table, request.BatchId);
     }

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2GraphStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2GraphStore.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Metadata;
 
 /// <summary>
@@ -76,10 +77,10 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
             // When both the V2 snapshot table and the V1 catalog are absent or empty the
             // server is freshly deployed with zero published datasets. Every catalog-style
             // endpoint (STAC /stac, GeoServices /rest/services, OGC API /collections, OData
-            // service document, WFS GetCapabilities, …) already handles an empty list
+            // service document, WFS GetCapabilities, â€¦) already handles an empty list
             // gracefully and returns a valid empty response. Returning an empty-but-valid
             // snapshot here makes ALL of those surfaces return 200 with zero
-            // items — the correct behaviour for a healthy but unpopulated server — instead
+            // items â€” the correct behaviour for a healthy but unpopulated server â€” instead
             // of surfacing a 500. A snapshot that EXISTS in the database but fails to load
             // (network/parse error) still 500s correctly because TryLoadCurrentAsync
             // propagates that exception rather than returning null. (honua-server#1619.)
@@ -195,7 +196,7 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
 
         // Self-heal the Metadata v2 schema so a fresh-DB container where migration
         // 031 has not yet run does not 500 the admin layer-publish path. Idempotent
-        // CREATE TABLE IF NOT EXISTS — a no-op once the migration is applied.
+        // CREATE TABLE IF NOT EXISTS â€” a no-op once the migration is applied.
         // (honua-server#1341.)
         await EnsureSchemaAsync(connection, cancellationToken).ConfigureAwait(false);
 
@@ -228,7 +229,7 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
         await RefreshSidecarsAsync(connection, transaction, graph, clearStaleEnvironmentRows: isBootstrap, cancellationToken).ConfigureAwait(false);
         await UpsertCurrentAsync(connection, transaction, graph.Revision, etag, cancellationToken).ConfigureAwait(false);
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
         var snapshot = new MetadataV2GraphSnapshot(graph, etag, DateTimeOffset.UtcNow);
         _cachedCurrent = snapshot;
@@ -583,7 +584,7 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
     /// <summary>
     /// Builds an empty-but-valid in-memory snapshot for a freshly deployed server with no
     /// published datasets. All catalog-style read surfaces (STAC, GeoServices, OGC API
-    /// Features, OData, WFS, …) enumerate the collections/services list and return a valid
+    /// Features, OData, WFS, â€¦) enumerate the collections/services list and return a valid
     /// empty response when the list is zero-length, so this snapshot produces 200s with no
     /// items rather than 500s. It is never persisted to the database. (honua-server#1619.)
     /// </summary>

--- a/src/Honua.Postgres/Features/Migration/GeoservicesImportService.ImportSteps.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoservicesImportService.ImportSteps.cs
@@ -19,6 +19,7 @@ using Honua.Core.Features.FileImport.Services;
 using Honua.Postgres.Features.Migration;
 using Honua.Postgres.Features.FileImport;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Migration;
 
 internal sealed partial class GeoservicesImportService
@@ -145,7 +146,7 @@ internal sealed partial class GeoservicesImportService
             await CreateSpatialIndexAsync(connection, targetSchema, request.TableName, cancellationToken);
             await AnalyzeTableAsync(connection, targetSchema, request.TableName, cancellationToken);
 
-            await transaction.CommitAsync(cancellationToken);
+            await transaction.CommitSafelyAsync(cancellationToken);
 
             PublishedLayerSummary? publishedLayer = null;
             if (request.AutoPublish)
@@ -189,7 +190,7 @@ internal sealed partial class GeoservicesImportService
                     "Layer advertises attachments, but no attachment store is registered; attachments were not copied.");
             }
 
-            // Phase 5: Validating — reconcile the published layer against the apply-time source
+            // Phase 5: Validating â€” reconcile the published layer against the apply-time source
             // snapshot before declaring the import complete. A hard finding routes the run to
             // NeedsReview (issue #1380) instead of Completed; warn findings are recorded but do
             // not block. Reconciliation runs outside the import transaction (which is already

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationBatchRunCatalog.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Migration;
 
 /// <summary>
@@ -126,7 +127,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
             }
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
         var persisted = await GetInternalAsync(connection, record.BatchId, cancellationToken).ConfigureAwait(false) ?? record;
         Log.BatchCreated(_logger, persisted.BatchId, persisted.SourceKind, persisted.TotalChildren);
@@ -308,7 +309,7 @@ internal sealed partial class PostgresMigrationBatchRunCatalog : IMigrationBatch
         }
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
         {
-            // The batch schema (migration 045) is not present yet — e.g. during the
+            // The batch schema (migration 045) is not present yet â€” e.g. during the
             // boot window before migrations run, or in test fixtures pinned to an
             // earlier schema. Treat as "no active batches" so the background poller
             // does not error every cycle; polling resumes once the table exists.

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
@@ -16,6 +16,7 @@ using Honua.Core.Features.FileImport.Services;
 using Honua.Postgres.Features.Migration;
 using Honua.Postgres.Features.FileImport;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Migration;
 
 /// <summary>
@@ -238,7 +239,7 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
                 await copyCmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
 
         var rowCount = await CountRowsAsync(connection, targetIdent, cancellationToken).ConfigureAwait(false);
@@ -518,7 +519,7 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
             """;
 
         // honua.relationships has CHECK constraints on relationship_id > 0 and
-        // relationship_type ∈ {esriRelRoleOrigin, esriRelRoleDestination,
+        // relationship_type âˆˆ {esriRelRoleOrigin, esriRelRoleDestination,
         // esriRelRoleAny}. Stable-hash the source identifier when the source did
         // not advertise an integer id so the row still satisfies the schema.
         var relationshipId = request.EsriRelationshipId ?? DeriveStableRelationshipId(request.SourceRelationshipId);

--- a/src/Honua.Postgres/Features/Migration/PostgresOgcApiFeaturesCollectionSink.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresOgcApiFeaturesCollectionSink.cs
@@ -16,6 +16,7 @@ using Honua.Core.Features.FileImport.Services;
 using Honua.Postgres.Features.Migration;
 using Honua.Postgres.Features.FileImport;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Migration;
 
 /// <summary>
@@ -24,10 +25,10 @@ namespace Honua.Postgres.Features.Migration;
 /// <remarks>
 /// The sink lazily provisions the target table with a stable schema:
 /// <list type="bullet">
-///   <item><c>source_feature_id text primary key</c> — natural key derived from the source feature id.</item>
-///   <item><c>properties jsonb</c> — verbatim GeoJSON properties payload.</item>
-///   <item><c>geometry geometry</c> — projected geometry parsed from the GeoJSON feature.</item>
-///   <item><c>imported_at timestamptz</c> — write timestamp used for telemetry.</item>
+///   <item><c>source_feature_id text primary key</c> â€” natural key derived from the source feature id.</item>
+///   <item><c>properties jsonb</c> â€” verbatim GeoJSON properties payload.</item>
+///   <item><c>geometry geometry</c> â€” projected geometry parsed from the GeoJSON feature.</item>
+///   <item><c>imported_at timestamptz</c> â€” write timestamp used for telemetry.</item>
 /// </list>
 /// Inserts use <c>ON CONFLICT (source_feature_id) DO UPDATE</c> so re-running the importer against
 /// the same source/target combination converges to the same row set.
@@ -164,7 +165,7 @@ internal sealed partial class PostgresOgcApiFeaturesCollectionSink : IOgcApiFeat
                 written++;
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {

--- a/src/Honua.Postgres/Features/Mobile/FieldCollection/PostgresFieldCollectionSyncStore.cs
+++ b/src/Honua.Postgres/Features/Mobile/FieldCollection/PostgresFieldCollectionSyncStore.cs
@@ -24,7 +24,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
     // honua.sync_generation sequence reports its last allocated value,
     // which can be ahead of any committed change row whenever a writer
     // has called nextval but not yet committed. Reading from the changes
-    // table — which is only visible to other sessions after commit —
+    // table â€” which is only visible to other sessions after commit â€”
     // gives a watermark that the puller can advance to without skipping
     // an in-flight write. Pulls bound their SELECT by this watermark, so
     // the watermark and the returned changes share a single committed
@@ -102,7 +102,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
     // pg_advisory_xact_lock serializes concurrent pushes that share a (client_id, change_id)
     // idempotency key; the lock is released on commit or rollback so we never leak it across
     // requests. The key is scoped by client_id to match the (client_id, change_id) idempotency
-    // PK — two devices sharing one API key but minting the same change_id are distinct
+    // PK â€” two devices sharing one API key but minting the same change_id are distinct
     // idempotency keys and must not serialize against (or dedup as) each other. The namespace
     // constant keeps this lock space distinct from other features (e.g. raster import) that
     // also use advisory locks. The literal mirrors ticket #894 to make grep-by-ticket easy.
@@ -110,8 +110,8 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
 
     // Feature-identity advisory lock keyed by (namespace, hashtext("<layer_id>:<feature_id>")).
     // Serializes concurrent pushes targeting the same (feature_id, layer_id) regardless of
-    // change_id. Required because SELECT … FOR UPDATE on fieldcollection_features only locks
-    // an existing row — concurrent inserts for an absent feature would otherwise both read
+    // change_id. Required because SELECT â€¦ FOR UPDATE on fieldcollection_features only locks
+    // an existing row â€” concurrent inserts for an absent feature would otherwise both read
     // current=null, both resolve as Applied, and the unconditional ON CONFLICT DO UPDATE
     // upsert would let the second silently overwrite the first. The namespace constant is
     // distinct from FieldCollectionPushLockNamespace so changeId and feature locks never
@@ -125,7 +125,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
     // push transaction, so without serialization two concurrent pushes to DIFFERENT features
     // can commit in inverted generation order: a pull then observes the higher generation as
     // the committed MAX(generation) watermark, the client acks it, and the lower-generation
-    // change that commits afterwards falls permanently below the cursor — silent data loss.
+    // change that commits afterwards falls permanently below the cursor â€” silent data loss.
     // Taking this transaction-scoped lock immediately before nextval and holding it through
     // commit makes generation order equal commit order for fieldcollection_changes writers,
     // so the committed-MAX watermark can never skip an in-flight lower generation. The lock
@@ -319,7 +319,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
         // ReadCommitted is required so that the post-advisory-lock idempotency
         // re-read sees the winner's freshly committed row. Under RepeatableRead
         // the loser's snapshot is fixed at the first statement (the lock
-        // acquisition), which precedes the winner's commit — the loser would
+        // acquisition), which precedes the winner's commit â€” the loser would
         // see count=0 and fall through to a unique-violation. Per-statement
         // snapshots under ReadCommitted give us a fresh visibility horizon
         // immediately after each advisory lock is released.
@@ -330,7 +330,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
         {
             // Serialize concurrent duplicate-changeId requests. The transaction-scoped
             // advisory lock guarantees the loser waits until the winner commits its
-            // idempotency row, then the post-lock read returns the stored response —
+            // idempotency row, then the post-lock read returns the stored response â€”
             // never a unique-violation surfaced as a 5xx.
             await AcquireChangeIdLockAsync(connection, transaction, clientId, request.ChangeId, cancellationToken).ConfigureAwait(false);
 
@@ -342,7 +342,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
             }
 
             // Serialize concurrent pushes that target the same (feature_id, layer_id),
-            // regardless of change_id. The SELECT … FOR UPDATE below only serializes
+            // regardless of change_id. The SELECT â€¦ FOR UPDATE below only serializes
             // the existing-row case; for an absent feature, two distinct change_ids
             // could both observe current=null and both resolve their inserts as
             // Applied. The feature advisory lock closes that race so the second
@@ -391,7 +391,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
             }
 
             await WriteIdempotencyRecordAsync(connection, transaction, clientId, request, result, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -701,7 +701,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
         // Composite key uses a colon separator between client_id and change_id so
         // that "<a>" + "<b...>" cannot alias a different "<ab>" + "<...>" pair, and
         // so the lock partitions on the same (client_id, change_id) key the
-        // idempotency table is now keyed by. hashtext collisions remain possible —
+        // idempotency table is now keyed by. hashtext collisions remain possible â€”
         // they only cause unnecessary serialization between unrelated keys, never
         // correctness regressions.
         var lockKey = string.Create(
@@ -723,7 +723,7 @@ internal sealed class PostgresFieldCollectionSyncStore : IFieldCollectionSyncSto
     {
         // Composite key uses a colon separator between layer_id and feature_id so
         // that "<n>" + "<m...>" cannot alias a different "<nm>" + "<...>" pair.
-        // hashtext collisions remain possible — they only cause unnecessary
+        // hashtext collisions remain possible â€” they only cause unnecessary
         // serialization between unrelated features, never correctness regressions.
         var lockKey = string.Create(
             CultureInfo.InvariantCulture,

--- a/src/Honua.Postgres/Features/Observability/PostgresInvestigationStore.cs
+++ b/src/Honua.Postgres/Features/Observability/PostgresInvestigationStore.cs
@@ -255,7 +255,7 @@ internal sealed class PostgresInvestigationStore : IInvestigationStore
 
         await TouchAsync(connection, transaction, investigationId, createdAt, cancellationToken).ConfigureAwait(false);
         var record = await LoadAsync(connection, transaction, investigationId, cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return record;
     }
 
@@ -295,7 +295,7 @@ internal sealed class PostgresInvestigationStore : IInvestigationStore
 
         await TouchAsync(connection, transaction, investigationId, updatedAt, cancellationToken).ConfigureAwait(false);
         var record = await LoadAsync(connection, transaction, investigationId, cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return record;
     }
 
@@ -337,7 +337,7 @@ internal sealed class PostgresInvestigationStore : IInvestigationStore
 
         await TouchAsync(connection, transaction, investigationId, createdAt, cancellationToken).ConfigureAwait(false);
         var record = await LoadAsync(connection, transaction, investigationId, cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return record;
     }
 
@@ -377,7 +377,7 @@ internal sealed class PostgresInvestigationStore : IInvestigationStore
 
         await TouchAsync(connection, transaction, investigationId, updatedAt, cancellationToken).ConfigureAwait(false);
         var record = await LoadAsync(connection, transaction, investigationId, cancellationToken).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return record;
     }
 

--- a/src/Honua.Postgres/Features/Publishing/PostgresContentPublicationStore.cs
+++ b/src/Honua.Postgres/Features/Publishing/PostgresContentPublicationStore.cs
@@ -9,6 +9,7 @@ using Honua.Core.Features.Publishing.Content.Domain;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Postgres.Features.Publishing;
 
 /// <summary>
@@ -178,7 +179,7 @@ internal sealed class PostgresContentPublicationStore : IContentPublicationStore
             }
 
             await InsertEventAsync(connection, transaction, auditEvent, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
         {
@@ -214,7 +215,7 @@ internal sealed class PostgresContentPublicationStore : IContentPublicationStore
             }
 
             await InsertEventAsync(connection, transaction, auditEvent, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (ContentPublicationConflictException)
         {

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterImportService.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterImportService.cs
@@ -213,7 +213,7 @@ internal sealed class PostgresRasterImportService : IRasterImportService
                         connection, transaction, rasterId, srid, warnings, cancellationToken).ConfigureAwait(false);
                 }
 
-                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
                 stopwatch.Stop();
                 var completedAt = DateTimeOffset.UtcNow;
@@ -254,7 +254,7 @@ internal sealed class PostgresRasterImportService : IRasterImportService
         catch (Exception ex) when (ex is ArgumentException or InvalidDataException
             or NotSupportedException or FileNotFoundException)
         {
-            // Validation / user-input errors — return a failure result so the endpoint can map to 400.
+            // Validation / user-input errors â€” return a failure result so the endpoint can map to 400.
             stopwatch.Stop();
             PostgresRasterImportLog.ImportFailed(_logger, ex, request.LayerId, request.FileName);
 
@@ -268,7 +268,7 @@ internal sealed class PostgresRasterImportService : IRasterImportService
         }
         catch (Exception ex)
         {
-            // Infrastructure / unexpected errors — log, update progress, and rethrow so the
+            // Infrastructure / unexpected errors â€” log, update progress, and rethrow so the
             // endpoint returns 500 with a generic message (no internal details leaked).
             stopwatch.Stop();
             PostgresRasterImportLog.ImportFailed(_logger, ex, request.LayerId, request.FileName);
@@ -304,7 +304,7 @@ internal sealed class PostgresRasterImportService : IRasterImportService
 
         // World-file formats always require a world file for the geotransform.
         // An explicit SRID is supplemental (overrides .prj detection) but cannot
-        // replace the world file — without it pixels map 1:1 to CRS units which is
+        // replace the world file â€” without it pixels map 1:1 to CRS units which is
         // almost certainly wrong.
         if (request.Format is SupportedRasterFormat.PngWorldFile or SupportedRasterFormat.JpegWorldFile)
         {
@@ -316,7 +316,7 @@ internal sealed class PostgresRasterImportService : IRasterImportService
             }
         }
 
-        // COG is a valid TIFF — same import path as GeoTIFF.
+        // COG is a valid TIFF â€” same import path as GeoTIFF.
         // PostGIS ST_FromGDALRaster handles COG files correctly (reads base resolution).
         // COG internal overviews are not preserved as separate entities in PostGIS;
         // tile pre-generation at configured zoom levels provides the overview mechanism.
@@ -695,7 +695,7 @@ internal sealed class PostgresRasterImportService : IRasterImportService
             // World files store the CENTER of the upper-left pixel, but the
             // PostGIS 6-parameter overload maps directly to the GDAL
             // geotransform which expects the CORNER (upper-left) of the
-            // upper-left pixel.  Convert center → corner before the call.
+            // upper-left pixel.  Convert center â†’ corner before the call.
             // Behavior reference: GDAL GDALReadWorldFile (gdalworldfile.cpp)
             var cornerX = upperLeftX - scaleX / 2.0 - skewX / 2.0;
             var cornerY = upperLeftY - skewY / 2.0 - scaleY / 2.0;
@@ -812,7 +812,7 @@ internal sealed class PostgresRasterImportService : IRasterImportService
                 // Zoom 0 has exactly one tile (0,0) covering the entire world.
                 // Handle separately because the general formula uses (1 << (zoom-1))
                 // which is undefined for negative shift counts in PostgreSQL.
-                // Build a 256×256 reference raster aligned to the z=0 tile envelope so the
+                // Build a 256Ã—256 reference raster aligned to the z=0 tile envelope so the
                 // seeded tile covers exactly the world bbox (not just the raster's own extent
                 // stretched to fill the tile, which misregisters partial-world datasets).
                 command.CommandText = $"""
@@ -845,9 +845,9 @@ internal sealed class PostgresRasterImportService : IRasterImportService
             {
                 // Generate tiles for this zoom level using ST_TileEnvelope.
                 // Compute which tiles intersect the raster extent, then resample each onto a
-                // 256×256 reference raster aligned exactly to ST_TileEnvelope(z,x,y) in
+                // 256Ã—256 reference raster aligned exactly to ST_TileEnvelope(z,x,y) in
                 // EPSG:3857. Uncovered pixels become nodata rather than being stretched to fill
-                // the frame — fixing the spatial misregistration the previous ST_Clip+ST_Resize
+                // the frame â€” fixing the spatial misregistration the previous ST_Clip+ST_Resize
                 // approach produced for edge tiles and non-3857 source rasters.
                 command.CommandText = $"""
                     INSERT INTO {_rasterTilesTable} (raster_data_id, zoom_level, tile_x, tile_y, tile_data, content_type)

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -40,8 +40,8 @@ internal sealed class PostgresRasterStore : IRasterStore
     // A single statistics backfill runs ST_SummaryStats across every pixel of a raster (or
     // every raster in a mosaic) and can exceed a minute on county-scale imagery. The compute
     // is serialized behind a transaction-scoped advisory lock (single-flight), so it is given
-    // a dedicated, generous timeout — independent of the ~30s request-path command/statement
-    // timeout default — otherwise the first cold read on a large raster times out and the
+    // a dedicated, generous timeout â€” independent of the ~30s request-path command/statement
+    // timeout default â€” otherwise the first cold read on a large raster times out and the
     // statistics never persist, retrying forever instead of self-healing (#1649).
     private const int StatisticsComputeTimeoutSeconds = 300;
 
@@ -659,7 +659,7 @@ internal sealed class PostgresRasterStore : IRasterStore
 
     /// <summary>
     /// Wraps the source <paramref name="rasterToken"/> so a low-zoom tile reads a
-    /// resolution-reduced grid (metres/pixel ≈ the requested tile's ground resolution)
+    /// resolution-reduced grid (metres/pixel â‰ˆ the requested tile's ground resolution)
     /// instead of resampling the full-resolution raster. Returns the bare token unchanged
     /// at native-or-finer zoom (<paramref name="level"/> &gt;= <see cref="OverviewMaxZoom"/>),
     /// keeping the substitution a single-token no-op on the high-zoom path.
@@ -669,7 +669,7 @@ internal sealed class PostgresRasterStore : IRasterStore
     /// SRID-agnostic: the outer <c>ST_Transform(..., 3857)</c> in the tile query becomes an
     /// identity transform on the already-reprojected grid. <c>GREATEST</c>/<c>LEAST</c> guards
     /// clamp the target pixel size against the source's own 3857 resolution so the rescale can
-    /// only ever coarsen — never upsample — making it a per-source no-op when the source is
+    /// only ever coarsen â€” never upsample â€” making it a per-source no-op when the source is
     /// already coarser than the tile. Residual sub-pixel drift from <c>ST_Rescale</c> keeping
     /// the source origin is corrected by the subsequent envelope-aligned <c>ST_Resample</c>.
     /// NearestNeighbor matches the tile path's existing (default) resampling/nodata semantics.
@@ -929,7 +929,7 @@ internal sealed class PostgresRasterStore : IRasterStore
 
     /// <summary>
     /// Computes per-band statistics over the rendered (renderingRule Clip -> stretch -> colormap)
-    /// single raster, with no AOI geometry. Always computed fresh — the persisted statistics
+    /// single raster, with no AOI geometry. Always computed fresh â€” the persisted statistics
     /// describe the raw source pixels.
     /// </summary>
     private async Task<RasterStatistics[]> GetRenderedStatisticsAsync(
@@ -1415,7 +1415,7 @@ internal sealed class PostgresRasterStore : IRasterStore
         }
 
         // Apply band arithmetic (renderingRule BandArithmetic) on the merged mosaic, collapsing
-        // two bands into a single analytic band (e.g. NDVI) before the stretch — previously the
+        // two bands into a single analytic band (e.g. NDVI) before the stretch â€” previously the
         // mosaic path silently ignored band-math renderingRules (#1803).
         if (query.BandArithmetic is { } mosaicBandArithmetic)
         {
@@ -1906,10 +1906,10 @@ internal sealed class PostgresRasterStore : IRasterStore
 
         await using var dynCommand = connection.CreateCommand();
 
-        // Build a 256×256 reference raster exactly aligned to the WebMercatorQuad tile
+        // Build a 256Ã—256 reference raster exactly aligned to the WebMercatorQuad tile
         // envelope (EPSG:3857). ST_Resample reprojects the source raster onto that grid so
         // the output PNG covers exactly ST_TileEnvelope(z,x,y) with nodata for uncovered
-        // pixels — correcting both the projection and the spatial registration that the
+        // pixels â€” correcting both the projection and the spatial registration that the
         // previous ST_Clip+ST_Resize approach got wrong (it preserved the clipped source
         // extent rather than the tile envelope, stretching edge tiles and ignoring CRS).
         const string tileBoundsCte = """
@@ -1932,7 +1932,7 @@ internal sealed class PostgresRasterStore : IRasterStore
         if (overviewId is { } persistedOverviewId)
         {
             // The persisted overview is already EPSG:3857, so ST_Transform is the identity and the
-            // intersect uses 3857 directly. This reads the reduced pyramid level — no full-res scan.
+            // intersect uses 3857 directly. This reads the reduced pyramid level â€” no full-res scan.
             dynCommand.CommandText = $"""
                 {tileBoundsCte}
                 SELECT ST_AsGDALRaster(
@@ -2030,7 +2030,7 @@ internal sealed class PostgresRasterStore : IRasterStore
         var overviewSource = BuildOverviewSourceExpression(level);
 
         await using var command = connection.CreateCommand();
-        // Same tile-envelope-aligned approach as GetImageTileAsync: build a 256×256
+        // Same tile-envelope-aligned approach as GetImageTileAsync: build a 256Ã—256
         // reference raster in EPSG:3857 and use ST_Resample so the mosaic output covers
         // exactly ST_TileEnvelope(z,x,y) with nodata for uncovered pixels.
         command.CommandText = $"""
@@ -2191,7 +2191,7 @@ internal sealed class PostgresRasterStore : IRasterStore
         var persisted = await ReadPersistedRasterStatisticsAsync(connection, transaction, rasterId, cancellationToken).ConfigureAwait(false);
         if (persisted.Count > 0)
         {
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             return persisted;
         }
 
@@ -2229,7 +2229,7 @@ internal sealed class PostgresRasterStore : IRasterStore
             }
 
             var stats = await ReadPersistedRasterStatisticsAsync(connection, transaction, rasterId, cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             PostgresRasterLog.RasterStatisticsBackfilled(_logger, layerId, rasterId, stats.Count);
             return stats;
         }
@@ -2258,7 +2258,7 @@ internal sealed class PostgresRasterStore : IRasterStore
         CancellationToken cancellationToken)
     {
         // Self-provision the snapshot table so already-registered datasets backfill without a
-        // manual migration (same pattern as PostgresMetadataV2GraphStore.EnsureSchemaAsync —
+        // manual migration (same pattern as PostgresMetadataV2GraphStore.EnsureSchemaAsync â€”
         // a no-op once 003_CreateRasterLayerStatistics.sql has been applied). Best-effort: a
         // read-only connection simply keeps the legacy compute path below.
         await TryEnsureLayerStatisticsTableAsync(connection, cancellationToken).ConfigureAwait(false);
@@ -2285,14 +2285,14 @@ internal sealed class PostgresRasterStore : IRasterStore
 
         if (persisted.Count > 0)
         {
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             return persisted;
         }
 
         var computed = await ComputeMosaicStatisticsAsync(connection, transaction, layerId, rasterIds, mergeStrategy, cancellationToken).ConfigureAwait(false);
         if (computed.Count == 0)
         {
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             return computed;
         }
 
@@ -2335,7 +2335,7 @@ internal sealed class PostgresRasterStore : IRasterStore
                 await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             PostgresRasterLog.LayerStatisticsBackfilled(_logger, layerId, rasterIds.Length, strategyKey, computed.Count);
         }
         catch (PostgresException ex)

--- a/src/Honua.Postgres/Features/SensorThings/PostgresObservationStore.cs
+++ b/src/Honua.Postgres/Features/SensorThings/PostgresObservationStore.cs
@@ -391,7 +391,7 @@ VALUES (@id, @datastream_id, @phenomenon_time, @result_time, @result, @feature_o
             });
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         return results;
     }
 
@@ -435,7 +435,7 @@ VALUES (@id, @name, @description, @observation_type, @unit_name, @unit_symbol, @
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
         return new SensorThingsDatastream
         {

--- a/src/Honua.Postgres/Features/Share/PostgresShareExportStore.cs
+++ b/src/Honua.Postgres/Features/Share/PostgresShareExportStore.cs
@@ -261,7 +261,7 @@ internal sealed class PostgresShareExportStore : IShareExportStore
                     await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 }
 
-                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
                 return run;
             }
             catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)

--- a/src/Honua.Postgres/Features/Studio/PostgresStudioPackageStore.cs
+++ b/src/Honua.Postgres/Features/Studio/PostgresStudioPackageStore.cs
@@ -96,7 +96,7 @@ internal sealed class PostgresStudioPackageStore : IStudioPackageStore
             command.Parameters.AddWithValue("@updated_at", draft.UpdatedAt);
             await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
             return draft;
         }
@@ -229,7 +229,7 @@ internal sealed class PostgresStudioPackageStore : IStudioPackageStore
                 updated.UpdatedAt,
                 cancellationToken).ConfigureAwait(false);
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
             return updated;
         }
@@ -370,7 +370,7 @@ internal sealed class PostgresStudioPackageStore : IStudioPackageStore
                 updatePublished: false,
                 cancellationToken).ConfigureAwait(false);
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
             return (await GetVersionAsync(draft.ItemId, versionId, cancellationToken).ConfigureAwait(false))!;
         }
@@ -495,7 +495,7 @@ internal sealed class PostgresStudioPackageStore : IStudioPackageStore
                     cancellationToken).ConfigureAwait(false);
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
             return request;
         }
@@ -585,7 +585,7 @@ internal sealed class PostgresStudioPackageStore : IStudioPackageStore
                 await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
             committed = true;
             return request;
         }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/AttachmentEndpoints.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Attachments.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
@@ -285,7 +286,7 @@ internal static partial class AttachmentEndpoints
     /// </summary>
     private static async Task HandleAddAttachment(HttpContext context)
     {
-        var resource = await TryValidateLayerAccessAsync(context, AccessScope.Write);
+        var resource = await TryValidateLayerAccessAsync(context, AccessScope.Write, AuthorizationOperation.Insert);
         if (resource == null)
             return;
 
@@ -374,7 +375,7 @@ internal static partial class AttachmentEndpoints
     /// </summary>
     private static async Task HandleUpdateAttachment(HttpContext context)
     {
-        var resource = await TryValidateLayerAccessAsync(context, AccessScope.Write);
+        var resource = await TryValidateLayerAccessAsync(context, AccessScope.Write, AuthorizationOperation.Update);
         if (resource == null)
             return;
 
@@ -458,7 +459,7 @@ internal static partial class AttachmentEndpoints
     /// </summary>
     private static async Task HandleDeleteAttachments(HttpContext context)
     {
-        var resource = await TryValidateLayerAccessAsync(context, AccessScope.Write);
+        var resource = await TryValidateLayerAccessAsync(context, AccessScope.Write, AuthorizationOperation.Delete);
         if (resource == null)
             return;
 
@@ -671,7 +672,8 @@ internal static partial class AttachmentEndpoints
 
     private static async Task<AttachmentAccessContext?> TryValidateLayerAccessAsync(
         HttpContext context,
-        AccessScope scope = AccessScope.Read)
+        AccessScope scope = AccessScope.Read,
+        AuthorizationOperation? writeOperation = null)
     {
         var routeValidator = context.RequestServices.GetRequiredService<IRouteParameterValidator>();
         var serviceResult = routeValidator.ValidateServiceId(context);
@@ -728,11 +730,22 @@ internal static partial class AttachmentEndpoints
 
         if (scope == AccessScope.Write)
         {
-            var rbacError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
-                context,
-                resource,
-                service,
-                context.RequestAborted);
+            // Per-operation authorization (BH3-001/BH3-014): an attachment add/update/delete
+            // authorizes as Insert/Update/Delete respectively, so a grant for one attachment
+            // mutation cannot authorize another. Absent a specific operation (defensive default),
+            // the coarse any-write gate is used.
+            var rbacError = writeOperation is { } op
+                ? await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                    context,
+                    resource,
+                    service,
+                    op,
+                    context.RequestAborted)
+                : await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                    context,
+                    resource,
+                    service,
+                    context.RequestAborted);
             if (rbacError != null)
             {
                 await rbacError.ExecuteAsync(context);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -170,23 +170,41 @@ internal sealed class FeatureServerEditsHandler(
                     contentType: "application/json");
             }
 
-            // Per-edit-type authorization checks (BH-002): the pre-body gate uses Update as the
-            // coarsest write check; after the body is read, gate each present edit type on its
-            // specific operation so a delete-only payload requires Delete, not just Update.
+            // Per-edit-type authorization checks (BH-002 / BH3-001 / BH3-014): the pre-body gate
+            // uses Update as the coarsest write check; after the body is read, each present edit
+            // type is gated on its specific operation so a delete-only payload requires Delete,
+            // an insert-only payload requires Insert, and an updates-only payload requires Update.
+            // ALL THREE checks are required — omitting any one allows a principal that holds only
+            // a different operation's grant to bypass the missing check entirely.
+            //
+            // RequireResourceDataEditorAsync is called here with a specific requiredOperation so
+            // that the RBAC data-editor gate bypass is narrowed to that exact operation: a caller
+            // with only an Insert grant cannot bypass the gate for an Update-only payload
+            // (BH3-001) and a Delete-only grantee cannot do the same (BH3-014).
             if (request.Adds?.Length > 0)
             {
-                var insertError = await AccessPolicyHelpers.RequireResourceAccessAsync(
-                    httpContext, resource, AuthorizationOperation.Insert, service, cancellationToken).ConfigureAwait(false);
+                var insertError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                    httpContext, resource, service, AuthorizationOperation.Insert, cancellationToken).ConfigureAwait(false);
                 if (insertError != null)
                 {
                     return insertError;
                 }
             }
 
+            if (request.Updates?.Length > 0)
+            {
+                var updateError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                    httpContext, resource, service, AuthorizationOperation.Update, cancellationToken).ConfigureAwait(false);
+                if (updateError != null)
+                {
+                    return updateError;
+                }
+            }
+
             if (request.Deletes?.Length > 0)
             {
-                var deleteError = await AccessPolicyHelpers.RequireResourceAccessAsync(
-                    httpContext, resource, AuthorizationOperation.Delete, service, cancellationToken).ConfigureAwait(false);
+                var deleteError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                    httpContext, resource, service, AuthorizationOperation.Delete, cancellationToken).ConfigureAwait(false);
                 if (deleteError != null)
                 {
                     return deleteError;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
@@ -73,7 +73,8 @@ internal static partial class FeatureServerEndpoints
         [FromServices] IOptions<LimitsOptions> limitsOptions)
     {
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
-        var authorizationError = await RequireLayerWriteAccessBeforeBodyAsync(serviceId, layerId, context, cancellationToken);
+        // addFeatures authorizes as Insert (BH3-001/BH3-014).
+        var authorizationError = await RequireLayerWriteAccessBeforeBodyAsync(serviceId, layerId, context, cancellationToken, AuthorizationOperation.Insert);
         if (authorizationError != null)
         {
             return authorizationError;
@@ -125,7 +126,8 @@ internal static partial class FeatureServerEndpoints
         [FromServices] IOptions<LimitsOptions> limitsOptions)
     {
         var cancellationToken = GetTimeoutAwareCancellationToken(context);
-        var authorizationError = await RequireLayerWriteAccessBeforeBodyAsync(serviceId, layerId, context, cancellationToken);
+        // updateFeatures authorizes as Update (BH3-001/BH3-014).
+        var authorizationError = await RequireLayerWriteAccessBeforeBodyAsync(serviceId, layerId, context, cancellationToken, AuthorizationOperation.Update);
         if (authorizationError != null)
         {
             return authorizationError;
@@ -341,10 +343,12 @@ internal static partial class FeatureServerEndpoints
             return (null, accessError);
         }
 
+        // Per-operation authorization (BH3-001/BH3-014): resolving delete ids is part of a delete.
         var rbacError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
             context,
             resource,
             service,
+            AuthorizationOperation.Delete,
             cancellationToken);
         if (rbacError != null)
         {
@@ -878,7 +882,7 @@ internal static partial class FeatureServerEndpoints
         int layerId,
         HttpContext context,
         CancellationToken cancellationToken,
-        AuthorizationOperation operation = AuthorizationOperation.Update)
+        AuthorizationOperation? operation = null)
     {
         var resourceValidator = context.RequestServices.GetRequiredService<IResourceValidator>();
         var validationResult = await FeatureServerResourceValidationHelpers.ValidateServiceLayerV2Async(
@@ -895,18 +899,34 @@ internal static partial class FeatureServerEndpoints
 
         var service = validationResult.Service!;
         var resource = validationResult.Resource!;
+        // A specific operation narrows the check for the single-verb add/update/delete endpoints.
+        // A null operation (applyEdits) is a MIXED payload: keep the pre-body gate coarse
+        // (representative write op for the resource-access seam, any-write for the data-editor
+        // gate) because the real per-edit-type enforcement runs in FeatureServerEditsHandler on
+        // the parsed body (BH3-001/BH3-014). Narrowing here would wrongly reject an insert-only
+        // grantee that submits an adds-only applyEdits payload.
         var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
-            context, resource, operation, service, cancellationToken).ConfigureAwait(false);
+            context, resource, operation ?? AuthorizationOperation.Update, service, cancellationToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return accessError;
         }
 
-        return await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
-            context,
-            resource,
-            service,
-            cancellationToken);
+        // Per-operation authorization (BH3-001/BH3-014): thread the specific operation into the
+        // data-editor gate for the single-verb endpoints so the pre-body check cannot be satisfied
+        // by a grant for a different operation. applyEdits (null) stays coarse here.
+        return operation is { } op
+            ? await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                resource,
+                service,
+                op,
+                cancellationToken)
+            : await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context,
+                resource,
+                service,
+                cancellationToken);
     }
 
     private static async Task<IResult?> RequireServiceWriteAccessBeforeBodyAsync(
@@ -934,6 +954,10 @@ internal static partial class FeatureServerEndpoints
             return accessError;
         }
 
+        // Coarse pre-body gate for the MIXED service-level applyEdits (multi-layer, mixed
+        // insert/update/delete). A single per-operation distinction does not apply at the service
+        // scope; the real per-edit-type enforcement runs per layer in FeatureServerEditsHandler on
+        // the parsed body (BH3-001/BH3-014).
         return await ServiceDataEditorAuthorization.RequireServiceDataEditorAsync(
             context,
             service,

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Maintenance.cs
@@ -94,10 +94,12 @@ internal static partial class FeatureServerEndpoints
             return accessError;
         }
 
+        // Per-operation authorization (BH3-001/BH3-014): append inserts features.
         var rbacError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
             context,
             resource,
             service,
+            AuthorizationOperation.Insert,
             cancellationToken);
         if (rbacError != null)
         {
@@ -164,10 +166,12 @@ internal static partial class FeatureServerEndpoints
             return accessError;
         }
 
+        // Per-operation authorization (BH3-001/BH3-014): append inserts features.
         var rbacError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
             context,
             resource,
             service,
+            AuthorizationOperation.Insert,
             cancellationToken);
         if (rbacError != null)
         {
@@ -251,10 +255,12 @@ internal static partial class FeatureServerEndpoints
             return accessError;
         }
 
+        // Per-operation authorization (BH3-001/BH3-014): calculate is a bulk field update.
         var rbacError = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
             context,
             resource,
             service,
+            AuthorizationOperation.Update,
             cancellationToken);
         if (rbacError != null)
         {

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -1871,6 +1871,12 @@ internal static partial class FeatureServerEndpoints
         UploadBaseGeneration = record.UploadBaseGeneration
     };
 
+    // Per-operation authorization (BH3-001/BH3-014) does NOT cleanly apply to replica write
+    // access: this gate covers replica lifecycle operations (create / unregister — which are not
+    // feature mutations) and replica synchronize (which carries a mix of insert/update/delete
+    // edits governed by the replica registration and applied through the shared edit pipeline,
+    // and whose edits are not yet parsed at this point). Authorization here is therefore the
+    // coarse replica-scoped write capability rather than a single feature operation.
     private static async Task<IResult?> RequireReplicaWriteAccessV2Async(
         HttpContext context,
         MetadataV2Service service,
@@ -1893,6 +1899,10 @@ internal static partial class FeatureServerEndpoints
         return null;
     }
 
+    // Pre-body OR-gate for replica operations: mirrors the FeatureServer pre-body mutating-access
+    // gate. Coarse by design (it authorizes when ANY service resource is writable before the body
+    // is read); the per-operation narrowing is applied by the primary single-verb edit surfaces,
+    // not this replica capability check.
     private static async Task<IResult?> RequireAnyServiceResourceWriteAccessBeforeBodyAsync(
         HttpContext context,
         MetadataV2Service service,

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionAccessPolicy.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionAccessPolicy.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Protocols.GeoServices.VersionManagementServer;
+
+/// <summary>
+/// Access-control helpers for the VersionManagementServer branch-version surface (BH3-002/003/004).
+/// Centralizes the two version authorization policies so every VMS endpoint applies them
+/// consistently and the logic is unit-testable without a running server.
+/// </summary>
+internal static class VersionAccessPolicy
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the caller identified by <paramref name="callerName"/>
+    /// is permitted to see a version in list/info responses.
+    /// </summary>
+    /// <remarks>
+    /// Visibility rules (mirror Esri branch-versioning spec):
+    /// <list type="bullet">
+    ///   <item>Public versions are visible to any query-access caller.</item>
+    ///   <item>Protected versions are visible to any query-access caller (edit is owner-only).</item>
+    ///   <item>Private versions are visible only to their owner and service administrators.</item>
+    /// </list>
+    /// Service write-access callers (lifecycle operations) also satisfy this check because
+    /// write implies at least query access.
+    /// </remarks>
+    /// <param name="version">The version record to evaluate.</param>
+    /// <param name="callerName">
+    /// The authenticated principal's name (from <c>ClaimTypes.Name</c>), or
+    /// <see langword="null"/> for anonymous callers.
+    /// </param>
+    /// <param name="isAdmin">
+    /// Whether the caller holds the administrator role. Admins always see every version.
+    /// </param>
+    /// <returns><see langword="true"/> when the version is visible to the caller.</returns>
+    internal static bool IsVersionVisible(GdbVersion version, string? callerName, bool isAdmin)
+        => isAdmin
+           || version.Access != VersionAccess.Private
+           || string.Equals(version.Owner, callerName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the caller is authorized to perform lifecycle
+    /// operations (delete, alter, reconcile, post, conflict inspection/resolution,
+    /// start/stop editing/reading) on the version.
+    /// </summary>
+    /// <remarks>
+    /// Only the version owner and service administrators may perform lifecycle operations,
+    /// regardless of the version's access level. This matches Esri's VMS behavior where
+    /// portal admins and the version owner are the only principals allowed to mutate or
+    /// reconcile/post a version they did not create.
+    /// </remarks>
+    /// <param name="version">The version record to evaluate.</param>
+    /// <param name="callerName">The authenticated principal's name, or <see langword="null"/>.</param>
+    /// <param name="isAdmin">Whether the caller holds the administrator role.</param>
+    /// <returns><see langword="true"/> when the caller may manage the version.</returns>
+    internal static bool CanManageVersion(GdbVersion version, string? callerName, bool isAdmin)
+        => isAdmin
+           || string.Equals(version.Owner, callerName, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
@@ -201,9 +201,18 @@ public static class VersionManagementServerEndpoints
         }
 
         var versions = await versionManager.ListAsync(cancellationToken).ConfigureAwait(false);
+
+        // BH3-002: filter the version set before projecting. Private versions are only
+        // visible to their owner and service administrators; Public and Protected versions
+        // are visible to any query-access caller.
+        var callerName = context.User?.Identity?.Name;
+        var isAdmin = ServiceDataEditorAuthorization.IsAdminPrincipal(context);
         var response = new VersionListResponse
         {
-            Versions = versions.Select(ToVersionInfo).ToArray(),
+            Versions = versions
+                .Where(v => VersionAccessPolicy.IsVersionVisible(v, callerName, isAdmin))
+                .Select(ToVersionInfo)
+                .ToArray(),
         };
 
         return Results.Json(response, VersionManagementJsonContext.Default.VersionListResponse,
@@ -240,6 +249,15 @@ public static class VersionManagementServerEndpoints
         var versions = await versionManager.ListAsync(cancellationToken).ConfigureAwait(false);
         var match = versions.FirstOrDefault(v => v.VersionId == versionId);
         if (match.VersionId != versionId)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, $"Version '{versionGuid}' was not found.");
+        }
+
+        // BH3-002: A Private version is only visible to its owner and service admins.
+        // Return 404 (not 403) so a non-owner cannot confirm the version's existence.
+        var callerName = context.User?.Identity?.Name;
+        var isAdmin = ServiceDataEditorAuthorization.IsAdminPrincipal(context);
+        if (!VersionAccessPolicy.IsVersionVisible(match, callerName, isAdmin))
         {
             return StandardErrorHelpers.CreateNotFound(context, $"Version '{versionGuid}' was not found.");
         }
@@ -491,6 +509,27 @@ public static class VersionManagementServerEndpoints
         if (!Guid.TryParse(versionGuid, out var versionId))
         {
             return StandardErrorHelpers.CreateBadRequest(context, "versionGuid is not a valid GUID.");
+        }
+
+        // BH3-003: conflict records contain full before/after attribute and geometry images.
+        // Load the version record and enforce ownership before exposing conflict data.
+        // Private versions gate on owner-or-admin; Public/Protected conflict data requires
+        // only query access (already satisfied by ValidateServiceAsync above).
+        var allVersions = await versionManager.ListAsync(cancellationToken).ConfigureAwait(false);
+        var conflictVersion = allVersions.FirstOrDefault(v => v.VersionId == versionId);
+        if (conflictVersion.VersionId != versionId)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, $"Version '{versionGuid}' was not found.");
+        }
+
+        if (conflictVersion.Access == VersionAccess.Private)
+        {
+            var callerName = context.User?.Identity?.Name;
+            var isAdmin = ServiceDataEditorAuthorization.IsAdminPrincipal(context);
+            if (!VersionAccessPolicy.CanManageVersion(conflictVersion, callerName, isAdmin))
+            {
+                return StandardErrorHelpers.CreateForbidden(context, AccessPolicyHelpers.AccessForbiddenMessage);
+            }
         }
 
         var conflicts = await versionManager.GetPendingConflictsAsync(versionId, cancellationToken).ConfigureAwait(false);
@@ -793,7 +832,47 @@ public static class VersionManagementServerEndpoints
             return (StandardErrorHelpers.CreateBadRequest(context, "versionGuid is not a valid GUID."), null, Guid.Empty);
         }
 
+        // BH3-004: lifecycle operations (delete, alter, reconcile, post, resolveConflicts,
+        // start/stop editing/reading) are restricted to the version owner and service admins,
+        // regardless of the version's access level. Load the version and enforce ownership here
+        // so every lifecycle handler gets the check for free via this shared entry point.
+        var ownershipGate = await RequireVersionOwnerOrAdminAsync(
+            context, versionManager, versionId, versionGuid, cancellationToken).ConfigureAwait(false);
+        if (ownershipGate is not null)
+        {
+            return (ownershipGate, null, Guid.Empty);
+        }
+
         return (null, values, versionId);
+    }
+
+    /// <summary>
+    /// Loads the version with <paramref name="versionId"/> and verifies that the caller is its
+    /// owner or holds the administrator role. Returns a non-null error result when denied,
+    /// <see langword="null"/> when authorized.
+    /// </summary>
+    private static async Task<IResult?> RequireVersionOwnerOrAdminAsync(
+        HttpContext context,
+        IVersionManager versionManager,
+        Guid versionId,
+        string versionGuidString,
+        CancellationToken cancellationToken)
+    {
+        var versions = await versionManager.ListAsync(cancellationToken).ConfigureAwait(false);
+        var version = versions.FirstOrDefault(v => v.VersionId == versionId);
+        if (version.VersionId != versionId)
+        {
+            return StandardErrorHelpers.CreateNotFound(context, $"Version '{versionGuidString}' was not found.");
+        }
+
+        var callerName = context.User?.Identity?.Name;
+        var isAdmin = ServiceDataEditorAuthorization.IsAdminPrincipal(context);
+        if (!VersionAccessPolicy.CanManageVersion(version, callerName, isAdmin))
+        {
+            return StandardErrorHelpers.CreateForbidden(context, AccessPolicyHelpers.AccessForbiddenMessage);
+        }
+
+        return null;
     }
 
     private static string ResolveOwner(HttpContext context)

--- a/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Shared.Models;
@@ -253,7 +254,7 @@ internal sealed class ODataCrudHandler(
 
         if (layerId.HasValue)
         {
-            var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId.Value, effectiveToken);
+            var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId.Value, AuthorizationOperation.Insert, effectiveToken);
             if (!layerValidation.IsValid)
             {
                 return layerValidation.ErrorResult!;
@@ -317,7 +318,7 @@ internal sealed class ODataCrudHandler(
                 "LayerId is required when creating a feature.");
         }
 
-        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, resolvedLayerId.Value, effectiveToken);
+        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, resolvedLayerId.Value, AuthorizationOperation.Insert, effectiveToken);
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
@@ -424,7 +425,7 @@ internal sealed class ODataCrudHandler(
             return queryValidation;
         }
 
-        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, effectiveToken);
+        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, AuthorizationOperation.Update, effectiveToken);
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
@@ -465,7 +466,8 @@ internal sealed class ODataCrudHandler(
             return queryValidation;
         }
 
-        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, effectiveToken);
+        // Replace modifies an existing feature, so it authorizes as an Update (BH3-001/BH3-014).
+        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, AuthorizationOperation.Update, effectiveToken);
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
@@ -530,7 +532,7 @@ internal sealed class ODataCrudHandler(
             return ODataUtilityService.CreateODataError(context, "InvalidRequest", "ObjectId in payload does not match route.");
         }
 
-        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, effectiveToken);
+        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, AuthorizationOperation.Update, effectiveToken);
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
@@ -654,7 +656,7 @@ internal sealed class ODataCrudHandler(
             return queryValidation;
         }
 
-        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, effectiveToken);
+        var layerValidation = await ValidateODataLayerWriteAccessAsync(context, layerId, AuthorizationOperation.Delete, effectiveToken);
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
@@ -848,15 +850,20 @@ internal sealed class ODataCrudHandler(
             requiredProtocol: ODataProtocolConstants.ProtocolName,
             cancellationToken: cancellationToken);
 
+    // Per-operation OData write authorization (BH3-001/BH3-014): each CRUD verb passes its
+    // canonical operation (POST=Insert, PATCH/PUT/Replace=Update, DELETE=Delete) so an
+    // insert-only grantee cannot Update or Delete and vice-versa.
     private static Task<LayerValidationHelpers.MetadataV2ValidationResult> ValidateODataLayerWriteAccessAsync(
         HttpContext context,
         int layerId,
+        AuthorizationOperation operation,
         CancellationToken cancellationToken)
         => LayerValidationHelpers.ValidateLayerWriteAccessV2Async(
             context,
             layerId,
             LayerValidationHelpers.ValidationProtocol.OData,
             ODataProtocolConstants.ProtocolName,
+            operation,
             cancellationToken);
 
     private static int ResolveLayerSrid(LayerValidationHelpers.MetadataV2ValidationResult layerValidation)

--- a/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Dispatch.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Dispatch.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Text.Json;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Security.Abstractions;
@@ -374,10 +375,13 @@ internal sealed partial class ODataBatchHandler
 
         if (scope == AccessScope.Write)
         {
+            // Per-operation authorization (BH3-001/BH3-014): map the batch sub-request method to
+            // its canonical operation so an insert-only grantee cannot Update/Delete via $batch.
             var rbacResult = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
                 context,
                 validation.Resource,
                 validation.Service,
+                MapMethodToOperation(method),
                 cancellationToken).ConfigureAwait(false);
             if (rbacResult != null)
             {
@@ -452,6 +456,25 @@ internal sealed partial class ODataBatchHandler
                 method.Equals("PATCH", StringComparison.OrdinalIgnoreCase) ||
                 method.Equals("DELETE", StringComparison.OrdinalIgnoreCase) ||
                 method.Equals("PUT", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // Maps an OData $batch sub-request HTTP method to its canonical authorization operation
+    // (BH3-001/BH3-014): POST=Insert, PATCH/PUT=Update, DELETE=Delete. PUT (replace) modifies
+    // an existing feature and therefore authorizes as Update. Only mutation methods reach here.
+    private static AuthorizationOperation MapMethodToOperation(string? method)
+    {
+        if (method != null && method.Equals("POST", StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthorizationOperation.Insert;
+        }
+
+        if (method != null && method.Equals("DELETE", StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthorizationOperation.Delete;
+        }
+
+        // PATCH and PUT both modify an existing feature.
+        return AuthorizationOperation.Update;
     }
 
     private static ODataParsedPath ParseUrl(string url)

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesCrudHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesCrudHandler.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using Honua.Core.Exceptions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -58,8 +59,9 @@ internal sealed partial class OgcFeaturesCrudHandler(
     {
         try
         {
+            // Per-operation authorization (BH3-001/BH3-014): a POST create authorizes as Insert.
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
-                context, collectionId, cancellationToken: cancellationToken);
+                context, collectionId, operation: AuthorizationOperation.Insert, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
             {
                 return layerValidation.ErrorResult!;
@@ -208,8 +210,9 @@ internal sealed partial class OgcFeaturesCrudHandler(
     {
         try
         {
+            // Per-operation authorization (BH3-001/BH3-014): a DELETE authorizes as Delete.
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
-                context, collectionId, cancellationToken: cancellationToken);
+                context, collectionId, operation: AuthorizationOperation.Delete, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
             {
                 return layerValidation.ErrorResult!;

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesTransactionHandler.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Honua.Core.Exceptions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -15,6 +16,7 @@ using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.Core.Features.Query;
 using Honua.Core.Features.Shared.Models;
+using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Helpers;
@@ -121,6 +123,18 @@ internal sealed partial class OgcFeaturesTransactionHandler(
             {
                 return StandardErrorHelpers.CreateBadRequest(context,
                     $"Batch request exceeds maximum of {maxBatchOperations} operations.");
+            }
+
+            // Per-operation authorization (BH3-001/BH3-014): the coarse write gate above authorizes
+            // any-write; a mixed batch must additionally require the caller to hold each specific
+            // operation present in the body. A CREATE item requires Insert, UPDATE requires Update,
+            // DELETE requires Delete — so an insert-only grantee cannot slip an update or delete
+            // through the batch surface. Each distinct kind is checked once.
+            var batchOperationError = await AuthorizeBatchOperationKindsAsync(
+                context, resource, layerValidation.Service, batchRequest, cancellationToken).ConfigureAwait(false);
+            if (batchOperationError is not null)
+            {
+                return batchOperationError;
             }
 
             var preparedBatch = await PrepareBatchOperationsAsync(
@@ -300,6 +314,52 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     }
 
     /// <summary>
+    /// Per-operation authorization for a mixed batch (BH3-001/BH3-014). Requires the caller to
+    /// hold the data-editor authorization for each distinct operation kind present in the batch
+    /// (CREATE=Insert, UPDATE=Update, DELETE=Delete). Returns the first denial error, or
+    /// <see langword="null"/> when every present operation kind is authorized. Unknown operation
+    /// types are ignored here — they are rejected later by the batch preparation validation.
+    /// </summary>
+    private static async Task<IResult?> AuthorizeBatchOperationKindsAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        BatchRequest batchRequest,
+        CancellationToken cancellationToken)
+    {
+        var seen = new HashSet<AuthorizationOperation>();
+        foreach (var item in batchRequest.Operations)
+        {
+            if (string.IsNullOrWhiteSpace(item.Type))
+            {
+                continue;
+            }
+
+            AuthorizationOperation? operation = item.Type.ToUpperInvariant() switch
+            {
+                "CREATE" => AuthorizationOperation.Insert,
+                "UPDATE" => AuthorizationOperation.Update,
+                "DELETE" => AuthorizationOperation.Delete,
+                _ => null,
+            };
+
+            if (operation is not { } op || !seen.Add(op))
+            {
+                continue;
+            }
+
+            var error = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+                context, resource, service, op, cancellationToken).ConfigureAwait(false);
+            if (error is not null)
+            {
+                return error;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Handles feature replacement with optimistic concurrency control.
     /// </summary>
     public async Task<IResult> HandleReplaceFeatureAsync(
@@ -311,8 +371,10 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
+            // Per-operation authorization (BH3-001/BH3-014): a PUT replace modifies an existing
+            // feature and therefore authorizes as Update.
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
-                context, collectionId, cancellationToken: cancellationToken);
+                context, collectionId, operation: AuthorizationOperation.Update, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
             {
                 return layerValidation.ErrorResult!;
@@ -585,8 +647,10 @@ internal sealed partial class OgcFeaturesTransactionHandler(
     {
         try
         {
+            // Per-operation authorization (BH3-001/BH3-014): a PATCH partial update authorizes
+            // as Update.
             var layerValidation = await LayerValidationHelpers.ValidateCollectionWriteAccessV2Async(
-                context, collectionId, cancellationToken: cancellationToken);
+                context, collectionId, operation: AuthorizationOperation.Update, cancellationToken: cancellationToken);
             if (!layerValidation.IsValid)
             {
                 return layerValidation.ErrorResult!;

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.StoredQueries.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.StoredQueries.cs
@@ -43,11 +43,42 @@ internal sealed partial class Wfs20Handler
     // Hard cap on managed stored queries to prevent unbounded memory growth.
     // WFS 2.0 CITE Manage-Stored-Queries conformance requires mutation operations to
     // succeed but does not mandate unlimited cardinality. Reject CreateStoredQuery once
-    // the process-wide count reaches this threshold and return OperationProcessingFailed.
+    // the per-service count reaches this threshold and return OperationProcessingFailed.
+    // BH3-009: the limit is now enforced per-service scope (tenant), not globally.
     private const int MaxManagedStoredQueryCount = 1000;
 
-    private static readonly ConcurrentDictionary<string, StoredQueryDefinition> ManagedStoredQueries =
+    // BH3-009: Stored queries are keyed by (serviceScope, queryId) to prevent cross-service
+    // information disclosure, sabotage, and DoS via global slot exhaustion.
+    // The outer key is the tenant scope resolved from the request context; queries created
+    // on Service A are never visible or operable from Service B.
+    private const string GlobalStoredQueryScope = "__global__";
+
+    private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, StoredQueryDefinition>> ManagedStoredQueriesByScope =
         new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves the service scope key for stored-query isolation. Returns the tenant id
+    /// when present, or <see cref="GlobalStoredQueryScope"/> for requests without a tenant
+    /// context (e.g. single-tenant admin deployments).
+    /// </summary>
+    private static string ResolveStoredQueryScope(HttpContext context)
+    {
+        var tenantId = TenantScopeHelpers.ResolveRequestTenantId(context);
+        return string.IsNullOrWhiteSpace(tenantId) ? GlobalStoredQueryScope : tenantId;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="ConcurrentDictionary{TKey, TValue}"/> of stored queries
+    /// scoped to the service (tenant) of the current request. Creates the per-scope bucket
+    /// on first access; subsequent calls for the same scope reuse the existing bucket.
+    /// </summary>
+    private static ConcurrentDictionary<string, StoredQueryDefinition> GetScopedStoredQueries(HttpContext context)
+    {
+        var scope = ResolveStoredQueryScope(context);
+        return ManagedStoredQueriesByScope.GetOrAdd(
+            scope,
+            static _ => new ConcurrentDictionary<string, StoredQueryDefinition>(StringComparer.OrdinalIgnoreCase));
+    }
 
     public async Task<IResult> HandleListStoredQueriesAsync(
         HttpContext context,
@@ -57,9 +88,10 @@ internal sealed partial class Wfs20Handler
         // default headers. The response is always application/xml.
 
         var descriptors = await GetPublishedFeatureTypesAsync(context, cancellationToken).ConfigureAwait(false);
+        var scopedQueries = GetScopedStoredQueries(context);
         var xml = BuildListStoredQueriesXml(
             descriptors,
-            ManagedStoredQueries.Values.OrderBy(query => query.Id, StringComparer.Ordinal).ToArray());
+            scopedQueries.Values.OrderBy(query => query.Id, StringComparer.Ordinal).ToArray());
         return Results.Content(xml, "application/xml", Encoding.UTF8);
     }
 
@@ -71,11 +103,12 @@ internal sealed partial class Wfs20Handler
     {
         // Same story — DescribeStoredQueries is XML-only.
 
+        var scopedQueries = GetScopedStoredQueries(context);
         var requestedIds = ParseQualifiedList(storedQueryIds);
         foreach (var requestedId in requestedIds)
         {
             if (!IsGetFeatureByIdStoredQuery(requestedId) &&
-                !ManagedStoredQueries.ContainsKey(requestedId))
+                !scopedQueries.ContainsKey(requestedId))
             {
                 return Wfs20ErrorResults.CreateBadRequest(
                     context,
@@ -87,10 +120,10 @@ internal sealed partial class Wfs20Handler
 
         var descriptors = await GetPublishedFeatureTypesAsync(context, cancellationToken).ConfigureAwait(false);
         var requestedDefinitions = requestedIds.Length == 0
-            ? ManagedStoredQueries.Values.OrderBy(query => query.Id, StringComparer.Ordinal).ToArray()
+            ? scopedQueries.Values.OrderBy(query => query.Id, StringComparer.Ordinal).ToArray()
             : requestedIds
-                .Where(id => ManagedStoredQueries.TryGetValue(id, out _))
-                .Select(id => ManagedStoredQueries[id])
+                .Where(id => scopedQueries.TryGetValue(id, out _))
+                .Select(id => scopedQueries[id])
                 .ToArray();
         var includeBuiltIn = requestedIds.Length == 0 || requestedIds.Any(IsGetFeatureByIdStoredQuery);
         var xml = BuildDescribeStoredQueriesXml(descriptors, requestedDefinitions, includeBuiltIn);
@@ -135,7 +168,8 @@ internal sealed partial class Wfs20Handler
                 "id");
         }
 
-        if (IsGetFeatureByIdStoredQuery(id) || ManagedStoredQueries.ContainsKey(id))
+        var scopedQueries = GetScopedStoredQueries(context);
+        if (IsGetFeatureByIdStoredQuery(id) || scopedQueries.ContainsKey(id))
         {
             return Wfs20ErrorResults.CreateBadRequest(
                 context,
@@ -144,7 +178,7 @@ internal sealed partial class Wfs20Handler
                 id);
         }
 
-        if (ManagedStoredQueries.Count >= MaxManagedStoredQueryCount)
+        if (scopedQueries.Count >= MaxManagedStoredQueryCount)
         {
             return Wfs20ErrorResults.CreateBadRequest(
                 context,
@@ -233,7 +267,7 @@ internal sealed partial class Wfs20Handler
             filterXml,
             parameters);
 
-        if (!ManagedStoredQueries.TryAdd(id, definition))
+        if (!scopedQueries.TryAdd(id, definition))
         {
             return Wfs20ErrorResults.CreateBadRequest(
                 context,
@@ -277,8 +311,9 @@ internal sealed partial class Wfs20Handler
                 "storedquery_id");
         }
 
+        var scopedQueries = GetScopedStoredQueries(context);
         if (IsGetFeatureByIdStoredQuery(storedQueryId) ||
-            !ManagedStoredQueries.TryRemove(storedQueryId, out _))
+            !scopedQueries.TryRemove(storedQueryId, out _))
         {
             return Wfs20ErrorResults.CreateBadRequest(
                 context,
@@ -310,7 +345,7 @@ internal sealed partial class Wfs20Handler
     {
         if (!IsGetFeatureByIdStoredQuery(storedQueryId))
         {
-            if (ManagedStoredQueries.TryGetValue(storedQueryId, out var definition))
+            if (GetScopedStoredQueries(context).TryGetValue(storedQueryId, out var definition))
             {
                 return await HandleManagedStoredQueryGetFeatureAsync(
                     context,

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
@@ -135,14 +135,17 @@ internal sealed partial class Wfs20Handler
                 }
             }
 
-            if (editResult.HasErrors)
+            // BH3-010: When rollbackOnFailure=false, WFS 2.0 §15.2.3.1.3 requires the server
+            // to commit as much as possible and return a 200 TransactionResponse that identifies
+            // which individual operations succeeded or failed — not a 400 error. Reserve the
+            // 400 for cases where the entire transaction was rolled back (rollbackOnFailure=true
+            // triggered the rollback path) or there was a protocol-level error. Returning 400 on
+            // a partial success causes clients to retry the whole request, re-inserting the
+            // already-committed features and producing duplicates (BH3-010).
+            if (editResult.HasErrors && editResult.WasRolledBack)
             {
                 var firstError = GetFirstTransactionError(editResult);
-                if (editResult.WasRolledBack)
-                {
-                    Wfs20Log.TransactionRolledBack(_logger, firstError);
-                }
-
+                Wfs20Log.TransactionRolledBack(_logger, firstError);
                 return Wfs20ErrorResults.CreateBadRequest(
                     context,
                     "OperationProcessingFailed",
@@ -1774,18 +1777,50 @@ internal sealed partial class Wfs20Handler
             var resource = operations[0].Descriptor.Resource;
             // Per-operation request-intent geometry flags, ordered to match the
             // EditOperation sequence the data layer iterates.
-            var layerResult = await ExecutePreparedEditAsync(
-                context,
-                layerGroup.Key,
-                resource,
-                operations
-                    .Select(static operation => operation.EditOperation)
-                    .ToImmutableArray(),
-                operations
-                    .Select(static operation => operation.RequestGeometryChanged)
-                    .ToImmutableArray(),
-                rollbackOnFailure,
-                cancellationToken).ConfigureAwait(false);
+            FeatureEditResult layerResult;
+            try
+            {
+                layerResult = await ExecutePreparedEditAsync(
+                    context,
+                    layerGroup.Key,
+                    resource,
+                    operations
+                        .Select(static operation => operation.EditOperation)
+                        .ToImmutableArray(),
+                    operations
+                        .Select(static operation => operation.RequestGeometryChanged)
+                        .ToImmutableArray(),
+                    rollbackOnFailure,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // BH3-011: If ExecutePreparedEditAsync throws for this layer, layers processed
+                // before it have already committed to the database. Rather than letting the
+                // exception escape (which would bypass the post-commit cache-invalidation block
+                // in HandleTransactionAsync and leave stale caches for those earlier layers),
+                // convert the exception into per-operation Failure results and continue building
+                // the aggregated result. HandleTransactionAsync will then see committed changes
+                // from earlier layers, invalidate their caches, and return a 200 TransactionResponse
+                // with the per-operation errors for this layer embedded.
+                var safeError = ex switch
+                {
+                    InvalidOperationException or ArgumentException => "Invalid feature data.",
+                    _ => "Transaction failed."
+                };
+                Wfs20Log.MultiLayerTransactionLayerFailed(_logger, ex, layerGroup.Key, safeError);
+
+                var failedCreates = operations.Count(static op => op.EditOperation.Kind == FeatureEditOperationKind.Create);
+                var failedUpdates = operations.Count(static op => op.EditOperation.Kind == FeatureEditOperationKind.Update);
+                var failedDeletes = operations.Count(static op => op.EditOperation.Kind == FeatureEditOperationKind.Delete);
+                layerResult = FeatureEditResult.Success(
+                    createdCount: 0,
+                    updatedCount: 0,
+                    deletedCount: 0,
+                    createResults: Enumerable.Repeat(EditOperationResult.Failure(safeError), failedCreates).ToImmutableArray(),
+                    updateResults: Enumerable.Repeat(EditOperationResult.Failure(safeError), failedUpdates).ToImmutableArray(),
+                    deleteResults: Enumerable.Repeat(EditOperationResult.Failure(safeError), failedDeletes).ToImmutableArray());
+            }
 
             createdCount += layerResult.CreatedCount;
             updatedCount += layerResult.UpdatedCount;

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Services/Wfs20Handler.Transaction.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 using System.Xml;
 using System.Xml.Linq;
 using Honua.Core.Configuration;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
@@ -237,7 +238,11 @@ internal sealed partial class Wfs20Handler
         var descriptors = await GetPublishedFeatureTypesAsync(context, cancellationToken).ConfigureAwait(false);
         var operations = ImmutableArray.CreateBuilder<PreparedTransactionOperation>();
         var distinctLayerIds = new HashSet<int>();
-        var validatedLayerIds = new HashSet<int>();
+        // Keyed on (layerId, operation) so per-operation authorization (BH3-001/BH3-014)
+        // is enforced independently for each action type: a transaction that both inserts
+        // into and updates the same layer must clear both the Insert and Update gates,
+        // not just the first one seen.
+        var validatedLayerIds = new HashSet<(int LayerId, AuthorizationOperation Operation)>();
         // Tracks whether the body contained at least one supported WFS action element.
         // ISO 19142 §15.2.5.3: a Delete or Update whose filter matches zero features is a
         // valid no-op that contributes zero operations but is still a recognised action.
@@ -360,7 +365,7 @@ internal sealed partial class Wfs20Handler
         IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
         ImmutableArray<PreparedTransactionOperation>.Builder operations,
         HashSet<int> distinctLayerIds,
-        HashSet<int> validatedLayerIds,
+        HashSet<(int LayerId, AuthorizationOperation Operation)> validatedLayerIds,
         CancellationToken cancellationToken)
     {
         var handle = insertElement.Attributes()
@@ -392,6 +397,7 @@ internal sealed partial class Wfs20Handler
             var validationError = await ValidateTransactionLayerWriteAccessAsync(
                 context,
                 descriptor.StorageLayerId,
+                AuthorizationOperation.Insert,
                 validatedLayerIds,
                 cancellationToken).ConfigureAwait(false);
             if (validationError != null)
@@ -428,7 +434,7 @@ internal sealed partial class Wfs20Handler
         IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
         ImmutableArray<PreparedTransactionOperation>.Builder operations,
         HashSet<int> distinctLayerIds,
-        HashSet<int> validatedLayerIds,
+        HashSet<(int LayerId, AuthorizationOperation Operation)> validatedLayerIds,
         CancellationToken cancellationToken)
     {
         var handle = updateElement.Attributes()
@@ -452,6 +458,7 @@ internal sealed partial class Wfs20Handler
         var validationError = await ValidateTransactionLayerWriteAccessAsync(
             context,
             descriptor.StorageLayerId,
+            AuthorizationOperation.Update,
             validatedLayerIds,
             cancellationToken).ConfigureAwait(false);
         if (validationError != null)
@@ -522,7 +529,7 @@ internal sealed partial class Wfs20Handler
         IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
         ImmutableArray<PreparedTransactionOperation>.Builder operations,
         HashSet<int> distinctLayerIds,
-        HashSet<int> validatedLayerIds,
+        HashSet<(int LayerId, AuthorizationOperation Operation)> validatedLayerIds,
         CancellationToken cancellationToken)
     {
         var handle = deleteElement.Attributes()
@@ -546,6 +553,7 @@ internal sealed partial class Wfs20Handler
         var validationError = await ValidateTransactionLayerWriteAccessAsync(
             context,
             descriptor.StorageLayerId,
+            AuthorizationOperation.Delete,
             validatedLayerIds,
             cancellationToken).ConfigureAwait(false);
         if (validationError != null)
@@ -607,7 +615,7 @@ internal sealed partial class Wfs20Handler
         IReadOnlyList<WfsFeatureTypeDescriptor> descriptors,
         ImmutableArray<PreparedTransactionOperation>.Builder operations,
         HashSet<int> distinctLayerIds,
-        HashSet<int> validatedLayerIds,
+        HashSet<(int LayerId, AuthorizationOperation Operation)> validatedLayerIds,
         CancellationToken cancellationToken)
     {
         var handle = replaceElement.Attributes()
@@ -626,9 +634,11 @@ internal sealed partial class Wfs20Handler
         }
 
         var descriptor = ResolveTransactionFeatureTypeDescriptor(descriptors, featureElement.Name.LocalName);
+        // Replace modifies an existing feature, so it authorizes as an Update (BH3-001/BH3-014).
         var validationError = await ValidateTransactionLayerWriteAccessAsync(
             context,
             descriptor.StorageLayerId,
+            AuthorizationOperation.Update,
             validatedLayerIds,
             cancellationToken).ConfigureAwait(false);
         if (validationError != null)
@@ -1017,10 +1027,11 @@ internal sealed partial class Wfs20Handler
     private static async Task<IResult?> ValidateTransactionLayerWriteAccessAsync(
         HttpContext context,
         int layerId,
-        HashSet<int> validatedLayerIds,
+        AuthorizationOperation operation,
+        HashSet<(int LayerId, AuthorizationOperation Operation)> validatedLayerIds,
         CancellationToken cancellationToken)
     {
-        if (!validatedLayerIds.Add(layerId))
+        if (!validatedLayerIds.Add((layerId, operation)))
         {
             return null;
         }
@@ -1041,10 +1052,14 @@ internal sealed partial class Wfs20Handler
             return null;
         }
 
+        // Per-operation authorization (BH3-001/BH3-014): each WFS-T action type is gated on its
+        // specific operation so an insert-only grantee cannot Update/Delete via a Transaction and
+        // vice-versa. Replace maps to Update since it modifies an existing feature.
         return await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
             context,
             layerValidation.Resource!,
             layerValidation.Service,
+            operation,
             cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Honua.Protocols.OgcClassic/Wfs20/Wfs20Log.cs
+++ b/src/Honua.Protocols.OgcClassic/Wfs20/Wfs20Log.cs
@@ -151,4 +151,12 @@ internal static partial class Wfs20Log
     /// </summary>
     [LoggerMessage(Level = LogLevel.Warning, Message = "WFS Transaction post-commit side-effects timed out for request {TraceId}; transaction was committed successfully.")]
     public static partial void PostCommitSideEffectsTimedOut(ILogger logger, string traceId);
+
+    /// <summary>
+    /// Logs when a layer's edit execution throws inside a multi-layer WFS Transaction with
+    /// rollbackOnFailure=false. Previously-committed layers are NOT rolled back; their cache
+    /// entries are still invalidated from the partial result that the caller receives.
+    /// </summary>
+    [LoggerMessage(Level = LogLevel.Error, Message = "WFS Transaction layer {LayerId} execution failed; treating as per-operation errors to preserve cache invalidation for earlier committed layers: {Error}")]
+    public static partial void MultiLayerTransactionLayerFailed(ILogger logger, Exception exception, int layerId, string error);
 }

--- a/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureSeeder.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/OperateObservabilityFixtureSeeder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
@@ -16,6 +16,7 @@ using Honua.Infrastructure.Monitoring;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Server.Features.Admin.OperateFixtures;
 
 internal interface IOperateObservabilityFixtureSeeder
@@ -378,7 +379,7 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
     }
 
     // Investigation-create audit is independent of the gated alert stores, so it is seeded even when
-    // the alert-fixture slice is skipped — the Operate observability events surface still shows an
+    // the alert-fixture slice is skipped â€” the Operate observability events surface still shows an
     // audit trail for the seeded investigation.
     private static Task EnsureInvestigationAuditEventAsync(
         IAdoNetDatabaseConnectionProvider connectionProvider,
@@ -789,7 +790,7 @@ internal sealed partial class OperateObservabilityFixtureSeeder(
             seededAt.AddMinutes(-2),
             cancellationToken).ConfigureAwait(false));
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
 
         return new OperateObservabilityInvestigationFixtureSeed
         {

--- a/src/Honua.Server/Features/Admin/OperateFixtures/PostgresOperateFixtureExecutionStore.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/PostgresOperateFixtureExecutionStore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Data.Common;
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using NpgsqlTypes;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Server.Features.Admin.OperateFixtures;
 
 internal sealed partial class PostgresOperateFixtureExecutionStore(
@@ -432,7 +433,7 @@ internal sealed partial class PostgresOperateFixtureExecutionStore(
             await insert.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<ScopedConnectionLease> OpenConnectionAsync(CancellationToken cancellationToken)

--- a/src/Honua.Server/Features/CloudDemo/CloudDemoServiceSeeder.cs
+++ b/src/Honua.Server/Features/CloudDemo/CloudDemoServiceSeeder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Data;
@@ -6,6 +6,7 @@ using System.Data.Common;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Metadata.Abstractions;
 
+using Honua.Postgres.Features.Infrastructure;
 namespace Honua.Server.Features.CloudDemo;
 
 internal sealed class CloudDemoServiceSeeder(
@@ -88,7 +89,7 @@ internal sealed class CloudDemoServiceSeeder(
                 await ExecuteSqlAsync(connection, transaction, statement, cancellationToken).ConfigureAwait(false);
             }
 
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {

--- a/src/Honua.Server/Features/Forms/FormSubmissionService.cs
+++ b/src/Honua.Server/Features/Forms/FormSubmissionService.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Attachments.Abstractions;
 using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
@@ -104,6 +105,7 @@ internal sealed class FormSubmissionService
             context,
             targetMetadata,
             targetMetadata.Service.Metadata.Name,
+            MapSubmissionOperation(request.Operation),
             context.RequestAborted).ConfigureAwait(false);
         if (authorizationFailure is not null)
         {
@@ -302,18 +304,25 @@ internal sealed class FormSubmissionService
         HttpContext context,
         FormTargetMetadataResolution target,
         string fallbackServiceId,
+        AuthorizationOperation operation,
         CancellationToken cancellationToken)
     {
         var (service, _, resource, _) = target;
         if (resource is not null)
         {
+            // Per-operation authorization (BH3-001/BH3-014): a form submission maps to
+            // Insert (create) / Update / Delete based on the submission operation, so a grant
+            // for one cannot authorize another.
             return await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
                 context,
                 resource,
                 service,
+                operation,
                 cancellationToken).ConfigureAwait(false);
         }
 
+        // Service-scoped fallbacks: no resource to run a per-operation resource check against, so
+        // the coarse service data-editor gate applies.
         if (service is not null)
         {
             return await ServiceDataEditorAuthorization.RequireServiceDataEditorAsync(
@@ -327,6 +336,17 @@ internal sealed class FormSubmissionService
             fallbackServiceId,
             cancellationToken).ConfigureAwait(false);
     }
+
+    // Maps a form submission operation to its canonical authorization operation
+    // (BH3-001/BH3-014): create=Insert, update=Update, delete=Delete. An unknown/empty value
+    // defaults to Insert since a submission with no explicit operation creates a feature.
+    private static AuthorizationOperation MapSubmissionOperation(string? submissionOperation)
+        => submissionOperation?.ToLowerInvariant() switch
+        {
+            FormSubmissionOperations.Update => AuthorizationOperation.Update,
+            FormSubmissionOperations.Delete => AuthorizationOperation.Delete,
+            _ => AuthorizationOperation.Insert,
+        };
 
     private async Task<IResult> ResolveClaimConflictAsync(
         HttpContext context,

--- a/src/Honua.Server/Features/Infrastructure/DataIntegrity/DataIntegrityCoordinator.cs
+++ b/src/Honua.Server/Features/Infrastructure/DataIntegrity/DataIntegrityCoordinator.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Data;
 using System.Globalization;
+using Honua.Postgres.Features.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
@@ -292,8 +293,10 @@ internal sealed class DataIntegrityCoordinator : IDataIntegrityCoordinator
 
             DataIntegrityCoordinatorLog.CommittingCoordinatedTransaction(_logger, _operationId, _operations.Count);
 
-            // First commit the database transaction
-            await DatabaseTransaction.CommitAsync(cancellationToken);
+            // First commit the database transaction (CommitSafelyAsync guards against the
+            // phantom-commit race: checks cancellation before COMMIT, then uses None so the
+            // in-flight round-trip is never interrupted — see HN0001).
+            await DatabaseTransaction.CommitSafelyAsync(cancellationToken);
 
             // Then commit file and cache operations
             var exceptions = new List<Exception>();

--- a/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrSubsetReaderTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Raster/ZarrParser/ZarrSubsetReaderTests.cs
@@ -2,8 +2,13 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Core.Features.Raster.ZarrParser;
 using Xunit;
@@ -278,6 +283,105 @@ public class ZarrSubsetReaderTests
         }
     }
 
+    // ─── BH3-022 regressions ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Regression test for BH3-022: the read ceiling passed to ICloudRangeReader.ReadRangeAsync
+    /// must be the metadata-declared chunk byte count, not int.MaxValue/4 (~512 MB).
+    /// Before the fix, eight parallel 512 MB reads could allocate ~4.3 GB of temporary
+    /// buffers for a request where the per-request cap is 256 MiB.
+    /// After the fix the ceiling equals chunkBytes so the allocation is bounded.
+    /// </summary>
+    [Fact]
+    public async Task ReadSubsetAsync_UncompressedChunk_ReadLengthBoundedToChunkBytes()
+    {
+        // 4×4 chunk of <f4: chunkBytes = 4 * 4 * 4 = 64 bytes.
+        var objects = ZarrFixtureBuilder.BuildSingleVariableUncompressed(
+            root: "datasets/ceiling",
+            rows: 4,
+            cols: 4,
+            chunkRows: 4,
+            chunkCols: 4,
+            sample: (r, c) => (float)(r * 4 + c));
+        var trackingReader = new TrackingZarrRangeReader(new InMemoryZarrRangeReader(objects));
+        var metadata = await new ZarrMetadataExtractor().ReadMetadataAsync(
+            new InMemoryZarrRangeReader(objects), "bucket", "datasets/ceiling");
+
+        var request = new ZarrSubsetRequest
+        {
+            Variable = "ceiling",
+            Start = new[] { 0, 0 },
+            Stop = new[] { 4, 4 }
+        };
+
+        await new ZarrSubsetReader().ReadSubsetAsync(
+            trackingReader, "bucket", "datasets/ceiling", metadata, request);
+
+        const int expectedChunkBytes = 4 * 4 * sizeof(float); // 64 bytes
+        trackingReader.RecordedLengths.Should().AllSatisfy(length =>
+            length.Should().Be(expectedChunkBytes,
+                "read ceiling must equal the declared chunk byte count (BH3-022), not int.MaxValue/4"));
+    }
+
+    /// <summary>
+    /// Regression test for BH3-022: when an attacker-controlled Zarr store writes a chunk
+    /// object that is larger than the declared chunk size, only <c>chunkBytes</c> bytes should
+    /// be consumed (the ICloudRangeReader implementation returns at most <c>length</c> bytes).
+    /// The read completes successfully and returns the correct subset values.
+    /// </summary>
+    [Fact]
+    public async Task ReadSubsetAsync_ChunkObjectLargerThanDeclaredSize_ReadsOnlyDeclaredBytes()
+    {
+        // Build a 2×2 <f4 store with 2×2 chunks (chunkBytes = 16 bytes).
+        var objects = ZarrFixtureBuilder.BuildSingleVariableUncompressed(
+            root: "datasets/oversized",
+            rows: 2,
+            cols: 2,
+            chunkRows: 2,
+            chunkCols: 2,
+            sample: (r, c) => (float)(r * 2 + c + 1)); // values: 1, 2, 3, 4
+
+        // Bloat the single chunk object to 1 MB (far beyond the 16-byte declared size).
+        // An attacker-controlled store could do this to exploit the old int.MaxValue/4 ceiling.
+        var bloatedData = new byte[1024 * 1024];
+        var originalChunk = objects["datasets/oversized/0.0"];
+        Array.Copy(originalChunk, bloatedData, originalChunk.Length);
+        objects["datasets/oversized/0.0"] = bloatedData;
+
+        var trackingReader = new TrackingZarrRangeReader(new InMemoryZarrRangeReader(objects));
+        var metadata = await new ZarrMetadataExtractor().ReadMetadataAsync(
+            new InMemoryZarrRangeReader(objects), "bucket", "datasets/oversized");
+
+        var request = new ZarrSubsetRequest
+        {
+            Variable = "oversized",
+            Start = new[] { 0, 0 },
+            Stop = new[] { 2, 2 }
+        };
+
+        var subset = await new ZarrSubsetReader().ReadSubsetAsync(
+            trackingReader, "bucket", "datasets/oversized", metadata, request);
+
+        const int expectedChunkBytes = 2 * 2 * sizeof(float); // 16 bytes
+        trackingReader.RecordedLengths.Should().AllSatisfy(length =>
+            length.Should().Be(expectedChunkBytes,
+                "read ceiling must be capped at the declared chunk byte count even when the cloud object is larger"));
+
+        // Data integrity: the first 16 bytes are correct despite the bloated object.
+        subset.Shape.Should().Equal(2, 2);
+        for (var r = 0; r < 2; r++)
+        {
+            for (var c = 0; c < 2; c++)
+            {
+                var expected = (float)(r * 2 + c + 1);
+                var actual = BitConverter.ToSingle(subset.Data, (r * 2 + c) * sizeof(float));
+                actual.Should().Be(expected, $"cell ({r},{c}) value must be correct after bounded read");
+            }
+        }
+    }
+
+    // ─── BH2-015 regressions ──────────────────────────────────────────────────────
+
     /// <summary>
     /// Regression test for BH2-015: WriteFillScalar had no case for &lt;u8 (uint64) so
     /// a missing chunk was zero-filled instead of using the declared fill_value.
@@ -313,5 +417,39 @@ public class ZarrSubsetReaderTests
             var actual = BitConverter.ToUInt64(subset.Data, i * sizeof(ulong));
             actual.Should().Be(fillValue, $"cell {i} should be filled with {fillValue} (BH2-015)");
         }
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Wraps an <see cref="ICloudRangeReader"/> and records every <c>length</c> argument
+    /// passed to <see cref="ReadRangeAsync"/> so tests can assert the read ceiling.
+    /// </summary>
+    private sealed class TrackingZarrRangeReader(ICloudRangeReader inner) : ICloudRangeReader
+    {
+        private readonly List<int> _lengths = new();
+
+        /// <summary>All <c>length</c> values recorded from calls to <see cref="ReadRangeAsync"/>.</summary>
+        public IReadOnlyList<int> RecordedLengths => _lengths;
+
+        public CloudStorageProvider Provider => inner.Provider;
+
+        public Task<byte[]> ReadRangeAsync(
+            string bucket, string key, long offset, int length,
+            CancellationToken cancellationToken = default)
+        {
+            _lengths.Add(length);
+            return inner.ReadRangeAsync(bucket, key, offset, length, cancellationToken);
+        }
+
+        public Task<Stream> ReadRangeStreamAsync(
+            string bucket, string key, long offset, int length,
+            CancellationToken cancellationToken = default)
+            => inner.ReadRangeStreamAsync(bucket, key, offset, length, cancellationToken);
+
+        public Task<long> GetObjectSizeAsync(
+            string bucket, string key,
+            CancellationToken cancellationToken = default)
+            => inner.GetObjectSizeAsync(bucket, key, cancellationToken);
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Infrastructure/DbTransactionExtensionsTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Infrastructure/DbTransactionExtensionsTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using Honua.Postgres.Features.Infrastructure;
+
+namespace Honua.Postgres.Tests.Features.Infrastructure;
+
+/// <summary>
+/// Regression tests for <see cref="DbTransactionExtensions.CommitSafelyAsync"/>.
+/// These tests verify the phantom-commit guard (BH3-018 / BH3-019): the method
+/// must throw <see cref="OperationCanceledException"/> when the token is already
+/// cancelled BEFORE touching the database, and must pass
+/// <see cref="CancellationToken.None"/> to the underlying commit so the in-flight
+/// round-trip is never interrupted.
+/// </summary>
+public sealed class DbTransactionExtensionsTests
+{
+    [Fact]
+    public async Task CommitSafelyAsync_PreCancelledToken_ThrowsBeforeCommitIsCalled()
+    {
+        var wasCommitCalled = false;
+        var stub = new StubDbTransaction(onCommit: _ => { wasCommitCalled = true; return Task.CompletedTask; });
+
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => stub.CommitSafelyAsync(cts.Token));
+
+        Assert.False(wasCommitCalled, "CommitAsync must not be called when the token is already cancelled.");
+    }
+
+    [Fact]
+    public async Task CommitSafelyAsync_ActiveToken_PassesCancellationTokenNoneToUnderlyingCommit()
+    {
+        CancellationToken capturedToken = default;
+        var stub = new StubDbTransaction(onCommit: ct => { capturedToken = ct; return Task.CompletedTask; });
+
+        using var cts = new CancellationTokenSource();
+        await stub.CommitSafelyAsync(cts.Token);
+
+        Assert.Equal(CancellationToken.None, capturedToken);
+    }
+
+    [Fact]
+    public async Task CommitSafelyAsync_CancellationTokenNoneInput_CommitsSuccessfully()
+    {
+        var wasCommitted = false;
+        var stub = new StubDbTransaction(onCommit: _ => { wasCommitted = true; return Task.CompletedTask; });
+
+        // CancellationToken.None is a common call site pattern after the pre-check has
+        // already been performed by the caller; verify it does not throw.
+        await stub.CommitSafelyAsync(CancellationToken.None);
+
+        Assert.True(wasCommitted);
+    }
+
+    /// <summary>Minimal concrete DbTransaction for unit-testing the extension.</summary>
+    private sealed class StubDbTransaction : DbTransaction
+    {
+        private readonly Func<CancellationToken, Task> _onCommit;
+
+        public StubDbTransaction(Func<CancellationToken, Task> onCommit)
+        {
+            _onCommit = onCommit;
+        }
+
+        public override IsolationLevel IsolationLevel => IsolationLevel.ReadCommitted;
+        protected override DbConnection? DbConnection => null;
+
+        public override void Commit() => throw new NotSupportedException();
+        public override void Rollback() => throw new NotSupportedException();
+
+        public override Task CommitAsync(CancellationToken cancellationToken) =>
+            _onCommit(cancellationToken);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionAccessPolicyTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionAccessPolicyTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Protocols.GeoServices.VersionManagementServer;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer;
+
+/// <summary>
+/// Unit tests for <see cref="VersionAccessPolicy"/> — the centralized visibility and lifecycle
+/// authorization helpers that fix BH3-002 (list/info), BH3-003 (inspectConflicts), and
+/// BH3-004 (delete/alter/reconcile/post/session) version-access gaps.
+/// </summary>
+public sealed class VersionAccessPolicyTests
+{
+    // ---- Test data helpers -----------------------------------------------------------------
+
+    private static GdbVersion MakeVersion(string owner, VersionAccess access) => new()
+    {
+        VersionId = Guid.NewGuid(),
+        VersionName = $"{owner}.test",
+        Owner = owner,
+        Access = access,
+        State = VersionState.Active,
+        CommonAncestorGeneration = 0,
+        BranchGeneration = 1,
+        CreatedAt = DateTimeOffset.UtcNow,
+        ModifiedAt = DateTimeOffset.UtcNow,
+    };
+
+    // ---- IsVersionVisible — Public / Protected visibility ----------------------------------
+
+    [UnitTest]
+    public void IsVersionVisible_PublicVersion_AllCallersCanSee()
+    {
+        var version = MakeVersion("alice", VersionAccess.Public);
+
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "bob", isAdmin: false).Should().BeTrue(
+            "Public versions are visible to any query-access caller");
+        VersionAccessPolicy.IsVersionVisible(version, callerName: null, isAdmin: false).Should().BeTrue(
+            "Public versions are visible to anonymous callers with service query access");
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "alice", isAdmin: false).Should().BeTrue(
+            "Public versions are visible to their owner");
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "admin", isAdmin: true).Should().BeTrue(
+            "Public versions are visible to administrators");
+    }
+
+    [UnitTest]
+    public void IsVersionVisible_ProtectedVersion_AllCallersCanSee()
+    {
+        var version = MakeVersion("alice", VersionAccess.Protected);
+
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "bob", isAdmin: false).Should().BeTrue(
+            "Protected versions are read-visible to any query-access caller");
+        VersionAccessPolicy.IsVersionVisible(version, callerName: null, isAdmin: false).Should().BeTrue(
+            "Protected versions are read-visible to anonymous callers with service query access");
+    }
+
+    // ---- IsVersionVisible — Private visibility (BH3-002) -----------------------------------
+
+    [UnitTest]
+    public void IsVersionVisible_PrivateVersion_OwnerCanSee()
+    {
+        var version = MakeVersion("alice", VersionAccess.Private);
+
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "alice", isAdmin: false).Should().BeTrue(
+            "a Private version owner must be able to see their own version");
+    }
+
+    [UnitTest]
+    public void IsVersionVisible_PrivateVersion_OwnerMatchIsCaseInsensitive()
+    {
+        var version = MakeVersion("Alice", VersionAccess.Private);
+
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "alice", isAdmin: false).Should().BeTrue(
+            "owner name comparison must be case-insensitive");
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "ALICE", isAdmin: false).Should().BeTrue(
+            "owner name comparison must be case-insensitive");
+    }
+
+    [UnitTest]
+    public void IsVersionVisible_PrivateVersion_AdminCanSee()
+    {
+        var version = MakeVersion("alice", VersionAccess.Private);
+
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "admin", isAdmin: true).Should().BeTrue(
+            "service administrators must be able to see all Private versions");
+    }
+
+    [UnitTest]
+    public void IsVersionVisible_PrivateVersion_NonOwnerNonAdminCannotSee()
+    {
+        // BH3-002 core regression: before the fix, HandleListVersions returned all Private
+        // versions to any query-access caller. This test pins the corrected behavior.
+        var version = MakeVersion("alice", VersionAccess.Private);
+
+        VersionAccessPolicy.IsVersionVisible(version, callerName: "bob", isAdmin: false).Should().BeFalse(
+            "a non-owner non-admin must not see a Private version");
+        VersionAccessPolicy.IsVersionVisible(version, callerName: null, isAdmin: false).Should().BeFalse(
+            "anonymous callers must not see a Private version");
+    }
+
+    // ---- CanManageVersion — owner-only lifecycle ops (BH3-003 / BH3-004) ------------------
+
+    [UnitTest]
+    public void CanManageVersion_Owner_CanManageRegardlessOfAccessLevel()
+    {
+        foreach (var access in Enum.GetValues<VersionAccess>())
+        {
+            var version = MakeVersion("alice", access);
+            VersionAccessPolicy.CanManageVersion(version, callerName: "alice", isAdmin: false).Should().BeTrue(
+                $"version owner must be able to manage their own {access} version");
+        }
+    }
+
+    [UnitTest]
+    public void CanManageVersion_Admin_CanManageRegardlessOfAccessLevel()
+    {
+        foreach (var access in Enum.GetValues<VersionAccess>())
+        {
+            var version = MakeVersion("alice", access);
+            VersionAccessPolicy.CanManageVersion(version, callerName: "admin", isAdmin: true).Should().BeTrue(
+                $"admin must be able to manage any {access} version");
+        }
+    }
+
+    [UnitTest]
+    public void CanManageVersion_NonOwnerNonAdmin_CannotManage_PrivateVersion()
+    {
+        // BH3-003 / BH3-004 core regression: before the fix any write-access principal
+        // could call delete/alter/reconcile/post/inspectConflicts on any version.
+        var version = MakeVersion("alice", VersionAccess.Private);
+
+        VersionAccessPolicy.CanManageVersion(version, callerName: "bob", isAdmin: false).Should().BeFalse(
+            "a non-owner must not perform lifecycle operations on a Private version");
+        VersionAccessPolicy.CanManageVersion(version, callerName: null, isAdmin: false).Should().BeFalse(
+            "an anonymous principal must not perform lifecycle operations on a Private version");
+    }
+
+    [UnitTest]
+    public void CanManageVersion_NonOwnerNonAdmin_CannotManage_PublicVersion()
+    {
+        // BH3-004: even a Public version's lifecycle operations are owner-or-admin-only.
+        // Read access is public, but delete/alter/reconcile/post are not.
+        var version = MakeVersion("alice", VersionAccess.Public);
+
+        VersionAccessPolicy.CanManageVersion(version, callerName: "bob", isAdmin: false).Should().BeFalse(
+            "a non-owner must not perform lifecycle operations on a Public version, " +
+            "even though they can read it");
+    }
+
+    [UnitTest]
+    public void CanManageVersion_NonOwnerNonAdmin_CannotManage_ProtectedVersion()
+    {
+        // BH3-004: same restriction applies to Protected versions.
+        var version = MakeVersion("alice", VersionAccess.Protected);
+
+        VersionAccessPolicy.CanManageVersion(version, callerName: "bob", isAdmin: false).Should().BeFalse(
+            "a non-owner must not perform lifecycle operations on a Protected version");
+    }
+
+    [UnitTest]
+    public void CanManageVersion_OwnerMatchIsCaseInsensitive()
+    {
+        var version = MakeVersion("Alice", VersionAccess.Private);
+
+        VersionAccessPolicy.CanManageVersion(version, callerName: "alice", isAdmin: false).Should().BeTrue(
+            "owner name comparison must be case-insensitive for lifecycle operations");
+        VersionAccessPolicy.CanManageVersion(version, callerName: "ALICE", isAdmin: false).Should().BeTrue(
+            "owner name comparison must be case-insensitive for lifecycle operations");
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20StoredQueryScopeTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/Wfs20StoredQueryScopeTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System;
+using System.Text;
+using System.Xml.Linq;
+using FluentAssertions;
+using Honua.Core.Features.MultiTenancy.Abstractions;
+using Honua.Protocols.Ogc.Classic.Wfs20;
+using Honua.Protocols.Ogc.Classic.Wfs20.Services;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20;
+
+/// <summary>
+/// Regression tests for BH3-009: <c>ManagedStoredQueries</c> was a process-global
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/> with no
+/// service or tenant scoping. Stored queries created on Service A were fully visible and
+/// operable from Service B, enabling information disclosure, sabotage (cross-service delete),
+/// and DoS via global slot exhaustion.
+///
+/// After the fix the dictionary is keyed by a composite (serviceScope, queryId) tuple derived
+/// from the request's tenant context, so queries created in one scope are invisible in another.
+/// </summary>
+[Protocol(TestProtocols.Wfs20)]
+public sealed class Wfs20StoredQueryScopeTests
+{
+    private const string WfsNs = "http://www.opengis.net/wfs/2.0";
+
+    // ─── BH3-009 regression ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A stored query created by tenant A must not be drop-able from tenant B's context.
+    /// Before the fix <see cref="Wfs20Handler.HandleDropStoredQuery"/> accepted any query ID
+    /// regardless of which service (tenant) created it.
+    /// </summary>
+    [UnitTest]
+    public void HandleDropStoredQuery_QueryFromOtherScope_ReturnsInvalidParameterValue()
+    {
+        var storedQueryId = $"urn:bh3-009:cross-drop:{Guid.NewGuid():N}";
+
+        // Service A creates the query.
+        var contextA = CreateContextWithTenant("tenant-a");
+        SetParsedCreateDocument(contextA, storedQueryId);
+        var createResult = Wfs20Handler.HandleCreateStoredQuery(contextA);
+        createResult.Should().BeAssignableTo<IResult>("create must return an IResult");
+        // The create should have succeeded (status 200 / CreateStoredQueryResponse).
+        AssertXmlResultStatus(contextA, createResult, expectedContains: "CreateStoredQueryResponse");
+
+        // Service B attempts to drop Service A's query — must be rejected.
+        var contextB = CreateContextWithTenant("tenant-b");
+        var dropResult = Wfs20Handler.HandleDropStoredQuery(contextB, storedQueryId);
+
+        AssertXmlResultStatus(contextB, dropResult, expectedContains: "InvalidParameterValue",
+            "a cross-scope drop must return InvalidParameterValue, not succeed");
+
+        // Service A can still drop its own query.
+        var ownDropResult = Wfs20Handler.HandleDropStoredQuery(contextA, storedQueryId);
+        AssertXmlResultStatus(contextA, ownDropResult, expectedContains: "DropStoredQueryResponse",
+            "owner tenant must be able to drop its own stored query");
+    }
+
+    /// <summary>
+    /// A stored query created under <c>tenant-a</c> must not appear in a
+    /// <c>DescribeStoredQueries</c> request that targets a non-existent query by that ID
+    /// under <c>tenant-b</c>'s scope — the response must be an error, not the definition.
+    /// </summary>
+    [UnitTest]
+    public void HandleCreateStoredQuery_TwoScopesReuseQueryId_BothSucceed()
+    {
+        // The same logical query ID may be registered independently in two different scopes.
+        var sharedId = $"urn:bh3-009:shared-id:{Guid.NewGuid():N}";
+
+        var contextA = CreateContextWithTenant("scope-x");
+        SetParsedCreateDocument(contextA, sharedId);
+        var resultA = Wfs20Handler.HandleCreateStoredQuery(contextA);
+        AssertXmlResultStatus(contextA, resultA, expectedContains: "CreateStoredQueryResponse",
+            "scope-x should be able to register the shared ID in its own namespace");
+
+        var contextB = CreateContextWithTenant("scope-y");
+        SetParsedCreateDocument(contextB, sharedId);
+        var resultB = Wfs20Handler.HandleCreateStoredQuery(contextB);
+        AssertXmlResultStatus(contextB, resultB, expectedContains: "CreateStoredQueryResponse",
+            "scope-y must not see scope-x's registration, so the same ID must be accepted independently");
+
+        // Cleanup: both scopes drop their own copy.
+        Wfs20Handler.HandleDropStoredQuery(contextA, sharedId);
+        Wfs20Handler.HandleDropStoredQuery(contextB, sharedId);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static DefaultHttpContext CreateContextWithTenant(string tenantId)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ITenantContext>(new FixedTenantContext(tenantId));
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        // Set the WFS path so the error formatter produces WFS XML responses
+        // (the formatter dispatches on path prefix via ProtocolRequestClassifier.IsWfs).
+        context.Request.Path = "/wfs";
+        return context;
+    }
+
+    private static void SetParsedCreateDocument(DefaultHttpContext context, string storedQueryId)
+    {
+        var xml = $"""
+            <wfs:CreateStoredQuery service="WFS" version="2.0.0"
+                xmlns:wfs="{WfsNs}" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+              <wfs:StoredQueryDefinition id="{storedQueryId}">
+                <wfs:Title>BH3-009 scope test</wfs:Title>
+                <wfs:QueryExpressionText returnFeatureTypes=""
+                    language="urn:ogc:def:queryLanguage:OGC-WFS::WFSQueryExpression" isPrivate="false">
+                  <wfs:Query typeNames="honua:test" />
+                </wfs:QueryExpressionText>
+              </wfs:StoredQueryDefinition>
+            </wfs:CreateStoredQuery>
+            """;
+        context.Items[Wfs20DispatcherEndpoint.ParsedXmlDocumentItemKey] = XDocument.Parse(xml);
+    }
+
+    /// <summary>
+    /// Executes an <see cref="IResult"/> against a temporary <see cref="DefaultHttpContext"/>
+    /// and asserts that the response body XML contains <paramref name="expectedContains"/>.
+    /// </summary>
+    private static void AssertXmlResultStatus(
+        DefaultHttpContext originalContext,
+        IResult result,
+        string expectedContains,
+        string? because = null)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = originalContext.RequestServices
+        };
+        httpContext.Response.Body = new System.IO.MemoryStream();
+
+        result.ExecuteAsync(httpContext).GetAwaiter().GetResult();
+
+        httpContext.Response.Body.Position = 0;
+        var body = new System.IO.StreamReader(httpContext.Response.Body, Encoding.UTF8).ReadToEnd();
+        body.Should().Contain(expectedContains,
+            because ?? $"response body must contain '{expectedContains}'");
+    }
+
+    /// <summary>
+    /// Simple <see cref="ITenantContext"/> that returns a fixed tenant ID.
+    /// </summary>
+    private sealed class FixedTenantContext(string tenantId) : ITenantContext
+    {
+        public string? TenantId { get; } = tenantId;
+
+        public TenantContextSource Source => TenantContextSource.Claim;
+
+        public bool RequireTenantId(out string outTenantId, out string? reason)
+        {
+            outTenantId = TenantId!;
+            reason = null;
+            return true;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/CatalogExecutableConformanceTests.cs
@@ -432,7 +432,8 @@ public sealed class CatalogExecutableConformanceTests
             new HonuaLayerSinkExecutor(monitor, NullLogger<HonuaLayerSinkExecutor>.Instance),
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
-                NullLogger<ImportDatasetJobExecutor>.Instance),
+                NullLogger<ImportDatasetJobExecutor>.Instance,
+                Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>()),
         };
 
         // Remote DAG source connectors self-register as IProcessExecutor, so they flow

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/GeoprocessingDispatchJobExecutorTests.cs
@@ -183,7 +183,8 @@ public sealed class GeoprocessingDispatchJobExecutorTests
             new ExternalPostgisSinkExecutor(monitor),
             new ImportDatasetJobExecutor(
                 Substitute.For<IServiceScopeFactory>(),
-                NullLogger<ImportDatasetJobExecutor>.Instance),
+                NullLogger<ImportDatasetJobExecutor>.Instance,
+                Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>()),
         };
 
         return new GeoprocessingDispatchJobExecutor(

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ImportDatasetJobExecutorPathTraversalTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ImportDatasetJobExecutorPathTraversalTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Geoprocessing;
+using Honua.Geoprocessing.Execution;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Geoprocessing.Execution;
+
+/// <summary>
+/// Unit-level regression for BH3-027: <c>ImportDatasetJobExecutor</c> must reject
+/// any <c>sourcePath</c> job input that resolves to a path outside the configured
+/// staging root directory.  These tests run without Docker / Testcontainers because
+/// the path-validation logic is pure in-process and requires no external services.
+/// </summary>
+[Protocol(TestProtocols.OgcApiProcesses)]
+public sealed class ImportDatasetJobExecutorPathTraversalTests
+{
+    // ─── BH3-027 regression ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A <c>sourcePath</c> that resolves to a location outside the staging root must be
+    /// rejected immediately — before any file I/O — with a <c>Failed</c> job status.
+    /// Before the fix the executor passed the path verbatim to <see cref="File.Exists"/>
+    /// and then to the import pipeline, allowing server-side path traversal by any
+    /// authenticated caller with GP execution rights.
+    /// </summary>
+    [UnitTest]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/processes/{processId}/execution")]
+    public async Task ExecuteAsync_SourcePathOutsideStagingRoot_FailsWithPathTraversalError()
+    {
+        // Staging root = a unique subdirectory of the system temp folder.
+        var stagingRoot = Path.Combine(Path.GetTempPath(), $"honua-staging-unit-{Guid.NewGuid():N}");
+
+        var options = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        options.CurrentValue.Returns(new GeoprocessingExecutorOptions
+        {
+            ImportStagingDirectory = stagingRoot
+        });
+
+        var executor = new ImportDatasetJobExecutor(
+            Substitute.For<IServiceScopeFactory>(),
+            NullLogger<ImportDatasetJobExecutor>.Instance,
+            options);
+
+        // Supply a traversal path that is a sibling of the staging root (not a descendant).
+        var traversalPath = Path.Combine(Path.GetTempPath(), "honua-traversal-target-unit.txt");
+        File.WriteAllText(traversalPath, "should not be read");
+        try
+        {
+            var job = BuildJobRecord(traversalPath);
+            var context = new NullJobExecutionContext("op-traversal-unit");
+
+            var result = await executor.ExecuteAsync(job, context, CancellationToken.None);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed,
+                "a source path outside the staging root must be rejected before any file access");
+            result.ErrorMessage.Should().Contain("staging directory",
+                "the rejection message must identify the staging-directory constraint (BH3-027)");
+        }
+        finally
+        {
+            if (File.Exists(traversalPath))
+            {
+                File.Delete(traversalPath);
+            }
+
+            if (Directory.Exists(stagingRoot))
+            {
+                Directory.Delete(stagingRoot, recursive: true);
+            }
+        }
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static ExecutionJobRecord BuildJobRecord(string sourcePath)
+    {
+        var prefix = $"{ExecutionJobParameterKeys.GeoprocessingStepInputPrefix}0.";
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ExecutionJobParameterKeys.GeoprocessingProcessDefinitions] = ImportDatasetJobExecutor.HandledProcessId,
+            ["protocolProcessId"] = ImportDatasetJobExecutor.HandledProcessId,
+            [prefix + "connection"] = Guid.NewGuid().ToString(),
+            [prefix + "sourcePath"] = sourcePath,
+            [prefix + "fileName"] = "traversal.txt",
+            [prefix + "tableName"] = "traversal_table",
+            [prefix + "layerName"] = "Traversal Layer",
+            [prefix + "serviceName"] = "traversal-service",
+            [prefix + "targetSrid"] = "4326"
+        };
+
+        return new ExecutionJobRecord
+        {
+            OperationId = "op-traversal-unit",
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                Kind = ExecutionJobKind.Geoprocessing,
+                TargetKind = BatchComputeTargetKind.KubernetesJob,
+                Backend = "local",
+                WorkloadName = "geoprocessing:import.dataset",
+                Parameters = parameters
+            }
+        };
+    }
+
+    /// <summary>No-op job execution context for path-traversal unit tests.</summary>
+    private sealed class NullJobExecutionContext(string operationId) : IJobExecutionContext
+    {
+        public string OperationId { get; } = operationId;
+
+        public Task ReportProgressAsync(double? percentComplete, string? phase, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task AppendLogAsync(ExecutionLogEntry entry, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task PublishArtifactAsync(string artifactReference, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ImportDatasetJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/ImportDatasetJobExecutorTests.cs
@@ -164,6 +164,14 @@ public sealed class ImportDatasetJobExecutorTests : IAsyncLifetime
         };
     }
 
+    /// <summary>
+    /// Staging directory that matches the <c>ImportStagingDirectory</c> default in
+    /// <c>GeoprocessingExecutorOptions</c> so the path-traversal guard (BH3-027) passes
+    /// for legitimate test files.
+    /// </summary>
+    private static readonly string StagingDirectory =
+        Path.Combine(Path.GetTempPath(), "honua-import-staging");
+
     private static string StageGeoJsonSource()
     {
         var geoJson = JsonSerializer.Serialize(new
@@ -177,7 +185,9 @@ public sealed class ImportDatasetJobExecutorTests : IAsyncLifetime
             }
         });
 
-        var path = Path.Combine(Path.GetTempPath(), $"import_dataset_{Guid.NewGuid():N}.geojson");
+        // BH3-027: files must be placed under the configured staging root.
+        Directory.CreateDirectory(StagingDirectory);
+        var path = Path.Combine(StagingDirectory, $"import_dataset_{Guid.NewGuid():N}.geojson");
         File.WriteAllText(path, geoJson, Encoding.UTF8);
         return path;
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
@@ -480,8 +480,32 @@ public sealed class CrossProtocolPermissionMatrixTests
     [Protocol(TestProtocols.OgcApiFeatures)]
     [Operation(Operations.Create)]
     [Endpoint("POST /ogc/features/collections/{collectionId}/items")]
-    public async Task OgcFeaturesCreate_UpdateGrant_OverridesCoarseDeny()
+    public async Task OgcFeaturesCreate_InsertGrant_OverridesCoarseDeny()
     {
+        // An OGC API Features POST authorizes as Insert (BH3-001/BH3-014), so a matching Insert
+        // grant must override the coarse data-editor deny. The in-memory fixture cannot complete
+        // the create, so the assertion is that authorization is cleared (not Forbidden / not
+        // Unauthorized) rather than a 201.
+        using var factory = CreateWriteFactory(Grant("insert"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/ogc/features/collections/{ServiceRbacTestFixture.AlphaLayerId}/items",
+            ServiceRbacTestFixture.CreateOgcFeatureContent());
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "a matching insert grant must clear per-operation authorization for an OGC create; body: {0}",
+            await response.Content.ReadAsStringAsync());
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiFeatures)]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeaturesCreate_UpdateOnlyGrant_DeniesCreate()
+    {
+        // BH3-001/BH3-014: an Update-only grantee must be denied an OGC create (POST=Insert).
         using var factory = CreateWriteFactory(Grant("update"));
         using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
 
@@ -489,7 +513,28 @@ public sealed class CrossProtocolPermissionMatrixTests
             $"/ogc/features/collections/{ServiceRbacTestFixture.AlphaLayerId}/items",
             ServiceRbacTestFixture.CreateOgcFeatureContent());
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Created);
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.OgcApiFeatures)]
+    [Operation(Operations.Update)]
+    [Endpoint("PUT /ogc/features/collections/{collectionId}/items/{featureId}")]
+    public async Task OgcFeaturesUpdate_InsertOnlyGrant_DeniesUpdate()
+    {
+        // BH3-001/BH3-014 primary regression for the OGC API Features write surface: an OGC PUT
+        // authorizes as Update, so an Insert-only grantee must be denied. Authorization runs before
+        // feature resolution, so the denial is a clean 403.
+        using var factory = CreateWriteFactory(Grant("insert"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PutAsync(
+            $"/ogc/features/collections/{ServiceRbacTestFixture.AlphaLayerId}/items/1",
+            ServiceRbacTestFixture.CreateOgcFeatureContent());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an insert-only principal must not execute an OGC API Features Update; body: {0}",
+            await response.Content.ReadAsStringAsync());
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
@@ -251,8 +251,35 @@ public sealed class CrossProtocolPermissionMatrixTests
     [Protocol(TestProtocols.ODataV4)]
     [Operation(Operations.Create)]
     [Endpoint("POST /odata/Layers({layerId})/Features")]
-    public async Task ODataCreate_UpdateGrant_OverridesCoarseDeny()
+    public async Task ODataCreate_InsertGrant_OverridesCoarseDeny()
     {
+        // An OData POST authorizes as Insert (BH3-001/BH3-014), so a matching Insert grant must
+        // override the coarse data-editor deny. The in-memory fixture cannot complete the create
+        // (the layer requires an objectid the payload does not carry), so the assertion is that
+        // authorization is cleared — not Forbidden / not Unauthorized — rather than a 201.
+        // (An Update grant is separately proven NOT to authorize a create via the per-operation
+        // gate; before the fix the coarse any-write gate let any write grant through.)
+        using var factory = CreateWriteFactory(Grant("insert"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.PostAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features",
+            ServiceRbacTestFixture.CreateODataFeatureContent());
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "a matching insert grant must clear per-operation authorization for an OData create; body: {0}",
+            await response.Content.ReadAsStringAsync());
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Create)]
+    [Endpoint("POST /odata/Layers({layerId})/Features")]
+    public async Task ODataCreate_UpdateOnlyGrant_DeniesCreate()
+    {
+        // BH3-001/BH3-014: an Update-only grantee must be denied an OData create (POST=Insert).
+        // Before the fix the coarse any-write gate accepted any write grant for any mutation.
         using var factory = CreateWriteFactory(Grant("update"));
         using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
 
@@ -260,7 +287,7 @@ public sealed class CrossProtocolPermissionMatrixTests
             $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features",
             ServiceRbacTestFixture.CreateODataFeatureContent());
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Created);
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
     }
 
     [IntegrationTest]
@@ -277,6 +304,76 @@ public sealed class CrossProtocolPermissionMatrixTests
             ServiceRbacTestFixture.CreateODataFeatureContent());
 
         await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+    }
+
+    // ---- OData CRUD per-operation authorization (BH3-001 / BH3-014 regression) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Update)]
+    [Endpoint("PATCH /odata/Layers({layerId})/Features({objectId})")]
+    public async Task ODataUpdate_InsertOnlyGrant_DeniesUpdate()
+    {
+        // BH3-001 / BH3-014: an OData PATCH authorizes as Update. A principal holding only an
+        // Insert grant must be denied — before the fix the coarse any-write gate allowed it.
+        using var factory = CreateWriteFactory(Grant("insert"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var payload = new StringContent(
+            @"{""name"":""unauthorized-update""}",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var response = await client.PatchAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features(1)",
+            payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an insert-only principal must not execute an OData Update; body: {0}",
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Delete)]
+    [Endpoint("DELETE /odata/Layers({layerId})/Features({objectId})")]
+    public async Task ODataDelete_InsertOnlyGrant_DeniesDelete()
+    {
+        // BH3-014: an OData DELETE authorizes as Delete. An Insert-only grantee must be denied.
+        using var factory = CreateWriteFactory(Grant("insert"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var response = await client.DeleteAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features(1)");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an insert-only principal must not execute an OData Delete; body: {0}",
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.ODataV4)]
+    [Operation(Operations.Update)]
+    [Endpoint("PATCH /odata/Layers({layerId})/Features({objectId})")]
+    public async Task ODataUpdate_UpdateGrant_AllowsUpdate()
+    {
+        // BH3-001 / BH3-014: an Update grantee must not be over-blocked on a PATCH. The request
+        // may still 404 (no such feature in the in-memory fixture) but must clear authorization,
+        // so it must not be Forbidden or Unauthorized.
+        using var factory = CreateWriteFactory(Grant("update"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var payload = new StringContent(
+            @"{""name"":""authorized-update""}",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var response = await client.PatchAsync(
+            $"/odata/Layers({ServiceRbacTestFixture.AlphaLayerId})/Features(1)",
+            payload);
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "an update grantee must clear per-operation authorization; body: {0}",
+            await response.Content.ReadAsStringAsync());
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
     }
 
     // ---- OData batch ----
@@ -723,6 +820,178 @@ public sealed class WfsReadVisibilitySeamTests
         };
 
     private sealed class SingleGrantRoleStore(string roleName, PermissionGrant grant) : IRoleStore
+    {
+        public Task<EffectivePermissions> GetEffectivePermissionsAsync(
+            string userId,
+            IReadOnlyList<string> roles,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new EffectivePermissions
+            {
+                UserId = userId,
+                Roles = roles,
+                Permissions = roles.Any(r => string.Equals(r, roleName, StringComparison.OrdinalIgnoreCase))
+                    ? [grant]
+                    : [],
+            });
+
+        public Task<IReadOnlyList<RoleDefinition>> ListRolesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<RoleDefinition>>([]);
+
+        public Task<RoleDefinition?> GetRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(null);
+
+        public Task<RoleDefinition> CreateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult(role);
+
+        public Task<RoleDefinition?> UpdateRoleAsync(RoleDefinition role, CancellationToken cancellationToken = default)
+            => Task.FromResult<RoleDefinition?>(role);
+
+        public Task<bool> DeleteRoleAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+
+        public Task<IReadOnlyList<PermissionGrant>> GetPermissionsAsync(Guid roleId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<PermissionGrant>>([]);
+
+        public Task<IReadOnlyList<PermissionGrant>> SetPermissionsAsync(Guid roleId, IReadOnlyList<PermissionGrant> permissions, CancellationToken cancellationToken = default)
+            => Task.FromResult(permissions);
+    }
+}
+
+/// <summary>
+/// Direct coverage of the WFS-T transaction write authorization seam
+/// (BH3-001 / BH3-014). WFS Transaction actions route through
+/// <c>ValidateTransactionLayerWriteAccessAsync</c>, which now calls
+/// <see cref="ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(HttpContext, MetadataV2Resource, MetadataV2Service?, AuthorizationOperation, CancellationToken)"/>
+/// with the action's specific operation (Insert / Update / Delete; Replace maps to
+/// Update). The ServiceRbacTestFixture cannot render a full WFS Transaction HTTP
+/// round-trip (it needs a PostGIS-backed store and non-admin principal injection),
+/// so these tests exercise that exact per-operation seam directly, mirroring the
+/// read-side <c>WfsReadVisibilitySeamTests</c> precedent. A service with no explicit
+/// write policy is used so the RBAC grant path (not an authoritative AccessPolicy)
+/// governs the decision.
+/// </summary>
+[Protocol(TestProtocols.Wfs20)]
+[Operation(Operations.Update)]
+public sealed class WfsTransactionWriteAuthorizationSeamTests
+{
+    private const string ServiceName = "alpha";
+    private const string GrantedRole = "wfs-write-grant-role";
+
+    [UnitTest]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task WfsTransactionSeam_InsertOnlyGrant_DeniesUpdate()
+    {
+        // An Insert-only grantee submitting a WFS-T Update action must be denied: the
+        // per-operation gate falls back to the data-editor role gate, which the principal fails.
+        var context = CreateContext(
+            grant: new PermissionGrant { Service = ServiceName, Layer = "*", Operation = "insert" });
+
+        var error = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+            context,
+            CreateResource(),
+            CreateService(),
+            AuthorizationOperation.Update,
+            CancellationToken.None);
+
+        error.Should().NotBeNull("an insert-only grantee must be denied a WFS-T Update action");
+    }
+
+    [UnitTest]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task WfsTransactionSeam_InsertOnlyGrant_DeniesDelete()
+    {
+        var context = CreateContext(
+            grant: new PermissionGrant { Service = ServiceName, Layer = "*", Operation = "insert" });
+
+        var error = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+            context,
+            CreateResource(),
+            CreateService(),
+            AuthorizationOperation.Delete,
+            CancellationToken.None);
+
+        error.Should().NotBeNull("an insert-only grantee must be denied a WFS-T Delete action");
+    }
+
+    [UnitTest]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task WfsTransactionSeam_InsertGrant_AllowsInsert()
+    {
+        // Positive control: the same Insert grant authorizes a WFS-T Insert action, proving the
+        // per-operation narrowing denies only the non-matching operations.
+        var context = CreateContext(
+            grant: new PermissionGrant { Service = ServiceName, Layer = "*", Operation = "insert" });
+
+        var error = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+            context,
+            CreateResource(),
+            CreateService(),
+            AuthorizationOperation.Insert,
+            CancellationToken.None);
+
+        error.Should().BeNull("an insert grantee must be allowed a WFS-T Insert action");
+    }
+
+    [UnitTest]
+    [Endpoint("POST /wfs")]
+    [InterfaceOperation(TestProtocols.Wfs20, "Transaction")]
+    public async Task WfsTransactionSeam_UpdateGrant_AllowsUpdate()
+    {
+        var context = CreateContext(
+            grant: new PermissionGrant { Service = ServiceName, Layer = "*", Operation = "update" });
+
+        var error = await ServiceDataEditorAuthorization.RequireResourceDataEditorAsync(
+            context,
+            CreateResource(),
+            CreateService(),
+            AuthorizationOperation.Update,
+            CancellationToken.None);
+
+        error.Should().BeNull("an update grantee must be allowed a WFS-T Update (or Replace) action");
+    }
+
+    private static DefaultHttpContext CreateContext(PermissionGrant grant)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IAccessPolicyEvaluator, AccessPolicyEvaluator>();
+        services.Configure<RbacOptions>(opts => opts.RoleClaimType = "roles");
+        services.AddSingleton<IRoleStore>(new WfsSingleGrantRoleStore(GrantedRole, grant));
+        services.AddSingleton<IPermissionResolver>(sp =>
+            new PermissionResolver(sp.GetRequiredService<IRoleStore>()));
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, "wfs-write-user"),
+            new(ClaimTypes.Role, GrantedRole),
+            new("roles", GrantedRole),
+        };
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"))
+        };
+    }
+
+    private static MetadataV2Resource CreateResource()
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "res-alpha", Name = "Alpha Layer" }
+        };
+
+    // A service with NO explicit write policy: the RBAC grant path governs, so the per-operation
+    // narrowing is what decides. An explicit AllowedRoles/AllowedWriteRoles policy would be
+    // authoritative and bypass grants entirely, which is covered separately.
+    private static MetadataV2Service CreateService()
+        => new()
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "svc-alpha", Name = ServiceName }
+        };
+
+    private sealed class WfsSingleGrantRoleStore(string roleName, PermissionGrant grant) : IRoleStore
     {
         public Task<EffectivePermissions> GetEffectivePermissionsAsync(
             string userId,

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
@@ -127,12 +127,20 @@ public sealed class CrossProtocolPermissionMatrixTests
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
     public async Task FeatureServerApplyEdits_UpdateGrant_OverridesCoarseDeny()
     {
+        // An Update RBAC grant must override the coarse data-editor role deny and
+        // allow Update operations for a principal that lacks the data-editor role.
+        // The payload is an updates-only request so the per-type Update check
+        // (BH3-001 fix) also exercises the correct grant path.
         using var factory = CreateWriteFactory(Grant("update"));
         using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
 
+        var payload = new StringContent(
+            @"{""updates"":[{""attributes"":{""objectid"":1,""name"":""rbac-test""}}]}",
+            System.Text.Encoding.UTF8,
+            "application/json");
         var response = await client.PostAsync(
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
-            ServiceRbacTestFixture.CreateApplyEditsContent());
+            payload);
 
         await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
@@ -486,6 +494,84 @@ public sealed class CrossProtocolPermissionMatrixTests
 
         response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Unauthorized);
         response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Forbidden);
+    }
+
+    // ---- FeatureServer applyEdits – Update payload (BH3-001 / BH3-014 regression) ----
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_UpdatePayload_InsertOnlyGrantDeniesUpdate()
+    {
+        // BH3-001 / BH3-014: applyEdits must check AuthorizationOperation.Update for an
+        // updates-only payload. Before the fix, an insert-only principal passed the pre-body
+        // coarse gate (any write op) and then sailed through the per-type block because there
+        // was no Update check — only Insert and Delete were gated. After the fix the
+        // per-type Update check must return 403 for insert-only principals.
+        using var factory = CreateWriteFactory(Grant("insert"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var payload = new StringContent(
+            @"{""updates"":[{""attributes"":{""objectid"":1,""name"":""unauthorized""}}]}",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
+            payload);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden,
+            "an insert-only principal must not execute Update operations; body: {0}",
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_UpdatePayload_UpdateGrantAllowsUpdate()
+    {
+        // BH3-001 / BH3-014: a principal with only an Update grant must be permitted to submit
+        // an updates-only payload. Validates the positive case so the regression check does not
+        // over-block.
+        using var factory = CreateWriteFactory(Grant("update"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var payload = new StringContent(
+            @"{""updates"":[{""attributes"":{""objectid"":1,""name"":""authorized""}}]}",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
+            payload);
+
+        response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Forbidden,
+            "an update-only principal must be permitted to execute Update operations; body: {0}",
+            await response.Content.ReadAsStringAsync());
+        response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.Unauthorized);
+    }
+
+    [IntegrationTest]
+    [Protocol(TestProtocols.FeatureServer)]
+    [Operation(Operations.ApplyEdits)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits")]
+    public async Task ApplyEdits_UpdatePayload_DeleteOnlyGrantDeniesUpdate()
+    {
+        // BH3-014: a delete-only principal must also be denied an updates-only payload.
+        using var factory = CreateWriteFactory(Grant("delete"));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, GrantedRole);
+
+        var payload = new StringContent(
+            @"{""updates"":[{""attributes"":{""objectid"":1,""name"":""unauthorized""}}]}",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        var response = await client.PostAsync(
+            $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
+            payload);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden,
+            "a delete-only principal must not execute Update operations; body: {0}",
+            await response.Content.ReadAsStringAsync());
     }
 
     // ---- WFS GetFeature + Transaction ----

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using FluentAssertions;
 using Honua.Infrastructure.Authentication;
@@ -193,6 +194,41 @@ public sealed class AtomicTokenReplayProtectionTests
 
         resultA.Should().BeTrue("token A must be accepted on first use");
         resultB.Should().BeTrue("token B is a distinct token and must be accepted independently");
+    }
+
+    // ─── BH3-033 regression ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Regression test for BH3-033: two concurrent requests carrying the same JWT must not
+    /// both be accepted as first-use.  The old read-delay-verify pattern had a TOCTOU race
+    /// where both requests could observe "not present" at T1, each write a unique marker,
+    /// and each verify their own marker before the other's write arrived — causing both to
+    /// return <see langword="true"/>.  After the fix a <see cref="SemaphoreSlim"/> serialises
+    /// the check-then-set window so exactly one concurrent caller wins.
+    /// </summary>
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_ConcurrentRequestsSameToken_ExactlyOneWins()
+    {
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        using var sp = services.BuildServiceProvider();
+
+        var token = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        // Fire 8 concurrent requests for the same token and collect all results.
+        var tasks = Enumerable.Range(0, 8)
+            .Select(_ => AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+                token, options, sp, CancellationToken.None))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        results.Count(r => r).Should().Be(1,
+            "exactly one concurrent first-use attempt must be accepted (BH3-033); " +
+            "the rest must be treated as replays");
+        results.Count(r => !r).Should().Be(7,
+            "all other concurrent attempts must be rejected as replay");
     }
 
     // ─── Helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Round 3 of the feature bug-bounty. 66 raw → 36 survivors (0 S0, 14 S1, 22 S2). The 14 S1s were fixed as **systemic CLASSES at the root**, not per-instance — because the reservoir wasn't converging (R1/R2 point-fixes kept resurfacing as new instances). S2s → backlog per the convergence goal.

## Classes killed (with un-reintroducible guards)
- **Phantom-commit-on-cancellation** (BH3-018/019): **37** `CommitAsync(token)` sites routed through a safe helper (`ThrowIfCancellationRequested` + `CommitAsync(None)`), **plus a Roslyn analyzer HN0001 that FAILS THE BUILD on `CommitAsync(<non-None token>)`** — the exit condition; the class cannot be reintroduced.
- **Scattered per-operation edit authz** (BH3-001/014 + swept): a central per-operation authorizer now gates *every* primary edit surface — FeatureServer (applyEdits per-type, single-verb, maintenance, attachments), OGC API Features (+$batch), OData (CRUD + $batch), WFS-T, Forms — so an Insert-only grantee can no longer Update/Delete anywhere. Deliberately-coarse pre-body/replication gates documented in-code. (Closes the gap our own R1 fix left when it added Insert/Delete but forgot Update.)
- **VersionManagementServer access control** (BH3-002/003/004): new `VersionAccessPolicy` (visibility + ownership) — private branch versions no longer leak to any reader; lifecycle ops enforce owner/admin.
- **Multi-layer transaction non-atomicity** (BH3-010/011) + **bulk-insert objectid ordering** (BH3-020, ROW_NUMBER over ctid).
- **Misc S1s**: WFS stored-query tenant isolation, Zarr chunk-read ceiling, GP import path-traversal containment, JWT replay TOCTOU serialization.

Consolidated `Honua.Server` build: 0 warnings / 0 errors (analyzer clean = no live-token commits remain). Regression tests throughout.