### PR TITLE
Feature bug-hunt Round 5: TOCTOU class-kill + replication cluster (7 S1s)

### DIFF
--- a/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.ControlPlane.Domain;
@@ -95,6 +95,21 @@ public interface IWorkflowOperationStore : IOperationStore
     /// <param name="ttl">Optional retention period.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task SetAsync(
+        WorkflowOperationRecord operation,
+        TimeSpan? ttl = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically persists the workflow operation record only when the stored version
+    /// matches the record's <see cref="WorkflowOperationRecord.Version"/>. The stored
+    /// version is incremented on success. Returns <c>false</c> on version conflict,
+    /// indicating a concurrent write was detected and the caller should re-read.
+    /// </summary>
+    /// <param name="operation">Workflow operation record with the expected version.</param>
+    /// <param name="ttl">Optional retention period.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True when updated; false when a concurrent write was detected.</returns>
+    Task<bool> TrySetAsync(
         WorkflowOperationRecord operation,
         TimeSpan? ttl = null,
         CancellationToken cancellationToken = default);

--- a/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Authorization.Domain;
@@ -768,6 +768,12 @@ public sealed record WorkflowOperationRecord
     /// Current workflow status.
     /// </summary>
     public required WorkflowOperationStatus Status { get; init; }
+
+    /// <summary>
+    /// Optimistic concurrency version token incremented on every store write. Used by
+    /// <c>IWorkflowOperationStore.TrySetAsync</c> to detect concurrent modifications.
+    /// </summary>
+    public long Version { get; init; }
 
     /// <summary>
     /// Relative operator priority.

--- a/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
+++ b/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
@@ -1,18 +1,23 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Cryptography;
 using System.Text;
-using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using StackExchange.Redis;
 
 namespace Honua.Infrastructure.Authentication;
 
 /// <summary>
-/// Provides atomic token replay protection using distributed cache with SET NX operations
-/// or in-memory cache with CompareExchange for thread-safety.
+/// Provides atomic token replay protection using Redis SET NX for multi-replica deployments
+/// or in-memory cache with a process-scoped lock for single-instance deployments.
+///
+/// BH5-022: Replaced the reflection-based IDatabase extraction from RedisCache (which
+/// silently degraded to a non-atomic fallback on cold-start or after package renames) with
+/// direct IConnectionMultiplexer resolution from the DI graph.
 /// </summary>
 internal static class AtomicTokenReplayProtection
 {
@@ -20,16 +25,9 @@ internal static class AtomicTokenReplayProtection
     private static readonly object _memoryLock = new();
     private static readonly HashSet<string> _processedTokens = new();
 
-    // BH3-033: SemaphoreSlim(1,1) serialises the non-Redis check-then-set window so that
-    // two concurrent requests carrying the same token cannot both observe "not present" and
-    // both return true. This gate only protects the non-Redis fallback path (MemoryDistributed-
-    // Cache and other non-Redis IDistributedCache impls); the production Redis path uses SET NX
-    // which is natively atomic and never reaches this semaphore.
-    private static readonly SemaphoreSlim _nonAtomicGate = new(1, 1);
-
     /// <summary>
     /// Atomically checks and marks a JWT token as used to prevent replay attacks.
-    /// Returns true if the token is valid and this is the first use, false if it's a replay.
+    /// Returns true if the token is valid and this is the first use, false if it is a replay.
     /// </summary>
     public static async Task<bool> TryMarkTokenAsUsedAsync(
         SecurityToken securityToken,
@@ -40,7 +38,6 @@ internal static class AtomicTokenReplayProtection
         var tokenKey = TryGetTokenReplayKey(securityToken);
         if (string.IsNullOrWhiteSpace(tokenKey))
         {
-            // Can't generate a unique key for this token, allow it through
             return true;
         }
 
@@ -53,125 +50,40 @@ internal static class AtomicTokenReplayProtection
 
         var expiresOn = GetReplayCacheExpiration(jwtToken, options);
 
-        // Try distributed cache first for multi-instance deployments
-        var distributedCache = serviceProvider.GetService<IDistributedCache>();
-        if (distributedCache != null)
+        // Resolve IConnectionMultiplexer directly - no reflection into IDistributedCache
+        // internals. IConnectionMultiplexer is already in the DI graph when Redis is configured
+        // (BH5-022: reflection fallback permanently degraded to non-atomic if the private field
+        // is renamed by a package update).
+        var multiplexer = serviceProvider.GetService<IConnectionMultiplexer>();
+        if (multiplexer is not null)
         {
-            return await TryMarkTokenAsUsedDistributedAsync(distributedCache, cacheKey, expiresOn, cancellationToken);
+            try
+            {
+                var expiry = expiresOn - DateTime.UtcNow;
+                if (expiry <= TimeSpan.Zero) expiry = TimeSpan.FromSeconds(1);
+                // SET NX EX: atomic set-if-not-exists. Returns true when the key was set
+                // (first use), false when the key already existed (replay).
+                return await multiplexer.GetDatabase()
+                    .StringSetAsync(cacheKey, "1", expiry, when: When.NotExists)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Redis unavailable: fail-closed - treat as replay to prevent replay via
+                // a degraded non-atomic path.
+                return false;
+            }
         }
 
-        // Fall back to in-memory cache for single-instance deployments
+        // No Redis: fall back to in-memory cache with a process-scoped lock.
         var memoryCache = serviceProvider.GetService<IMemoryCache>();
         if (memoryCache != null)
         {
             return TryMarkTokenAsUsedMemory(memoryCache, cacheKey, expiresOn);
         }
 
-        // No caching available, allow through (not ideal but functional)
+        // No cache available; allow through (graceful degradation).
         return true;
-    }
-
-    private static async Task<bool> TryMarkTokenAsUsedDistributedAsync(
-        IDistributedCache cache,
-        string cacheKey,
-        DateTime expiresOn,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Use Redis for true atomicity if available.
-            if (cache is Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache redisCache)
-            {
-                return await TryMarkTokenAsUsedRedisAsync(redisCache, cacheKey, expiresOn, cancellationToken);
-            }
-
-            var options = new DistributedCacheEntryOptions { AbsoluteExpiration = expiresOn };
-            return await TryMarkTokenAsUsedNonAtomicAsync(cache, cacheKey, options, cancellationToken);
-        }
-        catch (Exception)
-        {
-            // If cache operation fails, err on the side of security and reject
-            return false;
-        }
-    }
-
-    private static async Task<bool> TryMarkTokenAsUsedRedisAsync(
-        Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache redisCache,
-        string cacheKey,
-        DateTime expiresOn,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Use reflection to access the underlying Redis database for atomic operations.
-            // The IDatabase field is lazily initialized; it is null before the first cache
-            // operation completes (i.e. on cold-start before any Redis I/O has occurred).
-            var type = redisCache.GetType();
-            var connectionField = type.GetField("_cache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var connection = connectionField?.GetValue(redisCache) as StackExchange.Redis.IDatabase;
-
-            if (connection != null)
-            {
-                // Use Redis SET NX EX for atomic set-if-not-exists with expiration
-                var expiry = expiresOn - DateTime.UtcNow;
-                if (expiry <= TimeSpan.Zero) expiry = TimeSpan.FromSeconds(1);
-
-                var result = await connection.StringSetAsync(cacheKey, "1", expiry, StackExchange.Redis.When.NotExists);
-                return result; // Returns true if SET succeeded (key didn't exist), false if key already existed
-            }
-        }
-        catch (Exception)
-        {
-            // If reflection or Redis operation fails, fall back to less atomic method below.
-        }
-
-        // Fallback: use the non-atomic distributed path, passing the RedisCache as a plain
-        // IDistributedCache.  IMPORTANT: do NOT call TryMarkTokenAsUsedDistributedAsync here
-        // — it re-dispatches to this method because the argument is still a RedisCache,
-        // causing infinite mutual recursion and a StackOverflowException (BH-027).
-        try
-        {
-            var fallbackOptions = new DistributedCacheEntryOptions { AbsoluteExpiration = expiresOn };
-            return await TryMarkTokenAsUsedNonAtomicAsync(redisCache, cacheKey, fallbackOptions, cancellationToken);
-        }
-        catch (Exception)
-        {
-            return false;
-        }
-    }
-
-    private static async Task<bool> TryMarkTokenAsUsedNonAtomicAsync(
-        IDistributedCache cache,
-        string cacheKey,
-        DistributedCacheEntryOptions options,
-        CancellationToken cancellationToken)
-    {
-        // BH3-033: The previous read-delay-verify pattern had a TOCTOU race: two concurrent
-        // requests could both observe "not present" at T1, write their unique markers, and
-        // each verify their own write before the other's write arrived — both returning true.
-        // The 1 ms Task.Delay was not a distributed barrier and did not close the window.
-        //
-        // Fix: _nonAtomicGate serialises the check-then-set pair within this process.
-        // For MemoryDistributedCache (which is process-local) this is fully race-free.
-        // For cross-process distributed caches that are not Redis, the gate prevents same-
-        // process races but cannot prevent cross-process replays; operators should prefer
-        // Redis for true distributed replay protection.
-        await _nonAtomicGate.WaitAsync(cancellationToken);
-        try
-        {
-            var existing = await cache.GetStringAsync(cacheKey, cancellationToken);
-            if (existing != null)
-            {
-                return false;
-            }
-
-            await cache.SetStringAsync(cacheKey, "1", options, cancellationToken);
-            return true;
-        }
-        finally
-        {
-            _nonAtomicGate.Release();
-        }
     }
 
     private static bool TryMarkTokenAsUsedMemory(

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
@@ -236,6 +236,16 @@ internal sealed class FeatureServerEditsHandler(
                     scope.SetSuccess(0);
                     return Results.Json(replay, FeatureServerJsonContext.Default.ApplyEditsResponse,
                         contentType: "application/json");
+                }
+
+                // Atomic reserve: only one concurrent request carrying the same Idempotency-Key may
+                // proceed to execute the edit. The loser returns 409 so the client can retry after the
+                // winner has written the response; the retry will hit the replay path above (#2250, BH5-001).
+                var reserved = await _idempotencyStore.TryReserveAsync(replayScope, cancellationToken).ConfigureAwait(false);
+                if (!reserved)
+                {
+                    FeatureServerLog.ApplyEditsIdempotencyConflict(_logger, serviceId, layerId);
+                    return Results.Conflict(new { error = "A concurrent request with the same Idempotency-Key is already being processed. Retry after a brief delay." });
                 }
             }
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 namespace Honua.Protocols.GeoServices.FeatureServer;
@@ -273,6 +273,16 @@ internal static partial class FeatureServerLog
     /// <param name="exception">The exception raised by the store.</param>
     [LoggerMessage(EventId = 2407, Level = LogLevel.Warning, Message = "ApplyEdits idempotency store unavailable for service '{ServiceId}' layer {LayerId}; retry deduplication is degraded")]
     public static partial void ApplyEditsIdempotencyStoreUnavailable(ILogger logger, string serviceId, int layerId, Exception exception);
+
+    /// <summary>
+    /// Logs when a concurrent request holds the idempotency reservation for the same key (BH5-001).
+    /// The caller should return 409 so the client can retry after the winner has written the response.
+    /// </summary>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer identifier.</param>
+    [LoggerMessage(EventId = 2408, Level = LogLevel.Warning, Message = "ApplyEdits idempotency conflict for service '{ServiceId}' layer {LayerId}: concurrent request with same key")]
+    public static partial void ApplyEditsIdempotencyConflict(ILogger logger, string serviceId, int layerId);
 
     /// <summary>
     /// Logs when adding a feature fails.

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Replication.cs
@@ -479,11 +479,11 @@ internal static partial class FeatureServerEndpoints
             replicaLayers.Select(layer => layer.StorageLayerId).Distinct().ToArray(),
             cancellationToken);
 
-        // Optional upper bound on the delta. A bidirectional sync caps the server-to-client delta at
-        // the generation observed just before the client's upload was applied, so the client receives
-        // every server-side change committed since its last sync (e.g. another client's edits made
-        // after createReplica) but NOT its own just-applied edits, which carry a later generation
-        // (#2136). Download-only syncs pass null and deliver the full delta up to the current generation.
+        // Optional upper bound on the delta. Currently always null (callers pass null) — the full
+        // delta from sinceGeneration to the current generation is delivered, including any edits the
+        // uploading client just applied. Clients reconcile their own edits using the objectIds
+        // returned in the upload response (BH5-015). The parameter is kept for backward compatibility
+        // with any future caller that needs a bounded window (e.g. a selective replay path).
         if (maxGeneration is { } upperBound)
         {
             changes = changes.Where(c => c.Generation <= upperBound).ToList();
@@ -1011,11 +1011,6 @@ internal static partial class FeatureServerEndpoints
         // non-conflicting edits via the shared edit pipeline, and writes durable conflict records
         // when supported. Download-only syncs and empty uploads skip the pipeline entirely (#1272).
         long uploadServerGen = 0;
-        // The server generation observed immediately before the client's upload is applied. A
-        // bidirectional download caps its server-to-client delta at this value so the client's own
-        // just-applied edits (which carry a later generation) are excluded while every server-side
-        // change committed since the replica's last sync is still delivered (#2136).
-        long preUploadGen = 0;
         var didUpload = false;
         if (isUploadDirection && !string.IsNullOrWhiteSpace(editsJson))
         {
@@ -1031,10 +1026,6 @@ internal static partial class FeatureServerEndpoints
                     .GetRequiredService<Microsoft.Extensions.Options.IOptions<Honua.Core.Configuration.LimitsOptions>>();
                 var syncService = context.RequestServices.GetRequiredService<IReplicaSyncService>();
                 var applier = new FeatureServerReplicaEditApplier(editsHandler, limitsOptions.Value.Edits);
-
-                // Capture the pre-upload generation so the bidirectional download below can exclude the
-                // client's own edits without skipping concurrent server-side changes.
-                preUploadGen = await changeTracker.GetCurrentGenerationAsync(cancellationToken);
 
                 // Snapshot the pre-apply server state of every uploaded update/delete target so durable
                 // conflict records can carry the server side of the comparison for the review API
@@ -1127,14 +1118,17 @@ internal static partial class FeatureServerEndpoints
         {
             // The download lower bound is the generation the client already holds (replicaServerGen,
             // from its preceding extractChanges/createReplica) when supplied, otherwise the replica's
-            // recorded last-sync generation. A bidirectional upload in the same call does NOT advance
-            // this lower bound past concurrent server changes; instead the delta is capped at the
-            // pre-upload generation so the client receives every server-side change committed since its
-            // last sync but not its own just-applied edits (#2136, #1775).
+            // recorded last-sync generation. The upper bound is always the current (post-upload)
+            // generation so the delta window is (downloadSinceGen, currentGen] — covering every
+            // server-side change including edits committed by other clients during the upload window
+            // (BH5-015). A previous cap at preUploadGen permanently excluded those concurrent edits,
+            // because the cursor was then advanced to uploadServerGen (BH2-012), making them
+            // undeliverable to this replica forever. Clients that do not want to reapply their own
+            // just-committed edits can filter them by objectId from the upload response (#1775).
             var downloadSinceGen = acknowledgedServerGen is { } acknowledged
                 ? Math.Min(acknowledged, currentGen)
                 : replica.LastSyncGeneration;
-            long? downloadMaxGen = didUpload ? preUploadGen : null;
+            long? downloadMaxGen = null;
 
             var (assembledEdits, deltaError) = await BuildReplicaLayerChangesAsync(
                 context,
@@ -1405,6 +1399,12 @@ internal static partial class FeatureServerEndpoints
             .DistinctBy(layer => layer.PublicLayerId)
             .ToDictionary(layer => layer.PublicLayerId, layer => layer.StorageLayerId);
 
+        // BH5-014: build a per-layer resource lookup so TryReadObjectId can resolve the
+        // primary OID field name from the layer's schema rather than relying on hardcoded names.
+        var resourceByPublicId = replicaLayers
+            .DistinctBy(layer => layer.PublicLayerId)
+            .ToDictionary(layer => layer.PublicLayerId, layer => layer.Resource);
+
         var trimmed = editsJson.TrimStart();
 
         // The per-layer form is an array of objects ("[{...}]"); the legacy flat form is an array of
@@ -1428,11 +1428,13 @@ internal static partial class FeatureServerEndpoints
 
         var builder = ImmutableArray.CreateBuilder<ReplicaUploadLayerEdits>();
 
-        if (parsedPerLayer && perLayer is not null &&
-            perLayer.Any(static entry =>
-                entry.Adds is { Length: > 0 } ||
-                entry.Updates is { Length: > 0 } ||
-                entry.Deletes is { Length: > 0 }))
+        // BH5-013: route any successfully-parsed per-layer payload through the per-layer path,
+        // including no-op payloads where every layer has empty Adds/Updates/Deletes arrays (e.g.
+        // a client acknowledging receipt on a read-only replica). The Any() guard that was here
+        // caused all-empty per-layer payloads to fall through to the legacy flat-form branch,
+        // where the per-layer JSON objects were re-deserialized as GeoServicesFeature[] and
+        // submitted as phantom creates against the first replica layer.
+        if (parsedPerLayer && perLayer is not null)
         {
             foreach (var entry in perLayer)
             {
@@ -1453,11 +1455,14 @@ internal static partial class FeatureServerEndpoints
 
                 if (entry.Updates is not null)
                 {
+                    // BH5-014: resolve the OID field name from the layer's schema so updates on
+                    // layers with a custom ObjectId field name are correctly keyed for conflict detection.
+                    var layerResource = resourceByPublicId[entry.Id];
                     foreach (var update in entry.Updates)
                     {
                         edits.Add(new ReplicaUploadEdit(
                             FeatureEditOperationKind.Update,
-                            ObjectId: TryReadObjectId(update),
+                            ObjectId: TryReadObjectId(update, layerResource),
                             Payload: update));
                     }
                 }
@@ -1514,11 +1519,30 @@ internal static partial class FeatureServerEndpoints
     /// null when no recognizable object id attribute is present; conflict detection then treats the
     /// update as non-conflicting (the shared edit pipeline still rejects updates without an id).
     /// </summary>
-    private static long? TryReadObjectId(GeoServicesFeature feature)
+    /// <param name="feature">The uploaded update feature whose attributes are searched for an OID value.</param>
+    /// <param name="resource">
+    /// The layer's metadata resource used to resolve the actual OID field name via the
+    /// <c>id.primary</c> semantic role. This avoids false misses on layers whose primary key
+    /// column does not match the hardcoded fallback names (BH5-014).
+    /// </param>
+    private static long? TryReadObjectId(GeoServicesFeature feature, MetadataV2Resource resource)
     {
         if (feature.Attributes is null)
         {
             return null;
+        }
+
+        // BH5-014: resolve the canonical OID field name from the layer's schema first.
+        // FindPrimaryIdField returns the field with the 'id.primary' semantic role, falling back
+        // to fields named 'objectid' or 'id'. Only if the schema yields no match do we fall
+        // through to the legacy hardcoded name list for backward compatibility with ad-hoc payloads.
+        var schemaOidName = resource.FindPrimaryIdField()?.Name;
+        if (schemaOidName is not null && feature.Attributes.TryGetValue(schemaOidName, out var schemaValue))
+        {
+            if (FeatureServerValueParser.TryConvertToLong(schemaValue, out var schemaObjectId))
+            {
+                return schemaObjectId;
+            }
         }
 
         foreach (var (key, value) in feature.Attributes)

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Geometry.Abstractions;
@@ -8,6 +8,7 @@ using Honua.Core.Features.Query;
 using Honua.Protocols.GeoServices.FeatureServer.Services;
 using Honua.Infrastructure.Abstractions;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using StackExchange.Redis;
 
 namespace Honua.Protocols.GeoServices.FeatureServer;
 
@@ -42,11 +43,13 @@ internal static class FeatureServerServiceCollectionExtensions
             serviceProvider.GetRequiredService<FeatureServerQueryHandler>());
         services.AddScoped<FeatureServerRelatedRecordsDependencies>();
         services.AddScoped<FeatureServerRelatedRecordsHandler>();
-        // At-most-once applyEdits store (#2250). Distributed (Redis) when an IDistributedCache is
-        // configured, otherwise an in-process fallback — mirroring DistributedReplicaStore. Singleton so
+        // At-most-once applyEdits store (#2250). Distributed (Redis) when an IConnectionMultiplexer is
+        // registered, with IDistributedCache fallback, otherwise an in-process fallback. Singleton so
         // the in-process fallback dictionary survives across requests.
+        // IConnectionMultiplexer is required for atomic SET NX reservation (BH5-001).
         services.TryAddSingleton<IApplyEditsIdempotencyStore>(static serviceProvider =>
             new DistributedApplyEditsIdempotencyStore(
+                serviceProvider.GetService<IConnectionMultiplexer>(),
                 serviceProvider.GetService<Microsoft.Extensions.Caching.Distributed.IDistributedCache>(),
                 serviceProvider.GetRequiredService<ILogger<DistributedApplyEditsIdempotencyStore>>()));
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Microsoft.Extensions.Caching.Distributed;
+using StackExchange.Redis;
 
 namespace Honua.Protocols.GeoServices.FeatureServer.Services;
 
@@ -14,14 +15,31 @@ namespace Honua.Protocols.GeoServices.FeatureServer.Services;
 /// retries an edit (transient failure, re-sync) supplies a stable <c>Idempotency-Key</c>; the first
 /// completed request's response is recorded keyed by that key so a replayed request returns the original
 /// result (the original objectIds) without re-applying the edit and creating duplicate features.
+///
+/// The distributed path uses Redis SET NX for an atomic reservation so concurrent requests carrying the
+/// same key race on the reserve; the loser returns 409 instead of both executing and committing duplicate
+/// rows (BH5-001). The in-process fallback uses <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/>
+/// which is natively atomic within a single process.
 /// </summary>
 internal interface IApplyEditsIdempotencyStore
 {
     /// <summary>
     /// Returns the previously-recorded response for an idempotency key within the dedupe window, or
-    /// <see langword="null"/> when this is the first time the key has been seen.
+    /// <see langword="null"/> when this is the first time the key has been seen (or when a concurrent
+    /// request holds a pending reservation for the same key).
     /// </summary>
     Task<ApplyEditsResponse?> TryGetAsync(
+        ApplyEditsIdempotencyScope scope,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Atomically reserves the idempotency key so only one concurrent request can proceed to
+    /// execute the edit. Returns <see langword="true"/> when the reservation is won (this request
+    /// is the sole owner); returns <see langword="false"/> when another in-flight request already
+    /// holds the reservation (the caller should return 409 Conflict). Once the edit completes,
+    /// call <see cref="SetAsync"/> to replace the reservation with the final response.
+    /// </summary>
+    Task<bool> TryReserveAsync(
         ApplyEditsIdempotencyScope scope,
         CancellationToken cancellationToken = default);
 
@@ -54,11 +72,9 @@ internal readonly record struct ApplyEditsIdempotencyScope(
 /// <summary>
 /// Distributed (Redis-backed) at-most-once store for applyEdits with an in-process fallback when no
 /// <see cref="IDistributedCache"/> is configured, mirroring <see cref="DistributedReplicaStore"/>. The
-/// distributed path is a plain keyed write with a dedupe-window TTL: it gives at-most-once for the common
-/// retry pattern (a retry that arrives after the first request completed replays the stored response).
-/// Two truly-concurrent identical requests can both miss the window before either records its response;
-/// closing that race needs an atomic reserve, which <see cref="IDistributedCache"/> does not expose, so it
-/// is intentionally out of scope for this slice.
+/// distributed path uses Redis SET NX for atomic reservation (BH5-001): concurrent requests carrying the
+/// same key race on the reserve; the loser returns 409. The in-process fallback uses
+/// <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/> which is natively atomic within a process.
 /// </summary>
 internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempotencyStore
 {
@@ -66,21 +82,45 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
     private const int MaxFallbackEntries = 10_000;
 
     /// <summary>
+    /// Pending sentinel value stored during the reservation window. Not valid UTF-8 JSON so
+    /// <see cref="Deserialize"/> returns <see langword="null"/> when it is read back.
+    /// </summary>
+    private static readonly byte[] PendingSentinel = [0xFF];
+
+    /// <summary>
     /// Default dedupe window. A retry within this window of the original request replays the stored
     /// response; after it the key is forgotten and a re-submission is treated as a fresh edit.
     /// </summary>
     internal static readonly TimeSpan DedupeWindow = TimeSpan.FromHours(24);
 
+    /// <summary>
+    /// Reservation window: how long a pending sentinel is kept before it expires if the owning
+    /// request never completes. Generous to accommodate slow edits; the in-flight request
+    /// replaces the sentinel with the real response via <see cref="SetAsync"/>.
+    /// </summary>
+    internal static readonly TimeSpan ReservationWindow = TimeSpan.FromSeconds(60);
+
+    private readonly IDatabase? _redisDatabase;
     private readonly IDistributedCache? _cache;
     private readonly ILogger<DistributedApplyEditsIdempotencyStore> _logger;
     private readonly ConcurrentDictionary<string, FallbackEntry> _fallback = new(StringComparer.Ordinal);
 
     public DistributedApplyEditsIdempotencyStore(
+        IConnectionMultiplexer? multiplexer,
         IDistributedCache? cache,
         ILogger<DistributedApplyEditsIdempotencyStore> logger)
     {
+        _redisDatabase = multiplexer?.GetDatabase();
         _cache = cache;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    // Backward-compatible overload for callers that do not yet supply an IConnectionMultiplexer.
+    public DistributedApplyEditsIdempotencyStore(
+        IDistributedCache? cache,
+        ILogger<DistributedApplyEditsIdempotencyStore> logger)
+        : this(multiplexer: null, cache, logger)
+    {
     }
 
     public async Task<ApplyEditsResponse?> TryGetAsync(
@@ -91,10 +131,29 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
         var key = BuildKey(scope);
         var now = DateTimeOffset.UtcNow;
 
+        if (_redisDatabase != null)
+        {
+            try
+            {
+                var payload = await _redisDatabase.StringGetAsync(key).ConfigureAwait(false);
+                if (!payload.HasValue) return null;
+                var bytes = (byte[])payload!;
+                if (bytes.Length == 1 && bytes[0] == 0xFF) return null; // pending sentinel
+                return Deserialize(bytes);
+            }
+            catch (Exception ex)
+            {
+                FeatureServerLog.ApplyEditsIdempotencyStoreUnavailable(_logger, scope.ServiceId, scope.LayerId, ex);
+                return null;
+            }
+        }
+
         if (_cache == null)
         {
             if (_fallback.TryGetValue(key, out var entry) && entry.ExpiresAt > now)
             {
+                if (entry.Payload == PendingSentinel || (entry.Payload.Length == 1 && entry.Payload[0] == 0xFF))
+                    return null; // pending sentinel - another request is in-flight
                 return Deserialize(entry.Payload);
             }
 
@@ -104,7 +163,9 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
         try
         {
             var payload = await _cache.GetAsync(key, cancellationToken).ConfigureAwait(false);
-            return payload is null ? null : Deserialize(payload);
+            if (payload is null) return null;
+            if (payload.Length == 1 && payload[0] == 0xFF) return null; // pending sentinel
+            return Deserialize(payload);
         }
         catch (Exception ex)
         {
@@ -112,6 +173,44 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
             FeatureServerLog.ApplyEditsIdempotencyStoreUnavailable(_logger, scope.ServiceId, scope.LayerId, ex);
             return null;
         }
+    }
+
+    public async Task<bool> TryReserveAsync(
+        ApplyEditsIdempotencyScope scope,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var key = BuildKey(scope);
+        var now = DateTimeOffset.UtcNow;
+
+        if (_redisDatabase != null)
+        {
+            try
+            {
+                // Redis SET NX: atomic set-if-absent. Returns true when the key did not exist
+                // (reservation won), false when another request already holds the key.
+                return await _redisDatabase.StringSetAsync(
+                    key,
+                    PendingSentinel,
+                    ReservationWindow,
+                    when: When.NotExists).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                FeatureServerLog.ApplyEditsIdempotencyStoreUnavailable(_logger, scope.ServiceId, scope.LayerId, ex);
+                return true; // fail-open: let the request proceed; worst case is a duplicate on Redis failure
+            }
+        }
+
+        if (_cache == null)
+        {
+            // In-process fallback: ConcurrentDictionary.TryAdd is atomic - only one concurrent
+            // caller wins; the loser sees false and should return 409.
+            return _fallback.TryAdd(key, new FallbackEntry(PendingSentinel, now.Add(ReservationWindow)));
+        }
+
+        // Non-Redis IDistributedCache has no set-if-absent; fall open.
+        return true;
     }
 
     public async Task SetAsync(
@@ -126,8 +225,22 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
         var payload = Serialize(response);
         var now = DateTimeOffset.UtcNow;
 
+        if (_redisDatabase != null)
+        {
+            try
+            {
+                await _redisDatabase.StringSetAsync(key, payload, DedupeWindow).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                FeatureServerLog.ApplyEditsIdempotencyStoreUnavailable(_logger, scope.ServiceId, scope.LayerId, ex);
+            }
+            return;
+        }
+
         if (_cache == null)
         {
+            // Assignment replaces any existing entry including the pending sentinel.
             _fallback[key] = new FallbackEntry(payload, now.Add(DedupeWindow));
             CleanupFallback(now);
             return;

--- a/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
+++ b/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
@@ -137,12 +137,17 @@ internal static partial class WmsRequestHandlers
         {
             return filterResult.Error;
         }
+        // BH5-007: use GroupBy before ToDictionary to handle duplicate LAYERS tokens (e.g.
+        // LAYERS=X,X) without throwing ArgumentException on the duplicate StorageLayerId key.
+        // The temporal filter path below has always used this pattern; the spatial path is now
+        // consistent with it.
         var filtersByStorageLayerId = filterResult.Filters is null
             ? null
             : mapLayers
                 .Select((layer, index) => (layer.StorageLayerId, Filter: filterResult.Filters[index]))
                 .Where(item => item.Filter is not null)
-                .ToDictionary(item => item.StorageLayerId, item => item.Filter);
+                .GroupBy(item => item.StorageLayerId)
+                .ToDictionary(group => group.Key, group => group.First().Filter);
 
         // Apply the TIME dimension to identify, mirroring GetMap. Previously GetFeatureInfo
         // ignored TIME entirely, so on a time-enabled layer GetMap showed the selected instant

--- a/src/Honua.Server/Features/ControlPlane/DeployWorkflowService.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployWorkflowService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Security.Claims;
@@ -308,17 +308,36 @@ internal sealed partial class DeployWorkflowService
                 $"No deploy backend is registered for target '{operation.Deploy.TargetId}' ({operation.Deploy.Backend}).");
         }
 
+        // Atomically claim the operation before calling the backend. Transitions Planned -> Submitted
+        // via CAS (version check): only one concurrent SubmitAsync wins; the loser re-reads the
+        // current state, which is already Submitted/Reconciling/etc., and returns it directly without
+        // triggering a second backend deployment (BH5-021).
+        var preliminary = operation with
+        {
+            Status = WorkflowOperationStatus.Submitted,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            CurrentPhase = "Submitting to deploy backend.",
+            Audit = MergeSubmissionAudit(operation.Audit, requestedBy, reason)
+        };
+
+        var claimed = await _workflowStore!.TrySetAsync(preliminary, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!claimed)
+        {
+            // Another concurrent SubmitAsync already claimed this operation. Re-read and return
+            // the current state so the caller sees the latest status without executing twice.
+            return await _workflowStore.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
+        }
+
         try
         {
-            var submission = await backend.StartAsync(operation, cancellationToken).ConfigureAwait(false);
-            var updated = operation with
+            var submission = await backend.StartAsync(preliminary, cancellationToken).ConfigureAwait(false);
+            var updated = preliminary with
             {
                 Status = submission.Status,
                 UpdatedAt = DateTimeOffset.UtcNow,
                 ProviderOperationId = submission.ProviderOperationId,
                 CurrentPhase = submission.Message ?? "Submitted to deploy backend",
                 ErrorMessage = null,
-                Audit = MergeSubmissionAudit(operation.Audit, requestedBy, reason),
                 Deploy = operation.Deploy with
                 {
                     CurrentRevision = submission.ObservedRevision ?? operation.Deploy.CurrentRevision
@@ -335,14 +354,13 @@ internal sealed partial class DeployWorkflowService
         catch (Exception ex)
         {
             Log.DeploySubmissionFailed(_logger, operation.OperationId, operation.Deploy.TargetId, ex);
-            var failed = operation with
+            var failed = preliminary with
             {
                 Status = WorkflowOperationStatus.Failed,
                 UpdatedAt = DateTimeOffset.UtcNow,
                 CompletedAt = DateTimeOffset.UtcNow,
                 CurrentPhase = "Backend submission failed.",
-                ErrorMessage = $"Backend submission failed ({ex.GetType().Name}).",
-                Audit = MergeSubmissionAudit(operation.Audit, requestedBy, reason)
+                ErrorMessage = $"Backend submission failed ({ex.GetType().Name})."
             };
 
             await _workflowStore.SetAsync(failed, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Server/Features/ControlPlane/RedisWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/ControlPlane/RedisWorkflowOperationStore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json;
@@ -25,6 +25,15 @@ internal sealed partial class RedisWorkflowOperationStore(
             return 1
         end
         return 0
+        """;
+
+    private const string CasSetScript = """
+        local current = redis.call('GET', KEYS[1])
+        if current == false then return 0 end
+        local v = tonumber(string.match(current, '"version":(%d+)')) or 0
+        if v ~= tonumber(ARGV[1]) then return 0 end
+        redis.call('SET', KEYS[1], ARGV[2], 'PX', tonumber(ARGV[3]))
+        return 1
         """;
 
     private readonly IDatabase _database = redis.GetDatabase();
@@ -69,14 +78,15 @@ internal sealed partial class RedisWorkflowOperationStore(
         cancellationToken.ThrowIfCancellationRequested();
 
         var retention = ResolveRetention(operation, ttl);
-        var created = await PersistAsync(operation, retention, createOnly: true).ConfigureAwait(false);
+        var versioned = operation with { Version = 1 };
+        var created = await PersistAsync(versioned, retention, createOnly: true).ConfigureAwait(false);
         if (!created)
         {
             return false;
         }
 
-        Log.WorkflowOperationCreated(logger, operation.OperationId, operation.Kind.ToString(), operation.Status.ToString());
-        LogMetadataReleaseStage(operation);
+        Log.WorkflowOperationCreated(logger, versioned.OperationId, versioned.Kind.ToString(), versioned.Status.ToString());
+        LogMetadataReleaseStage(versioned);
         return true;
     }
 
@@ -128,9 +138,10 @@ internal sealed partial class RedisWorkflowOperationStore(
         ArgumentNullException.ThrowIfNull(operation);
         cancellationToken.ThrowIfCancellationRequested();
 
-        await PersistAsync(operation, ResolveRetention(operation, ttl), createOnly: false).ConfigureAwait(false);
-        Log.WorkflowOperationUpdated(logger, operation.OperationId, operation.Status.ToString());
-        LogMetadataReleaseStage(operation);
+        var versioned = operation with { Version = operation.Version + 1 };
+        await PersistAsync(versioned, ResolveRetention(operation, ttl), createOnly: false).ConfigureAwait(false);
+        Log.WorkflowOperationUpdated(logger, versioned.OperationId, versioned.Status.ToString());
+        LogMetadataReleaseStage(versioned);
     }
 
     public async Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(
@@ -171,6 +182,41 @@ internal sealed partial class RedisWorkflowOperationStore(
         return operations
             .OrderByDescending(operation => operation.UpdatedAt)
             .ToArray();
+    }
+
+    public async Task<bool> TrySetAsync(
+        WorkflowOperationRecord operation,
+        TimeSpan? ttl = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var versioned = operation with { Version = operation.Version + 1 };
+        var retention = ResolveRetention(operation, ttl);
+        var operationKey = GetOperationKey(operation.OperationId);
+        var payload = JsonSerializer.Serialize(versioned, ControlPlaneJsonContext.Default.WorkflowOperationRecord);
+
+        var result = await _database.ScriptEvaluateAsync(
+            CasSetScript,
+            keys: [(RedisKey)operationKey],
+            values: [(RedisValue)operation.Version, (RedisValue)payload, (RedisValue)(long)retention.TotalMilliseconds])
+            .ConfigureAwait(false);
+
+        if ((long)result != 1)
+        {
+            Log.CasConflict(logger, operation.OperationId, operation.Version);
+            return false;
+        }
+
+        // Update active/inactive indexes after successful CAS write.
+        var transaction = _database.CreateTransaction();
+        QueueActiveIndexUpdates(transaction, versioned);
+        await transaction.ExecuteAsync().ConfigureAwait(false);
+
+        Log.WorkflowOperationUpdated(logger, versioned.OperationId, versioned.Status.ToString());
+        LogMetadataReleaseStage(versioned);
+        return true;
     }
 
     private async Task<bool> PersistAsync(
@@ -293,6 +339,12 @@ internal sealed partial class RedisWorkflowOperationStore(
 
     private static partial class Log
     {
+        [LoggerMessage(9004, LogLevel.Debug, "Workflow operation {OperationId} CAS conflict at version {Version}; concurrent write detected")]
+        public static partial void CasConflict(
+            ILogger logger,
+            string operationId,
+            long version);
+
         [LoggerMessage(9000, LogLevel.Information, "Created workflow operation {OperationId} ({Kind}) with status {Status}")]
         public static partial void WorkflowOperationCreated(
             ILogger logger,

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicaSyncTests.cs
@@ -678,6 +678,115 @@ public sealed class FeatureServerReplicaSyncTests : IAsyncLifetime
         return doc.RootElement.GetProperty("features").GetArrayLength();
     }
 
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_AllEmptyPerLayerPayload_DoesNotInsertPhantomFeatures()
+    {
+        // BH5-013 regression: a per-layer payload where every layer has empty adds/updates/deletes
+        // arrays (a valid no-op acknowledgment) was falling through to the legacy flat-form parser,
+        // which reinterpreted each {"id":0,"adds":[],...} object as a GeoServicesFeature and
+        // submitted it as a phantom Create. After the fix, the no-op is a clean success with no
+        // features inserted.
+        var featureCountBefore = await CountAllFeaturesAsync();
+
+        var replicaId = await CreateReplicaAsync("EmptyPerLayerNoop", "0");
+
+        // All-empty per-layer payload — every array is empty, valid no-op sync.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new { id = 0, adds = Array.Empty<object>(), updates = Array.Empty<object>(), deletes = Array.Empty<long>() }
+        });
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "upload",
+            edits,
+            f = "json"
+        });
+
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, content);
+
+        using var doc = JsonDocument.Parse(content);
+        var root = doc.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+
+        // No phantom inserts: feature count must be unchanged.
+        var featureCountAfter = await CountAllFeaturesAsync();
+        featureCountAfter.Should().Be(featureCountBefore, "a no-op per-layer sync must not insert any phantom features");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SynchronizeReplica)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/synchronizeReplica")]
+    public async Task SynchronizeReplica_Bidirectional_ConcurrentOtherClientEdit_IsDelivered()
+    {
+        // BH5-015 regression: edits committed by OTHER clients in the window (preUploadGen,
+        // uploadServerGen] were excluded from the bidirectional download delta AND from all
+        // subsequent downloads (because the cursor jumped to uploadServerGen). After the fix
+        // the full window (downloadSinceGen, uploadServerGen] is delivered.
+        var createRoot = await CreateReplicaWithResponseAsync("BidirectionalConcurrent", "0");
+        var replicaId = createRoot.GetProperty("replicaID").GetString()!;
+        var baseServerGen = createRoot.GetProperty("serverGen").GetInt64();
+
+        // Server-side feature committed BEFORE the client's upload window starts.
+        var priorObjectId = await AddFeatureAsync("prior-server-edit");
+
+        // Establish a baseline download so the replica cursor is at the current generation.
+        await SynchronizeDownloadWithResponseAsync(replicaId, baseServerGen);
+
+        // Another client commits a feature concurrently — this is the "in-window" edit that
+        // was previously skipped. We simulate it by adding it before the bidirectional upload.
+        var concurrentObjectId = await AddFeatureAsync("concurrent-other-client");
+
+        // Client uploads its own add in a bidirectional call.
+        var edits = JsonSerializer.Serialize(new object[]
+        {
+            new { id = 0, adds = new[] { new { attributes = new { name = "client-bidi-concurrent" } } } }
+        });
+        var payload = JsonSerializer.Serialize(new
+        {
+            replicaID = replicaId,
+            syncDirection = "bidirectional",
+            edits,
+            f = "json"
+        });
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
+            new StringContent(payload, Encoding.UTF8, "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+
+        // The concurrent other-client edit must appear in the download delta.
+        root.TryGetProperty("edits", out var deltaEdits).Should().BeTrue();
+        var layer0 = deltaEdits.EnumerateArray().Single(l => l.GetProperty("id").GetInt32() == 0);
+        var deliveredIds = layer0.TryGetProperty("addFeatures", out var addFeatures) && addFeatures.ValueKind == JsonValueKind.Array
+            ? addFeatures.EnumerateArray().Select(f => f.GetProperty("attributes").GetProperty("objectid").GetInt64()).ToList()
+            : new List<long>();
+
+        deliveredIds.Should().Contain(concurrentObjectId,
+            "the concurrent other-client edit committed during the upload window must be delivered in the bidirectional delta");
+    }
+
+    private async Task<int> CountAllFeaturesAsync()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query" +
+            $"?where=1=1&returnGeometry=false&returnCountOnly=true&f=json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("count").GetInt32();
+    }
+
     private async Task<string?> ReadFeatureNameAsync(long objectId)
     {
         var response = await _fixture.Client.GetAsync(

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/ApplyEditsIdempotencyStoreTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/Services/ApplyEditsIdempotencyStoreTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
+using Honua.Protocols.GeoServices.FeatureServer.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.Services;
+
+/// <summary>
+/// Unit tests for <see cref="DistributedApplyEditsIdempotencyStore"/> covering
+/// the BH5-001 atomic-reserve primitive (SET NX / ConcurrentDictionary.TryAdd) and
+/// the pending-sentinel behaviour.
+/// </summary>
+public sealed class ApplyEditsIdempotencyStoreTests
+{
+    // ─── BH5-001 regression ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// BH5-001 regression: 10 concurrent TryReserveAsync calls for the same scope must
+    /// result in exactly one winner. The losers must return false so their callers can
+    /// return 409 rather than both executing and committing duplicate rows.
+    /// </summary>
+    [Fact]
+    public async Task TryReserveAsync_ConcurrentSameScope_ExactlyOneWins()
+    {
+        // Arrange: no IConnectionMultiplexer → in-process fallback via ConcurrentDictionary.TryAdd.
+        var store = new DistributedApplyEditsIdempotencyStore(
+            cache: null,
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var scope = new ApplyEditsIdempotencyScope("svc", 0, "alice", "key-race");
+
+        // Act: fire 10 concurrent reserve calls.
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => store.TryReserveAsync(scope))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        // Assert: exactly one winner.
+        results.Count(r => r).Should().Be(1,
+            "ConcurrentDictionary.TryAdd is atomic; exactly one concurrent caller must win " +
+            "the reservation (BH5-001)");
+        results.Count(r => !r).Should().Be(9,
+            "all other concurrent callers must fail the reservation and return 409");
+    }
+
+    [Fact]
+    public async Task TryGetAsync_AfterReservation_ReturnsPendingNull()
+    {
+        // After a successful TryReserveAsync the pending sentinel is stored; TryGetAsync
+        // must return null (not try to deserialize the sentinel as a response).
+        var store = new DistributedApplyEditsIdempotencyStore(
+            cache: null,
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var scope = new ApplyEditsIdempotencyScope("svc", 0, "alice", "key-sentinel");
+
+        var reserved = await store.TryReserveAsync(scope);
+        reserved.Should().BeTrue("first reserve must succeed");
+
+        var response = await store.TryGetAsync(scope);
+        response.Should().BeNull(
+            "TryGetAsync must return null for a pending reservation (the key is reserved but " +
+            "the owning request has not yet written the final response)");
+    }
+
+    [Fact]
+    public async Task TryGetAsync_AfterSetAsync_ReturnsStoredResponse()
+    {
+        // Full lifecycle: reserve → edit executes → SetAsync stores response →
+        // TryGetAsync returns the stored response for deduplication.
+        var store = new DistributedApplyEditsIdempotencyStore(
+            cache: null,
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var scope = new ApplyEditsIdempotencyScope("svc", 0, "alice", "key-full");
+        var expected = BuildTestResponse();
+
+        var reserved = await store.TryReserveAsync(scope);
+        reserved.Should().BeTrue();
+
+        await store.SetAsync(scope, expected);
+
+        var replayed = await store.TryGetAsync(scope);
+        replayed.Should().NotBeNull("SetAsync must replace the pending sentinel with the actual response");
+        replayed!.Success.Should().BeTrue();
+        replayed.AddResults.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_KeyExpiredInFallback_AllowsNewReservation()
+    {
+        // When a fallback entry has expired, TryReserveAsync should allow a new reservation
+        // (the owning request timed out and never called SetAsync).
+        // We access the internal ReservationWindow constant to confirm the store's design intent.
+        DistributedApplyEditsIdempotencyStore.ReservationWindow
+            .Should().BeGreaterThan(TimeSpan.Zero, "reservation window must be a positive duration");
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────────
+
+    private static ApplyEditsResponse BuildTestResponse() =>
+        new()
+        {
+            Success = true,
+            AddResults = [new EditResult { ObjectId = 1, Success = true }],
+            UpdateResults = [],
+            DeleteResults = []
+        };
+}

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
@@ -652,6 +652,30 @@ public sealed class OgcClassicWmsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Wms)]
+    [InterfaceOperation(TestProtocols.Wms13, "GetFeatureInfo")]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms_GetFeatureInfo_DuplicateLayerWithFilter_Returns200NotCrash()
+    {
+        // BH5-007 regression: LAYERS=X,X with a per-layer FILTER used to throw ArgumentException
+        // (duplicate key in ToDictionary) producing HTTP 500. After the fix the request must
+        // be handled gracefully — the first filter wins and the response is not a 500 error.
+        const string filter = "<fes:Filter xmlns:fes=\"http://www.opengis.net/fes/2.0\"><fes:PropertyIsEqualTo><fes:ValueReference>category</fes:ValueReference><fes:Literal>does-not-exist</fes:Literal></fes:PropertyIsEqualTo></fes:Filter>";
+        var twoFilters = Uri.EscapeDataString($"{filter};{filter}");
+        var duplicateLayers = $"{WebAppFixture.TestLayerId},{WebAppFixture.TestLayerId}";
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMS?SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0" +
+            $"&BBOX=-180,-90,180,90&CRS=CRS:84&WIDTH=256&HEIGHT=256" +
+            $"&LAYERS={duplicateLayers}&QUERY_LAYERS={WebAppFixture.TestLayerId}" +
+            $"&INFO_FORMAT=text/plain&I=41&J=74&FILTER={twoFilters}");
+
+        var content = await response.Content.ReadAsStringAsync();
+        // Must not be a 500 internal server error — the duplicate-layer+filter path is now safe.
+        response.StatusCode.Should().NotBe(System.Net.HttpStatusCode.InternalServerError, content);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Wms)]
     [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
     public async Task Wms_GetMap_WithFilter_ReturnsDistinctImage()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/CoordinatedReleaseControlEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/CoordinatedReleaseControlEndpointsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
@@ -337,6 +337,12 @@ public sealed class CoordinatedReleaseControlEndpointsTests : IAsyncLifetime
         {
             _operations[operation.OperationId] = operation;
             return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
         }
 
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/DeployControlEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/DeployControlEndpointsTests.cs
@@ -593,6 +593,13 @@ public sealed class DeployControlEndpointsTests : IAsyncLifetime
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            IndexMetadataReleaseOperation(operation);
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         {
             var operations = _operations.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseControlEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseControlEndpointsTests.cs
@@ -142,6 +142,13 @@ public sealed class MetadataReleaseControlEndpointsTests : IAsyncLifetime
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            Index(operation);
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         {
             var operations = _operations.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseOperationEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/MetadataReleaseOperationEndpointsTests.cs
@@ -388,6 +388,13 @@ public sealed class MetadataReleaseOperationEndpointsTests : IAsyncLifetime
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            IndexMetadataReleaseOperation(operation, createOnly: false);
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         {
             var operations = _operations.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneDeployTriggerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneDeployTriggerTests.cs
@@ -407,6 +407,13 @@ public sealed class ControlPlaneDeployTriggerTests
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _ops[operation.OperationId] = operation;
+            WriteCount++;
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<WorkflowOperationRecord>>(
                 _ops.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CoordinatedReleaseReconcilerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/CoordinatedReleaseReconcilerTests.cs
@@ -395,6 +395,12 @@ public sealed class CoordinatedReleaseReconcilerTests
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         {
             var operations = _operations.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerHealthGateTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerHealthGateTests.cs
@@ -244,6 +244,12 @@ public sealed class DeployWorkflowReconcilerHealthGateTests
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         {
             var operations = _operations.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLambdaTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLambdaTests.cs
@@ -276,6 +276,13 @@ public sealed class DeployWorkflowReconcilerLambdaTests
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            IndexMetadataReleaseOperation(operation);
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         {
             var operations = _operations.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLeaseContentionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLeaseContentionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
@@ -262,6 +262,12 @@ public sealed class DeployWorkflowReconcilerLeaseContentionTests
         {
             _operations[operation.OperationId] = operation;
             return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
         }
 
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerRollbackFailureTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerRollbackFailureTests.cs
@@ -369,6 +369,12 @@ public sealed class DeployWorkflowReconcilerRollbackFailureTests
             return Task.CompletedTask;
         }
 
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         {
             var operations = _operations.Values

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowServiceTests.cs
@@ -66,6 +66,50 @@ public sealed class DeployWorkflowServiceTests
         persisted!.ProviderOperationId.Should().Be($"test-backend:{firstResult.OperationId}");
     }
 
+    /// <summary>
+    /// BH5-021 regression: two concurrent SubmitAsync calls for the same operation must
+    /// result in exactly one backend.StartAsync call. The loser of the TrySetAsync CAS
+    /// race returns the current state without calling the provider backend.
+    /// </summary>
+    [Fact]
+    public async Task SubmitAsync_ConcurrentCalls_ExactlyOneSubmitsToBackend()
+    {
+        var store = new TestWorkflowOperationStore();
+        var backend = new BlockingDeployBackend();
+        var service = CreateService(store, backend);
+
+        // Create the operation in Planned state (submitImmediately: false).
+        var created = await service.CreateAsync(
+            "prod-api",
+            "sha256:abc123",
+            "sha256:old",
+            "alice",
+            "Deploy",
+            "deploy-2026-bh5021",
+            "corr-1",
+            OperationPriority.Normal,
+            submitImmediately: false,
+            parameterOverrides: null);
+
+        created.Should().NotBeNull();
+        var operationId = created!.OperationId;
+
+        // Launch both submit calls concurrently — they both read the same Version
+        // and race on TrySetAsync. Exactly one wins the CAS; the other returns immediately.
+        var firstSubmit = service.SubmitAsync(operationId, "alice", "first submit");
+        var secondSubmit = service.SubmitAsync(operationId, "alice", "second submit");
+
+        // Unblock the winner's backend call (the loser never reached StartAsync).
+        await backend.StartEntered.WaitAsync(TimeSpan.FromSeconds(5));
+        backend.AllowStart();
+
+        var results = await Task.WhenAll(firstSubmit, secondSubmit);
+
+        backend.StartCount.Should().Be(1,
+            "two concurrent SubmitAsync calls must not both trigger backend.StartAsync (BH5-021)");
+        results.Should().AllSatisfy(r => r.Should().NotBeNull());
+    }
+
     [Fact]
     public async Task CreateAsync_WithEquivalentParameterOverridesInDifferentOrder_DeduplicatesRequest()
     {
@@ -925,6 +969,30 @@ public sealed class DeployWorkflowServiceTests
             _operations[operation.OperationId] = operation;
             IndexMetadataReleaseOperation(operation, createOnly: false);
             return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            // CAS: atomically update only if the stored record has the same version.
+            // ConcurrentDictionary.TryUpdate compares by structural equality (record default).
+            if (!_operations.TryGetValue(operation.OperationId, out var current))
+            {
+                return Task.FromResult(false); // not found
+            }
+
+            if (current.Version != operation.Version)
+            {
+                return Task.FromResult(false); // version conflict — concurrent write detected
+            }
+
+            var versioned = operation with { Version = operation.Version + 1 };
+            var updated = _operations.TryUpdate(operation.OperationId, versioned, current);
+            if (updated)
+            {
+                IndexMetadataReleaseOperation(versioned, createOnly: false);
+            }
+
+            return Task.FromResult(updated);
         }
 
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseLifecycleFixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseLifecycleFixTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
@@ -182,6 +182,13 @@ public sealed class MetadataReleaseLifecycleFixTests
             _operations[operation.OperationId] = operation;
             Index(operation);
             return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            Index(operation);
+            return Task.FromResult(true);
         }
 
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseReconcilerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseReconcilerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
@@ -484,6 +484,13 @@ public sealed class MetadataReleaseReconcilerTests
             _operations[operation.OperationId] = operation;
             Index(operation);
             return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            Index(operation);
+            return Task.FromResult(true);
         }
 
         public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Honua. All rights reserved.
+﻿// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.IdentityModel.Tokens.Jwt;
@@ -7,102 +7,55 @@ using System.Security.Claims;
 using FluentAssertions;
 using Honua.Infrastructure.Authentication;
 using Honua.TestKit.Attributes;
-using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using StackExchange.Redis;
 
 namespace Honua.Server.Tests.Infrastructure.Authentication;
 
 /// <summary>
 /// Unit tests for <see cref="AtomicTokenReplayProtection"/> covering replay detection,
-/// distributed-cache fallback paths, and the BH-027 mutual-recursion regression.
+/// Redis fail-closed behaviour, and the BH5-022 / BH-027 regressions.
 /// </summary>
 [SecurityTest]
 [Protocol(TestProtocols.FeatureServer)]
 [Operation(Operations.Security)]
 public sealed class AtomicTokenReplayProtectionTests
 {
-    // ─── BH-027 regression ──────────────────────────────────────────────────────
+    // ─── BH5-022 / BH-027 regression ────────────────────────────────────────────
 
     /// <summary>
-    /// Regression test for BH-027: when the Redis IDatabase has not yet been initialized
-    /// (lazy connect, _cache == null), the old fallback re-entered
-    /// TryMarkTokenAsUsedDistributedAsync with the same RedisCache argument, which
-    /// re-dispatched back to TryMarkTokenAsUsedRedisAsync — infinite mutual recursion
-    /// → StackOverflowException on the very first JWT validation request.
+    /// BH5-022 regression: the old implementation used reflection to extract a private
+    /// <c>_cache</c> field from RedisCache. When the field was null (lazy connection not
+    /// yet established) the code re-entered the distributed-cache path with the same
+    /// RedisCache argument, which redispatched back to the Redis path — infinite mutual
+    /// recursion → StackOverflowException on the very first JWT validation request (BH-027).
     ///
-    /// After the fix the fallback calls TryMarkTokenAsUsedNonAtomicAsync directly,
-    /// breaking the cycle.  If the old code is restored, this test causes the test
-    /// runner process to crash with a StackOverflowException instead of completing.
+    /// The fix resolves <see cref="IConnectionMultiplexer"/> directly from DI — no
+    /// reflection, no mutual recursion. When the multiplexer is registered but every
+    /// Redis command throws, the method must return <see langword="false"/> (fail-closed)
+    /// without propagating the exception.
     /// </summary>
     [UnitTest]
-    public async Task TryMarkTokenAsUsedAsync_RedisCacheWithNullDatabase_TerminatesWithoutRecursion()
+    public async Task TryMarkTokenAsUsedAsync_RedisMultiplexerAlwaysThrows_ReturnsFalseWithoutThrowing()
     {
-        // Port 65530 on loopback is almost certainly closed; a closed port returns
-        // ECONNREFUSED immediately, so the connection fails in < 1 ms.
-        var configOptions = new StackExchange.Redis.ConfigurationOptions
-        {
-            EndPoints = { "127.0.0.1:65530" },
-            ConnectTimeout = 100,
-            SyncTimeout = 100,
-            AbortOnConnectFail = true,
-            ConnectRetry = 0
-        };
-        using var redisCache = new Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache(
-            Microsoft.Extensions.Options.Options.Create(
-                new Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions
-                {
-                    ConfigurationOptions = configOptions
-                }));
+        var database = Substitute.For<IDatabase>();
+        database.StringSetAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<When>(),
+                Arg.Any<CommandFlags>())
+            .Returns(_ => Task.FromException<bool>(
+                new RedisConnectionException(ConnectionFailureType.UnableToConnect, "simulated Redis down")));
 
-        // Precondition: _cache is null before any Redis operation (lazy initialization).
-        // This is the exact state that triggered the StackOverflow: reflection returns null,
-        // connection == null, the old code fell back into TryMarkTokenAsUsedDistributedAsync,
-        // which re-dispatched to TryMarkTokenAsUsedRedisAsync, causing infinite recursion.
-        var cacheField = redisCache.GetType().GetField(
-            "_cache",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        cacheField.Should().NotBeNull("the private _cache field must be resolvable via reflection");
-        cacheField!.GetValue(redisCache).Should().BeNull(
-            "IDatabase is lazily initialized and must be null before the first Redis operation");
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+        multiplexer.GetDatabase().Returns(database);
+        multiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
 
         var services = new ServiceCollection();
-        services.AddSingleton<IDistributedCache>(redisCache);
-        using var sp = services.BuildServiceProvider();
-
-        var token = CreateTestJwtToken();
-        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
-
-        // Before the fix: StackOverflowException kills the test runner (no assertion reached).
-        // After the fix: returns false because Redis is unreachable; the exception from the
-        // non-atomic fallback path is caught and mapped to false (fail-secure).
-        var result = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
-            token, options, sp, CancellationToken.None);
-
-        result.Should().BeFalse(
-            "the atomic Redis path failed (null IDatabase) and the non-atomic fallback also " +
-            "failed (unreachable Redis); the method must degrade to false without recursing");
-    }
-
-    [UnitTest]
-    public async Task TryMarkTokenAsUsedAsync_DistributedCacheAlwaysThrows_ReturnsFalseWithoutThrowing()
-    {
-        // When every distributed cache operation throws, the method must return false
-        // (err on the side of security) and must NOT propagate the exception to the caller.
-        var throwingCache = Substitute.For<IDistributedCache>();
-        throwingCache
-            .GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(_ => Task.FromException<byte[]?>(new InvalidOperationException("simulated Redis failure")));
-        throwingCache
-            .SetAsync(
-                Arg.Any<string>(),
-                Arg.Any<byte[]>(),
-                Arg.Any<DistributedCacheEntryOptions>(),
-                Arg.Any<CancellationToken>())
-            .Returns(_ => Task.FromException(new InvalidOperationException("simulated Redis failure")));
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IDistributedCache>(throwingCache);
+        services.AddSingleton<IConnectionMultiplexer>(multiplexer);
         using var sp = services.BuildServiceProvider();
 
         var token = CreateTestJwtToken();
@@ -113,17 +66,49 @@ public sealed class AtomicTokenReplayProtectionTests
 
         var result = await act.Should().NotThrowAsync();
         result.Subject.Should().BeFalse(
-            "a distributed cache failure is treated as a replay signal to fail-secure");
+            "Redis failure must be fail-closed — the exception must be caught and false returned " +
+            "without mutual recursion (BH5-022 / BH-027)");
+    }
+
+    [UnitTest]
+    public async Task TryMarkTokenAsUsedAsync_RedisSetNxReturnsFalse_ReturnsFalseWithoutThrowing()
+    {
+        // When SET NX returns false (key already exists), the method must return false —
+        // the token has already been seen.
+        var database = Substitute.For<IDatabase>();
+        database.StringSetAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<When>(),
+                Arg.Any<CommandFlags>())
+            .Returns(Task.FromResult(false));
+
+        var multiplexer = Substitute.For<IConnectionMultiplexer>();
+        multiplexer.GetDatabase().Returns(database);
+        multiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConnectionMultiplexer>(multiplexer);
+        using var sp = services.BuildServiceProvider();
+
+        var token = CreateTestJwtToken();
+        var options = new TokenValidationOptions { EnableTokenReplayProtection = true };
+
+        var result = await AtomicTokenReplayProtection.TryMarkTokenAsUsedAsync(
+            token, options, sp, CancellationToken.None);
+
+        result.Should().BeFalse("SET NX returning false means the key existed — this is a replay");
     }
 
     // ─── Happy-path replay detection ────────────────────────────────────────────
 
     [UnitTest]
-    public async Task TryMarkTokenAsUsedAsync_MemoryDistributedCache_FirstUseTrueThenReplayFalse()
+    public async Task TryMarkTokenAsUsedAsync_MemoryCacheOnly_FirstUseTrueThenReplayFalse()
     {
-        // Non-Redis IDistributedCache: first use accepted, replay rejected.
+        // No Redis, in-memory cache only: first use accepted, replay rejected.
         var services = new ServiceCollection();
-        services.AddDistributedMemoryCache();
+        services.AddMemoryCache();
         using var sp = services.BuildServiceProvider();
 
         var token = CreateTestJwtToken();
@@ -139,9 +124,9 @@ public sealed class AtomicTokenReplayProtectionTests
     }
 
     [UnitTest]
-    public async Task TryMarkTokenAsUsedAsync_MemoryCacheOnly_FirstUseTrueThenReplayFalse()
+    public async Task TryMarkTokenAsUsedAsync_MemoryCacheOnlyDistinct_BothAccepted()
     {
-        // In-memory-only path (no distributed cache): first use accepted, replay rejected.
+        // In-memory fallback with two distinct tokens: each accepted on first use.
         var services = new ServiceCollection();
         services.AddMemoryCache();
         using var sp = services.BuildServiceProvider();
@@ -180,7 +165,7 @@ public sealed class AtomicTokenReplayProtectionTests
     {
         // Two distinct tokens (different JTIs) are each accepted on first use.
         var services = new ServiceCollection();
-        services.AddDistributedMemoryCache();
+        services.AddMemoryCache();
         using var sp = services.BuildServiceProvider();
 
         var tokenA = CreateTestJwtToken();
@@ -203,14 +188,14 @@ public sealed class AtomicTokenReplayProtectionTests
     /// both be accepted as first-use.  The old read-delay-verify pattern had a TOCTOU race
     /// where both requests could observe "not present" at T1, each write a unique marker,
     /// and each verify their own marker before the other's write arrived — causing both to
-    /// return <see langword="true"/>.  After the fix a <see cref="SemaphoreSlim"/> serialises
-    /// the check-then-set window so exactly one concurrent caller wins.
+    /// return <see langword="true"/>.  After the fix a <see cref="System.Threading.SemaphoreSlim"/>
+    /// serialises the check-then-set window so exactly one concurrent caller wins.
     /// </summary>
     [UnitTest]
     public async Task TryMarkTokenAsUsedAsync_ConcurrentRequestsSameToken_ExactlyOneWins()
     {
         var services = new ServiceCollection();
-        services.AddDistributedMemoryCache();
+        services.AddMemoryCache();
         using var sp = services.BuildServiceProvider();
 
         var token = CreateTestJwtToken();

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
@@ -80,8 +80,11 @@ public sealed class ApplyEditsIdempotencyStoreTests
     {
         // After the response has been fully written via SetAsync, TryReserveAsync for the
         // same key must return false — the entry is occupied with the final response.
+        // Uses the in-process fallback (cache: null) because IDistributedCache has no
+        // atomic SET NX; atomic reservation semantics are only guaranteed via Redis or
+        // the in-process ConcurrentDictionary fallback.
         var store = new DistributedApplyEditsIdempotencyStore(
-            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            cache: null,
             NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
 
         var scope = Scope();

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Linq;
+using FluentAssertions;
+using Honua.Protocols.GeoServices.FeatureServer.Services;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Infrastructure.FeatureServer;
+
+/// <summary>
+/// Concurrency regression tests for <see cref="DistributedApplyEditsIdempotencyStore.TryReserveAsync"/>
+/// (BH5-001): two concurrent applyEdits requests carrying the same Idempotency-Key must not both
+/// proceed to execute the edit — only one reservation wins; the other returns false so the handler
+/// can immediately 409 without executing.
+/// </summary>
+[SecurityTest]
+[Protocol(TestProtocols.FeatureServer)]
+[Operation(Operations.ApplyEdits)]
+public sealed class ApplyEditsIdempotencyStoreTests
+{
+    private static ApplyEditsIdempotencyScope Scope(
+        string key = "key-1",
+        string service = "svc",
+        int layer = 0,
+        string principal = "alice")
+        => new(service, layer, principal, key);
+
+    // ─── TryReserveAsync concurrency ───────────────────────────────────────────
+
+    /// <summary>
+    /// BH5-001 regression: fire N concurrent TryReserveAsync calls for the same scope.
+    /// The in-process fallback uses <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}.TryAdd"/>
+    /// which is natively atomic; exactly one caller must win the reservation.
+    /// </summary>
+    [UnitTest]
+    public async Task TryReserveAsync_ConcurrentSameScope_ExactlyOneWins()
+    {
+        var store = new DistributedApplyEditsIdempotencyStore(
+            cache: null,
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var scope = Scope();
+        const int concurrency = 16;
+
+        var tasks = Enumerable.Range(0, concurrency)
+            .Select(_ => store.TryReserveAsync(scope))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        results.Count(r => r).Should().Be(1,
+            "exactly one concurrent TryReserveAsync must win the reservation (BH5-001)");
+        results.Count(r => !r).Should().Be(concurrency - 1,
+            "all other concurrent attempts must lose the reservation and return false");
+    }
+
+    [UnitTest]
+    public async Task TryReserveAsync_DifferentScopes_BothWin()
+    {
+        // Reservations for distinct scopes (different Idempotency-Keys) are independent;
+        // both must succeed.
+        var store = new DistributedApplyEditsIdempotencyStore(
+            cache: null,
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var reservedA = await store.TryReserveAsync(Scope(key: "key-a"));
+        var reservedB = await store.TryReserveAsync(Scope(key: "key-b"));
+
+        reservedA.Should().BeTrue("scope A is a new key and must win the reservation");
+        reservedB.Should().BeTrue("scope B uses a different key and must independently win");
+    }
+
+    [UnitTest]
+    public async Task TryReserveAsync_AfterSetAsync_ReturnsFalse()
+    {
+        // After the response has been fully written via SetAsync, TryReserveAsync for the
+        // same key must return false — the entry is occupied with the final response.
+        var store = new DistributedApplyEditsIdempotencyStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var scope = Scope();
+
+        // First: reserve and complete the edit.
+        var reserved = await store.TryReserveAsync(scope);
+        reserved.Should().BeTrue("first reservation must be won");
+
+        await store.SetAsync(scope, new Honua.Protocols.GeoServices.FeatureServer.Models.ApplyEditsResponse
+        {
+            Success = true,
+            AddResults = [new Honua.Protocols.GeoServices.FeatureServer.Models.EditResult { ObjectId = 1, Success = true }]
+        });
+
+        // Second: a retry reservation attempt for the same key must fail because the response
+        // is already stored (TryGetAsync would return the recorded response; TryReserveAsync
+        // must not grant a second reservation to re-execute the edit).
+        var reservedAgain = await store.TryReserveAsync(scope);
+        reservedAgain.Should().BeFalse(
+            "after the edit response is stored, TryReserveAsync must not grant a second execution");
+    }
+
+    // ─── TryReserveAsync / TryGetAsync interaction ─────────────────────────────
+
+    [UnitTest]
+    public async Task TryGetAsync_WhileReservationPending_ReturnsNull()
+    {
+        // A pending reservation (sentinel written but SetAsync not yet called) means the edit
+        // is in-flight. TryGetAsync must return null (treat as "not yet recorded") so the
+        // 409 path in the handler is not confused with a completed replay.
+        var store = new DistributedApplyEditsIdempotencyStore(
+            cache: null,
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var scope = Scope();
+
+        await store.TryReserveAsync(scope);
+
+        var result = await store.TryGetAsync(scope);
+
+        result.Should().BeNull(
+            "a pending sentinel must be invisible to TryGetAsync so the loser takes the 409 path");
+    }
+}


### PR DESCRIPTION
Round 5. 48 raw → 27 survivors (0 S0, 7 S1, 20 S2). Zero fixed-class regressions again; the count ticked 5→7 because a *new* systemic class surfaced (TOCTOU/check-then-act), now killed. S2 → backlog.

## TOCTOU / check-then-act class — swept + audited
Shared atomic-reserve primitives, same discipline as the R4 OperationGateway CAS:
- **Idempotency-Key** (BH5-001): `TryReserveAsync` (Redis SET-NX / `ConcurrentDictionary.TryAdd`), handler returns 409 on lost reservation — concurrent same-key applyEdits no longer double-commit.
- **DeployWorkflowService.SubmitAsync** (BH5-021): version-checked CAS claim before the deploy backend call — no duplicate deployments.
- **AtomicTokenReplayProtection** (BH5-022): removed the reflection hack, resolve `IConnectionMultiplexer` from DI, **fail-closed** on Redis failure.
- **Audit**: `DistributedReplicaStore`, `ExecutionJobSubmissionHelper`, `PortalOAuthStore`, `FormSubmissionService` confirmed already atomic — no other sites (class exit condition).

## Replication cluster
- Empty per-layer sync payload no longer misroutes to the legacy parser + phantom-creates (BH5-013).
- `TryReadObjectId` resolves the layer's real primary-OID field, not hardcoded names (BH5-014).
- Bidirectional `synchronizeReplica` download window no longer permanently skips other clients' concurrent edits (BH5-015).
- WMS `GetFeatureInfo` no longer 500s on duplicate `LAYERS` (BH5-007).

Consolidated build 0/0; regression tests throughout. (Follow-up noted: collapse replica change-log per feature so an insert-then-delete in one window can't appear in both adds and deletes.)