### PR TITLE
fix(edit): stop requiring the server-assigned object id on creates for unroled id fields

### DIFF
--- a/src/Honua.Core/Features/Edit/EditProcessor.cs
+++ b/src/Honua.Core/Features/Edit/EditProcessor.cs
@@ -750,10 +750,41 @@ public sealed class EditProcessor : IEditProcessor
         return 10000; // Default maximum operations per resource
     }
 
+    /// <summary>
+    /// Determines whether <paramref name="field"/> is the resource's server-assigned primary id
+    /// field, which must never be required from a create/update client payload. A field qualifies
+    /// when it carries the <c>id.primary</c> semantic role OR when its name matches the resource's
+    /// authoritative primary-id field name (<see cref="MetadataV2SpatialExtensions.FindPrimaryIdField"/>,
+    /// which falls back to the conventional <c>objectid</c>/<c>id</c> name).
+    /// </summary>
+    /// <remarks>
+    /// The semantic-role check alone is insufficient: many seeded and published layers declare a
+    /// non-nullable <c>objectid</c> field without the <c>id.primary</c> role. BH2-014 (#2456) added a
+    /// per-field required-attribute gate that keyed exclusively on the role, so every create that
+    /// omitted <c>objectid</c> — the normal case, since the server assigns it — was rejected with
+    /// "Required attribute(s) missing for create operation: objectid". Keying the skip on the
+    /// resource's authoritative id-field name as well restores valid creates while still rejecting
+    /// genuinely-missing non-id required fields.
+    /// </remarks>
+    private static bool IsResourcePrimaryIdField(MetadataV2Field field, string? primaryIdFieldName)
+    {
+        for (var i = 0; i < field.SemanticRoles.Count; i++)
+        {
+            if (string.Equals(field.SemanticRoles[i], "id.primary", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return primaryIdFieldName is not null
+            && string.Equals(field.Name, primaryIdFieldName, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool RequiresAttributes(MetadataV2Resource resource)
     {
         // V2 fields carry Nullable but no DefaultValue — match the v1 contract by
         // treating any non-nullable, non-geometry, non-system field as required.
+        var primaryIdFieldName = resource.FindPrimaryIdField()?.Name;
         foreach (var field in resource.SchemaFields)
         {
             if (field.Nullable)
@@ -765,15 +796,11 @@ public sealed class EditProcessor : IEditProcessor
                 continue;
             }
             // Skip the primary id field — it is generated server-side on create.
-            for (var i = 0; i < field.SemanticRoles.Count; i++)
+            if (IsResourcePrimaryIdField(field, primaryIdFieldName))
             {
-                if (string.Equals(field.SemanticRoles[i], "id.primary", StringComparison.OrdinalIgnoreCase))
-                {
-                    goto next;
-                }
+                continue;
             }
             return true;
-        next:;
         }
         return false;
     }
@@ -788,6 +815,7 @@ public sealed class EditProcessor : IEditProcessor
         ImmutableDictionary<string, object?> attributes)
     {
         var missing = new List<string>();
+        var primaryIdFieldName = resource.FindPrimaryIdField()?.Name;
 
         foreach (var field in resource.SchemaFields)
         {
@@ -801,17 +829,7 @@ public sealed class EditProcessor : IEditProcessor
             }
 
             // Skip the primary id field — it is generated server-side on create.
-            var isPrimaryId = false;
-            for (var i = 0; i < field.SemanticRoles.Count; i++)
-            {
-                if (string.Equals(field.SemanticRoles[i], "id.primary", StringComparison.OrdinalIgnoreCase))
-                {
-                    isPrimaryId = true;
-                    break;
-                }
-            }
-
-            if (isPrimaryId)
+            if (IsResourcePrimaryIdField(field, primaryIdFieldName))
             {
                 continue;
             }

--- a/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorCreateValidationTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Edit/EditProcessorCreateValidationTests.cs
@@ -113,6 +113,105 @@ public sealed class EditProcessorCreateValidationTests
             "the empty-attributes guard fires before the per-field check");
     }
 
+    // Resource whose non-nullable "objectid" field carries NO semantic roles — mirrors the many
+    // seeded/published layers (e.g. WebAppFixtureMetadataV2Mixin, ServiceRbacTestFixture) that
+    // declare objectid as Nullable=false without the "id.primary" role. BH2-014 (#2456) keyed its
+    // primary-id skip exclusively on the role, so every create omitting objectid was rejected.
+    private static MetadataV2Resource CreateResourceWithUnroledObjectId() => new()
+    {
+        SchemaFields =
+        [
+            new MetadataV2Field
+            {
+                Name = "objectid",
+                Type = MetadataV2FieldType.Integer,
+                Nullable = false,
+                SemanticRoles = []
+            },
+            new MetadataV2Field
+            {
+                Name = "name",
+                Type = MetadataV2FieldType.String,
+                Nullable = false,
+                SemanticRoles = []
+            },
+            new MetadataV2Field
+            {
+                Name = "notes",
+                Type = MetadataV2FieldType.String,
+                Nullable = true,
+                SemanticRoles = []
+            }
+        ]
+    };
+
+    // Regression (#2456): a create that supplies every required NON-id field but omits the
+    // server-assigned "objectid" must validate, even when objectid lacks the "id.primary" role.
+    // Before the fix this failed with "Required attribute(s) missing for create operation: objectid".
+    [UnitTest]
+    public void ValidateEdit_CreateOmittingUnroledObjectId_Succeeds()
+    {
+        var processor = CreateProcessor();
+        var resource = CreateResourceWithUnroledObjectId();
+
+        var attributes = ImmutableDictionary.Create<string, object?>(StringComparer.OrdinalIgnoreCase)
+            .Add("name", "Honua");
+
+        var request = UnifiedEditRequest.WithCreates(
+            ImmutableArray.Create(EditFeature.ForCreate(geometry: null, attributes)));
+
+        var result = processor.ValidateEdit(request, resource);
+
+        result.IsValid.Should().BeTrue(
+            "the server-assigned object-id field must never be required from the client, "
+            + "even when it does not carry the id.primary semantic role");
+    }
+
+    // The fix must not weaken BH2-014: a genuinely-missing required NON-id field is still rejected
+    // even on a layer whose objectid lacks the id.primary role.
+    [UnitTest]
+    public void ValidateEdit_CreateMissingRequiredFieldOnUnroledObjectIdLayer_StillFails()
+    {
+        var processor = CreateProcessor();
+        var resource = CreateResourceWithUnroledObjectId();
+
+        // Supplies only the nullable "notes" field — the required "name" field is absent.
+        var attributes = ImmutableDictionary.Create<string, object?>(StringComparer.OrdinalIgnoreCase)
+            .Add("notes", "some note");
+
+        var request = UnifiedEditRequest.WithCreates(
+            ImmutableArray.Create(EditFeature.ForCreate(geometry: null, attributes)));
+
+        var result = processor.ValidateEdit(request, resource);
+
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("name",
+            "a genuinely-missing required non-id field must still be reported");
+        result.ErrorMessage.Should().NotContain("objectid",
+            "the server-assigned object-id field must never appear as a missing required attribute");
+    }
+
+    // The update path must likewise not require the object-id field as a client attribute: the
+    // caller identifies the row via EditFeature.ObjectId, not via an "objectid" attribute entry.
+    [UnitTest]
+    public void ValidateEdit_UpdateOmittingUnroledObjectIdAttribute_Succeeds()
+    {
+        var processor = CreateProcessor();
+        var resource = CreateResourceWithUnroledObjectId();
+
+        var attributes = ImmutableDictionary.Create<string, object?>(StringComparer.OrdinalIgnoreCase)
+            .Add("name", "Updated");
+
+        var request = UnifiedEditRequest.WithUpdates(
+            ImmutableArray.Create(EditFeature.ForUpdate(objectId: 42, geometry: null, attributes)));
+
+        var result = processor.ValidateEdit(request, resource);
+
+        result.IsValid.Should().BeTrue(
+            "an update identifies the row via EditFeature.ObjectId, so the object-id field is not "
+            + "required as a client attribute");
+    }
+
     [UnitTest]
     public void ValidateEdit_CreateWithCaseInsensitiveFieldName_Succeeds()
     {


### PR DESCRIPTION
Related to #2456 (BH2-014). Unblocks the merge train.

## Summary

Full CI on trunk is red: every FeatureServer/OGC/OData create against layers whose non-nullable `objectid` field lacks the `id.primary` semantic role fails with `Required attribute(s) missing for create operation: objectid` (500s across dozens of integration shards; first full-matrix run since #2456 merged — evidence: Actions run 28736838578 on `ctrl/format-green`, which is trunk + format hygiene only). The BH2-014 required-attribute gate keyed its id-field skip exclusively on the `id.primary` semantic role, but many seeded and published layers declare `objectid` with no roles (see `WebAppFixtureMetadataV2Mixin`, `ServiceRbacTestFixture`); the gate's own unit tests passed only because they seed the role.

Fix: the skip now also matches the resource's authoritative primary-id field name via the existing `FindPrimaryIdField()` extension (role-based resolution with the conventional `objectid`/`id` fallback) — the same id determination the rest of the system uses. Genuinely-missing non-id required fields are still rejected.

## Changes Made

- `EditProcessor`: shared `IsResourcePrimaryIdField` helper used by `RequiresAttributes` and `FindMissingRequiredFields`; id-field name precomputed per resource
- Regression tests seeding the real fixture shape (non-nullable `objectid`, no roles): create omitting objectid → valid; missing required non-id field → still rejected; update-path equivalent

## Breaking Changes

None. Restores pre-#2456 create behavior for unroled-id layers; DB NOT NULL constraints still back the edge case of a genuinely-required field named `objectid` via the shared error path.

## Gate Impact

- [x] Fixes the currently-red trunk integration shards (FeatureServer/OGC/OData creates)

## Testing

- [x] New `EditProcessorCreateValidationTests` 7/7; full `Features.Edit` unit suite 44/44
- [x] Release build (warnings-as-errors) green; format clean
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Integration shards validated by the next batch CI (Docker unavailable locally).
