### PR TITLE
fix(alerts): implement TrySetAsync on the notifying workflow-operation store

### DIFF
--- a/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
@@ -55,6 +55,28 @@ internal sealed partial class NotifyingWorkflowOperationStore : IWorkflowOperati
         }
     }
 
+    /// <inheritdoc />
+    public async Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        // Authoritative CAS write first; notify only when this write actually won —
+        // a losing writer's terminal transition was not persisted, and the winning
+        // writer's own SetAsync/TrySetAsync raises the notification instead. The
+        // outbox dedupe key keeps repeated terminal writes idempotent regardless.
+        var updated = await _inner.TrySetAsync(operation, ttl, cancellationToken).ConfigureAwait(false);
+
+        if (updated
+            && _options.Ops.Enabled
+            && operation.Kind == WorkflowOperationKind.Deploy
+            && TryMapSeverity(operation.Status, out var severity))
+        {
+            await NotifyTerminalAsync(operation, severity, cancellationToken).ConfigureAwait(false);
+        }
+
+        return updated;
+    }
+
     private async Task NotifyTerminalAsync(WorkflowOperationRecord operation, AlertSeverity severity, CancellationToken cancellationToken)
     {
         var attributes = new Dictionary<string, string>(StringComparer.Ordinal)


### PR DESCRIPTION
Related to #2427 / #2472. Fixes the trunk build break.

## Summary

Trunk fails to compile: #2472 (bug-hunt Round 5) added `TrySetAsync` to `IWorkflowOperationStore` while #2468's `NotifyingWorkflowOperationStore` decorator was in flight in the same train batch; the batch landed because the train's pre-existing-failure filter matched the failing job name (`Build & Format Check`) against trunk's then-current format failure — same job, different cause. This implements the missing member: authoritative CAS pass-through, ops notification raised only when the write wins (a losing writer's transition was not persisted; the winner raises it, and the outbox dedupe key keeps repeats idempotent).

## Changes Made

- `NotifyingWorkflowOperationStore.TrySetAsync`: delegate to inner store, notify on successful terminal deploy transitions only

## Breaking Changes

None.

## Gate Impact

- [x] Restores trunk compilation (Build & Format Check)

## Testing

- [x] `dotnet build src/Honua.Server/Honua.Server.csproj -c Release` on trunk+fix: 0 warnings, 0 errors (trunk alone fails CS0535)
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Decorator unit suites re-validated in CI (local Docker unavailable; the change is a guarded pass-through).
