### PR TITLE
test(e2e): local-substrate lane - YARP rolling deploy, process pool, migration gate

### DIFF
--- a/.github/workflows/cloud-integration-harness.yml
+++ b/.github/workflows/cloud-integration-harness.yml
@@ -140,3 +140,60 @@ jobs:
           name: cloud-integration-results
           path: tests/TestResults/
           retention-days: 14
+
+  local-substrate:
+    name: Local Substrate (YARP rolling + local process + migration gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # ADR-0060 substrate-neutral lane (#2166, #2457): proves the single-host, zero-cloud (containers
+    # only — no Kubernetes, no cloud) deploy / rolling-upgrade / expand-contract-migration / rollback
+    # story on BOTH planes. Serving = YarpRollingDeployBackend + real embedded YARP + real docker
+    # replica containers; GP = LocalProcessPoolBatchComputeBackend + real child processes; migration
+    # gate = the real PostgresDatabaseMigrationRunner over a Testcontainers Postgres. FREE (no cloud
+    # secrets), plain ubuntu runner with Docker. Every test [SkippableFact]-skips when Docker is absent.
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Honua.sln
+
+      - name: Build cloud-integration test binaries
+        timeout-minutes: 15
+        run: dotnet build ${{ env.CSPROJ }} --no-restore --configuration Release
+
+      - name: Pre-pull local-substrate base images
+        shell: bash
+        run: |
+          # Warm the docker cache for the disposable images the lane builds/runs so provisioning does
+          # not pull mid-test:
+          #   busybox          -> the two-tag HTTP replica images the serving lane builds and runs.
+          #   postgres:alpine  -> the migration-gate Testcontainers database.
+          docker pull busybox:1.36 || echo "::warning::could not pre-pull busybox"
+          docker pull postgres:17-alpine || echo "::warning::could not pre-pull postgres"
+
+      - name: Run local-substrate tests
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: false
+        run: |
+          mkdir -p ./tests/TestResults
+          dotnet test ${{ env.CSPROJ }} \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "Category=LocalSubstrate" \
+            --logger "trx;LogFileName=local-substrate.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Upload results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: local-substrate-results
+          path: tests/TestResults/
+          retention-days: 14

--- a/docs/internal/contributor/testkit.md
+++ b/docs/internal/contributor/testkit.md
@@ -595,6 +595,38 @@ The kind lane builds three busybox worker images (`/bin/true`, `/bin/false`, `/b
 with `ImagePullPolicy=Never`; the backend's `BuildManifest` sets no container command, so each
 image self-selects behaviour via its `ENTRYPOINT`.
 
+### Local-substrate lane — `Category=LocalSubstrate` (ADR-0060 §Verification, #2166 / #2457)
+
+Runs in the `local-substrate` job of `.github/workflows/cloud-integration-harness.yml` (same
+nightly + manual triggers, no cloud secrets, plain ubuntu runner with Docker). It is the
+substrate-neutral proof that a **single host — containers only, no Kubernetes, no cloud** — can
+deploy, rolling-upgrade, run the expand/contract migration gate, and roll back with **zero
+downtime** on BOTH planes. Every test is `[SkippableFact]` and skips (never fails) when Docker is
+absent; the GP process tests need only a resolvable `dotnet` muxer, so they also run without Docker.
+
+It drives the real trunk seams end-to-end — `YarpRollingDeployBackend` (`honua-yarp-rolling`,
+`DeployTargetKind.SelfHostedRolling`) with a real embedded-YARP `InMemoryConfigProvider` and the
+real `ProcessContainerRuntimeClient` against docker; `LocalProcessPoolBatchComputeBackend`
+(`honua-local-process`, `BatchComputeTargetKind.LocalProcess`) spawning real child processes; and
+the real `PostgresDatabaseMigrationRunner` expand/contract gate over a Testcontainers Postgres.
+
+Matrix cells — {serving, GP} × {local/YARP} × {deploy, rolling-upgrade, expand/contract-migration, rollback}:
+
+| Plane | Deploy | Rolling-upgrade | Expand/contract migration | Rollback |
+|-------|--------|-----------------|---------------------------|----------|
+| **Serving** (`LocalSubstrateRollingDeployTests`) | launch v2 standby, health-gate → `PromotionRecommended` | atomic proxy destination swap v1→v2; continuous request loop asserts **zero failed requests** across cutover | contract migrations gate the coordinated deploy (see migration row) | pre-cutover rollback keeps v1 serving (zero downtime); post-cutover rollback repoints the proxy at the previous replica, drains the failed one, and settles `RolledBack` |
+| **GP** (`LocalSubstrateProcessPoolTests`) | child-process launch → `Running`→`Succeeded` with exit-code mapping; `HONUA_*` env contract asserted | non-blocking pool-saturation admission: pending marker then launch once a slot frees; contract-version gate declares baseline v1 so a v2 job is refused | — | `CancelAsync` kills the process tree → `Cancelled` |
+| **Migration gate** (`LocalSubstrateMigrationGateTests`) | — | — | real runner over real Postgres: unannotated `DROP COLUMN` → **fail-closed** naming the compatibility-review marker; annotated → applies; `PlanMigrationsAsync` reports pending contract scripts (the `DeployPreflightProbe` signal that blocks a coordinated deploy) | — |
+
+Image/binary choices: the serving lane builds two tiny `busybox:1.36` `httpd` images
+(`honua-ci/ls-replica:v1|v2`) whose one-file docroot is the revision marker (HTTP 200 at `/`
+doubles as the health signal). The GP lane compiles a shell-free managed helper with Roslyn and
+launches it via the absolute-path `dotnet` muxer (no OS coreutil, PATH-shim-safe). The migration
+lane compiles per-scenario synthetic migration assemblies (embedded `.sql` resources) with Roslyn so
+the real runner is driven over a controlled expand/contract script set. The pure classification logic
+(`MigrationSafetyClassifierTests`) and the probe's plan consumption (`DeployPreflightProbeTests`) stay
+unit-tested; this lane exercises the real runner + real database path rather than duplicating them.
+
 ### Real-AWS certification lane — `Category=RealAwsCertification`
 
 Runs in `.github/workflows/real-aws-certification.yml` (weekly + manual, never on `pull_request`)

--- a/src/Honua.Jobs/Honua.Jobs.csproj
+++ b/src/Honua.Jobs/Honua.Jobs.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Honua.Server" />
     <InternalsVisibleTo Include="Honua.Server.Tests" />
+    <InternalsVisibleTo Include="Honua.CloudIntegration.Tests" />
     <InternalsVisibleTo Include="Honua.Worker.Gdal" />
     <InternalsVisibleTo Include="Honua.Worker.Gdal.Tests" />
     <InternalsVisibleTo Include="Honua.Architecture.Tests" />

--- a/src/Honua.Postgres/Honua.Postgres.csproj
+++ b/src/Honua.Postgres/Honua.Postgres.csproj
@@ -16,6 +16,9 @@
       <_Parameter1>Honua.Server.Tests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Honua.CloudIntegration.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Honua.TestKit</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/CloudIntegrationTraits.cs
@@ -26,6 +26,19 @@ internal static class CloudIntegrationTraits
     public const string CloudIntegration = "CloudIntegration";
 
     /// <summary>
+    /// Trait value applied to the ADR-0060 substrate-neutral local lane (#2166, #2457). These
+    /// tests prove the single-host, zero-cloud (containers only, no Kubernetes, no cloud) deploy /
+    /// rolling-upgrade / expand-contract-migration / rollback story on BOTH planes (serving via
+    /// <c>YarpRollingDeployBackend</c> + real embedded YARP; GP via
+    /// <c>LocalProcessPoolBatchComputeBackend</c>) plus the real
+    /// <c>PostgresDatabaseMigrationRunner</c> expand/contract gate. They are kept in a distinct
+    /// category so the dedicated <c>local-substrate</c> workflow job opts in with
+    /// <c>--filter "Category=LocalSubstrate"</c>, and every Docker-dependent test
+    /// <c>[SkippableFact]</c>-skips (never fails) when Docker is unavailable.
+    /// </summary>
+    public const string LocalSubstrate = "LocalSubstrate";
+
+    /// <summary>
     /// Trait value applied to the real-AWS certification lane (#2164). These tests target a
     /// LIVE AWS account (not an emulator) and are kept in a distinct category so neither the
     /// default PR run nor the emulated <c>cloud-integration-harness.yml</c>

--- a/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
@@ -47,6 +47,15 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Xunit.SkippableFact" />
     <PackageReference Include="Testcontainers" />
+    <!-- LocalSubstrate migration-gate lane (#2166 / #2457): a real Postgres via Testcontainers to
+         drive PostgresDatabaseMigrationRunner end-to-end, and Roslyn to compile synthetic migration
+         assemblies (embedded .sql resources) so the expand/contract fail-closed gate is exercised. -->
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <!-- LocalSubstrate serving lane: a real embedded-YARP reverse proxy fronts the rolling cutover so
+         the continuous request loop proves zero downtime through the atomic destination swap. -->
+    <PackageReference Include="Yarp.ReverseProxy" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
@@ -58,6 +67,11 @@
     <ProjectReference Include="..\..\..\src\Honua.Core\Honua.Core.csproj" />
     <ProjectReference Include="..\..\..\src\Honua.Aws\Honua.Aws.csproj" />
     <ProjectReference Include="..\..\..\src\Honua.Server\Honua.Server.csproj" />
+    <!-- LocalProcessPoolBatchComputeBackend (GP lane) lives in Honua.Jobs; the real
+         PostgresDatabaseMigrationRunner (migration-gate lane) lives in Honua.Postgres. Both are
+         internal and made visible via InternalsVisibleTo on those assemblies. -->
+    <ProjectReference Include="..\..\..\src\Honua.Jobs\Honua.Jobs.csproj" />
+    <ProjectReference Include="..\..\..\src\Honua.Postgres\Honua.Postgres.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateDockerFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateDockerFixture.cs
@@ -1,0 +1,275 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Honua.ControlPlane;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Docker fixture for the ADR-0060 substrate-neutral serving lane (#2166, #2457). Builds two tiny
+/// disposable HTTP replica images that stand in for two revisions of the Honua serving process, and
+/// exposes the REAL container-runtime and local-health-probe seams
+/// (<see cref="ProcessContainerRuntimeClient"/> / <see cref="HttpLocalReplicaHealthProbe"/>) that the
+/// <see cref="YarpRollingDeployBackend"/> drives against a real <c>docker</c> daemon.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Image choice: a 3-line <c>busybox:1.36</c> Dockerfile running <c>httpd</c> over a one-file docroot
+/// whose <c>index.html</c> is the revision marker. This mirrors the existing kind lane's busybox worker
+/// images (no new base-image dependency), serves HTTP 200 on <c>/</c> (satisfying the backend's default
+/// <c>/healthz/ready</c> health probe once the probe path is pointed at <c>/</c>), and returns an
+/// identifiable version body so the zero-downtime request loop can prove the v1→v2 flip. The two images
+/// are built by the fixture itself (idempotent) so the lane is self-contained on any Docker host; the
+/// workflow additionally pre-pulls <c>busybox</c> to warm the cache.
+/// </para>
+/// <para>
+/// When Docker is unavailable the build fails, <see cref="Available"/> stays false, and the dependent
+/// <c>[SkippableFact]</c> tests skip (never fail) — mirroring <see cref="KindClusterFixture"/> and
+/// <see cref="LocalStackFixture"/>.
+/// </para>
+/// </remarks>
+public sealed class LocalSubstrateDockerFixture : IAsyncLifetime
+{
+    private const string ContainerRuntime = "docker";
+    private const string BaseImage = "busybox:1.36";
+
+    /// <summary>Container image serving the "v1" revision marker on port 8080.</summary>
+    public string V1Image { get; } = "honua-ci/ls-replica:v1";
+
+    /// <summary>Container image serving the "v2" revision marker on port 8080.</summary>
+    public string V2Image { get; } = "honua-ci/ls-replica:v2";
+
+    /// <summary>Revision marker body served by <see cref="V1Image"/>.</summary>
+    public const string V1Marker = "honua-revision-v1";
+
+    /// <summary>Revision marker body served by <see cref="V2Image"/>.</summary>
+    public const string V2Marker = "honua-revision-v2";
+
+    /// <summary>Container port the replica images publish.</summary>
+    public const int ReplicaContainerPort = 8080;
+
+    private ServiceProvider? _services;
+
+    /// <summary>True when Docker is available and both replica images built successfully.</summary>
+    public bool Available { get; private set; }
+
+    /// <summary>Real container runtime seam the rolling-deploy backend drives.</summary>
+    internal IContainerRuntimeClient Runtime { get; private set; } = null!;
+
+    /// <summary>Real loopback replica health-probe seam the rolling-deploy backend drives.</summary>
+    internal ILocalReplicaHealthProbe HealthProbe { get; private set; } = null!;
+
+    /// <summary>The container runtime executable name (<c>docker</c>).</summary>
+    public string RuntimeExecutable => ContainerRuntime;
+
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            if (!await IsDockerAvailableAsync().ConfigureAwait(false))
+            {
+                Available = false;
+                return;
+            }
+
+            await BuildReplicaImageAsync(V1Image, V1Marker).ConfigureAwait(false);
+            await BuildReplicaImageAsync(V2Image, V2Marker).ConfigureAwait(false);
+
+            // Real seams the backend consumes. HttpLocalReplicaHealthProbe resolves the named
+            // "control-plane-telemetry" HttpClient, so a minimal AddHttpClient container is enough.
+            var services = new ServiceCollection();
+            services.AddHttpClient();
+            _services = services.BuildServiceProvider();
+
+            Runtime = new ProcessContainerRuntimeClient(NullLogger<ProcessContainerRuntimeClient>.Instance);
+            HealthProbe = new HttpLocalReplicaHealthProbe(
+                _services.GetRequiredService<IHttpClientFactory>());
+
+            Available = true;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Available = false;
+            if (_services is not null)
+            {
+                await _services.DisposeAsync().ConfigureAwait(false);
+                _services = null;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DisposeAsync()
+    {
+        if (_services is not null)
+        {
+            await _services.DisposeAsync().ConfigureAwait(false);
+            _services = null;
+        }
+    }
+
+    /// <summary>
+    /// Force-removes every container carrying the supplied <c>honua.target</c> label. Best-effort
+    /// cleanup so a failed scenario cannot leak the standby/active replicas it launched.
+    /// </summary>
+    public async Task CleanupTargetAsync(string targetId)
+    {
+        var (_, stdout, _) = await RunProcessAsync(
+            ContainerRuntime,
+            ["ps", "-aq", "--filter", $"label={YarpRollingDeployBackend.LabelTarget}={targetId}"],
+            CancellationToken.None).ConfigureAwait(false);
+
+        foreach (var id in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            await RunProcessAsync(ContainerRuntime, ["rm", "-f", id], CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Polls a URL until it returns HTTP 200 with the expected body, or the timeout elapses. Used to
+    /// confirm a freshly launched replica container is actually serving before a scenario proceeds.
+    /// </summary>
+    public static async Task<bool> WaitForBodyAsync(string url, string expectedBody, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            try
+            {
+                using var response = await client.GetAsync(url).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    var body = (await response.Content.ReadAsStringAsync().ConfigureAwait(false)).Trim();
+                    if (body.Contains(expectedBody, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+            {
+                // Replica still starting.
+            }
+
+            await Task.Delay(200).ConfigureAwait(false);
+        }
+
+        return false;
+    }
+
+    /// <summary>Reserves an ephemeral loopback TCP port for a replica container's host binding.</summary>
+    public static int GetFreeTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static async Task<bool> IsDockerAvailableAsync()
+    {
+        try
+        {
+            var (exitCode, _, _) = await RunProcessAsync(
+                ContainerRuntime,
+                ["version", "--format", "{{.Server.Version}}"],
+                CancellationToken.None).ConfigureAwait(false);
+            return exitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static async Task BuildReplicaImageAsync(string image, string marker)
+    {
+        var contextDir = Directory.CreateTempSubdirectory("honua-ls-image").FullName;
+        try
+        {
+            // busybox httpd over a one-file docroot: GET / returns the marker with HTTP 200, which
+            // doubles as the health signal (probe path pointed at "/") and the version response.
+            var dockerfile =
+                $"""
+                FROM {BaseImage}
+                RUN mkdir -p /www && printf '%s' '{marker}' > /www/index.html
+                ENTRYPOINT ["httpd", "-f", "-p", "{ReplicaContainerPort.ToString(System.Globalization.CultureInfo.InvariantCulture)}", "-h", "/www"]
+                """;
+            await File.WriteAllTextAsync(Path.Combine(contextDir, "Dockerfile"), dockerfile).ConfigureAwait(false);
+
+            var (exitCode, _, stderr) = await RunProcessAsync(
+                ContainerRuntime,
+                ["build", "-t", image, contextDir],
+                CancellationToken.None).ConfigureAwait(false);
+            if (exitCode != 0)
+            {
+                throw new InvalidOperationException($"Failed to build replica image '{image}': {stderr.Trim()}");
+            }
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(contextDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort temp cleanup.
+            }
+        }
+    }
+
+    private static async Task<(int ExitCode, string StandardOutput, string StandardError)> RunProcessAsync(
+        string executable,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+        return (process.ExitCode, stdout.ToString(), stderr.ToString());
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateMigrationGateTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateMigrationGateTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.Core.Features.Infrastructure.Migrations;
+using Honua.Postgres.Features.Infrastructure.Migrations;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// ADR-0060 substrate-neutral MIGRATION-GATE lane (#2166, #2457). Puts the expand/contract discipline
+/// in the loop end-to-end: drives the REAL <see cref="PostgresDatabaseMigrationRunner"/> against a real
+/// PostgreSQL database with synthetic migration assemblies so the fail-closed rejection, the annotated
+/// apply path, and the plan-level "pending contract scripts block coordinated deploy" signal are all
+/// proven against a live database rather than a fake.
+/// </summary>
+/// <remarks>
+/// The pure classification logic is unit-tested in <c>MigrationSafetyClassifierTests</c>, and the
+/// probe's consumption of the plan signal is unit-tested in <c>DeployPreflightProbeTests</c>; this lane
+/// deliberately does not duplicate those and instead exercises the real runner + real database path.
+/// Every test <c>[SkippableFact]</c>-skips when Docker is unavailable.
+/// </remarks>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.LocalSubstrate)]
+public sealed class LocalSubstrateMigrationGateTests : IClassFixture<LocalSubstratePostgresFixture>
+{
+    private const string ExpandScript =
+        """
+        CREATE TABLE honua_ci_demo (
+            id INTEGER PRIMARY KEY,
+            legacy_name TEXT
+        );
+        """;
+
+    private const string UnannotatedContractScript =
+        """
+        ALTER TABLE honua_ci_demo DROP COLUMN legacy_name;
+        """;
+
+    private const string AnnotatedContractScript =
+        """
+        -- honua:compatibility-review reason=legacy_name removed in the contract phase after v2 rollout
+        ALTER TABLE honua_ci_demo DROP COLUMN legacy_name;
+        """;
+
+    private readonly LocalSubstratePostgresFixture _postgres;
+
+    public LocalSubstrateMigrationGateTests(LocalSubstratePostgresFixture postgres)
+    {
+        _postgres = postgres;
+    }
+
+    [SkippableFact]
+    public async Task RunMigrations_UnannotatedContractScript_FailsClosedNamingMarkerConvention()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var runner = CreateEnforcingRunner();
+        var assembly = SyntheticMigrationsCompiler.Compile(
+            $"honua_synthetic_unannotated_{Guid.NewGuid():N}",
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_unannotated.sql", UnannotatedContractScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, assembly);
+
+        result.Successful.Should().BeFalse("an unannotated contract-phase migration must be rejected fail-closed");
+        result.ErrorMessage.Should().NotBeNull();
+        result.ErrorMessage!.Should().Contain("honua:compatibility-review",
+            "the rejection names the compatibility-review marker convention authors must add");
+        result.ErrorMessage!.Should().Contain("002_drop_legacy_unannotated.sql",
+            "the rejection names the offending script");
+
+        // Fail-closed: the gate rejects before any script executes, so even the expand script is not applied.
+        (await TableExistsAsync(connectionString, "honua_ci_demo"))
+            .Should().BeFalse("the runner must not apply any script when the batch is rejected");
+    }
+
+    [SkippableFact]
+    public async Task RunMigrations_AnnotatedContractScript_AppliesExpandThenContract()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var runner = CreateEnforcingRunner();
+        var assembly = SyntheticMigrationsCompiler.Compile(
+            $"honua_synthetic_annotated_{Guid.NewGuid():N}",
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_annotated.sql", AnnotatedContractScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, assembly);
+
+        result.Successful.Should().BeTrue($"the annotated contract migration is rollout-safe. Error: {result.ErrorMessage}");
+        result.AppliedScripts.Should().HaveCount(2, "both the expand and the annotated contract scripts apply");
+
+        // The expand created the table and the annotated contract dropped the column.
+        (await TableExistsAsync(connectionString, "honua_ci_demo")).Should().BeTrue();
+        (await ColumnExistsAsync(connectionString, "honua_ci_demo", "legacy_name"))
+            .Should().BeFalse("the annotated contract migration dropped the legacy column");
+    }
+
+    [SkippableFact]
+    public async Task PlanMigrations_UnannotatedContractScript_ReportsContractBlockingCoordinatedDeploy()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var runner = CreateEnforcingRunner();
+        var assembly = SyntheticMigrationsCompiler.Compile(
+            $"honua_synthetic_plan_{Guid.NewGuid():N}",
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_unannotated.sql", UnannotatedContractScript));
+
+        var plan = await runner.PlanMigrationsAsync(connectionString, assembly);
+
+        plan.Successful.Should().BeTrue("planning succeeds even when the batch would be rejected on apply");
+        plan.UpgradeRequired.Should().BeTrue();
+
+        // These are exactly the signals DeployPreflightProbe reads to set ReadyForCoordinatedDeploy=false:
+        // a pending contract-phase script must run in a dedicated contract step, never on a rolling deploy.
+        plan.HasContractScripts.Should().BeTrue("a pending contract-phase script blocks a coordinated deploy");
+        plan.HasUnannotatedBreakingScripts.Should().BeTrue();
+        plan.ContractScriptNames.Should().Contain(name => name.EndsWith("002_drop_legacy_unannotated.sql", StringComparison.Ordinal));
+        plan.UnannotatedBreakingScriptNames.Should().Contain(name => name.EndsWith("002_drop_legacy_unannotated.sql", StringComparison.Ordinal));
+    }
+
+    private static PostgresDatabaseMigrationRunner CreateEnforcingRunner()
+        => new(Options.Create(new MigrationSafetyOptions { Enforce = true }));
+
+    private static async Task<bool> TableExistsAsync(string connectionString, string table)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT to_regclass(@qualified) IS NOT NULL";
+        command.Parameters.AddWithValue("qualified", $"public.{table}");
+        return (bool)(await command.ExecuteScalarAsync())!;
+    }
+
+    private static async Task<bool> ColumnExistsAsync(string connectionString, string table, string column)
+    {
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = @table AND column_name = @column
+            )
+            """;
+        command.Parameters.AddWithValue("table", table);
+        command.Parameters.AddWithValue("column", column);
+        return (bool)(await command.ExecuteScalarAsync())!;
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstratePostgresFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstratePostgresFixture.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Npgsql;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Testcontainers fixture that boots a single throwaway PostgreSQL container for the ADR-0060
+/// migration-gate lane (#2166, #2457). A plain <c>postgres</c> image is sufficient because the lane
+/// exercises the expand/contract safety gate over synthetic migration scripts (no PostGIS objects).
+///
+/// When Docker is unavailable the container fails to start, <see cref="Available"/> stays false, and the
+/// dependent <c>[SkippableFact]</c> tests skip — mirroring <see cref="LocalStackFixture"/>.
+/// </summary>
+public sealed class LocalSubstratePostgresFixture : IAsyncLifetime
+{
+    private const string Image = "postgres:17-alpine";
+
+    private PostgreSqlContainer? _container;
+
+    /// <summary>True when the PostgreSQL container started, so the migration-gate tests can run.</summary>
+    public bool Available { get; private set; }
+
+    /// <summary>Admin connection string to the container's default database.</summary>
+    public string ConnectionString { get; private set; } = string.Empty;
+
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            _container = new PostgreSqlBuilder()
+                .WithImage(Image)
+                .Build();
+
+            await _container.StartAsync();
+            ConnectionString = _container.GetConnectionString();
+            Available = true;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Available = false;
+            if (_container is not null)
+            {
+                await _container.DisposeAsync();
+                _container = null;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DisposeAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync();
+            _container = null;
+        }
+    }
+
+    /// <summary>
+    /// Creates a fresh, uniquely named database and returns a connection string targeting it. Each
+    /// migration scenario runs against its own database so the DbUp journal and applied objects never
+    /// cross-contaminate between tests.
+    /// </summary>
+    public async Task<string> CreateFreshDatabaseAsync()
+    {
+        var databaseName = $"honua_ci_{Guid.NewGuid():N}";
+
+        await using (var connection = new NpgsqlConnection(ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"CREATE DATABASE \"{databaseName}\"";
+            await command.ExecuteNonQueryAsync();
+        }
+
+        return new NpgsqlConnectionStringBuilder(ConnectionString)
+        {
+            Database = databaseName
+        }.ConnectionString;
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateProcessHelperFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateProcessHelperFixture.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Compiles a tiny, dependency-free managed child binary the GP process-pool lane launches through
+/// <see cref="Honua.ControlPlane.LocalProcessPoolBatchComputeBackend"/>. The binary self-selects its
+/// behaviour from arguments (<c>--sleep N</c>, <c>--exit CODE</c>, <c>--env-out PATH</c>) so a single
+/// portable executable covers the run-to-completion, non-zero-exit, cancellation, pool-saturation, and
+/// <c>HONUA_*</c> environment-contract scenarios — with no shell and no OS-specific coreutil.
+/// </summary>
+/// <remarks>
+/// The binary is invoked as <c>dotnet &lt;helper.dll&gt; …</c>. The <c>dotnet</c> muxer is resolved by
+/// ABSOLUTE path (from <c>DOTNET_ROOT</c> or the running shared-framework directory) so the child spawn
+/// bypasses any PATH shim and works identically in CI and locally. When the muxer cannot be resolved the
+/// fixture reports <see cref="Available"/> = false and the dependent tests skip.
+/// </remarks>
+public sealed class LocalSubstrateProcessHelperFixture : IAsyncLifetime
+{
+    private string? _workDir;
+
+    /// <summary>True when the helper compiled and a runnable <c>dotnet</c> muxer was resolved.</summary>
+    public bool Available { get; private set; }
+
+    /// <summary>Absolute path to the <c>dotnet</c> muxer used to launch the helper.</summary>
+    public string DotnetMuxerPath { get; private set; } = string.Empty;
+
+    /// <summary>Absolute path to the compiled helper assembly.</summary>
+    public string HelperDllPath { get; private set; } = string.Empty;
+
+    /// <inheritdoc />
+    public Task InitializeAsync()
+    {
+        try
+        {
+            var muxer = ResolveDotnetMuxer();
+            if (muxer is null)
+            {
+                Available = false;
+                return Task.CompletedTask;
+            }
+
+            _workDir = Directory.CreateTempSubdirectory("honua-ls-gp").FullName;
+            HelperDllPath = Path.Combine(_workDir, "honua-envprobe.dll");
+            EmitHelperAssembly(HelperDllPath);
+            WriteRuntimeConfig(Path.ChangeExtension(HelperDllPath, ".runtimeconfig.json"));
+
+            DotnetMuxerPath = muxer;
+            Available = true;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Available = false;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync()
+    {
+        if (_workDir is not null && Directory.Exists(_workDir))
+        {
+            try
+            {
+                Directory.Delete(_workDir, recursive: true);
+            }
+            catch
+            {
+                // Best-effort temp cleanup.
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void EmitHelperAssembly(string outputPath)
+    {
+        const string source =
+            """
+            using System;
+            using System.Collections;
+            using System.IO;
+            using System.Threading;
+
+            internal static class HonuaEnvProbe
+            {
+                private static int Main(string[] args)
+                {
+                    var sleepMs = 0;
+                    var exitCode = 0;
+                    string? envOut = null;
+
+                    for (var i = 0; i < args.Length; i++)
+                    {
+                        switch (args[i])
+                        {
+                            case "--sleep":
+                                sleepMs = int.Parse(args[++i]) * 1000;
+                                break;
+                            case "--exit":
+                                exitCode = int.Parse(args[++i]);
+                                break;
+                            case "--env-out":
+                                envOut = args[++i];
+                                break;
+                        }
+                    }
+
+                    if (envOut is not null)
+                    {
+                        using var writer = new StreamWriter(envOut, append: false);
+                        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+                        {
+                            var key = (string)entry.Key;
+                            if (key.StartsWith("HONUA_", StringComparison.Ordinal)
+                                || key.StartsWith("CUSTOM_", StringComparison.Ordinal))
+                            {
+                                writer.WriteLine(key + "=" + entry.Value);
+                            }
+                        }
+                    }
+
+                    if (sleepMs > 0)
+                    {
+                        Thread.Sleep(sleepMs);
+                    }
+
+                    return exitCode;
+                }
+            }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Latest));
+
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToArray();
+
+        var compilation = CSharpCompilation.Create(
+            "honua-envprobe",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication, optimizationLevel: OptimizationLevel.Release));
+
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        if (!result.Success)
+        {
+            var errors = string.Join(
+                "; ",
+                result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(d => d.ToString()));
+            throw new InvalidOperationException($"Failed to compile the GP process helper: {errors}");
+        }
+    }
+
+    private static void WriteRuntimeConfig(string path)
+    {
+        var version = Environment.Version; // e.g. 10.0.0
+        var runtimeConfig =
+            $$"""
+            {
+              "runtimeOptions": {
+                "tfm": "net{{version.Major}}.{{version.Minor}}",
+                "framework": {
+                  "name": "Microsoft.NETCore.App",
+                  "version": "{{version.Major}}.{{version.Minor}}.0"
+                },
+                "rollForward": "LatestMajor"
+              }
+            }
+            """;
+        File.WriteAllText(path, runtimeConfig);
+    }
+
+    private static string? ResolveDotnetMuxer()
+    {
+        var muxerName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+
+        var dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+        if (!string.IsNullOrWhiteSpace(dotnetRoot))
+        {
+            var fromRoot = Path.Combine(dotnetRoot, muxerName);
+            if (File.Exists(fromRoot))
+            {
+                return fromRoot;
+            }
+        }
+
+        // GetRuntimeDirectory() -> <root>/shared/Microsoft.NETCore.App/<version>/ ; the muxer sits at <root>.
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var root = new DirectoryInfo(runtimeDir).Parent?.Parent?.Parent;
+        if (root is not null)
+        {
+            var fromRuntime = Path.Combine(root.FullName, muxerName);
+            if (File.Exists(fromRuntime))
+            {
+                return fromRuntime;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateProcessPoolTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateProcessPoolTests.cs
@@ -1,0 +1,279 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// ADR-0060 substrate-neutral GEOPROCESSING lane (#2166, #2457). Proves the single-host, zero-cloud GP
+/// executor by driving the REAL <see cref="LocalProcessPoolBatchComputeBackend"/> against real child
+/// processes: run-to-completion with exit-code mapping, cancellation that kills the process tree,
+/// non-blocking pool-saturation admission (pending marker then launch), the injected <c>HONUA_*</c>
+/// environment contract, and the serving↔worker job-contract-version gate.
+///
+/// The child binary is a shell-free managed helper compiled by
+/// <see cref="LocalSubstrateProcessHelperFixture"/> and launched via the <c>dotnet</c> muxer, so no OS
+/// coreutil is required. Tests that launch a process skip when that helper is unavailable.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.LocalSubstrate)]
+public sealed class LocalSubstrateProcessPoolTests : IClassFixture<LocalSubstrateProcessHelperFixture>
+{
+    private readonly LocalSubstrateProcessHelperFixture _helper;
+
+    public LocalSubstrateProcessPoolTests(LocalSubstrateProcessHelperFixture helper)
+    {
+        _helper = helper;
+    }
+
+    [SkippableFact]
+    public async Task ProcessJob_RunsToCompletion_ReportsSucceeded()
+    {
+        Skip.IfNot(_helper.Available, "The GP process helper could not be compiled/launched.");
+
+        using var context = CreateBackend(maxConcurrent: 2);
+        var job = CreateJob(context, "success", "--exit", "0");
+
+        var submission = await context.Backend.StartAsync(job);
+        submission.Status.Should().Be(ExecutionJobStatus.Running);
+        submission.ProviderOperationId.Should().StartWith(LocalProcessPoolBatchComputeBackend.LaunchedMarkerPrefix);
+
+        var terminal = await PollUntilTerminalAsync(context.Backend, job with { ProviderOperationId = submission.ProviderOperationId });
+        terminal.Status.Should().Be(ExecutionJobStatus.Succeeded, "a child process that exits 0 maps to Succeeded");
+    }
+
+    [SkippableFact]
+    public async Task ProcessJob_NonZeroExit_ReportsFailed()
+    {
+        Skip.IfNot(_helper.Available, "The GP process helper could not be compiled/launched.");
+
+        using var context = CreateBackend(maxConcurrent: 2);
+        var job = CreateJob(context, "failure", "--exit", "7");
+
+        var submission = await context.Backend.StartAsync(job);
+        submission.Status.Should().Be(ExecutionJobStatus.Running);
+
+        var terminal = await PollUntilTerminalAsync(context.Backend, job with { ProviderOperationId = submission.ProviderOperationId });
+        terminal.Status.Should().Be(ExecutionJobStatus.Failed, "a child process that exits non-zero maps to Failed, not Succeeded");
+        terminal.Message.Should().Contain("7", "the exit code is surfaced in the failure message");
+    }
+
+    [SkippableFact]
+    public async Task ProcessJob_CancelWhileRunning_ReportsCancelled()
+    {
+        Skip.IfNot(_helper.Available, "The GP process helper could not be compiled/launched.");
+
+        using var context = CreateBackend(maxConcurrent: 2);
+        var job = CreateJob(context, "cancel", "--sleep", "60");
+
+        var submission = await context.Backend.StartAsync(job);
+        submission.Status.Should().Be(ExecutionJobStatus.Running);
+        var running = job with { ProviderOperationId = submission.ProviderOperationId };
+
+        var cancel = await context.Backend.CancelAsync(running);
+        cancel.Status.Should().Be(ExecutionJobStatus.Cancelled, "cancelling a still-running child process kills the tree and reports Cancelled");
+
+        // The monitor settles the terminal state to Cancelled once the killed process is reaped.
+        var terminal = await PollUntilTerminalAsync(context.Backend, running);
+        terminal.Status.Should().Be(ExecutionJobStatus.Cancelled);
+    }
+
+    [SkippableFact]
+    public async Task ProcessPool_WhenSaturated_DefersWithPendingMarkerThenLaunches()
+    {
+        Skip.IfNot(_helper.Available, "The GP process helper could not be compiled/launched.");
+
+        // Pool size 1: the second submission cannot get a slot and must defer non-blockingly.
+        using var context = CreateBackend(maxConcurrent: 1);
+
+        var occupying = CreateJob(context, "occupy", "--sleep", "4");
+        var deferred = CreateJob(context, "deferred", "--exit", "0");
+
+        var occupyingSubmission = await context.Backend.StartAsync(occupying);
+        occupyingSubmission.Status.Should().Be(ExecutionJobStatus.Running, "the first job takes the single pool slot");
+
+        // Saturated: admission defers with a pending marker rather than blocking on the reconcile lease.
+        var deferredSubmission = await context.Backend.StartAsync(deferred);
+        deferredSubmission.Status.Should().Be(ExecutionJobStatus.Provisioning);
+        deferredSubmission.ProviderOperationId.Should().StartWith(LocalProcessPoolBatchComputeBackend.PendingSubmissionMarkerPrefix);
+
+        var pending = deferred with { ProviderOperationId = deferredSubmission.ProviderOperationId };
+
+        // While the slot is still held, observing the pending job keeps deferring.
+        var stillPending = await context.Backend.ObserveAsync(pending);
+        stillPending.Status.Should().Be(ExecutionJobStatus.Provisioning, "the pool is still saturated");
+
+        // Once the occupying job frees the slot, a later observe launches and completes the deferred job.
+        var terminal = await PollUntilTerminalAsync(context.Backend, pending, TimeSpan.FromSeconds(30));
+        terminal.Status.Should().Be(ExecutionJobStatus.Succeeded, "the deferred job launches and completes once a slot frees");
+    }
+
+    [SkippableFact]
+    public async Task ProcessJob_InjectsHonuaEnvironmentContract()
+    {
+        Skip.IfNot(_helper.Available, "The GP process helper could not be compiled/launched.");
+
+        using var context = CreateBackend(maxConcurrent: 2);
+        var envFile = Path.Combine(context.WorkingRoot, $"env-{Guid.NewGuid():N}.txt");
+
+        var job = CreateJob(
+            context,
+            "env-contract",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["env.CUSTOM_FLAG"] = "honua-ci-local-substrate"
+            },
+            "--env-out",
+            envFile);
+
+        var submission = await context.Backend.StartAsync(job);
+        submission.Status.Should().Be(ExecutionJobStatus.Running);
+
+        var terminal = await PollUntilTerminalAsync(context.Backend, job with { ProviderOperationId = submission.ProviderOperationId });
+        terminal.Status.Should().Be(ExecutionJobStatus.Succeeded);
+
+        File.Exists(envFile).Should().BeTrue("the child process writes the injected environment to the file");
+        var lines = await File.ReadAllLinesAsync(envFile);
+
+        // The HONUA_* contract mirrors what the cloud batch backends inject, so a workload behaves
+        // identically whether it runs here as a child process or on a cloud batch service.
+        lines.Should().Contain($"HONUA_OPERATION_ID={job.OperationId}");
+        lines.Should().Contain($"HONUA_WORKLOAD_NAME={job.Spec.WorkloadName}");
+        lines.Should().Contain("HONUA_JOB_KIND=Geoprocessing");
+        lines.Should().Contain($"HONUA_WORKLOAD_ID={job.Spec.WorkloadId}");
+        lines.Should().Contain("CUSTOM_FLAG=honua-ci-local-substrate");
+    }
+
+    [Fact]
+    public async Task ProcessPool_DeclaresBaselineContractVersion_SoNewerContractJobsAreRejected()
+    {
+        // The serving↔worker job-contract gate (ADR-0060 principle #3b) is enforced by the shared
+        // dispatcher, which consults the backend's MaxSupportedContractVersion. This asserts the local
+        // process backend declares the baseline (v1) so a v2 job is refused during a rolling version
+        // step — the backend seam the dispatcher's rejection at
+        // GeoprocessingJobDispatcher (contract-version gate) depends on.
+        using var context = CreateBackend(maxConcurrent: 1);
+
+        var capabilities = await context.Backend.GetCapabilitiesAsync();
+        capabilities.MaxSupportedContractVersion.Should().Be(1);
+
+        // A v1 job runs on this backend; a v2 job exceeds its supported contract and is rejected by the gate.
+        (1 > capabilities.MaxSupportedContractVersion).Should().BeFalse();
+        (2 > capabilities.MaxSupportedContractVersion).Should().BeTrue();
+    }
+
+    private BackendContext CreateBackend(int maxConcurrent)
+    {
+        var workingRoot = Directory.CreateTempSubdirectory("honua-ls-gp-run").FullName;
+        var backend = new LocalProcessPoolBatchComputeBackend(
+            Options.Create(new LocalProcessPoolOptions
+            {
+                MaxConcurrentProcesses = maxConcurrent,
+                WorkingRoot = workingRoot
+            }),
+            NullLogger<LocalProcessPoolBatchComputeBackend>.Instance);
+
+        return new BackendContext(backend, workingRoot);
+    }
+
+    private ExecutionJobRecord CreateJob(
+        BackendContext context,
+        string label,
+        params string[] helperArgs)
+        => CreateJob(context, label, extraParameters: null, helperArgs);
+
+    private ExecutionJobRecord CreateJob(
+        BackendContext context,
+        string label,
+        IReadOnlyDictionary<string, string>? extraParameters,
+        params string[] helperArgs)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LocalProcessParameterKeys.Executable] = _helper.DotnetMuxerPath,
+            // arg.0 is the helper assembly; the behaviour flags follow in order.
+            [LocalProcessParameterKeys.ArgumentPrefix + "0"] = _helper.HelperDllPath
+        };
+        for (var i = 0; i < helperArgs.Length; i++)
+        {
+            parameters[LocalProcessParameterKeys.ArgumentPrefix + (i + 1).ToString(CultureInfo.InvariantCulture)] = helperArgs[i];
+        }
+
+        if (extraParameters is not null)
+        {
+            foreach (var (key, value) in extraParameters)
+            {
+                parameters[key] = value;
+            }
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var spec = new ExecutionJobSpec
+        {
+            Kind = ExecutionJobKind.Geoprocessing,
+            TargetKind = BatchComputeTargetKind.LocalProcess,
+            Backend = LocalProcessPoolBatchComputeBackend.AdapterBackendName,
+            WorkloadId = $"ls-gp-{label}",
+            WorkloadName = $"local-substrate-{label}",
+            Parameters = parameters
+        };
+
+        return new ExecutionJobRecord
+        {
+            OperationId = $"ls-gp-{label}-{Guid.NewGuid():N}"[..24],
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Spec = spec
+        };
+    }
+
+    private static async Task<BatchComputeObservation> PollUntilTerminalAsync(
+        LocalProcessPoolBatchComputeBackend backend,
+        ExecutionJobRecord job,
+        TimeSpan? timeout = null)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout ?? TimeSpan.FromSeconds(20));
+        BatchComputeObservation last = new() { Status = ExecutionJobStatus.Running };
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            last = await backend.ObserveAsync(job);
+            if (last.Status is ExecutionJobStatus.Succeeded
+                or ExecutionJobStatus.Failed
+                or ExecutionJobStatus.Cancelled)
+            {
+                return last;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+        }
+
+        throw new TimeoutException($"Local process job did not reach a terminal state. Last status: {last.Status}.");
+    }
+
+    private sealed class BackendContext(LocalProcessPoolBatchComputeBackend backend, string workingRoot) : IDisposable
+    {
+        public LocalProcessPoolBatchComputeBackend Backend { get; } = backend;
+
+        public string WorkingRoot { get; } = workingRoot;
+
+        public void Dispose()
+        {
+            Backend.Dispose();
+            try
+            {
+                Directory.Delete(WorkingRoot, recursive: true);
+            }
+            catch
+            {
+                // Best-effort temp cleanup.
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateRollingDeployTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateRollingDeployTests.cs
@@ -1,0 +1,484 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Yarp.ReverseProxy.Configuration;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// ADR-0060 substrate-neutral SERVING lane (#2166, #2457). Proves the single-host, zero-cloud
+/// (containers only — no Kubernetes, no cloud) zero-downtime deploy / rolling-upgrade / rollback story
+/// end-to-end by driving the REAL <see cref="YarpRollingDeployBackend"/> against real
+/// <c>docker</c> replica containers, with the REAL <see cref="YarpInMemoryProxyStateSwapper"/> wired to
+/// a REAL embedded-YARP <see cref="InMemoryConfigProvider"/> fronting the traffic. A continuous request
+/// loop through the proxied endpoint measures the zero-downtime property across the atomic cutover.
+///
+/// Every test <c>[SkippableFact]</c>-skips (never fails) when Docker is unavailable, mirroring the
+/// existing kind/LocalStack lanes.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.LocalSubstrate)]
+public sealed class LocalSubstrateRollingDeployTests : IClassFixture<LocalSubstrateDockerFixture>
+{
+    private readonly LocalSubstrateDockerFixture _docker;
+
+    public LocalSubstrateRollingDeployTests(LocalSubstrateDockerFixture docker)
+    {
+        _docker = docker;
+    }
+
+    [SkippableFact]
+    public async Task RollingDeploy_HealthGatedPromotion_FlipsTrafficWithZeroDowntime()
+    {
+        Skip.IfNot(_docker.Available, "Docker is not available for the local-substrate serving lane.");
+
+        await using var env = await RollingDeployEnvironment.StartAsync(_docker);
+
+        // A continuous request loop spans the entire deploy: start it while v1 is serving so it
+        // observes every request through the standby launch, health gate, and cutover.
+        using var loop = env.StartRequestLoop();
+
+        var operation = env.CreateDeployOperation();
+
+        // 1. Submit: the backend launches the v2 standby replica; the v1 active replica keeps serving.
+        var submission = await env.Backend.StartAsync(operation);
+        submission.Status.Should().Be(WorkflowOperationStatus.Submitted);
+        submission.ProviderOperationId.Should().NotBeNullOrWhiteSpace();
+        operation = operation with { ProviderOperationId = submission.ProviderOperationId };
+
+        // 2. Observe until the health-gated standby is ready for promotion.
+        var observation = await PollObservationAsync(
+            () => env.Backend.ObserveAsync(operation),
+            o => o.PromotionRecommended,
+            TimeSpan.FromSeconds(90));
+        observation.PromotionRecommended.Should().BeTrue("the v2 standby replica must pass its health gate");
+
+        // 3. Promote: atomic proxy destination swap to v2, then drain and stop the old v1 replica.
+        var promote = await env.Backend.PromoteAsync(operation);
+        promote.Status.Should().Be(WorkflowOperationStatus.Succeeded);
+        promote.ObservedRevision.Should().Be(_docker.V2Image);
+
+        // Let the loop capture post-cutover v2 responses before stopping it.
+        await Task.Delay(500);
+        var result = await loop.StopAsync();
+
+        // Zero-downtime proof: not one request through the proxy failed across the cutover, and the
+        // observed body flipped v1 -> v2.
+        result.Failures.Should().Be(0, "the atomic cutover keeps the old replica serving until the new one is healthy");
+        result.Total.Should().BeGreaterThan(0);
+        result.SawV1.Should().BeTrue("traffic served the previous revision before promotion");
+        result.SawV2.Should().BeTrue("traffic served the new revision after promotion");
+        result.LastBody.Should().Contain(LocalSubstrateDockerFixture.V2Marker);
+    }
+
+    [SkippableFact]
+    public async Task RollingDeploy_RollbackBeforeCutover_KeepsPreviousServingWithZeroDowntime()
+    {
+        Skip.IfNot(_docker.Available, "Docker is not available for the local-substrate serving lane.");
+
+        await using var env = await RollingDeployEnvironment.StartAsync(_docker);
+        using var loop = env.StartRequestLoop();
+
+        var operation = env.CreateDeployOperation();
+
+        var submission = await env.Backend.StartAsync(operation);
+        submission.Status.Should().Be(WorkflowOperationStatus.Submitted);
+        operation = operation with { ProviderOperationId = submission.ProviderOperationId };
+
+        // Health-gate the standby, then roll back BEFORE the cutover.
+        var observation = await PollObservationAsync(
+            () => env.Backend.ObserveAsync(operation),
+            o => o.PromotionRecommended,
+            TimeSpan.FromSeconds(90));
+        observation.PromotionRecommended.Should().BeTrue();
+
+        // Pre-cutover rollback: the proxy was never repointed, so the old replica was never touched.
+        var rollback = await env.Backend.RollbackAsync(operation);
+        rollback.Status.Should().Be(WorkflowOperationStatus.RolledBack);
+
+        await Task.Delay(500);
+        var result = await loop.StopAsync();
+
+        // The v1 replica kept serving the whole time: zero failures and traffic never flipped to v2.
+        result.Failures.Should().Be(0, "a pre-cutover rollback never disturbs the serving replica");
+        result.SawV1.Should().BeTrue();
+        result.SawV2.Should().BeFalse("traffic must never have reached the discarded standby before promotion");
+        result.LastBody.Should().Contain(LocalSubstrateDockerFixture.V1Marker);
+    }
+
+    [SkippableFact]
+    public async Task RollingDeploy_RollbackAfterCutover_RepointsToPreviousAndSettlesRolledBack()
+    {
+        Skip.IfNot(_docker.Available, "Docker is not available for the local-substrate serving lane.");
+
+        await using var env = await RollingDeployEnvironment.StartAsync(_docker);
+
+        var operation = env.CreateDeployOperation();
+
+        var submission = await env.Backend.StartAsync(operation);
+        operation = operation with { ProviderOperationId = submission.ProviderOperationId };
+
+        var observation = await PollObservationAsync(
+            () => env.Backend.ObserveAsync(operation),
+            o => o.PromotionRecommended,
+            TimeSpan.FromSeconds(90));
+        observation.PromotionRecommended.Should().BeTrue();
+
+        // Promote to v2 (this stops the old v1 replica), then request a post-cutover rollback.
+        var promote = await env.Backend.PromoteAsync(operation);
+        promote.Status.Should().Be(WorkflowOperationStatus.Succeeded);
+
+        var rollback = await env.Backend.RollbackAsync(operation);
+        rollback.Status.Should().Be(WorkflowOperationStatus.RollbackRequested,
+            "a post-cutover rollback repoints the proxy at the previous revision and drains the failed one");
+
+        // The proxy was repointed back at the previous (active-port) replica address.
+        env.Swapper.ActiveDestinationAddress.Should().Be(env.ActiveAddress);
+
+        // The rollback settles once the failed standby replica has drained and gone.
+        var rolledBack = operation with { Status = WorkflowOperationStatus.RollbackRequested };
+        var settled = await PollObservationAsync(
+            () => env.Backend.ObserveAsync(rolledBack),
+            o => o.Status == WorkflowOperationStatus.RolledBack,
+            TimeSpan.FromSeconds(60));
+        settled.Status.Should().Be(WorkflowOperationStatus.RolledBack);
+
+        // The relaunched previous revision is serving again through the proxy.
+        var servingV1 = await LocalSubstrateDockerFixture.WaitForBodyAsync(
+            env.ProxyBaseUrl + "/", LocalSubstrateDockerFixture.V1Marker, TimeSpan.FromSeconds(30));
+        servingV1.Should().BeTrue("the previous revision is relaunched and fronted by the proxy after rollback");
+    }
+
+    private static async Task<DeployObservation> PollObservationAsync(
+        Func<Task<DeployObservation>> observe,
+        Func<DeployObservation, bool> predicate,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        DeployObservation last = new() { Status = WorkflowOperationStatus.Reconciling };
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            last = await observe();
+            if (last.Status == WorkflowOperationStatus.Failed)
+            {
+                throw new InvalidOperationException($"Rolling deploy observation failed: {last.Message}");
+            }
+
+            if (predicate(last))
+            {
+                return last;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
+        }
+
+        throw new TimeoutException(
+            $"Rolling deploy did not satisfy the expected condition within {timeout}. Last status: {last.Status} ({last.Message}).");
+    }
+
+    /// <summary>
+    /// One self-hosted rolling-deploy scenario's live environment: the co-located v1 active replica,
+    /// the running embedded-YARP proxy fronting it, the real proxy-swap seam, and the backend under
+    /// test. Owns cleanup of every container it launched plus the proxy host.
+    /// </summary>
+    private sealed class RollingDeployEnvironment : IAsyncDisposable
+    {
+        private readonly LocalSubstrateDockerFixture _docker;
+        private readonly WebApplication _proxy;
+        private readonly SelfHostedDeployOptions _options;
+
+        private RollingDeployEnvironment(
+            LocalSubstrateDockerFixture docker,
+            WebApplication proxy,
+            SelfHostedDeployOptions options,
+            YarpRollingDeployBackend backend,
+            YarpInMemoryProxyStateSwapper swapper,
+            string targetId,
+            string proxyBaseUrl)
+        {
+            _docker = docker;
+            _proxy = proxy;
+            _options = options;
+            Backend = backend;
+            Swapper = swapper;
+            TargetId = targetId;
+            ProxyBaseUrl = proxyBaseUrl;
+        }
+
+        public YarpRollingDeployBackend Backend { get; }
+
+        public YarpInMemoryProxyStateSwapper Swapper { get; }
+
+        public string TargetId { get; }
+
+        public string ProxyBaseUrl { get; }
+
+        public string ActiveAddress =>
+            $"http://{_options.Host}:{_options.ActivePort.ToString(CultureInfo.InvariantCulture)}/";
+
+        public static async Task<RollingDeployEnvironment> StartAsync(LocalSubstrateDockerFixture docker)
+        {
+            var suffix = Guid.NewGuid().ToString("N")[..8];
+            var targetId = $"honua-ci-ls-{suffix}";
+            var activePort = LocalSubstrateDockerFixture.GetFreeTcpPort();
+            int standbyPort;
+            do
+            {
+                standbyPort = LocalSubstrateDockerFixture.GetFreeTcpPort();
+            }
+            while (standbyPort == activePort);
+
+            var options = new SelfHostedDeployOptions
+            {
+                Enabled = true,
+                ContainerRuntime = docker.RuntimeExecutable,
+                ContainerNamePrefix = $"honua-ci-ls-{suffix}",
+                Host = "127.0.0.1",
+                // busybox httpd answers 200 at "/", which doubles as the replica health signal.
+                HealthPath = "/",
+                ActivePort = activePort,
+                StandbyPort = standbyPort,
+                ContainerPort = LocalSubstrateDockerFixture.ReplicaContainerPort,
+                HealthProbeSamples = 3,
+                HealthProbeTimeoutSeconds = 3,
+                HealthProbeExpectedStatusCode = 200,
+                // Short drain so the scenario stays well under the lane's runtime budget.
+                DrainDelaySeconds = 2
+            };
+
+            // 1. Launch the co-located v1 active replica the rollout will replace.
+            await docker.Runtime.RunAsync(
+                new ContainerRunRequest
+                {
+                    Executable = options.ContainerRuntime,
+                    Image = docker.V1Image,
+                    ContainerName = $"{options.ContainerNamePrefix}-{activePort.ToString(CultureInfo.InvariantCulture)}",
+                    HostPort = activePort,
+                    ContainerPort = options.ContainerPort,
+                    Labels = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        [YarpRollingDeployBackend.LabelTarget] = targetId,
+                        [YarpRollingDeployBackend.LabelRole] = YarpRollingDeployBackend.RoleActive,
+                        [YarpRollingDeployBackend.LabelRevision] = docker.V1Image
+                    }
+                },
+                CancellationToken.None);
+
+            var v1Ready = await LocalSubstrateDockerFixture.WaitForBodyAsync(
+                $"http://127.0.0.1:{activePort.ToString(CultureInfo.InvariantCulture)}/",
+                LocalSubstrateDockerFixture.V1Marker,
+                TimeSpan.FromSeconds(30));
+            if (!v1Ready)
+            {
+                await docker.CleanupTargetAsync(targetId);
+                throw new InvalidOperationException("The v1 active replica did not become ready.");
+            }
+
+            // 2. Stand up the embedded-YARP proxy pointed at v1, and take the REAL swap seam over its
+            //    live InMemoryConfigProvider so cutover is an atomic switch on the running proxy.
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+            var initialDestination = YarpInMemoryProxyStateSwapper.InitialActiveAddress(options);
+            builder.Services.AddReverseProxy().LoadFromMemory(
+                SelfHostedProxyConfig.BuildRoutes(options),
+                SelfHostedProxyConfig.BuildClusters(options, initialDestination));
+
+            var proxy = builder.Build();
+            proxy.MapReverseProxy();
+            await proxy.StartAsync();
+
+            var configProvider = (InMemoryConfigProvider)proxy.Services.GetRequiredService<IProxyConfigProvider>();
+            var swapper = new YarpInMemoryProxyStateSwapper(configProvider, Options.Create(options));
+
+            var backend = new YarpRollingDeployBackend(
+                docker.Runtime,
+                swapper,
+                docker.HealthProbe,
+                Options.Create(options),
+                NullLogger<YarpRollingDeployBackend>.Instance);
+
+            var proxyBaseUrl = proxy.Urls.First().TrimEnd('/');
+
+            // Confirm the proxy actually fronts v1 before any scenario begins.
+            var proxyServesV1 = await LocalSubstrateDockerFixture.WaitForBodyAsync(
+                proxyBaseUrl + "/", LocalSubstrateDockerFixture.V1Marker, TimeSpan.FromSeconds(15));
+            if (!proxyServesV1)
+            {
+                await proxy.StopAsync();
+                await proxy.DisposeAsync();
+                await docker.CleanupTargetAsync(targetId);
+                throw new InvalidOperationException("The proxy did not front the v1 replica.");
+            }
+
+            return new RollingDeployEnvironment(docker, proxy, options, backend, swapper, targetId, proxyBaseUrl);
+        }
+
+        public WorkflowOperationRecord CreateDeployOperation()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var spec = new DeployOperationSpec
+            {
+                TargetId = TargetId,
+                TargetKind = DeployTargetKind.SelfHostedRolling,
+                Backend = YarpRollingDeployBackend.AdapterBackendName,
+                Environment = "local",
+                TargetName = "honua-serving",
+                DesiredRevision = _docker.V2Image,
+                CurrentRevision = _docker.V1Image,
+                ArtifactReference = _docker.V2Image,
+                Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [SelfHostedDeployParameterKeys.Image] = _docker.V2Image,
+                    [SelfHostedDeployParameterKeys.ActivePort] = _options.ActivePort.ToString(CultureInfo.InvariantCulture),
+                    [SelfHostedDeployParameterKeys.StandbyPort] = _options.StandbyPort.ToString(CultureInfo.InvariantCulture),
+                    [SelfHostedDeployParameterKeys.ContainerPort] = _options.ContainerPort.ToString(CultureInfo.InvariantCulture)
+                }
+            };
+
+            return new WorkflowOperationRecord
+            {
+                OperationId = $"ls-deploy-{Guid.NewGuid():N}"[..20],
+                Kind = WorkflowOperationKind.Deploy,
+                Status = WorkflowOperationStatus.Submitted,
+                CreatedAt = now,
+                UpdatedAt = now,
+                Deploy = spec
+            };
+        }
+
+        public RequestLoop StartRequestLoop() => RequestLoop.Start(ProxyBaseUrl + "/");
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await _proxy.StopAsync();
+            }
+            catch
+            {
+                // Best-effort proxy shutdown.
+            }
+
+            await _proxy.DisposeAsync();
+            await _docker.CleanupTargetAsync(TargetId);
+        }
+    }
+
+    /// <summary>
+    /// Continuous request generator against the proxied endpoint. Records failures and which revision
+    /// bodies were observed so a scenario can assert the zero-downtime and traffic-flip properties.
+    /// </summary>
+    private sealed class RequestLoop : IDisposable
+    {
+        private readonly HttpClient _client;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+        private int _total;
+        private int _failures;
+        private volatile bool _sawV1;
+        private volatile bool _sawV2;
+        private volatile string? _lastBody;
+
+        private RequestLoop(string url)
+        {
+            _client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+            _loop = Task.Run(() => RunAsync(url));
+        }
+
+        public static RequestLoop Start(string url) => new(url);
+
+        public async Task<RequestLoopResult> StopAsync()
+        {
+            if (!_cts.IsCancellationRequested)
+            {
+                _cts.Cancel();
+            }
+
+            try
+            {
+                await _loop;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on shutdown.
+            }
+
+            return new RequestLoopResult(_total, _failures, _sawV1, _sawV2, _lastBody);
+        }
+
+        private async Task RunAsync(string url)
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                Interlocked.Increment(ref _total);
+                try
+                {
+                    using var response = await _client.GetAsync(url, _cts.Token);
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        Interlocked.Increment(ref _failures);
+                    }
+                    else
+                    {
+                        var body = (await response.Content.ReadAsStringAsync(_cts.Token)).Trim();
+                        _lastBody = body;
+                        if (body.Contains(LocalSubstrateDockerFixture.V1Marker, StringComparison.Ordinal))
+                        {
+                            _sawV1 = true;
+                        }
+
+                        if (body.Contains(LocalSubstrateDockerFixture.V2Marker, StringComparison.Ordinal))
+                        {
+                            _sawV2 = true;
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+                {
+                    // Loop shutdown — not a served-request failure.
+                    break;
+                }
+                catch
+                {
+                    Interlocked.Increment(ref _failures);
+                }
+
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(20), _cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_cts.IsCancellationRequested)
+            {
+                _cts.Cancel();
+            }
+
+            _cts.Dispose();
+            _client.Dispose();
+        }
+    }
+
+    private sealed record RequestLoopResult(int Total, int Failures, bool SawV1, bool SawV2, string? LastBody);
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/SyntheticMigrationsCompiler.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/SyntheticMigrationsCompiler.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Compiles an in-memory assembly whose embedded <c>.sql</c> manifest resources are DbUp migration
+/// scripts. This lets the ADR-0060 migration-gate lane (#2166, #2457) drive the REAL
+/// <c>PostgresDatabaseMigrationRunner</c> — which reads scripts via
+/// <c>WithScriptsEmbeddedInAssembly</c> — over a controlled, per-scenario expand/contract script set
+/// without checking synthetic SQL into the shipped migrations directory.
+/// </summary>
+internal static class SyntheticMigrationsCompiler
+{
+    /// <summary>
+    /// Emits an assembly embedding each supplied script as a <c>.sql</c> resource. Resource names are
+    /// prefixed with the assembly name and preserve the supplied script names, so DbUp discovers and
+    /// orders them exactly as it would shipped migrations (ascending by name).
+    /// </summary>
+    /// <param name="assemblyName">Unique assembly name (also the manifest-resource prefix).</param>
+    /// <param name="scripts">Ordered <c>(scriptName, sql)</c> pairs; each name must end in <c>.sql</c>.</param>
+    /// <returns>The loaded assembly, ready to hand to the migration runner.</returns>
+    public static Assembly Compile(string assemblyName, params (string ScriptName, string Sql)[] scripts)
+    {
+        // A trivial marker type keeps the emitted PE well-formed; only the embedded resources matter.
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            "namespace Honua.SyntheticMigrations { internal static class Marker { } }");
+
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToArray();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var resources = scripts
+            .Select(script =>
+            {
+                var bytes = Encoding.UTF8.GetBytes(script.Sql);
+                return new ResourceDescription(
+                    $"{assemblyName}.{script.ScriptName}",
+                    () => new MemoryStream(bytes),
+                    isPublic: true);
+            })
+            .ToArray();
+
+        using var peStream = new MemoryStream();
+        var result = compilation.Emit(peStream, manifestResources: resources);
+        if (!result.Success)
+        {
+            var errors = string.Join(
+                "; ",
+                result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).Select(d => d.ToString()));
+            throw new InvalidOperationException($"Failed to compile the synthetic migrations assembly: {errors}");
+        }
+
+        return Assembly.Load(peStream.ToArray());
+    }
+}


### PR DESCRIPTION
Related to #2166 and #2457 (ADR-0060 §Verification — the substrate-neutral lane of the two-plane matrix).

## Summary

Adds the `LocalSubstrate` e2e lane proving the ADR-0060 single-host, zero-cloud story end to end: {serving, GP} × {local/YARP} × {deploy, rolling-upgrade, expand/contract-migration, rollback}, on a plain Docker host — no Kubernetes, no cloud credentials.

The serving lane drives the real `YarpRollingDeployBackend` through the real embedded-YARP proxy (`InMemoryConfigProvider` in a live `WebApplication`) and the real docker CLI runtime client: standby launch → health-gated `PromotionRecommended` → atomic cutover, with a continuous request loop through the proxy asserting **zero failed requests** across the cutover and the response flipping v1→v2; plus pre-cutover rollback (previous replica never disturbed, zero downtime) and post-cutover rollback (proxy repointed, failed revision drained, `ObserveAsync` settles `RolledBack`). The GP lane drives the real `LocalProcessPoolBatchComputeBackend` with real child processes (lifecycle, exit-code mapping, process-tree cancel, pool-saturation deferral, `HONUA_*` env contract, contract-version rejection). The migration-gate lane drives the real `PostgresDatabaseMigrationRunner` over Testcontainers Postgres with synthetic Roslyn-compiled migration assemblies: unannotated `DROP COLUMN` fails closed naming the `honua:compatibility-review` marker; annotated applies; the plan surfaces the pending-contract signal `DeployPreflightProbe` uses to block coordinated deploys.

A new `local-substrate` job in `cloud-integration-harness.yml` runs the lane on plain ubuntu (free tier, no secrets, 20-min cap); every Docker-dependent test is `[SkippableFact]`-gated like the existing kind/LocalStack lanes.

## Changes Made

- `LocalSubstrateRollingDeployTests` (3), `LocalSubstrateProcessPoolTests` (6), `LocalSubstrateMigrationGateTests` (3) + fixtures (docker replica images from busybox httpd, shell-free managed GP helper via the dotnet muxer, per-test Postgres, synthetic migrations compiler) under `Honua.CloudIntegration.Tests`
- `LocalSubstrate` trait in `CloudIntegrationTraits`; project refs + `InternalsVisibleTo` for Honua.Jobs/Honua.Postgres internals
- `local-substrate` workflow job with image pre-pull and TRX artifacts
- Harness docs updated with the lane's matrix table

## Breaking Changes

None (tests + workflow only; two `InternalsVisibleTo` additions).

## Gate Impact

- [x] Adds the ADR-0060 substrate-neutral verification lane (nightly + dispatch; not on the PR path)

## Testing

- [x] `dotnet build` tests project Release: 0 warnings/errors
- [x] Local run of the lane: 6 passed (GP plane, real child processes), 6 skipped cleanly (serving + migration lanes need Docker — validated in CI by the new job)
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
