### PR TITLE
style: full-solution format sweep (BOM, final newlines)

### DIFF
--- a/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.ControlPlane.Domain;

--- a/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Authorization.Domain;

--- a/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
+++ b/src/Honua.Hosting/Features/Authentication/AtomicTokenReplayProtection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.IdentityModel.Tokens.Jwt;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerEditsHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 namespace Honua.Protocols.GeoServices.FeatureServer;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Geometry.Abstractions;

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;

--- a/src/Honua.Server/Features/ControlPlane/DeployWorkflowService.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployWorkflowService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Security.Claims;

--- a/src/Honua.Server/Features/ControlPlane/RedisWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/ControlPlane/RedisWorkflowOperationStore.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json;

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/CoordinatedReleaseControlEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/CoordinatedReleaseControlEndpointsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLeaseContentionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/DeployWorkflowReconcilerLeaseContentionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseLifecycleFixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseLifecycleFixTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseReconcilerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/MetadataReleaseReconcilerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/AtomicTokenReplayProtectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.IdentityModel.Tokens.Jwt;

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Linq;


### PR DESCRIPTION
Related to #2475 (train gate weakness) and #1641 (BOM history).

## Summary

Full-solution `dotnet format` sweep clearing the current format drift on trunk (UTF-8 BOMs, missing final newlines, whitespace) — 10 files, all from recent merges whose batches never ran the full-solution format check. Until the train's gate keys on failure signatures (#2475), this drift class re-accumulates and turns the shared `Build & Format Check` job red, which both masks real failures and feeds the job-name-based pre-existing filter.

## Changes Made

- `dotnet format Honua.sln` output committed verbatim (no manual edits)

## Breaking Changes

None (whitespace/encoding only).

## Gate Impact

- [x] Restores full-solution format check to green on trunk

## Testing

- [x] `dotnet format Honua.sln --verify-no-changes` clean after the sweep
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
