### PR TITLE
test(cert): real-AWS certification matrix - Batch execution, S3, Lambda alias, tag-driven reaper

### DIFF
--- a/.github/workflows/real-aws-certification.yml
+++ b/.github/workflows/real-aws-certification.yml
@@ -8,13 +8,45 @@ name: Real AWS Certification
 #   * Gated   — runs the live tests ONLY when the maintainer OIDC role variable
 #               `vars.REALAWS_CERT_ROLE_ARN` is configured. On forks, PRs, and any repo without
 #               that variable the live step is skipped and the lane is an explicit no-op (it never
-#               costs money and never fails for lack of credentials).
-#   * Budgeted — the seeded test (RegisterThenDeregisterJobDefinition) only REGISTERS a job
-#               definition; it never submits a job, so there is no compute and ZERO cost.
-#   * Teardown — every test namespaces its resources honua-cert-* and deregisters them in a
-#               finally block, so no standing resources remain.
+#               costs money and never fails for lack of credentials). The certify job runs in the
+#               `cert` GitHub environment so it matches the honua-iac OIDC role's subject pin
+#               (repo:honua-io/honua-server:environment:cert).
+#   * Budgeted — each certification cell is tiny and short-lived (a register/deregister smoke, two
+#               smallest-tier Batch jobs, one small S3 object, a no-op Lambda alias flip) and every
+#               resource is torn down; the reaper sweeps any crash-orphaned leftover.
+#   * Teardown — every cell namespaces its resources honua-cert-* and tags them honua-cert-run=<runId>
+#               and tears them down in a finally block; a dedicated always() reaper step then reaps
+#               any honua-cert-run-tagged resource older than the TTL, so no standing resources remain.
 #
 # Never runs on pull_request, so it cannot be triggered by forks or untrusted contributors.
+#
+# STACK-OUTPUT → REPO-VARIABLE → ENV-VAR CONTRACT (honua-iac examples/aws-cert). Every input is
+# OPTIONAL and dormant-safe: each certification cell skips cleanly when its inputs are absent, so
+# the lane degrades cell-by-cell. Set the repo variables (Settings → Secrets and variables →
+# Actions → Variables) from the Terraform outputs to light up each cell:
+#   terraform output           repo variable                              env var (fixture reads)
+#   ------------------------   ----------------------------------------   ------------------------------------------
+#   (OIDC role)                REALAWS_CERT_ROLE_ARN                      (assumed via configure-aws-credentials)
+#   region                     REALAWS_CERT_REGION (default us-east-1)    HONUA_REALAWS_CERT_REGION
+#   gp_job_queue_arn           REALAWS_CERT_JOB_QUEUE_ARN                 HONUA_REALAWS_CERT_JOB_QUEUE_ARN
+#   gp_job_definition_arns.s   REALAWS_CERT_JOBDEF_ARN_S                  HONUA_REALAWS_CERT_JOBDEF_ARN_S
+#   gp_job_definition_arns.m   REALAWS_CERT_JOBDEF_ARN_M                  HONUA_REALAWS_CERT_JOBDEF_ARN_M
+#   gp_job_definition_arns.l   REALAWS_CERT_JOBDEF_ARN_L                  HONUA_REALAWS_CERT_JOBDEF_ARN_L
+#   gp_job_definition_arns.xl  REALAWS_CERT_JOBDEF_ARN_XL                 HONUA_REALAWS_CERT_JOBDEF_ARN_XL
+#   gp_job_role_arn            REALAWS_CERT_JOB_ROLE_ARN                  HONUA_REALAWS_CERT_JOB_ROLE_ARN
+#   gp_execution_role_arn      REALAWS_CERT_EXECUTION_ROLE_ARN            HONUA_REALAWS_CERT_EXECUTION_ROLE_ARN
+#   cert_artifact_bucket       REALAWS_CERT_ARTIFACT_BUCKET               HONUA_REALAWS_CERT_ARTIFACT_BUCKET
+#   (cert Lambda function)     REALAWS_CERT_LAMBDA_FUNCTION               HONUA_REALAWS_CERT_LAMBDA_FUNCTION
+#   (cert Lambda alias)        REALAWS_CERT_LAMBDA_ALIAS                  HONUA_REALAWS_CERT_LAMBDA_ALIAS
+#   (cert ECS cluster)         REALAWS_CERT_ECS_CLUSTER                   HONUA_REALAWS_CERT_ECS_CLUSTER          (deferred cell)
+#   (cert ECS service)         REALAWS_CERT_ECS_SERVICE                   HONUA_REALAWS_CERT_ECS_SERVICE          (deferred cell)
+#   (cert ALB listener)        REALAWS_CERT_ALB_LISTENER_ARN              HONUA_REALAWS_CERT_ALB_LISTENER_ARN     (deferred cell)
+#   (cert canary target group) REALAWS_CERT_CANARY_TARGET_GROUP_ARN       HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN (deferred cell)
+#   (cert stable target group) REALAWS_CERT_STABLE_TARGET_GROUP_ARN       HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN (deferred cell)
+#
+# The Batch execution cell submits against the smallest-tier job definition, which the maintainer
+# must provision (in the cert stack) as a trivially- and quickly-succeeding container (e.g. busybox
+# `true`) — the SubmitJob seam can override env + resources but NOT the container image/command.
 
 on:
   schedule:
@@ -38,8 +70,10 @@ concurrency:
 
 jobs:
   certify:
-    name: Certify (live AWS Batch control-plane)
+    name: Certify (live AWS control-plane)
     runs-on: ubuntu-latest
+    # Match the honua-iac OIDC role's subject pin (repo:honua-io/honua-server:environment:cert).
+    environment: cert
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -65,7 +99,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
         with:
           role-to-assume: ${{ vars.REALAWS_CERT_ROLE_ARN }}
-          aws-region: ${{ vars.REALAWS_CERT_REGION || 'us-west-2' }}
+          # Default aligned with the honua-iac examples/aws-cert stack default (us-east-1).
+          aws-region: ${{ vars.REALAWS_CERT_REGION || 'us-east-1' }}
           role-session-name: honua-real-aws-certification
 
       - name: Run real-AWS certification tests
@@ -73,15 +108,52 @@ jobs:
         env:
           # Master switch the RealAwsCertificationFixture reads; only set when creds are present.
           HONUA_REALAWS_CERT_ENABLED: 'true'
-          HONUA_REALAWS_CERT_REGION: ${{ vars.REALAWS_CERT_REGION || 'us-west-2' }}
+          HONUA_REALAWS_CERT_REGION: ${{ vars.REALAWS_CERT_REGION || 'us-east-1' }}
+          # Stack-output inputs (all optional / dormant-safe). Each cell skips when its inputs are absent.
+          HONUA_REALAWS_CERT_JOB_QUEUE_ARN: ${{ vars.REALAWS_CERT_JOB_QUEUE_ARN }}
+          HONUA_REALAWS_CERT_JOBDEF_ARN_S: ${{ vars.REALAWS_CERT_JOBDEF_ARN_S }}
+          HONUA_REALAWS_CERT_JOBDEF_ARN_M: ${{ vars.REALAWS_CERT_JOBDEF_ARN_M }}
+          HONUA_REALAWS_CERT_JOBDEF_ARN_L: ${{ vars.REALAWS_CERT_JOBDEF_ARN_L }}
+          HONUA_REALAWS_CERT_JOBDEF_ARN_XL: ${{ vars.REALAWS_CERT_JOBDEF_ARN_XL }}
+          HONUA_REALAWS_CERT_JOB_ROLE_ARN: ${{ vars.REALAWS_CERT_JOB_ROLE_ARN }}
+          HONUA_REALAWS_CERT_EXECUTION_ROLE_ARN: ${{ vars.REALAWS_CERT_EXECUTION_ROLE_ARN }}
+          HONUA_REALAWS_CERT_ARTIFACT_BUCKET: ${{ vars.REALAWS_CERT_ARTIFACT_BUCKET }}
+          HONUA_REALAWS_CERT_LAMBDA_FUNCTION: ${{ vars.REALAWS_CERT_LAMBDA_FUNCTION }}
+          HONUA_REALAWS_CERT_LAMBDA_ALIAS: ${{ vars.REALAWS_CERT_LAMBDA_ALIAS }}
+          HONUA_REALAWS_CERT_ECS_CLUSTER: ${{ vars.REALAWS_CERT_ECS_CLUSTER }}
+          HONUA_REALAWS_CERT_ECS_SERVICE: ${{ vars.REALAWS_CERT_ECS_SERVICE }}
+          HONUA_REALAWS_CERT_ALB_LISTENER_ARN: ${{ vars.REALAWS_CERT_ALB_LISTENER_ARN }}
+          HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN: ${{ vars.REALAWS_CERT_CANARY_TARGET_GROUP_ARN }}
+          HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN: ${{ vars.REALAWS_CERT_STABLE_TARGET_GROUP_ARN }}
+        run: |
+          mkdir -p ./tests/TestResults
+          # Exclude the reaper here; it runs LAST in its own always() step so it sweeps this run's
+          # leftovers (and any prior crash-orphaned resources) without racing the cells.
+          dotnet test ${{ env.CSPROJ }} \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "Category=RealAwsCertification&FullyQualifiedName!~Reaper" \
+            --logger "trx;LogFileName=real-aws-certification.trx" \
+            --logger "console;verbosity=minimal" \
+            --results-directory ./tests/TestResults
+
+      - name: Reap crash-orphaned certification resources
+        # always(): run even if a cell above failed, so a broken run still cleans up. Gated on the
+        # same OIDC-role variable and enabled flag so it stays dormant on forks / unconfigured repos.
+        if: ${{ always() && vars.REALAWS_CERT_ROLE_ARN != '' }}
+        env:
+          HONUA_REALAWS_CERT_ENABLED: 'true'
+          HONUA_REALAWS_CERT_REGION: ${{ vars.REALAWS_CERT_REGION || 'us-east-1' }}
+          HONUA_REALAWS_CERT_ARTIFACT_BUCKET: ${{ vars.REALAWS_CERT_ARTIFACT_BUCKET }}
         run: |
           mkdir -p ./tests/TestResults
           dotnet test ${{ env.CSPROJ }} \
             --no-build \
             --no-restore \
             --configuration Release \
-            --filter "Category=RealAwsCertification" \
-            --logger "trx;LogFileName=real-aws-certification.trx" \
+            --filter "Category=RealAwsCertification&FullyQualifiedName~Reaper" \
+            --logger "trx;LogFileName=real-aws-certification-reaper.trx" \
             --logger "console;verbosity=minimal" \
             --results-directory ./tests/TestResults
 
@@ -89,9 +161,9 @@ jobs:
         if: ${{ vars.REALAWS_CERT_ROLE_ARN == '' }}
         run: |
           echo "::notice::Real-AWS certification lane is dormant — vars.REALAWS_CERT_ROLE_ARN is not set."
-          echo "Configure an OIDC role with least-privilege AWS Batch register/describe/deregister"
-          echo "permissions and set vars.REALAWS_CERT_ROLE_ARN (and optionally vars.REALAWS_CERT_REGION)"
-          echo "to enable live certification. No tests ran; no resources were created."
+          echo "Configure the honua-iac examples/aws-cert OIDC role and set vars.REALAWS_CERT_ROLE_ARN"
+          echo "(and the optional per-cell HONUA_REALAWS_CERT_* stack-output variables documented in the"
+          echo "header) to enable live certification. No tests ran; no resources were created."
 
       - name: Upload results
         if: ${{ always() && vars.REALAWS_CERT_ROLE_ARN != '' }}

--- a/docs/internal/contributor/testkit.md
+++ b/docs/internal/contributor/testkit.md
@@ -630,28 +630,76 @@ unit-tested; this lane exercises the real runner + real database path rather tha
 ### Real-AWS certification lane — `Category=RealAwsCertification`
 
 Runs in `.github/workflows/real-aws-certification.yml` (weekly + manual, never on `pull_request`)
-and targets a LIVE AWS account. It is gated, budgeted, and teardown-guaranteed:
+and targets a LIVE AWS account, driving Honua's production cloud seams against the standing
+certification stack provisioned by `honua-iac` (`examples/aws-cert`). It is gated, budgeted, and
+teardown-guaranteed:
 
-- **Gated** — the live test step runs only when `vars.REALAWS_CERT_ROLE_ARN` is configured
-  (OIDC role assumption). Without it the lane is an explicit no-op; the tests also self-skip
-  unless `HONUA_REALAWS_CERT_ENABLED=true`, so forks and credential-less runs never fail.
-- **Budgeted** — `AwsBatchRealCertificationTests` only *registers* a job definition (never submits
-  a job), so there is no compute and zero cost.
-- **Isolated + torn down** — `RealAwsCertificationFixture` mints a unique `honua-cert-*` prefix for
-  every resource; tests deregister in a `finally` block and assert no `ACTIVE` resource remains.
+- **Gated** — the live test step runs only when `vars.REALAWS_CERT_ROLE_ARN` is configured (OIDC
+  role assumption). The `certify` job runs in the `cert` GitHub environment so it matches the
+  honua-iac OIDC role's subject pin (`repo:honua-io/honua-server:environment:cert`). Without the
+  role variable the lane is an explicit no-op; the tests also self-skip unless
+  `HONUA_REALAWS_CERT_ENABLED=true`, and each cell self-skips when its own stack-output inputs are
+  absent, so the lane degrades cell-by-cell and forks / credential-less runs never fail.
+- **Budgeted** — each cell is tiny and short-lived: a register/deregister smoke, two smallest-tier
+  Batch jobs (one polled to `SUCCEEDED` under a hard <8-minute budget, one cancelled), one small S3
+  object, and a no-op Lambda alias flip.
+- **Isolated + torn down** — `RealAwsCertificationFixture` mints a unique `honua-cert-{runId}`
+  prefix and a `honua-cert-run=<runId>` tag; every cell tears its resources down in a `finally`
+  block. A dedicated `always()` reaper step (`CertificationResourceReaper`, filtered by
+  `FullyQualifiedName~Reaper`) then sweeps any `honua-cert-run`-tagged Batch job definition (aged by
+  its `honua-cert-created` tag) or S3 object (aged by `LastModified`) older than a 24h TTL — the
+  belt-and-braces backstop for a crash between create and delete. The reaper keys **strictly** off
+  the run tag, never a name prefix, so it can never touch the standing stack.
 
-Run locally against your own account (credentials via the default chain):
+**Cells:** `AwsBatchRealCertificationTests` (job-def register/deregister smoke),
+`AwsBatchExecutionRealCertificationTests` (submit→`SUCCEEDED` and submit→cancel through the real
+`AwsBatchComputeBackend` + `AwsSdkBatchJobClient`), `S3ArtifactRealCertificationTests` (artifact
+round-trip through the production S3 client seam against `cert_artifact_bucket`), and
+`AwsLambdaAliasRealCertificationTests` (read→no-op-flip→restore through the production
+`AwsSdkLambdaAliasClient`, certifying the alias-flip primitive that cutover/rollback ride).
+
+**Deferred (`DeferredRealCertificationPlaceholders`, explicit skipped placeholders):** live
+failure-of-failure / double-fault certification (#2161 — covered today by reconciler unit tests),
+and the ECS/ALB weighted-cutover cell (ALB weight mechanics are heavily unit-tested and already have
+a Terraform-gated live path via `AwsEcsAlbDeployBackendLiveTests`; a live cutover in this lane needs
+standing ALB + dual target-group + ECS-service infrastructure).
+
+**Stack-output → repo-variable → env-var contract** (set repo Actions *variables* from the
+`honua-iac examples/aws-cert` Terraform outputs; every input is optional/dormant-safe):
+
+| `terraform output` | repo variable | env var (fixture reads) |
+| --- | --- | --- |
+| (OIDC role) | `REALAWS_CERT_ROLE_ARN` | (assumed via `configure-aws-credentials`) |
+| `region` (default `us-east-1`) | `REALAWS_CERT_REGION` | `HONUA_REALAWS_CERT_REGION` |
+| `gp_job_queue_arn` | `REALAWS_CERT_JOB_QUEUE_ARN` | `HONUA_REALAWS_CERT_JOB_QUEUE_ARN` |
+| `gp_job_definition_arns.s` | `REALAWS_CERT_JOBDEF_ARN_S` | `HONUA_REALAWS_CERT_JOBDEF_ARN_S` |
+| `gp_job_definition_arns.{m,l,xl}` | `REALAWS_CERT_JOBDEF_ARN_{M,L,XL}` | `HONUA_REALAWS_CERT_JOBDEF_ARN_{M,L,XL}` |
+| `gp_job_role_arn` | `REALAWS_CERT_JOB_ROLE_ARN` | `HONUA_REALAWS_CERT_JOB_ROLE_ARN` |
+| `gp_execution_role_arn` | `REALAWS_CERT_EXECUTION_ROLE_ARN` | `HONUA_REALAWS_CERT_EXECUTION_ROLE_ARN` |
+| `cert_artifact_bucket` | `REALAWS_CERT_ARTIFACT_BUCKET` | `HONUA_REALAWS_CERT_ARTIFACT_BUCKET` |
+| (cert Lambda function) | `REALAWS_CERT_LAMBDA_FUNCTION` | `HONUA_REALAWS_CERT_LAMBDA_FUNCTION` |
+| (cert Lambda alias) | `REALAWS_CERT_LAMBDA_ALIAS` | `HONUA_REALAWS_CERT_LAMBDA_ALIAS` |
+| (cert ECS/ALB set — deferred cell) | `REALAWS_CERT_ECS_CLUSTER`, `REALAWS_CERT_ECS_SERVICE`, `REALAWS_CERT_ALB_LISTENER_ARN`, `REALAWS_CERT_CANARY_TARGET_GROUP_ARN`, `REALAWS_CERT_STABLE_TARGET_GROUP_ARN` | `HONUA_REALAWS_CERT_ECS_CLUSTER`, `HONUA_REALAWS_CERT_ECS_SERVICE`, `HONUA_REALAWS_CERT_ALB_LISTENER_ARN`, `HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN`, `HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN` |
+
+**Maintainer bootstrap:** (1) apply `honua-iac examples/aws-cert`; (2) set `REALAWS_CERT_ROLE_ARN`
+to its `github_oidc_role_arn` output and the per-cell variables above from the matching outputs;
+(3) ensure the smallest-tier job definition (`gp_job_definition_arns.s`) resolves to a trivially-
+and quickly-succeeding container (e.g. busybox `true`) — the SubmitJob seam overrides env + resources
+but NOT the image/command, so the "tiny job" shape is a property of the provisioned job definition.
+
+Run locally against your own account (credentials via the default chain), pointing each cell at your
+own stack outputs:
 
 ```bash
-HONUA_REALAWS_CERT_ENABLED=true HONUA_REALAWS_CERT_REGION=us-west-2 \
+HONUA_REALAWS_CERT_ENABLED=true HONUA_REALAWS_CERT_REGION=us-east-1 \
+  HONUA_REALAWS_CERT_JOB_QUEUE_ARN=... HONUA_REALAWS_CERT_JOBDEF_ARN_S=... \
+  HONUA_REALAWS_CERT_ARTIFACT_BUCKET=... \
   dotnet test tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj \
   --filter "Category=RealAwsCertification"
 ```
 
-**Remainder (tracked under #2164):** the full submit-to-`SUCCEEDED` Batch lifecycle and the
-ECS/Lambda deploy + rollback certifications need an ephemeral Fargate compute environment + IAM
-execution role whose teardown is slower and must be supervised, so they are not performed
-automatically by this lane yet.
+Cells whose inputs you omit skip cleanly. With the lane disabled (no `HONUA_REALAWS_CERT_ENABLED`)
+every certification test skips, which is the correct local/PR outcome.
 
 ## Environment Requirements
 

--- a/tests/dotnet/Honua.CloudIntegration.Tests/AwsBatchExecutionRealCertificationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/AwsBatchExecutionRealCertificationTests.cs
@@ -1,0 +1,260 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Real-AWS certification lane (#2164) — the CORE Batch execution cell. Unlike the seeded
+/// register/deregister smoke (<see cref="AwsBatchRealCertificationTests"/>), this drives a REAL
+/// end-to-end job lifecycle through the PRODUCTION seam: the real
+/// <see cref="AwsSdkBatchJobClient"/> behind the real <see cref="AwsBatchComputeBackend"/>, exactly
+/// as production wires them (the backend's unit tests construct it the same way, but with a stub
+/// client). It certifies that Honua's canonical batch-compute boundary actually submits, observes
+/// to a terminal state, and cancels against LIVE AWS Batch — the seam every GP workload rides.
+///
+/// It submits against the standing certification stack's SMALLEST-tier job definition + queue
+/// (honua-iac <c>examples/aws-cert</c>), so no compute environment or job definition is created
+/// here; the Fargate task runs to completion and ages out on its own. Per-job vCPU/memory/timeout
+/// overrides are exercised through the spec parameter keys (the per-job on-demand model). Every
+/// submission's provider job name is derived from an <c>honua-cert-{runId}</c> operation id so a
+/// run is traceable; the AWS Batch SubmitJob path the production seam uses does not attach resource
+/// tags (the seam sets no tags), and jobs are ephemeral run-to-completion, so there is nothing for
+/// the reaper to sweep here — teardown is a guaranteed cancel of any still-running job in a
+/// <c>finally</c> block.
+///
+/// BUDGET: two tiny jobs on the smallest tier, one polled to SUCCEEDED under a hard &lt;8-minute
+/// budget and one cancelled promptly. SAFETY: OFF unless
+/// <see cref="RealAwsCertificationFixture.BatchExecutionConfigured"/>; every path
+/// <c>[SkippableFact]</c>-skips otherwise.
+///
+/// LIVE-RUN ASSUMPTION (documented risk, not verifiable without AWS): the cert stack's smallest-tier
+/// job definition must resolve to a trivially- and quickly-succeeding container (for example a
+/// busybox <c>true</c>/<c>echo</c>). The AWS Batch SubmitJob ContainerOverrides the production seam
+/// emits can override environment + resource requirements but NOT the container image or command, so
+/// the "tiny echo/sleep" shape is a property of the maintainer-provisioned job definition, not of
+/// this test. The polled assertion is Succeeded; a job definition that fails fast would surface as a
+/// real certification failure by design.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.RealAwsCertification)]
+public sealed class AwsBatchExecutionRealCertificationTests : IClassFixture<RealAwsCertificationFixture>
+{
+    // Hard wall-clock budget for the submit→SUCCEEDED poll. Keeps a stuck/misconfigured job from
+    // burning the workflow's 30-minute timeout and keeps live cost bounded.
+    private static readonly TimeSpan SucceedBudget = TimeSpan.FromMinutes(8);
+    private static readonly TimeSpan CancelBudget = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(10);
+
+    private readonly RealAwsCertificationFixture _cert;
+
+    public AwsBatchExecutionRealCertificationTests(RealAwsCertificationFixture cert)
+    {
+        _cert = cert;
+    }
+
+    [SkippableFact]
+    public async Task SubmitAndObserve_RunsTinyJobToSucceeded_ThroughProductionBackend()
+    {
+        Skip.IfNot(
+            _cert.BatchExecutionConfigured,
+            "Real-AWS Batch execution cell not configured (needs HONUA_REALAWS_CERT_ENABLED=true, "
+            + "HONUA_REALAWS_CERT_JOB_QUEUE_ARN, HONUA_REALAWS_CERT_JOBDEF_ARN_S with credentials present).");
+
+        var backend = CreateBackend();
+        var job = CreateJob("succeed");
+
+        BatchComputeSubmissionResult submission;
+        var providerId = (string?)null;
+        try
+        {
+            submission = await backend.StartAsync(job);
+            submission.Status.Should().Be(
+                ExecutionJobStatus.Queued,
+                "a live AWS Batch submission through the production backend must return Queued");
+            submission.ProviderOperationId.Should().NotBeNullOrWhiteSpace(
+                "live AWS Batch must return a concrete provider job id");
+            providerId = submission.ProviderOperationId;
+
+            var observed = job with { Status = submission.Status, ProviderOperationId = providerId };
+            var terminal = await PollToTerminalAsync(backend, observed, SucceedBudget);
+
+            terminal.Status.Should().Be(
+                ExecutionJobStatus.Succeeded,
+                "the smallest-tier certification job definition must run to SUCCEEDED within the budget");
+            providerId = null; // reached a terminal state; nothing to tear down.
+        }
+        finally
+        {
+            await BestEffortCancelAsync(backend, job, providerId);
+        }
+    }
+
+    [SkippableFact]
+    public async Task SubmitThenCancel_ReachesTerminalCancelled_ThroughProductionBackend()
+    {
+        Skip.IfNot(
+            _cert.BatchExecutionConfigured,
+            "Real-AWS Batch execution cell not configured (needs HONUA_REALAWS_CERT_ENABLED=true, "
+            + "HONUA_REALAWS_CERT_JOB_QUEUE_ARN, HONUA_REALAWS_CERT_JOBDEF_ARN_S with credentials present).");
+
+        var backend = CreateBackend();
+        var job = CreateJob("cancel");
+
+        var providerId = (string?)null;
+        try
+        {
+            var submission = await backend.StartAsync(job);
+            submission.ProviderOperationId.Should().NotBeNullOrWhiteSpace();
+            providerId = submission.ProviderOperationId;
+
+            var running = job with { Status = submission.Status, ProviderOperationId = providerId };
+
+            // Drive the production cancel path (CancelJob while SUBMITTED/RUNNABLE, TerminateJob
+            // otherwise) and then poll until AWS reaches a terminal state.
+            var cancelObservation = await backend.CancelAsync(running);
+            var terminal = IsTerminal(cancelObservation.Status)
+                ? cancelObservation
+                : await PollCancelToTerminalAsync(backend, running, CancelBudget);
+
+            IsTerminal(terminal.Status).Should().BeTrue(
+                "cancellation must drive the job to a terminal state");
+            terminal.Status.Should().BeOneOf(
+                new[] { ExecutionJobStatus.Cancelled, ExecutionJobStatus.Succeeded, ExecutionJobStatus.Failed },
+                "a promptly-cancelled job resolves to Cancelled, or to Succeeded/Failed if it finished first");
+            providerId = null;
+        }
+        finally
+        {
+            await BestEffortCancelAsync(backend, job, providerId);
+        }
+    }
+
+    private static async Task<BatchComputeObservation> PollToTerminalAsync(
+        AwsBatchComputeBackend backend,
+        ExecutionJobRecord job,
+        TimeSpan budget)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var latest = new BatchComputeObservation { Status = job.Status, ProviderOperationId = job.ProviderOperationId };
+        while (stopwatch.Elapsed < budget)
+        {
+            latest = await backend.ObserveAsync(job);
+            if (IsTerminal(latest.Status))
+            {
+                return latest;
+            }
+
+            // Track the provider id in case the backend rebinds it (pending-discovery path).
+            job = job with { Status = latest.Status, ProviderOperationId = latest.ProviderOperationId ?? job.ProviderOperationId };
+            await Task.Delay(PollInterval);
+        }
+
+        throw new TimeoutException(
+            $"AWS Batch job '{job.ProviderOperationId}' did not reach a terminal state within {budget}. "
+            + $"Last observed status: {latest.Status}.");
+    }
+
+    private static async Task<BatchComputeObservation> PollCancelToTerminalAsync(
+        AwsBatchComputeBackend backend,
+        ExecutionJobRecord job,
+        TimeSpan budget)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        // Carry a durable cancellation signal so the backend's discovery paths terminalize correctly.
+        var cancelling = job with { CancellationRequestedAt = DateTimeOffset.UtcNow };
+        var latest = new BatchComputeObservation { Status = job.Status, ProviderOperationId = job.ProviderOperationId };
+        while (stopwatch.Elapsed < budget)
+        {
+            latest = await backend.ObserveAsync(cancelling);
+            if (IsTerminal(latest.Status))
+            {
+                return latest;
+            }
+
+            cancelling = cancelling with { Status = latest.Status, ProviderOperationId = latest.ProviderOperationId ?? cancelling.ProviderOperationId };
+            await Task.Delay(PollInterval);
+        }
+
+        throw new TimeoutException(
+            $"Cancelled AWS Batch job '{job.ProviderOperationId}' did not reach a terminal state within {budget}. "
+            + $"Last observed status: {latest.Status}.");
+    }
+
+    private static async Task BestEffortCancelAsync(
+        AwsBatchComputeBackend backend,
+        ExecutionJobRecord job,
+        string? providerId)
+    {
+        if (string.IsNullOrWhiteSpace(providerId))
+        {
+            return;
+        }
+
+        try
+        {
+            // Guaranteed teardown: cancel/terminate any job left non-terminal by an assertion
+            // failure above so the lane never leaves a live Fargate task running.
+            await backend.CancelAsync(job with
+            {
+                ProviderOperationId = providerId,
+                CancellationRequestedAt = DateTimeOffset.UtcNow,
+            });
+        }
+        catch
+        {
+            // Best-effort: the job is ephemeral run-to-completion and ages out on its own; a
+            // transient cancel blip must not mask the primary assertion outcome.
+        }
+    }
+
+    private AwsBatchComputeBackend CreateBackend()
+        => new(new AwsSdkBatchJobClient(), NullLogger<AwsBatchComputeBackend>.Instance);
+
+    private ExecutionJobRecord CreateJob(string purpose)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        // The operation id seeds the deterministic provider job name (honua-cert-{runId}-...), so a
+        // submitted job is traceable back to this run even though the SubmitJob seam sets no tags.
+        var operationId = $"{_cert.ResourcePrefix}-{purpose}";
+
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // Non-tiered path: submit against the smallest-tier job definition directly.
+            [AwsBatchParameterKeys.JobDefinitionArn] = _cert.JobDefinitionArnSmall!,
+            [AwsBatchParameterKeys.JobQueueArn] = _cert.JobQueueArn!,
+            [AwsBatchParameterKeys.Region] = _cert.Region,
+            // Per-job on-demand overrides (a valid Fargate vCPU/memory combo) + a short attempt cap
+            // so a wedged job cannot outlive the budget.
+            [AwsBatchParameterKeys.Vcpus] = "1",
+            [AwsBatchParameterKeys.MemoryMib] = "2048",
+            [AwsBatchParameterKeys.TimeoutSeconds] = "300",
+        };
+
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Queued,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = AwsBatchComputeBackend.AdapterBackendName,
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "honua-cert-smoke",
+                WorkloadId = "honua-cert-smoke",
+                Parameters = parameters,
+            },
+        };
+    }
+
+    private static bool IsTerminal(ExecutionJobStatus status)
+        => status is ExecutionJobStatus.Succeeded or ExecutionJobStatus.Failed or ExecutionJobStatus.Cancelled;
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/AwsBatchRealCertificationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/AwsBatchRealCertificationTests.cs
@@ -56,6 +56,9 @@ public sealed class AwsBatchRealCertificationTests : IClassFixture<RealAwsCertif
         {
             JobDefinitionName = jobDefinitionName,
             Type = JobDefinitionType.Container,
+            // Tag with the per-run tag + created stamp so the reaper (CertificationResourceReaper)
+            // can reclaim this definition if a crash between register and deregister orphans it.
+            Tags = new Dictionary<string, string>(_cert.RunTags(), StringComparer.Ordinal),
             ContainerProperties = new ContainerProperties
             {
                 Image = "public.ecr.aws/docker/library/busybox:latest",

--- a/tests/dotnet/Honua.CloudIntegration.Tests/AwsLambdaAliasRealCertificationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/AwsLambdaAliasRealCertificationTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Real-AWS certification lane (#2164) — the Lambda alias-flip cell. Certifies the alias
+/// read → flip → restore SDK path that <see cref="AwsLambdaGitOpsDeployBackend"/>'s cutover and
+/// rollback rides, at the NARROWEST real-SDK level, through the PRODUCTION seam
+/// (<see cref="AwsSdkLambdaAliasClient"/> — the same <c>UpdateAlias</c>/<c>GetAlias</c> client the
+/// backend is wired with in production).
+///
+/// CONSERVATIVE-BY-DESIGN (documented rationale): a faithful full-backend deploy certification would
+/// need a published deploy artifact + telemetry connection + a distinct target function version to
+/// flip between, which mutates a production-relevant function and needs standing rollout
+/// infrastructure. Instead this cell targets ONLY the dedicated certification-stack function and
+/// performs a NO-OP flip: read the alias's current <c>FunctionVersion</c> and routing weights, then
+/// <c>UpdateAlias</c> the alias to that SAME version (exercising the exact production
+/// <c>UpdateAliasAsync</c> control-plane call — the alias-flip primitive both cutover and rollback
+/// are built on), and RESTORE the original version + weights in a guaranteed <c>finally</c>. It
+/// never changes which version serves traffic, so it certifies the alias-flip control-plane
+/// mechanics without a deploy artifact and without risk to a production-relevant function. The
+/// weighted-cutover and rollback-decision mechanics themselves stay covered by the backend's
+/// extensive unit tests; a full live cutover certification is deferred (see the ECS/ALB deferral in
+/// <see cref="DeferredRealCertificationPlaceholders"/> and #2161).
+///
+/// Alias updates are in-place mutations of a standing resource, not created resources, so there is
+/// nothing to tag or reap; correctness is the guaranteed restore. OFF unless
+/// <see cref="RealAwsCertificationFixture.LambdaAliasConfigured"/>; skips otherwise.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.RealAwsCertification)]
+public sealed class AwsLambdaAliasRealCertificationTests : IClassFixture<RealAwsCertificationFixture>
+{
+    private readonly RealAwsCertificationFixture _cert;
+
+    public AwsLambdaAliasRealCertificationTests(RealAwsCertificationFixture cert)
+    {
+        _cert = cert;
+    }
+
+    [SkippableFact]
+    public async Task ReadFlipRestore_CertifiesAliasFlipPrimitive_ThroughProductionSeam()
+    {
+        Skip.IfNot(
+            _cert.LambdaAliasConfigured,
+            "Real-AWS Lambda alias cell not configured (needs HONUA_REALAWS_CERT_ENABLED=true, "
+            + "HONUA_REALAWS_CERT_LAMBDA_FUNCTION and HONUA_REALAWS_CERT_LAMBDA_ALIAS with credentials present).");
+
+        var client = new AwsSdkLambdaAliasClient();
+        var function = _cert.LambdaFunctionName!;
+        var alias = _cert.LambdaAliasName!;
+        var region = _cert.Region;
+
+        // Capture the original alias state so the restore is exact.
+        var original = await client.GetAliasAsync(function, alias, region);
+        original.FunctionVersion.Should().NotBeNullOrWhiteSpace(
+            "a live alias must resolve to a concrete function version");
+
+        var originalWeights = original.AdditionalVersionWeights.Count > 0
+            ? new Dictionary<string, double>(original.AdditionalVersionWeights, StringComparer.Ordinal)
+            : null;
+
+        var restoreRequired = true;
+        try
+        {
+            // Flip the alias to the SAME version (no traffic change) — this is the production
+            // UpdateAliasAsync control-plane call the backend's cutover/rollback are built on.
+            var flipped = await client.UpdateAliasAsync(
+                function,
+                alias,
+                original.FunctionVersion!,
+                additionalVersionWeights: null,
+                region);
+
+            flipped.FunctionVersion.Should().Be(
+                original.FunctionVersion,
+                "the alias-flip primitive must land the alias on the requested version");
+
+            // Restore explicitly (idempotent with the finally), then mark the finally a no-op.
+            await client.UpdateAliasAsync(function, alias, original.FunctionVersion!, originalWeights, region);
+
+            var restored = await client.GetAliasAsync(function, alias, region);
+            restored.FunctionVersion.Should().Be(
+                original.FunctionVersion,
+                "the alias must be restored to its original version");
+            restoreRequired = false;
+        }
+        finally
+        {
+            if (restoreRequired)
+            {
+                try
+                {
+                    // Guaranteed restore if an assertion above threw after the flip: never leave the
+                    // dedicated cert function's alias mutated.
+                    await client.UpdateAliasAsync(function, alias, original.FunctionVersion!, originalWeights, region);
+                }
+                catch
+                {
+                    // Best-effort: the flip was a no-op (same version), so even a failed restore
+                    // leaves the alias serving the original version's traffic unchanged.
+                }
+            }
+        }
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/CertificationReaperRealCertificationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/CertificationReaperRealCertificationTests.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Amazon;
+using Amazon.Batch;
+using Amazon.Batch.Model;
+using Amazon.S3;
+using Amazon.S3.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Real-AWS certification lane (#2164) — the run-scoped resource REAPER. A guaranteed
+/// <c>finally</c>/teardown protects the happy path, but a crashed runner (OOM, cancelled workflow,
+/// power loss between create and delete) can still orphan a resource. This sweeper is the
+/// belt-and-braces backstop: it reaps <c>honua-cert-run</c>-tagged resources older than a TTL so
+/// cost stays bounded even when a run dies mid-flight.
+///
+/// It keys STRICTLY off the <see cref="RealAwsCertificationFixture.RunTagKey"/> tag (never a name
+/// prefix), so it can NEVER touch the standing certification-stack resources — those share the
+/// <c>honua-cert-*</c> NAME prefix but carry no <c>honua-cert-run</c> TAG. Budget is describe/list +
+/// get-tagging + delete only.
+///
+/// The reaper runs LAST: it is filtered into a dedicated <c>always()</c> workflow step by
+/// <c>FullyQualifiedName~Reaper</c> AFTER the main certification step (which excludes it with
+/// <c>FullyQualifiedName!~Reaper</c>), so it sweeps this run's leftovers plus any prior run's
+/// leaked, aged-out resources without racing the cells that create them.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.RealAwsCertification)]
+public sealed class CertificationReaperRealCertificationTests : IClassFixture<RealAwsCertificationFixture>
+{
+    // Only reap resources older than this so a concurrent run's in-flight resources are never
+    // reaped out from under it. Comfortably longer than any single cell's budget.
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
+
+    private readonly RealAwsCertificationFixture _cert;
+
+    public CertificationReaperRealCertificationTests(RealAwsCertificationFixture cert)
+    {
+        _cert = cert;
+    }
+
+    [SkippableFact]
+    public async Task Reaper_SweepsAgedTaggedResources_WithoutTouchingTheStandingStack()
+    {
+        Skip.IfNot(
+            _cert.Enabled,
+            "Real-AWS certification lane disabled (set HONUA_REALAWS_CERT_ENABLED=true with credentials present).");
+
+        var now = DateTimeOffset.UtcNow;
+        var region = RegionEndpoint.GetBySystemName(_cert.Region);
+
+        using var batch = new AmazonBatchClient(region);
+        var reapedJobDefinitions = await CertificationResourceReaper
+            .ReapJobDefinitionsAsync(batch, Ttl, now);
+        reapedJobDefinitions.Should().BeGreaterThanOrEqualTo(
+            0, "reaping job definitions must complete without error");
+
+        if (!string.IsNullOrWhiteSpace(_cert.ArtifactBucket))
+        {
+            using var s3 = new AmazonS3Client(new AmazonS3Config { RegionEndpoint = region });
+            var reapedObjects = await CertificationResourceReaper
+                .ReapArtifactsAsync(s3, _cert.ArtifactBucket!, CertificationResourceReaper.ArtifactPrefix, Ttl, now);
+            reapedObjects.Should().BeGreaterThanOrEqualTo(
+                0, "reaping S3 artifacts must complete without error");
+        }
+    }
+}
+
+/// <summary>
+/// Tag-driven sweeper for leaked real-AWS certification resources (#2164). Reaps only resources
+/// carrying <see cref="RealAwsCertificationFixture.RunTagKey"/> that are older than a TTL, so it can
+/// never touch the standing certification stack (which shares the name prefix but not the run tag).
+/// </summary>
+internal static class CertificationResourceReaper
+{
+    /// <summary>S3 key prefix under which certification artifacts are written and swept.</summary>
+    public const string ArtifactPrefix = "cert/";
+
+    /// <summary>
+    /// Deregisters every ACTIVE Batch job definition tagged <see cref="RealAwsCertificationFixture.RunTagKey"/>
+    /// whose <see cref="RealAwsCertificationFixture.CreatedTagKey"/> stamp is older than <paramref name="ttl"/>.
+    /// Job definitions expose no native creation timestamp, so the created-tag is the TTL clock.
+    /// </summary>
+    public static async Task<int> ReapJobDefinitionsAsync(
+        IAmazonBatch batch,
+        TimeSpan ttl,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        var reaped = 0;
+        string? nextToken = null;
+        do
+        {
+            var response = await batch.DescribeJobDefinitionsAsync(
+                new DescribeJobDefinitionsRequest { Status = "ACTIVE", NextToken = nextToken },
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var definition in response.JobDefinitions ?? [])
+            {
+                if (!IsReapable(definition.Tags, now, ttl))
+                {
+                    continue;
+                }
+
+                await batch.DeregisterJobDefinitionAsync(
+                    new DeregisterJobDefinitionRequest { JobDefinition = definition.JobDefinitionArn },
+                    cancellationToken).ConfigureAwait(false);
+                reaped++;
+            }
+
+            nextToken = response.NextToken;
+        }
+        while (!string.IsNullOrEmpty(nextToken));
+
+        return reaped;
+    }
+
+    /// <summary>
+    /// Deletes every object under <paramref name="prefix"/> in <paramref name="bucket"/> that is
+    /// older than <paramref name="ttl"/> (by S3 <c>LastModified</c>) AND carries the
+    /// <see cref="RealAwsCertificationFixture.RunTagKey"/> tag. Object tagging is only fetched for
+    /// aged objects to keep the request budget low.
+    /// </summary>
+    public static async Task<int> ReapArtifactsAsync(
+        IAmazonS3 s3,
+        string bucket,
+        string prefix,
+        TimeSpan ttl,
+        DateTimeOffset now,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(s3);
+        ArgumentException.ThrowIfNullOrWhiteSpace(bucket);
+
+        var reaped = 0;
+        string? continuationToken = null;
+        do
+        {
+            var response = await s3.ListObjectsV2Async(
+                new ListObjectsV2Request
+                {
+                    BucketName = bucket,
+                    Prefix = prefix,
+                    ContinuationToken = continuationToken,
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var entry in response.S3Objects ?? [])
+            {
+                var lastModified = entry.LastModified;
+                if (!lastModified.HasValue || now - new DateTimeOffset(lastModified.Value, TimeSpan.Zero) < ttl)
+                {
+                    continue;
+                }
+
+                var tagging = await s3.GetObjectTaggingAsync(
+                    new GetObjectTaggingRequest { BucketName = bucket, Key = entry.Key },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (tagging.Tagging is null
+                    || !tagging.Tagging.Exists(tag => tag.Key == RealAwsCertificationFixture.RunTagKey))
+                {
+                    continue;
+                }
+
+                await s3.DeleteObjectAsync(
+                    new DeleteObjectRequest { BucketName = bucket, Key = entry.Key },
+                    cancellationToken).ConfigureAwait(false);
+                reaped++;
+            }
+
+            continuationToken = response.IsTruncated == true ? response.NextContinuationToken : null;
+        }
+        while (!string.IsNullOrEmpty(continuationToken));
+
+        return reaped;
+    }
+
+    private static bool IsReapable(Dictionary<string, string>? tags, DateTimeOffset now, TimeSpan ttl)
+    {
+        if (tags is null
+            || !tags.ContainsKey(RealAwsCertificationFixture.RunTagKey)
+            || !tags.TryGetValue(RealAwsCertificationFixture.CreatedTagKey, out var createdRaw)
+            || !long.TryParse(createdRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var createdEpoch))
+        {
+            // Missing run tag → not ours. Missing/unparseable created-tag → cannot age it safely; the
+            // guaranteed finally already deregisters happy-path resources, so leave it rather than
+            // risk deleting something whose age we cannot prove.
+            return false;
+        }
+
+        var created = DateTimeOffset.FromUnixTimeSeconds(createdEpoch);
+        return now - created >= ttl;
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/DeferredRealCertificationPlaceholders.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/DeferredRealCertificationPlaceholders.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Real-AWS certification lane (#2164) — intentionally-deferred cells, kept as explicit skipped
+/// placeholders so the matrix documents WHY they are absent rather than silently under-covering.
+/// Both always skip regardless of lane state; they exist for traceability and to reserve the cell
+/// name for the follow-up that implements them.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.RealAwsCertification)]
+public sealed class DeferredRealCertificationPlaceholders
+{
+    /// <summary>
+    /// DEFERRED (#2161): failure-of-failure certification — asserting the control plane's behaviour
+    /// when a rollback or teardown itself fails (double-fault handling). Implementing it live needs a
+    /// fault-injection surface on standing infrastructure whose complexity is not justified now; the
+    /// double-fault reconciliation paths are covered by unit/integration tests today (for example
+    /// <c>DeployWorkflowReconcilerRollbackFailureTests</c>). Reserved here so the live matrix records
+    /// the gap and points at the owning issue.
+    /// </summary>
+    [SkippableFact]
+    public void FailureOfFailure_Certification_IsDeferred()
+    {
+        Skip.If(
+            true,
+            "Deferred to #2161: live failure-of-failure (double-fault) certification is intentionally "
+            + "not implemented; the reconciliation paths are unit/integration-tested. This placeholder "
+            + "reserves the cell and documents the deferral.");
+    }
+
+    /// <summary>
+    /// DEFERRED: ECS/ALB weighted-cutover certification. The ALB weight mechanics are heavily unit-
+    /// tested (<c>AwsEcsAlbDeployBackendTests</c>) and already have a Terraform-gated live path keyed
+    /// off the separate <c>HONUA_LIVE_ECS_ALB_*</c> variables (<c>AwsEcsAlbDeployBackendLiveTests</c>).
+    /// Folding a live weighted cutover into THIS lane needs standing ALB + dual target-group + running
+    /// ECS service infrastructure and a canary-promotion decision, which is a deliberate
+    /// infrastructure/cost decision deferred out of the initial cert tier. Reserved here so the live
+    /// matrix records the deferral; the fixture already surfaces the ECS/ALB inputs
+    /// (<c>HONUA_REALAWS_CERT_ECS_*</c> / <c>_ALB_*</c> / <c>_TARGET_GROUP_ARN</c>) for when it lands.
+    /// </summary>
+    [SkippableFact]
+    public void EcsAlbWeightedCutover_Certification_IsDeferred()
+    {
+        Skip.If(
+            true,
+            "Deferred: live ECS/ALB weighted-cutover certification needs standing ALB + dual "
+            + "target-group + ECS-service infrastructure. The weight mechanics are unit-tested and a "
+            + "Terraform-gated live path already exists (AwsEcsAlbDeployBackendLiveTests). This "
+            + "placeholder reserves the cell and documents the deferral.");
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/RealAwsCertificationFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/RealAwsCertificationFixture.cs
@@ -16,9 +16,26 @@ namespace Honua.CloudIntegration.Tests;
 ///
 /// Credentials are resolved by the AWS SDK default chain (OIDC web-identity in CI, the shared
 /// <c>~/.aws</c> profile locally) — this fixture deliberately does not handle secrets itself. It
-/// only surfaces the master switch, the target <see cref="Region"/>, and a per-run unique
-/// <see cref="ResourcePrefix"/> so every resource a certification test creates is namespaced
-/// <c>honua-cert-*</c> and can never collide with or clobber pre-existing account infrastructure.
+/// only surfaces the master switch, the target <see cref="Region"/>, a per-run unique
+/// <see cref="RunId"/> / <see cref="ResourcePrefix"/> so every resource a certification test
+/// creates is namespaced <c>honua-cert-*</c> and can never collide with or clobber pre-existing
+/// account infrastructure, and the ARNs/names of the standing certification stack provisioned by
+/// <c>honua-iac</c> (<c>examples/aws-cert</c>).
+///
+/// STACK-OUTPUT → ENV-VAR CONTRACT (honua-iac <c>examples/aws-cert</c> outputs → repo variable →
+/// env var this fixture reads). Every input is OPTIONAL: each certification cell <c>Skip</c>s
+/// cleanly when its specific inputs are absent, so the lane degrades cell-by-cell rather than
+/// failing wholesale.
+/// <list type="table">
+///   <item><term>gp_job_queue_arn</term><description><c>HONUA_REALAWS_CERT_JOB_QUEUE_ARN</c></description></item>
+///   <item><term>gp_job_definition_arns.s</term><description><c>HONUA_REALAWS_CERT_JOBDEF_ARN_S</c> (required for the Batch execution cell)</description></item>
+///   <item><term>gp_job_definition_arns.{m,l,xl}</term><description><c>HONUA_REALAWS_CERT_JOBDEF_ARN_M/_L/_XL</c> (optional)</description></item>
+///   <item><term>gp_job_role_arn</term><description><c>HONUA_REALAWS_CERT_JOB_ROLE_ARN</c></description></item>
+///   <item><term>gp_execution_role_arn</term><description><c>HONUA_REALAWS_CERT_EXECUTION_ROLE_ARN</c></description></item>
+///   <item><term>cert_artifact_bucket</term><description><c>HONUA_REALAWS_CERT_ARTIFACT_BUCKET</c> (required for the S3 cell)</description></item>
+///   <item><term>(cert stack Lambda)</term><description><c>HONUA_REALAWS_CERT_LAMBDA_FUNCTION</c> + <c>HONUA_REALAWS_CERT_LAMBDA_ALIAS</c> (required for the Lambda cell)</description></item>
+///   <item><term>(cert stack ECS/ALB)</term><description><c>HONUA_REALAWS_CERT_ECS_CLUSTER</c>, <c>HONUA_REALAWS_CERT_ECS_SERVICE</c>, <c>HONUA_REALAWS_CERT_ALB_LISTENER_ARN</c>, <c>HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN</c>, <c>HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN</c> (ECS/ALB cell — deferred placeholder)</description></item>
+/// </list>
 /// </summary>
 public sealed class RealAwsCertificationFixture : IAsyncLifetime
 {
@@ -28,6 +45,66 @@ public sealed class RealAwsCertificationFixture : IAsyncLifetime
     /// <summary>Optional region override for the certification lane.</summary>
     public const string RegionEnvVar = "HONUA_REALAWS_CERT_REGION";
 
+    /// <summary><c>gp_job_queue_arn</c> stack output — the Batch job queue the execution cell submits to.</summary>
+    public const string JobQueueArnEnvVar = "HONUA_REALAWS_CERT_JOB_QUEUE_ARN";
+
+    /// <summary><c>gp_job_definition_arns.s</c> stack output — smallest-tier Batch job definition.</summary>
+    public const string JobDefinitionArnSmallEnvVar = "HONUA_REALAWS_CERT_JOBDEF_ARN_S";
+
+    /// <summary><c>gp_job_definition_arns.m</c> stack output (optional).</summary>
+    public const string JobDefinitionArnMediumEnvVar = "HONUA_REALAWS_CERT_JOBDEF_ARN_M";
+
+    /// <summary><c>gp_job_definition_arns.l</c> stack output (optional).</summary>
+    public const string JobDefinitionArnLargeEnvVar = "HONUA_REALAWS_CERT_JOBDEF_ARN_L";
+
+    /// <summary><c>gp_job_definition_arns.xl</c> stack output (optional).</summary>
+    public const string JobDefinitionArnExtraLargeEnvVar = "HONUA_REALAWS_CERT_JOBDEF_ARN_XL";
+
+    /// <summary><c>gp_job_role_arn</c> stack output — the Batch container task role.</summary>
+    public const string JobRoleArnEnvVar = "HONUA_REALAWS_CERT_JOB_ROLE_ARN";
+
+    /// <summary><c>gp_execution_role_arn</c> stack output — the Fargate execution role.</summary>
+    public const string ExecutionRoleArnEnvVar = "HONUA_REALAWS_CERT_EXECUTION_ROLE_ARN";
+
+    /// <summary><c>cert_artifact_bucket</c> stack output — the S3 bucket the artifact cell round-trips.</summary>
+    public const string ArtifactBucketEnvVar = "HONUA_REALAWS_CERT_ARTIFACT_BUCKET";
+
+    /// <summary>Cert-stack Lambda function name/ARN driven by the Lambda alias-flip cell.</summary>
+    public const string LambdaFunctionEnvVar = "HONUA_REALAWS_CERT_LAMBDA_FUNCTION";
+
+    /// <summary>Cert-stack Lambda alias name the alias-flip cell reads, flips, and restores.</summary>
+    public const string LambdaAliasEnvVar = "HONUA_REALAWS_CERT_LAMBDA_ALIAS";
+
+    /// <summary>Cert-stack ECS cluster (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    public const string EcsClusterEnvVar = "HONUA_REALAWS_CERT_ECS_CLUSTER";
+
+    /// <summary>Cert-stack ECS service (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    public const string EcsServiceEnvVar = "HONUA_REALAWS_CERT_ECS_SERVICE";
+
+    /// <summary>Cert-stack ALB listener ARN (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    public const string AlbListenerArnEnvVar = "HONUA_REALAWS_CERT_ALB_LISTENER_ARN";
+
+    /// <summary>Cert-stack canary target group ARN (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    public const string CanaryTargetGroupArnEnvVar = "HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN";
+
+    /// <summary>Cert-stack stable target group ARN (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    public const string StableTargetGroupArnEnvVar = "HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN";
+
+    /// <summary>
+    /// Tag key applied to every certification-created resource (where the AWS API supports tags)
+    /// carrying the per-run <see cref="RunId"/>. The reaper (<see cref="CertificationResourceReaper"/>)
+    /// keys STRICTLY off this tag so it can never touch the standing certification-stack resources,
+    /// which do not carry it — even though they share the <c>honua-cert-*</c> name prefix.
+    /// </summary>
+    public const string RunTagKey = "honua-cert-run";
+
+    /// <summary>
+    /// Tag key carrying the resource's creation time as Unix seconds. The reaper uses it as the TTL
+    /// clock for resources (like Batch job definitions) whose describe responses expose no native
+    /// creation timestamp.
+    /// </summary>
+    public const string CreatedTagKey = "honua-cert-created";
+
     /// <summary>
     /// True only when the lane is explicitly enabled. Defaults to false so the certification
     /// tests skip everywhere except the gated workflow / an opted-in local run.
@@ -36,15 +113,97 @@ public sealed class RealAwsCertificationFixture : IAsyncLifetime
 
     /// <summary>
     /// Target AWS region. Resolves <c>HONUA_REALAWS_CERT_REGION</c> → <c>AWS_REGION</c> →
-    /// <c>AWS_DEFAULT_REGION</c> → <c>us-west-2</c> (the Honua substrate region).
+    /// <c>AWS_DEFAULT_REGION</c> → <c>us-east-1</c> (the honua-iac <c>examples/aws-cert</c> default).
     /// </summary>
-    public string Region { get; private set; } = "us-west-2";
+    public string Region { get; private set; } = DefaultRegion;
+
+    /// <summary>Default region, aligned with the honua-iac <c>examples/aws-cert</c> stack default.</summary>
+    public const string DefaultRegion = "us-east-1";
 
     /// <summary>
-    /// Per-run unique prefix (<c>honua-cert-{8 hex}</c>) applied to every created resource so a
+    /// Per-run unique 8-hex id. Every created resource is namespaced/tagged with it so a
+    /// certification run is isolated, traceable, and reap-able, and can never be confused with
+    /// existing infrastructure.
+    /// </summary>
+    public string RunId { get; private set; } = "unset0000";
+
+    /// <summary>
+    /// Per-run unique prefix (<c>honua-cert-{RunId}</c>) applied to every created resource so a
     /// certification run is isolated and traceable, and can never be confused with existing infra.
     /// </summary>
     public string ResourcePrefix { get; private set; } = "honua-cert-unset";
+
+    /// <summary><c>gp_job_queue_arn</c> — null when unconfigured.</summary>
+    public string? JobQueueArn { get; private set; }
+
+    /// <summary><c>gp_job_definition_arns.s</c> — null when unconfigured.</summary>
+    public string? JobDefinitionArnSmall { get; private set; }
+
+    /// <summary><c>gp_job_definition_arns.m</c> — null when unconfigured.</summary>
+    public string? JobDefinitionArnMedium { get; private set; }
+
+    /// <summary><c>gp_job_definition_arns.l</c> — null when unconfigured.</summary>
+    public string? JobDefinitionArnLarge { get; private set; }
+
+    /// <summary><c>gp_job_definition_arns.xl</c> — null when unconfigured.</summary>
+    public string? JobDefinitionArnExtraLarge { get; private set; }
+
+    /// <summary><c>gp_job_role_arn</c> — null when unconfigured.</summary>
+    public string? JobRoleArn { get; private set; }
+
+    /// <summary><c>gp_execution_role_arn</c> — null when unconfigured.</summary>
+    public string? ExecutionRoleArn { get; private set; }
+
+    /// <summary><c>cert_artifact_bucket</c> — null when unconfigured.</summary>
+    public string? ArtifactBucket { get; private set; }
+
+    /// <summary>Cert-stack Lambda function name/ARN — null when unconfigured.</summary>
+    public string? LambdaFunctionName { get; private set; }
+
+    /// <summary>Cert-stack Lambda alias name — null when unconfigured.</summary>
+    public string? LambdaAliasName { get; private set; }
+
+    /// <summary>Cert-stack ECS cluster — null when unconfigured.</summary>
+    public string? EcsCluster { get; private set; }
+
+    /// <summary>Cert-stack ECS service — null when unconfigured.</summary>
+    public string? EcsService { get; private set; }
+
+    /// <summary>Cert-stack ALB listener ARN — null when unconfigured.</summary>
+    public string? AlbListenerArn { get; private set; }
+
+    /// <summary>Cert-stack canary target group ARN — null when unconfigured.</summary>
+    public string? CanaryTargetGroupArn { get; private set; }
+
+    /// <summary>Cert-stack stable target group ARN — null when unconfigured.</summary>
+    public string? StableTargetGroupArn { get; private set; }
+
+    /// <summary>
+    /// True when the lane is enabled AND the Batch execution cell's required inputs (job queue +
+    /// smallest-tier job definition) are present.
+    /// </summary>
+    public bool BatchExecutionConfigured
+        => Enabled && !string.IsNullOrWhiteSpace(JobQueueArn) && !string.IsNullOrWhiteSpace(JobDefinitionArnSmall);
+
+    /// <summary>True when the lane is enabled AND the artifact bucket is present.</summary>
+    public bool S3ArtifactConfigured
+        => Enabled && !string.IsNullOrWhiteSpace(ArtifactBucket);
+
+    /// <summary>True when the lane is enabled AND both the Lambda function and alias are present.</summary>
+    public bool LambdaAliasConfigured
+        => Enabled && !string.IsNullOrWhiteSpace(LambdaFunctionName) && !string.IsNullOrWhiteSpace(LambdaAliasName);
+
+    /// <summary>
+    /// The per-run resource-tag set: <see cref="RunTagKey"/>=<see cref="RunId"/> plus a
+    /// <see cref="CreatedTagKey"/> creation stamp. Applied wherever the AWS API supports tags so the
+    /// reaper can find and expire leaked resources without ever matching the standing stack.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> RunTags()
+        => new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [RunTagKey] = RunId,
+            [CreatedTagKey] = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
 
     /// <summary>Resolves the lane configuration from the environment.</summary>
     public Task InitializeAsync()
@@ -57,15 +216,38 @@ public sealed class RealAwsCertificationFixture : IAsyncLifetime
                 Environment.GetEnvironmentVariable(RegionEnvVar),
                 Environment.GetEnvironmentVariable("AWS_REGION"),
                 Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION"))
-            ?? "us-west-2";
+            ?? DefaultRegion;
 
-        ResourcePrefix = $"honua-cert-{Guid.NewGuid():N}"[..18];
+        RunId = Guid.NewGuid().ToString("N")[..8];
+        ResourcePrefix = $"honua-cert-{RunId}";
+
+        JobQueueArn = Read(JobQueueArnEnvVar);
+        JobDefinitionArnSmall = Read(JobDefinitionArnSmallEnvVar);
+        JobDefinitionArnMedium = Read(JobDefinitionArnMediumEnvVar);
+        JobDefinitionArnLarge = Read(JobDefinitionArnLargeEnvVar);
+        JobDefinitionArnExtraLarge = Read(JobDefinitionArnExtraLargeEnvVar);
+        JobRoleArn = Read(JobRoleArnEnvVar);
+        ExecutionRoleArn = Read(ExecutionRoleArnEnvVar);
+        ArtifactBucket = Read(ArtifactBucketEnvVar);
+        LambdaFunctionName = Read(LambdaFunctionEnvVar);
+        LambdaAliasName = Read(LambdaAliasEnvVar);
+        EcsCluster = Read(EcsClusterEnvVar);
+        EcsService = Read(EcsServiceEnvVar);
+        AlbListenerArn = Read(AlbListenerArnEnvVar);
+        CanaryTargetGroupArn = Read(CanaryTargetGroupArnEnvVar);
+        StableTargetGroupArn = Read(StableTargetGroupArnEnvVar);
 
         return Task.CompletedTask;
     }
 
     /// <summary>No standing resources; certification tests own their own create/teardown.</summary>
     public Task DisposeAsync() => Task.CompletedTask;
+
+    private static string? Read(string envVar)
+    {
+        var value = Environment.GetEnvironmentVariable(envVar);
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
 
     private static string? FirstNonEmpty(params string?[] candidates)
     {

--- a/tests/dotnet/Honua.CloudIntegration.Tests/S3ArtifactRealCertificationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/S3ArtifactRealCertificationTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Amazon;
+using Amazon.S3;
+using Amazon.S3.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Real-AWS certification lane (#2164) — the S3 artifact cell. Round-trips a small artifact through
+/// the SAME production S3 code path the LocalStack cell
+/// (<see cref="S3ArtifactRoundTripCloudIntegrationTests"/>) exercises — an <see cref="AmazonS3Client"/>
+/// configured exactly as <c>AwsS3FileStorage.CreateClient</c> does (region-scoped client, default
+/// credential chain, no ServiceURL override) — but against the LIVE certification-stack bucket
+/// (<c>cert_artifact_bucket</c>) instead of an emulator. It certifies the S3 seam every GP
+/// input/output and certification-evidence artifact rides.
+///
+/// SAFETY / BUDGET: a single tiny object under the run-scoped <c>cert/{runId}/</c> key prefix,
+/// tagged <c>honua-cert-run={runId}</c>, deleted in a guaranteed <c>finally</c> block. The tag lets
+/// the reaper reclaim any leaked object without ever matching non-certification bucket contents.
+/// OFF unless <see cref="RealAwsCertificationFixture.S3ArtifactConfigured"/>; skips otherwise.
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.RealAwsCertification)]
+public sealed class S3ArtifactRealCertificationTests : IClassFixture<RealAwsCertificationFixture>
+{
+    private readonly RealAwsCertificationFixture _cert;
+
+    public S3ArtifactRealCertificationTests(RealAwsCertificationFixture cert)
+    {
+        _cert = cert;
+    }
+
+    [SkippableFact]
+    public async Task PutThenGet_RoundTripsArtifact_ThroughLiveCertBucket()
+    {
+        Skip.IfNot(
+            _cert.S3ArtifactConfigured,
+            "Real-AWS S3 artifact cell not configured (needs HONUA_REALAWS_CERT_ENABLED=true and "
+            + "HONUA_REALAWS_CERT_ARTIFACT_BUCKET with credentials present).");
+
+        using var client = CreateClient(_cert.Region);
+
+        var bucket = _cert.ArtifactBucket!;
+        var key = $"cert/{_cert.RunId}/artifact-{Guid.NewGuid():N}.txt";
+        var payload = $"honua-real-aws-certification-{Guid.NewGuid():N}";
+
+        try
+        {
+            // 1. Put: write the artifact, tagged with the per-run tag so the reaper can reclaim it.
+            await client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucket,
+                Key = key,
+                ContentBody = payload,
+                TagSet =
+                [
+                    new Tag { Key = RealAwsCertificationFixture.RunTagKey, Value = _cert.RunId },
+                ],
+            });
+
+            // 2. Get: read it back and assert the bytes round-trip byte-for-byte.
+            using var response = await client.GetObjectAsync(new GetObjectRequest
+            {
+                BucketName = bucket,
+                Key = key,
+            });
+
+            using var reader = new StreamReader(response.ResponseStream, Encoding.UTF8);
+            var roundTripped = await reader.ReadToEndAsync();
+
+            roundTripped.Should().Be(
+                payload,
+                "the object written to the live certification bucket must be retrievable byte-for-byte");
+
+            // 3. Assert the run tag is present so the reaper contract holds end-to-end.
+            var tagging = await client.GetObjectTaggingAsync(new GetObjectTaggingRequest
+            {
+                BucketName = bucket,
+                Key = key,
+            });
+            tagging.Tagging.Should().Contain(
+                tag => tag.Key == RealAwsCertificationFixture.RunTagKey && tag.Value == _cert.RunId,
+                "every certification-created S3 object must carry the honua-cert-run tag");
+        }
+        finally
+        {
+            // 4. Guaranteed teardown: delete the object so the lane leaves zero standing artifacts.
+            try
+            {
+                await client.DeleteObjectAsync(new DeleteObjectRequest { BucketName = bucket, Key = key });
+            }
+            catch
+            {
+                // Best-effort: a leaked object still carries the honua-cert-run tag and is reaped
+                // by the TTL sweeper, so a transient delete blip cannot accumulate cost.
+            }
+        }
+    }
+
+    // Mirrors AwsS3FileStorage.CreateClient for the real-cloud case: a region-scoped client with no
+    // ServiceURL override and no static credentials, so the SDK default chain (OIDC in CI) signs.
+    private static AmazonS3Client CreateClient(string region)
+        => new(new AmazonS3Config { RegionEndpoint = RegionEndpoint.GetBySystemName(region) });
+}


### PR DESCRIPTION
Related to #2164 (real-AWS certification tier; ECS/ALB and #2161 failure-of-failure cells deferred with skipped placeholders, so the issue stays open until those land and the lane runs live).

## Summary

Fills out the real-AWS certification lane from its single control-plane smoke to the core #2164 matrix, all `Category=RealAwsCertification`, `[SkippableFact]`-gated per cell, budget-conscious, and torn down in `finally` with a tag-driven crash-backstop reaper.

New cells: **Batch execution** — a real job submitted through the production `AwsBatchComputeBackend`/`AwsSdkBatchJobClient` seam against the cert stack's smallest tier with per-job SubmitJob overrides, polled to `Succeeded` under a hard budget, plus a second job driven through `CancelAsync` to a terminal state; **S3 artifact** — round-trip through the production S3 path against the cert bucket, run-tagged and deleted; **Lambda alias** — conservative read→same-version-flip→restore through the production alias client (cannot shift served traffic even if restore fails). The pre-existing register/deregister smoke now stamps `honua-cert-run`/`honua-cert-created` tags. ECS/ALB weighted cutover and the #2161 failure-of-failure paths are explicit skipped placeholders with rationale.

The fixture reads the aws-cert stack outputs from optional env vars, so the lane degrades cell-by-cell when a variable is unset. The reaper deregisters/deletes only resources carrying the `honua-cert-run` tag older than 24h — never name-prefix matching, so the standing stack (same `honua-cert-*` prefix, no run tag) is untouchable — and runs as a dedicated `always()` workflow step.

Workflow: the certify job now runs in the `cert` GitHub environment (matches the honua-iac OIDC role's subject pin — previously AssumeRole would have been denied), the default region aligns with the stack default (`us-east-1`), and the full terraform-output → repo-variable → env-var contract is documented in the workflow header and testkit doc. Companion IAM/README changes: honua-io/honua-iac#109.

## Maintainer bootstrap (the only manual steps)

1. Dedicated AWS account/region; apply `honua-iac examples/aws-cert` (uncomment S3 backend, fill tfvars; ensure the small-tier job definition is a trivially-succeeding container, e.g. busybox `true`).
2. Create the GitHub Environment `cert` on this repo.
3. Set repo Actions variables from the stack outputs per the workflow-header table (`REALAWS_CERT_ROLE_ARN` minimum; each additional variable lights up a cell).
4. Confirm the budget-alarm SNS subscription.

## Breaking Changes

None (tests + workflow + docs only; no `src/` changes).

## Gate Impact

- [x] Extends the dormant weekly certification lane; zero effect on PR/trunk gates

## Testing

- [x] Release build (warnings-as-errors) green; `dotnet test --filter Category=RealAwsCertification` locally: 8/8 skip cleanly (correct dormant outcome); reaper/non-reaper filter split verified; workflow YAML parses; format clean
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Live execution requires the maintainer bootstrap above; the weekly schedule then certifies.
