### PR TITLE
Defer branch-versioning to Preview + fix 2 VMS access-leak S1s

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -9155,6 +9155,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithExplicitlyRejectedXmlAccept_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithTextXmlRejectedAndWildcardAllowed_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithUnsupportedAcceptAndWildcardFallback_ReturnsXml",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_DuplicateLayerWithFilter_Returns200NotCrash",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_FiltersInternalAttributes",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_ReturnsPlainText",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_WithFilter_AppliesLayerFilter",
@@ -9773,10 +9774,11 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.VmsEndpoint_WhenExperimentalDisabled_Returns404ExperimentalDisabled",
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.ServiceInfo_ReturnsCapabilities"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-rest-services-serviceid-versionmanagementserver-versions",
@@ -9789,7 +9791,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.ListVersions_AfterCreate_ContainsVersion"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-rest-services-serviceid-versionmanagementserver-versions-versionguid",
@@ -9802,7 +9804,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.VersionInfo_ReturnsSingleVersion"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-rest-services-serviceid-versionmanagementserver-versions-versionguid-inspectconflicts",
@@ -9815,7 +9817,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.InspectConflicts_CleanVersion_ReturnsNoConflicts"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-rest-services-serviceid-versionmanagementserver-versions-versionguid-jobs-jobid",
@@ -9828,7 +9830,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.JobStatus_UnknownJob_ReturnsNotFound"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "get-saml-metadata",
@@ -15800,8 +15802,10 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.CloudDemo.CloudDemoEndpointsTests.WritableFeatureGuard_WithoutWriteToken_ReturnsUnauthorizedForWritableOperations",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_AllEmptyPerLayerPayload_DoesNotInsertPhantomFeatures",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_AttributeConflict_RemainsClassifiedAsAttribute",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_Bidirectional_AppliesUploadAndDeliversServerDelta",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_Bidirectional_ConcurrentOtherClientEdit_IsDelivered",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_ConcurrentServerEdit_RecordsConflictAndAppliesLastWriteWins",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_Download_DeliversPostReplicaChangesAndAdvancesServerGen",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_GeometryOnlyConflict_ClassifiesAsGeometry",
@@ -17049,7 +17053,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.Create_NewVersion_ReturnsVersionInfo"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-alter",
@@ -17062,7 +17066,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.Alter_UpdatesDescription"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-delete",
@@ -17072,10 +17076,11 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
-        "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.Delete_RemovesVersion"
+        "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.Delete_RemovesVersion",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.Delete_VersionMidReconcile_Returns409Conflict"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-post",
@@ -17088,7 +17093,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.Post_AfterReconcile_Succeeds"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-reconcile",
@@ -17106,7 +17111,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.Reconcile_WithPost_CleanVersion_PostsInline"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-resolveconflicts",
@@ -17120,7 +17125,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.ResolveConflicts_NoPendingConflicts_ReturnsCanPost"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-startediting",
@@ -17135,7 +17140,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.StartEditing_VersionMidReconcile_Returns409Locked"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-startreading",
@@ -17149,7 +17154,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.StartReading_UnknownVersion_ReturnsNotFound"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-stopediting",
@@ -17162,7 +17167,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.StopEditing_AcknowledgesSession"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-rest-services-serviceid-versionmanagementserver-versions-versionguid-stopreading",
@@ -17175,7 +17180,7 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.VersionManagementServer.VersionManagementServerEndpointTests.StopReading_AcknowledgesSession"
       ],
       "proof_ledger_surface": "version-management-server",
-      "maturity": "implemented"
+      "maturity": "experimental"
     },
     {
       "id": "post-saml-acs",

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -192,11 +192,11 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
         // manifest omits them (B3), the T5 endpoint gates 404 their route groups, and
         // the feature catalog projects them as `experimental`. A customer opts in per
         // capability via Capabilities:Experimental:{id}:Enabled=true. Concepts whose
-        // built-experimental surface has no distinct registry descriptor (versioned
-        // editing/VMS, SIEM/investigations, cross-environment promotion,
-        // rollback/auto-rollback, collaborative map sessions, governance auth
-        // SSO/OIDC/SAML/SCIM, forms/form-packages, mobile field-collection beyond
-        // offline sync) are intentionally left as-is — there is no descriptor to flip.
+        // built-experimental surface has no distinct registry descriptor (SIEM/investigations,
+        // cross-environment promotion, rollback/auto-rollback, collaborative map sessions,
+        // governance auth SSO/OIDC/SAML/SCIM, forms/form-packages, mobile field-collection
+        // beyond offline sync) are intentionally left as-is — there is no descriptor to flip.
+        // versioning.branch (VMS) is now gated here via its own descriptor (added below).
         (string Id, string Category, string? EntitlementKey, CapabilityKind Kind, string? PackageSchemaVersion, CapabilityMaturity Maturity)[] capabilities =
         [
             ("package.metadata-v2", "packages", null, CapabilityKind.Feature, MetadataV2Constants.SchemaVersion, CapabilityMaturity.Implemented),
@@ -243,6 +243,10 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
             ("publication.metadata-release", "publication", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
             ("upload.file", "upload", "import.file", CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
             ("edit.features", "edit", FeatureCatalog.FeatureServerEditsKey, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            // Branch versioning (VMS REST surface) — built-experimental (ADR-0058 / BH6-001/BH6-002 fix).
+            // The VMS endpoints are gated OFF the GA surface by default (versioning.branch descriptor).
+            // Opt in via Capabilities:Experimental:versioning.branch:Enabled=true.
+            ("versioning.branch", "versioning", FeatureCatalog.BranchVersioningKey, CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
         ];
 
         foreach (var (id, category, entitlementKey, kind, packageSchemaVersion, maturity) in capabilities)

--- a/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
+++ b/src/Honua.Protocols.GeoServices/VersionManagementServer/VersionManagementServerEndpoints.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Validation.Abstractions;
 using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Capabilities;
 using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Models;
 using Honua.Protocols.GeoServices.FeatureServer;
@@ -61,96 +62,105 @@ public static class VersionManagementServerEndpoints
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
+        // versioning.branch is built-experimental (ADR-0058 / #2346): the VMS surface is
+        // implemented but gated OFF the GA surface by default. Routes return 404 when the
+        // capability resolves experimental-disabled (the production default). Opt in via
+        // Capabilities:Experimental:versioning.branch:Enabled=true (or the global master
+        // switch Capabilities:Experimental:Enabled=true). This does NOT affect the
+        // FeatureServer gdbVersion/replication paths — only the VMS REST surface.
+        var group = endpoints.MapGroup(BasePath)
+            .WithCapabilityGate("versioning.branch");
+
         // HANDLER-AUTHORIZED (#1144): every route below enforces authorization in its handler —
         // service read (Query) access for the read surface, plus the Enterprise branch-versioning
         // entitlement and service write authorization (Update + data-editor RBAC) for lifecycle
         // operations. Marked AllowAnonymous so the audit architecture guard records the
         // intentional decision, matching the sibling GeoServices endpoint files.
-        endpoints.MapGet(BasePath, HandleServiceInfo)
+        group.MapGet("", HandleServiceInfo)
             .WithName("GetVersionManagementServiceInfo")
             .WithSummary("Get VersionManagementServer service metadata")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapGet($"{BasePath}/versions", HandleListVersions)
+        group.MapGet("/versions", HandleListVersions)
             .WithName("ListVersions")
             .WithSummary("List branch versions")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapGet($"{BasePath}/versions/{{versionGuid}}", HandleVersionInfo)
+        group.MapGet("/versions/{versionGuid}", HandleVersionInfo)
             .WithName("GetVersionInfo")
             .WithSummary("Get a single branch version's metadata")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/create", HandleCreate)
+        group.MapPost("/create", HandleCreate)
             .WithName("CreateVersion")
             .WithSummary("Create a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/delete", HandleDelete)
+        group.MapPost("/versions/{versionGuid}/delete", HandleDelete)
             .WithName("DeleteVersion")
             .WithSummary("Delete a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/alter", HandleAlter)
+        group.MapPost("/versions/{versionGuid}/alter", HandleAlter)
             .WithName("AlterVersion")
             .WithSummary("Alter a branch version's metadata")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/startReading", HandleStartReading)
+        group.MapPost("/versions/{versionGuid}/startReading", HandleStartReading)
             .WithName("StartReadingVersion")
             .WithSummary("Begin a read session against a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/stopReading", HandleStopReading)
+        group.MapPost("/versions/{versionGuid}/stopReading", HandleStopReading)
             .WithName("StopReadingVersion")
             .WithSummary("End a read session against a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/startEditing", HandleStartEditing)
+        group.MapPost("/versions/{versionGuid}/startEditing", HandleStartEditing)
             .WithName("StartEditingVersion")
             .WithSummary("Begin an edit session against a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/stopEditing", HandleStopEditing)
+        group.MapPost("/versions/{versionGuid}/stopEditing", HandleStopEditing)
             .WithName("StopEditingVersion")
             .WithSummary("End an edit session against a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/reconcile", HandleReconcile)
+        group.MapPost("/versions/{versionGuid}/reconcile", HandleReconcile)
             .WithName("ReconcileVersion")
             .WithSummary("Reconcile a branch version against DEFAULT")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapGet($"{BasePath}/versions/{{versionGuid}}/inspectConflicts", HandleInspectConflicts)
+        group.MapGet("/versions/{versionGuid}/inspectConflicts", HandleInspectConflicts)
             .WithName("InspectVersionConflicts")
             .WithSummary("Retrieve the pending conflict set for a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/resolveConflicts", HandleResolveConflicts)
+        group.MapPost("/versions/{versionGuid}/resolveConflicts", HandleResolveConflicts)
             .WithName("ResolveVersionConflicts")
             .WithSummary("Submit manual conflict resolutions for a branch version")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapPost($"{BasePath}/versions/{{versionGuid}}/post", HandlePost)
+        group.MapPost("/versions/{versionGuid}/post", HandlePost)
             .WithName("PostVersion")
             .WithSummary("Post a reconciled branch version's changes onto DEFAULT")
             .WithTags(Tag)
             .AllowAnonymous();
 
-        endpoints.MapGet($"{BasePath}/versions/{{versionGuid}}/jobs/{{jobId}}", HandleJobStatus)
+        group.MapGet("/versions/{versionGuid}/jobs/{jobId}", HandleJobStatus)
             .WithName("GetVersionJobStatus")
             .WithSummary("Poll the status of an async reconcile/post job")
             .WithTags(Tag)
@@ -322,6 +332,22 @@ public static class VersionManagementServerEndpoints
         if (gate is not null)
         {
             return gate;
+        }
+
+        // BH6-002: refuse to delete a version that is mid-reconcile or mid-post.
+        // Calling DeleteAsync against a locked version produces undefined behavior in the version
+        // store — the in-flight reconcile job may write its result to a deleted record, corrupt the
+        // DEFAULT branch, or leave dangling change rows that can never be cleaned up. Return 409
+        // so the caller retries once the operation completes, mirroring the state guard already
+        // present in AcknowledgeSessionAsync (startEditing path).
+        var versions = await versionManager.ListAsync(cancellationToken).ConfigureAwait(false);
+        var version = versions.FirstOrDefault(v => v.VersionId == versionId);
+        if (version.VersionId == versionId && version.State is VersionState.Reconciling or VersionState.Posting)
+        {
+            return StandardErrorHelpers.CreateConflict(
+                context,
+                $"Version '{version.VersionName}' is {StatusToString(version.State)} and cannot be deleted.",
+                ["A reconcile or post is in progress for this version. Delete it once the operation completes."]);
         }
 
         var deleted = await versionManager.DeleteAsync(versionId, cancellationToken).ConfigureAwait(false);
@@ -511,10 +537,14 @@ public static class VersionManagementServerEndpoints
             return StandardErrorHelpers.CreateBadRequest(context, "versionGuid is not a valid GUID.");
         }
 
-        // BH3-003: conflict records contain full before/after attribute and geometry images.
-        // Load the version record and enforce ownership before exposing conflict data.
-        // Private versions gate on owner-or-admin; Public/Protected conflict data requires
-        // only query access (already satisfied by ValidateServiceAsync above).
+        // BH3-003 / BH6-001: conflict records contain full before/after attribute and geometry
+        // images. Load the version record and enforce ownership before exposing conflict data.
+        // Private AND Protected versions require owner-or-admin (CanManageVersion). Only Public
+        // versions (whose conflict state is intentionally world-readable by design) bypass the
+        // ownership check. A comment at the original site incorrectly equated query-level access
+        // with authorization to view raw conflict diffs for Protected versions — BH6-001 corrects
+        // the conditional so Protected versions are now gated on CanManageVersion, matching the
+        // sibling HandleResolveConflicts which checks unconditionally via AuthorizeReadAndResolveVersionAsync.
         var allVersions = await versionManager.ListAsync(cancellationToken).ConfigureAwait(false);
         var conflictVersion = allVersions.FirstOrDefault(v => v.VersionId == versionId);
         if (conflictVersion.VersionId != versionId)
@@ -522,7 +552,7 @@ public static class VersionManagementServerEndpoints
             return StandardErrorHelpers.CreateNotFound(context, $"Version '{versionGuid}' was not found.");
         }
 
-        if (conflictVersion.Access == VersionAccess.Private)
+        if (conflictVersion.Access is VersionAccess.Private or VersionAccess.Protected)
         {
             var callerName = context.User?.Identity?.Name;
             var isAdmin = ServiceDataEditorAuthorization.IsAdminPrincipal(context);

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogDriftTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogDriftTests.cs
@@ -149,6 +149,8 @@ public sealed class FeatureCatalogDriftTests
         experimentalRoutes.Should().Contain(route => route.StartsWith("/api/v1/admin/security/client-certificates", StringComparison.OrdinalIgnoreCase));
         experimentalRoutes.Should().Contain(route => route.Contains("/replicas", StringComparison.OrdinalIgnoreCase));
         experimentalRoutes.Should().Contain(route => route.StartsWith("/api/v1/streaming/features", StringComparison.OrdinalIgnoreCase));
+        // Branch versioning (VMS REST surface) gated Preview in the BH6-001/BH6-002 fix batch.
+        experimentalRoutes.Should().Contain(route => route.Contains("/VersionManagementServer", StringComparison.OrdinalIgnoreCase));
     }
 
     [ArchitectureTest]

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
@@ -267,6 +267,14 @@ internal static class FeatureCatalogGenerator
             return "realtime.feature-streams";
         }
 
+        // Branch versioning (VMS REST surface) — /rest/services/{serviceId}/VersionManagementServer/*
+        // Gated Preview in the BH6-001/BH6-002 fix batch (ADR-0058).
+        if (route.StartsWith("/rest/services/", StringComparison.OrdinalIgnoreCase) &&
+            route.Contains("/VersionManagementServer", StringComparison.OrdinalIgnoreCase))
+        {
+            return "versioning.branch";
+        }
+
         return null;
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
@@ -56,6 +56,7 @@ public sealed class CapabilityManifestRegistryProjectionTests
         "publication.metadata-release",
         "upload.file",
         "edit.features",
+        "versioning.branch",
     ];
 
     private static bool IsManifestCapability(CapabilityDescriptor descriptor)
@@ -87,6 +88,8 @@ public sealed class CapabilityManifestRegistryProjectionTests
         "realtime.feature-streams",
         // alerts.geofence promoted to Implemented (GA) in #2427 — no longer omitted.
         "security.mtls",
+        // versioning.branch (VMS REST surface) gated Preview in the BH6-001/BH6-002 fix batch.
+        "versioning.branch",
     ];
 
     [Fact]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionAccessPolicyTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionAccessPolicyTests.cs
@@ -171,4 +171,28 @@ public sealed class VersionAccessPolicyTests
         VersionAccessPolicy.CanManageVersion(version, callerName: "ALICE", isAdmin: false).Should().BeTrue(
             "owner name comparison must be case-insensitive for lifecycle operations");
     }
+
+    // ---- BH6-001 regression: HandleInspectConflicts Protected-version access leak ----------
+
+    [UnitTest]
+    public void CanManageVersion_ProtectedVersion_NonOwnerNonAdmin_CannotInspectConflicts()
+    {
+        // BH6-001 regression: HandleInspectConflicts previously only gated CanManageVersion on
+        // Private versions; Protected versions bypassed the check, exposing full conflict
+        // before/after attribute and geometry payloads to any query-authorized caller. The fix
+        // widens the condition to `Private or Protected`. This test pins the policy the fixed
+        // endpoint now applies for Protected versions: a non-owner, non-admin must be blocked.
+        var version = MakeVersion("alice", VersionAccess.Protected);
+
+        VersionAccessPolicy.CanManageVersion(version, callerName: "bob", isAdmin: false).Should().BeFalse(
+            "BH6-001: a non-owner non-admin must not inspect conflicts on a Protected version");
+        VersionAccessPolicy.CanManageVersion(version, callerName: null, isAdmin: false).Should().BeFalse(
+            "BH6-001: an anonymous principal must not inspect conflicts on a Protected version");
+
+        // Only the owner and admins may inspect Protected version conflicts.
+        VersionAccessPolicy.CanManageVersion(version, callerName: "alice", isAdmin: false).Should().BeTrue(
+            "the version owner can always inspect their own version's conflicts");
+        VersionAccessPolicy.CanManageVersion(version, callerName: "admin", isAdmin: true).Should().BeTrue(
+            "an administrator can inspect conflicts on any version");
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
@@ -499,6 +499,37 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
     [Operation(Operations.VersionManagement)]
     [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/delete")]
     [InterfaceOperation(TestProtocols.VersionManagementServer, "delete")]
+    public async Task Delete_VersionMidReconcile_Returns409Conflict()
+    {
+        // BH6-002 regression: before the fix HandleDelete called DeleteAsync without a
+        // VersionState guard, allowing deletion during an in-flight reconcile/post job.
+        // This caused the running reconcile to write its result to a deleted record and
+        // could corrupt the DEFAULT branch or leave dangling change rows.
+        var created = await CreateVersionAsync("admin.delete_midreconcile");
+        var guid = created.GetProperty("versionGuid").GetString();
+
+        // VersionState.Reconciling == 1; pin the version into that state via SQL,
+        // mirroring the pattern used by StartEditing_VersionMidReconcile_Returns409Locked.
+        // #2020: route the global honua.gdb_versions UPDATE through the schema-mutation advisory lock.
+        await _fixture.Postgres.ApplyGlobalSeedSqlAsync(
+            $"UPDATE honua.gdb_versions SET state = 1 WHERE version_id = '{guid}'::uuid");
+
+        var response = await PostFormAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/delete",
+            ("f", "json"));
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict,
+            "BH6-002: deleting a reconciling version must return 409; body: {0}",
+            await response.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(
+            "GeoServices protocol wraps errors in an 'error' envelope");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.VersionManagement)]
+    [Endpoint("POST /rest/services/{serviceId}/VersionManagementServer/versions/{versionGuid}/delete")]
+    [InterfaceOperation(TestProtocols.VersionManagementServer, "delete")]
     public async Task Delete_RemovesVersion()
     {
         var created = await CreateVersionAsync("admin.delete_me");

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/ExperimentalCapabilityGatingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/ExperimentalCapabilityGatingIntegrationTests.cs
@@ -61,6 +61,8 @@ public sealed class ExperimentalCapabilityGatingIntegrationTests
         "realtime.feature-streams",
         // alerts.geofence promoted to GA (Implemented) in #2427 — no longer experimental-gated.
         "security.mtls",
+        // versioning.branch (VMS REST surface) gated Preview in the BH6-001/BH6-002 fix batch.
+        "versioning.branch",
     ];
 
     [IntegrationTest]
@@ -155,6 +157,31 @@ public sealed class ExperimentalCapabilityGatingIntegrationTests
             using var client = fixture.CreateAdminClient();
             using var response = await client.GetAsync(
                 "/api/v1/temporal/services/svc-experimental/layers/1/capabilities");
+
+            await AssertExperimentalDisabledAsync(response);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{serviceId}/VersionManagementServer")]
+    public async Task VmsEndpoint_WhenExperimentalDisabled_Returns404ExperimentalDisabled()
+    {
+        // The VMS REST surface (versioning.branch) is gated Preview in the BH6-001/BH6-002 fix
+        // batch. With experimental OFF the capability-gate filter must short-circuit with
+        // 404 honua:capability-experimental-disabled before any handler runs — proving the GA
+        // surface no longer exposes the VMS endpoints by default.
+        var fixture = CreateFixture(experimentalGlobalEnabled: false);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            using var response = await client.GetAsync(
+                "/rest/services/svc-vms-gate-test/VersionManagementServer?f=json");
 
             await AssertExperimentalDisabledAsync(response);
         }


### PR DESCRIPTION
Per the GA-readiness call: branch-versioning (VersionManagementServer) kept producing S1s and was already 'verify depth' — so it's gated Preview (Maturity=Experimental, all VMS routes behind a capability gate → 404 unless Capabilities:Experimental:versioning.branch:Enabled=true). FeatureServer/replication untouched; feature-catalog regenerated. First fixed its 2 access-leak S1s: BH6-001 (Protected conflict-data leak — CanManageVersion now enforced for Private AND Protected) and BH6-002 (delete-during-reconcile → 409 guard). Build 0/0, architecture/catalog tests pass.