### PR TITLE
feat(observability): consolidated ops-health snapshot + deterministic ops findings with approval-gated proposals

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -2664,6 +2664,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-admin-observability-findings",
+      "route": "/api/v1/admin/observability/findings",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetFindings_WithAdminAuth_ReturnsFindingsEnvelope",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetFindings_WithoutAdminAuth_IsUnauthorized"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-admin-observability-logs",
       "route": "/api/v1/admin/observability/logs",
       "method": "GET",
@@ -2688,6 +2702,20 @@
         "Honua.Server.Tests.Features.Admin.ObservabilityEndpointsTests.GetMigrationStatus_ReturnsInstanceScopedLifecycleAndPlan",
         "Honua.Server.Tests.Features.Admin.ObservabilityEndpointsTests.GetMigrationStatus_WhenPlanFails_ReturnsPlanErrorWithoutThrowing",
         "Honua.Server.Tests.Features.Admin.ObservabilityEndpointsTests.GetMigrationStatus_WhenPlanThrows_ReturnsProblemDetails"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-observability-ops-health",
+      "route": "/api/v1/admin/observability/ops-health",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetOpsHealth_WithAdminAuth_ReturnsComposedSnapshot",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetOpsHealth_WithoutAdminAuth_IsUnauthorized"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -9155,6 +9183,8 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithExplicitlyRejectedXmlAccept_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithTextXmlRejectedAndWildcardAllowed_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithUnsupportedAcceptAndWildcardFallback_ReturnsXml",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_BboxExtendingOutsideCrsBoundsButIntersecting_DoesNotReject400",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_DuplicateLayerWithFilter_Returns200NotCrash",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_FiltersInternalAttributes",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_ReturnsPlainText",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_WithFilter_AppliesLayerFilter",
@@ -13030,6 +13060,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "post-api-v1-admin-observability-findings-findingid-propose",
+      "route": "/api/v1/admin/observability/findings/{findingId}/propose",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.ProposeFinding_UnknownId_Returns404",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.ProposeFinding_WithoutAdminAuth_IsUnauthorized"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "post-api-v1-admin-oidc-providers",
       "route": "/api/v1/admin/oidc/providers",
       "method": "POST",
@@ -15800,8 +15844,10 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.CloudDemo.CloudDemoEndpointsTests.WritableFeatureGuard_WithoutWriteToken_ReturnsUnauthorizedForWritableOperations",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_AllEmptyPerLayerPayload_DoesNotInsertPhantomFeatures",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_AttributeConflict_RemainsClassifiedAsAttribute",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_Bidirectional_AppliesUploadAndDeliversServerDelta",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_Bidirectional_ConcurrentOtherClientEdit_IsDelivered",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_ConcurrentServerEdit_RecordsConflictAndAppliesLastWriteWins",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_Download_DeliversPostReplicaChangesAndAdvancesServerGen",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerReplicaSyncTests.SynchronizeReplica_GeometryOnlyConflict_ClassifiesAsGeometry",

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -2664,6 +2664,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-admin-observability-findings",
+      "route": "/api/v1/admin/observability/findings",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetFindings_WithAdminAuth_ReturnsFindingsEnvelope",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetFindings_WithoutAdminAuth_IsUnauthorized"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-admin-observability-logs",
       "route": "/api/v1/admin/observability/logs",
       "method": "GET",
@@ -2688,6 +2702,20 @@
         "Honua.Server.Tests.Features.Admin.ObservabilityEndpointsTests.GetMigrationStatus_ReturnsInstanceScopedLifecycleAndPlan",
         "Honua.Server.Tests.Features.Admin.ObservabilityEndpointsTests.GetMigrationStatus_WhenPlanFails_ReturnsPlanErrorWithoutThrowing",
         "Honua.Server.Tests.Features.Admin.ObservabilityEndpointsTests.GetMigrationStatus_WhenPlanThrows_ReturnsProblemDetails"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-admin-observability-ops-health",
+      "route": "/api/v1/admin/observability/ops-health",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetOpsHealth_WithAdminAuth_ReturnsComposedSnapshot",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetOpsHealth_WithoutAdminAuth_IsUnauthorized"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -9155,6 +9183,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithExplicitlyRejectedXmlAccept_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithTextXmlRejectedAndWildcardAllowed_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithUnsupportedAcceptAndWildcardFallback_ReturnsXml",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_BboxExtendingOutsideCrsBoundsButIntersecting_DoesNotReject400",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_DuplicateLayerWithFilter_Returns200NotCrash",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_FiltersInternalAttributes",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_ReturnsPlainText",
@@ -13027,6 +13056,20 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.ObservabilityAlertEndpointsTests.SuppressAlert_RequiresFutureSuppressUntil"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
+      "id": "post-api-v1-admin-observability-findings-findingid-propose",
+      "route": "/api/v1/admin/observability/findings/{findingId}/propose",
+      "method": "POST",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.ProposeFinding_UnknownId_Returns404",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.ProposeFinding_WithoutAdminAuth_IsUnauthorized"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/src/Honua.Core/Features/Observability/Abstractions/IOpsFindingsService.cs
+++ b/src/Honua.Core/Features/Observability/Abstractions/IOpsFindingsService.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Core.Features.Observability.Abstractions;
+
+/// <summary>
+/// Deterministic ops-findings engine. Evaluates a fixed rule set against live operational signals
+/// on demand and, for findings that carry a safe recommended fix, materializes that fix through the
+/// approval-gated operation gateway. No model/LLM reasoning happens server-side (ADR-0028): every
+/// finding and recommended action is produced by deterministic rules, and every change is
+/// approval-gated.
+/// </summary>
+public interface IOpsFindingsService
+{
+    /// <summary>
+    /// Evaluates all rules against current signals and returns the findings that are active now.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The active findings, ordered by descending severity.</returns>
+    Task<IReadOnlyList<OpsFinding>> EvaluateAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Re-evaluates findings, locates the one with <paramref name="findingId"/>, and routes its
+    /// recommended action through the operation gateway (idempotency-keyed on the finding id).
+    /// </summary>
+    /// <param name="findingId">The deterministic finding identifier to propose.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// The proposal outcome, including the created proposal id when the gateway required approval,
+    /// or a not-found/no-action status when the finding vanished or has no recommended action.
+    /// </returns>
+    Task<OpsFindingProposalResult> ProposeAsync(string findingId, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Observability/Domain/OpsFindingModels.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsFindingModels.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text;
+using Honua.Core.Features.Guardrails.Domain;
+
+namespace Honua.Core.Features.Observability.Domain;
+
+/// <summary>
+/// Severity of a deterministic ops finding, ordered from lowest to highest operational urgency.
+/// </summary>
+public enum OpsFindingSeverity
+{
+    /// <summary>Informational: an observation an operator may want to know; no urgency.</summary>
+    Info = 0,
+
+    /// <summary>Warning: a condition worth attention that may degrade service if unaddressed.</summary>
+    Warning = 1,
+
+    /// <summary>Critical: an active operational problem requiring prompt operator action.</summary>
+    Critical = 2,
+}
+
+/// <summary>
+/// The subject a finding is about: a small set of stable identifiers pinning the finding to a
+/// concrete operational entity. Only the identifiers relevant to the emitting rule are populated;
+/// unset identifiers are omitted from serialized output.
+/// </summary>
+public sealed record OpsFindingSubject
+{
+    /// <summary>Gets the deploy target identifier this finding concerns, when applicable.</summary>
+    public string? TargetId { get; init; }
+
+    /// <summary>Gets the execution workload / batch-compute backend identifier, when applicable.</summary>
+    public string? WorkloadId { get; init; }
+
+    /// <summary>Gets the notification/alert channel identifier this finding concerns, when applicable.</summary>
+    public string? Channel { get; init; }
+
+    /// <summary>Gets the workflow/deploy operation identifier this finding concerns, when applicable.</summary>
+    public string? OperationId { get; init; }
+
+    /// <summary>Gets the platform release version this finding concerns, when applicable.</summary>
+    public string? ReleaseVersion { get; init; }
+
+    /// <summary>
+    /// Produces a canonical, order-stable key over the populated identifiers, used to derive the
+    /// finding's deterministic identifier. The format is fixed so the same condition instance always
+    /// hashes to the same value.
+    /// </summary>
+    /// <returns>A canonical subject key.</returns>
+    public string ToCanonicalKey()
+        => string.Join(
+            '|',
+            $"target={TargetId}",
+            $"workload={WorkloadId}",
+            $"channel={Channel}",
+            $"operation={OperationId}",
+            $"release={ReleaseVersion}");
+}
+
+/// <summary>
+/// A recommended, approval-gated fix for a finding. Materializing it produces an operation-gateway
+/// request; the gateway either executes it directly or (far more commonly) creates an approval
+/// proposal. The reasoning about whether to act stays client-side/operator-side — this record only
+/// carries the deterministic, ready-to-route payload.
+/// </summary>
+public sealed record OpsFindingRecommendedAction
+{
+    /// <summary>Gets the operation class the gateway routes this action through.</summary>
+    public required OperationClass Kind { get; init; }
+
+    /// <summary>Gets a short, plain-language summary of what the action does.</summary>
+    public required string Summary { get; init; }
+
+    /// <summary>
+    /// Gets the opaque, class-specific execution payload (JSON) that the matching gateway executor
+    /// understands. It is passed through verbatim; findings never interpret it.
+    /// </summary>
+    public required string ExecutionPayload { get; init; }
+
+    /// <summary>Gets the operator-facing reason recorded on the resulting gateway request/proposal.</summary>
+    public required string Reason { get; init; }
+}
+
+/// <summary>
+/// A single deterministic operational finding produced by the ops-findings engine. Findings are
+/// computed on demand from live signals; no model/LLM reasoning is involved. A finding with a
+/// <see cref="RecommendedAction"/> can be proposed through the approval gateway.
+/// </summary>
+public sealed record OpsFinding
+{
+    /// <summary>
+    /// Gets the stable identifier for this finding, deterministic per condition instance
+    /// (a hash of the rule id and subject); the same live condition always yields the same id.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>Gets the kebab-case rule identifier that produced this finding (e.g. <c>platform-release-skew</c>).</summary>
+    public required string Rule { get; init; }
+
+    /// <summary>Gets the finding severity.</summary>
+    public required OpsFindingSeverity Severity { get; init; }
+
+    /// <summary>Gets a short, human-readable title.</summary>
+    public required string Title { get; init; }
+
+    /// <summary>Gets a plain-language, deterministic explanation of the condition and its meaning.</summary>
+    public required string Explanation { get; init; }
+
+    /// <summary>Gets the UTC time at which the condition was detected (the evaluation time).</summary>
+    public required DateTimeOffset DetectedAt { get; init; }
+
+    /// <summary>Gets the subject identifiers the finding pins to.</summary>
+    public required OpsFindingSubject Subject { get; init; }
+
+    /// <summary>
+    /// Gets the supporting evidence references (operate-feed event ids, metric names, or endpoint
+    /// paths an operator can follow to corroborate the finding).
+    /// </summary>
+    public required IReadOnlyList<string> EvidenceRefs { get; init; }
+
+    /// <summary>
+    /// Gets the recommended, approval-gated fix, or <c>null</c> when the finding is informational
+    /// and has no safe automatic action.
+    /// </summary>
+    public OpsFindingRecommendedAction? RecommendedAction { get; init; }
+}
+
+/// <summary>
+/// Outcome of materializing a finding's recommended action through the operation gateway.
+/// </summary>
+public enum OpsFindingProposalStatus
+{
+    /// <summary>The finding no longer exists (the underlying condition cleared before proposing).</summary>
+    FindingNotFound = 0,
+
+    /// <summary>The finding exists but carries no recommended action to propose.</summary>
+    NoRecommendedAction = 1,
+
+    /// <summary>The gateway executed the action directly (no approval required).</summary>
+    Executed = 2,
+
+    /// <summary>The gateway created an approval proposal; see <see cref="OpsFindingProposalResult.ProposalId"/>.</summary>
+    ProposalCreated = 3,
+
+    /// <summary>The gateway blocked the action.</summary>
+    Blocked = 4,
+
+    /// <summary>The gateway does not support the action's operation class.</summary>
+    NotSupported = 5,
+}
+
+/// <summary>
+/// Result of a propose-through-gateway request for a finding's recommended action.
+/// </summary>
+public sealed record OpsFindingProposalResult
+{
+    /// <summary>Gets the proposal outcome status.</summary>
+    public required OpsFindingProposalStatus Status { get; init; }
+
+    /// <summary>Gets the finding identifier the request targeted.</summary>
+    public required string FindingId { get; init; }
+
+    /// <summary>Gets the created proposal identifier when <see cref="Status"/> is <see cref="OpsFindingProposalStatus.ProposalCreated"/>.</summary>
+    public string? ProposalId { get; init; }
+
+    /// <summary>Gets the executed operation identifier when <see cref="Status"/> is <see cref="OpsFindingProposalStatus.Executed"/>.</summary>
+    public string? ExecutionOperationId { get; init; }
+
+    /// <summary>Gets an operator-facing message describing the outcome, when available.</summary>
+    public string? Message { get; init; }
+}
+
+/// <summary>
+/// Derives deterministic finding identifiers so the same live condition always maps to the same id
+/// across evaluations (enabling idempotent propose-through-gateway routing keyed on the id).
+/// </summary>
+public static class OpsFindingId
+{
+    /// <summary>
+    /// Computes a stable identifier from a rule id and a finding subject.
+    /// </summary>
+    /// <param name="rule">The kebab-case rule identifier.</param>
+    /// <param name="subject">The finding subject.</param>
+    /// <returns>A deterministic, URL-safe finding identifier.</returns>
+    public static string Create(string rule, OpsFindingSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        return Create(rule, subject.ToCanonicalKey());
+    }
+
+    /// <summary>
+    /// Computes a stable identifier from a rule id and a pre-computed canonical subject key.
+    /// </summary>
+    /// <param name="rule">The kebab-case rule identifier.</param>
+    /// <param name="subjectKey">The canonical subject key.</param>
+    /// <returns>A deterministic, URL-safe finding identifier.</returns>
+    public static string Create(string rule, string subjectKey)
+    {
+        var material = $"{rule} {subjectKey}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(material));
+        // 128 bits of the digest as lowercase hex is ample to avoid collisions while staying compact.
+        return $"{rule}-{Convert.ToHexStringLower(hash.AsSpan(0, 16))}";
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.AdminObservability.cs
+++ b/src/Honua.Server/EndpointRegistry.AdminObservability.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server;
+
+public static partial class EndpointRegistry
+{
+    // Admin observability: consolidated ops-health snapshot + deterministic ops-findings engine
+    // (ADR-0060 WS4 / epic #2457). Expression-bodied (computed) to stay independent of cross-file
+    // static-init order, mirroring the other EndpointRegistry.<Area> fragments.
+    private static IReadOnlyList<EndpointDefinition> AdminObservabilityEndpoints =>
+    [
+        new("GET", "/api/v1/admin/observability/ops-health"),
+        new("GET", "/api/v1/admin/observability/findings"),
+        new("POST", "/api/v1/admin/observability/findings/{findingId}/propose"),
+    ];
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -31,6 +31,7 @@ public static partial class EndpointRegistry
     [
         .. PlatformEndpoints,
         .. AdminEndpoints,
+        .. AdminObservabilityEndpoints,
         .. IdentityProvisioningEndpoints,
         .. ConsoleEndpoints,
         .. StudioEndpoints,

--- a/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Models;
+using Honua.Infrastructure.Monitoring;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Admin endpoints for the consolidated ops-health snapshot and the deterministic ops-findings
+/// engine (ADR-0060 WS4 / epic #2457). Findings' recommended fixes are proposed through the existing
+/// operation-gateway approval flow; no model calls happen server-side (ADR-0028).
+/// </summary>
+internal static class OpsObservabilityEndpoints
+{
+    /// <summary>
+    /// Maps the admin observability endpoints (ops-health snapshot + ops findings).
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    public static void MapOpsObservabilityEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/observability")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Admin", "Observability")
+            .RequireAdminAuthorization();
+
+        group.MapGet("/ops-health", HandleGetOpsHealth)
+            .WithDisplayName("Get Ops Health Snapshot")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<OpsHealthSnapshotResponse>();
+
+        group.MapGet("/findings", HandleGetFindings)
+            .WithDisplayName("Get Ops Findings")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<OpsFindingsListResponse>();
+
+        group.MapPost("/findings/{findingId}/propose", HandleProposeFinding)
+            .WithDisplayName("Propose Ops Finding Action")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
+            .Produces<OpsFindingProposeResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<IResult> HandleGetOpsHealth(
+        [FromServices] IOpsHealthSnapshotService service,
+        HttpContext context)
+    {
+        var snapshot = await service.GetAsync(context.RequestAborted).ConfigureAwait(false);
+        return Results.Json(snapshot, OpsObservabilityJsonContext.Default.OpsHealthSnapshotResponse);
+    }
+
+    private static async Task<IResult> HandleGetFindings(
+        [FromServices] IOpsFindingsService service,
+        HttpContext context)
+    {
+        var findings = await service.EvaluateAsync(context.RequestAborted).ConfigureAwait(false);
+        var response = new OpsFindingsListResponse
+        {
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Findings = findings.Select(MapFinding).ToList(),
+        };
+
+        return Results.Json(response, OpsObservabilityJsonContext.Default.OpsFindingsListResponse);
+    }
+
+    private static async Task<IResult> HandleProposeFinding(
+        string findingId,
+        [FromServices] IOpsFindingsService service,
+        HttpContext context)
+    {
+        var result = await service.ProposeAsync(findingId, context.RequestAborted).ConfigureAwait(false);
+
+        if (result.Status is OpsFindingProposalStatus.FindingNotFound or OpsFindingProposalStatus.NoRecommendedAction)
+        {
+            var detail = result.Status == OpsFindingProposalStatus.FindingNotFound
+                ? $"Finding '{findingId}' was not found or its underlying condition has cleared."
+                : $"Finding '{findingId}' has no recommended action to propose.";
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                StatusCodes.Status404NotFound,
+                ProblemDetailsHelpers.GetTitle(StatusCodes.Status404NotFound),
+                detail);
+        }
+
+        var response = new OpsFindingProposeResponse
+        {
+            FindingId = result.FindingId,
+            Status = result.Status.ToString(),
+            ProposalId = result.ProposalId,
+            ExecutionOperationId = result.ExecutionOperationId,
+            Message = result.Message,
+        };
+
+        return Results.Json(response, OpsObservabilityJsonContext.Default.OpsFindingProposeResponse);
+    }
+
+    private static OpsFindingView MapFinding(OpsFinding finding)
+        => new()
+        {
+            Id = finding.Id,
+            Rule = finding.Rule,
+            Severity = finding.Severity.ToString(),
+            Title = finding.Title,
+            Explanation = finding.Explanation,
+            DetectedAt = finding.DetectedAt,
+            Subject = new OpsFindingSubjectView
+            {
+                TargetId = finding.Subject.TargetId,
+                WorkloadId = finding.Subject.WorkloadId,
+                Channel = finding.Subject.Channel,
+                OperationId = finding.Subject.OperationId,
+                ReleaseVersion = finding.Subject.ReleaseVersion,
+            },
+            EvidenceRefs = finding.EvidenceRefs,
+            RecommendedAction = finding.RecommendedAction is null
+                ? null
+                : new OpsFindingActionView
+                {
+                    Kind = finding.RecommendedAction.Kind.ToString(),
+                    Summary = finding.RecommendedAction.Summary,
+                    Reason = finding.RecommendedAction.Reason,
+                },
+        };
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -48,6 +48,15 @@ internal static class ObservabilityServiceCollectionExtensions
 
         AddOperateObservability(services);
 
+        // Ops-health snapshot composer + deterministic ops-findings engine (ADR-0060 WS4 / #2457).
+        // Both are scoped because they compose the scoped deploy-preflight probe.
+        services.AddOptions<OpsFindingsOptions>()
+            .Bind(configuration.GetSection(OpsFindingsOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.AddScoped<IOpsHealthSnapshotService, OpsHealthSnapshotService>();
+        services.AddScoped<IOpsFindingsService, OpsFindingsService>();
+
         return services;
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsOptions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Thresholds that drive the deterministic ops-findings rule set (<c>Observability:OpsFindings</c>).
+/// Defaults are conservative so the engine only surfaces findings for genuinely notable conditions.
+/// </summary>
+public sealed class OpsFindingsOptions
+{
+    /// <summary>
+    /// Configuration section name.
+    /// </summary>
+    public const string SectionName = "Observability:OpsFindings";
+
+    /// <summary>
+    /// Gets or sets the alert-dispatch pending backlog count at or above which the
+    /// <c>alert-dispatch-backlog</c> rule raises a warning finding. Default is 250.
+    /// </summary>
+    [Range(1, long.MaxValue)]
+    public long AlertDispatchPendingBacklogThreshold { get; set; } = 250;
+
+    /// <summary>
+    /// Gets or sets the alert-dispatch dead-letter count at or above which the
+    /// <c>alert-dispatch-backlog</c> rule escalates to a critical finding. Default is 1
+    /// (any dead-lettered notification is worth operator attention).
+    /// </summary>
+    [Range(1, long.MaxValue)]
+    public long AlertDispatchDeadLetterThreshold { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the total active GP queue depth (queued + provisioning + running) at or above
+    /// which the <c>gp-queue-depth</c> rule raises a finding. Default is 200.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int GpQueueDepthThreshold { get; set; } = 200;
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
@@ -1,0 +1,330 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Alerts;
+using Honua.ControlPlane;
+using Honua.ControlPlane.Executors;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Deterministic, evaluation-on-demand implementation of <see cref="IOpsFindingsService"/>. Each rule
+/// is small, side-effect-free, and reads a single live signal; recommended actions route through the
+/// existing <see cref="IOperationGateway"/> approval flow. No background loop and no model calls
+/// (ADR-0028) — findings are computed only when requested.
+/// </summary>
+internal sealed class OpsFindingsService : IOpsFindingsService
+{
+    internal const string RequestedByAgent = "ops-findings";
+
+    internal const string RuleAlertDispatchBacklog = "alert-dispatch-backlog";
+    internal const string RulePlatformReleaseSkew = "platform-release-skew";
+    internal const string RulePendingContractMigrations = "pending-contract-migrations";
+    internal const string RuleGpQueueDepth = "gp-queue-depth";
+    internal const string RuleDeployManualIntervention = "deploy-manual-intervention";
+
+    private readonly IOptionsMonitor<OpsFindingsOptions> _options;
+    private readonly IOptionsMonitor<ControlPlaneOptions> _controlPlaneOptions;
+    private readonly IAlertDispatchHealth _alertHealth;
+    private readonly IDeployPreflightProbe _deployProbe;
+    private readonly IOperationGateway _gateway;
+    private readonly IWorkflowOperationStore? _workflowStore;
+    private readonly IExecutionJobStore? _jobStore;
+
+    public OpsFindingsService(
+        IOptionsMonitor<OpsFindingsOptions> options,
+        IOptionsMonitor<ControlPlaneOptions> controlPlaneOptions,
+        IAlertDispatchHealth alertHealth,
+        IDeployPreflightProbe deployProbe,
+        IOperationGateway gateway,
+        IWorkflowOperationStore? workflowStore = null,
+        IExecutionJobStore? jobStore = null)
+    {
+        _options = options;
+        _controlPlaneOptions = controlPlaneOptions;
+        _alertHealth = alertHealth;
+        _deployProbe = deployProbe;
+        _gateway = gateway;
+        _workflowStore = workflowStore;
+        _jobStore = jobStore;
+    }
+
+    public async Task<IReadOnlyList<OpsFinding>> EvaluateAsync(CancellationToken cancellationToken = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var options = _options.CurrentValue;
+        var findings = new List<OpsFinding>();
+
+        EvaluateAlertDispatchBacklog(now, options, findings);
+        EvaluatePlatformReleaseSkew(now, findings);
+        await EvaluatePendingContractMigrationsAsync(now, findings, cancellationToken).ConfigureAwait(false);
+        await EvaluateGpQueueDepthAsync(now, options, findings, cancellationToken).ConfigureAwait(false);
+        await EvaluateDeployManualInterventionAsync(now, findings, cancellationToken).ConfigureAwait(false);
+
+        // Most urgent first; stable ordering by rule then id keeps output deterministic.
+        return findings
+            .OrderByDescending(f => (int)f.Severity)
+            .ThenBy(f => f.Rule, StringComparer.Ordinal)
+            .ThenBy(f => f.Id, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public async Task<OpsFindingProposalResult> ProposeAsync(string findingId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(findingId))
+        {
+            return new OpsFindingProposalResult { Status = OpsFindingProposalStatus.FindingNotFound, FindingId = findingId ?? string.Empty };
+        }
+
+        var findings = await EvaluateAsync(cancellationToken).ConfigureAwait(false);
+        var finding = findings.FirstOrDefault(f => string.Equals(f.Id, findingId, StringComparison.Ordinal));
+        if (finding is null)
+        {
+            return new OpsFindingProposalResult { Status = OpsFindingProposalStatus.FindingNotFound, FindingId = findingId };
+        }
+
+        if (finding.RecommendedAction is null)
+        {
+            return new OpsFindingProposalResult { Status = OpsFindingProposalStatus.NoRecommendedAction, FindingId = findingId };
+        }
+
+        var action = finding.RecommendedAction;
+        var request = new OperationGatewayRequest
+        {
+            Kind = action.Kind,
+            RequestedByAgent = RequestedByAgent,
+            Reason = action.Reason,
+            ExecutionPayload = action.ExecutionPayload,
+            // Idempotency-keyed on the deterministic finding id so re-proposing the same live
+            // condition folds onto the same gateway operation rather than spawning duplicates.
+            IdempotencyKey = findingId,
+        };
+
+        var result = await _gateway.RouteAsync(request, cancellationToken).ConfigureAwait(false);
+
+        return new OpsFindingProposalResult
+        {
+            Status = MapOutcome(result.Outcome),
+            FindingId = findingId,
+            ProposalId = result.ProposalId,
+            ExecutionOperationId = result.ExecutionOperationId,
+            Message = result.Message,
+        };
+    }
+
+    private static OpsFindingProposalStatus MapOutcome(OperationGatewayOutcome outcome) => outcome switch
+    {
+        OperationGatewayOutcome.Executed => OpsFindingProposalStatus.Executed,
+        OperationGatewayOutcome.ProposalCreated => OpsFindingProposalStatus.ProposalCreated,
+        OperationGatewayOutcome.Blocked => OpsFindingProposalStatus.Blocked,
+        _ => OpsFindingProposalStatus.NotSupported,
+    };
+
+    // Rule (a): alert-dispatch backlog / dead-letters over threshold. Informational — points the
+    // operator at channel health; there is no safe automatic fix for a delivery backlog.
+    private void EvaluateAlertDispatchBacklog(DateTimeOffset now, OpsFindingsOptions options, List<OpsFinding> findings)
+    {
+        if (!_alertHealth.IsDispatcherEnabled || _alertHealth.LastBacklog is not { } backlog)
+        {
+            return;
+        }
+
+        var deadLettersOverThreshold = backlog.DeadLetteredCount >= options.AlertDispatchDeadLetterThreshold;
+        var backlogOverThreshold = backlog.PendingCount >= options.AlertDispatchPendingBacklogThreshold;
+        if (!deadLettersOverThreshold && !backlogOverThreshold)
+        {
+            return;
+        }
+
+        var subject = new OpsFindingSubject { Channel = "alert-dispatch" };
+        var severity = deadLettersOverThreshold ? OpsFindingSeverity.Critical : OpsFindingSeverity.Warning;
+        var explanation = deadLettersOverThreshold
+            ? $"The alert dispatcher has {backlog.DeadLetteredCount} dead-lettered notification(s) that exhausted retries and require operator triage (pending backlog {backlog.PendingCount}). Inspect the affected notification channels' health and re-drive or discard the dead-lettered rows."
+            : $"The alert dispatcher pending backlog is {backlog.PendingCount}, at or above the configured threshold of {options.AlertDispatchPendingBacklogThreshold}. Deliveries are lagging; check channel throughput and downstream availability.";
+
+        findings.Add(new OpsFinding
+        {
+            Id = OpsFindingId.Create(RuleAlertDispatchBacklog, subject),
+            Rule = RuleAlertDispatchBacklog,
+            Severity = severity,
+            Title = deadLettersOverThreshold ? "Alert dispatch dead-letters require triage" : "Alert dispatch backlog is elevated",
+            Explanation = explanation,
+            DetectedAt = now,
+            Subject = subject,
+            EvidenceRefs = ["healthcheck:alert-dispatch", "GET /monitoring/health/comprehensive"],
+            RecommendedAction = null,
+        });
+    }
+
+    // Rule (b): platform-release skew. Informational — a safe automatic fix is not robustly derivable
+    // (redeploying each skewed plane needs an approved per-target revision), so we surface the skew
+    // and its skewed ids for an operator to reconcile.
+    private void EvaluatePlatformReleaseSkew(DateTimeOffset now, List<OpsFinding> findings)
+    {
+        var skew = PlatformReleaseSkewProjector.Build(_controlPlaneOptions.CurrentValue);
+
+        if (!skew.ReleaseDeclared || skew.IsCoVersioned || skew.SkewedIds.Count == 0)
+        {
+            return;
+        }
+
+        var subject = new OpsFindingSubject { ReleaseVersion = skew.ReleaseVersion };
+        var evidence = new List<string> { "GET /api/v1/admin/deploy/preflight?includeDiagnostics=true" };
+        evidence.AddRange(skew.SkewedIds.Select(id => $"skewed:{id}"));
+
+        findings.Add(new OpsFinding
+        {
+            Id = OpsFindingId.Create(RulePlatformReleaseSkew, subject),
+            Rule = RulePlatformReleaseSkew,
+            Severity = OpsFindingSeverity.Warning,
+            Title = "Platform release is not co-versioned",
+            Explanation = $"Declared platform release '{skew.ReleaseVersion}' is not co-versioned: {skew.SkewedIds.Count} plane(s) are skewed from the release ({string.Join(", ", skew.SkewedIds)}). No automatic fix is offered because a safe reconciliation requires an operator-approved revision for each skewed plane; redeploy the skewed planes to the release revision to restore co-versioning.",
+            DetectedAt = now,
+            Subject = subject,
+            EvidenceRefs = evidence,
+            RecommendedAction = null,
+        });
+    }
+
+    // Rule (c): pending contract migrations blocking a coordinated deploy. Informational — explains the
+    // expand -> deploy -> migrate -> contract discipline; contracting is an operator-sequenced step.
+    private async Task EvaluatePendingContractMigrationsAsync(DateTimeOffset now, List<OpsFinding> findings, CancellationToken cancellationToken)
+    {
+        var snapshot = await _deployProbe.ProbeAsync(cancellationToken).ConfigureAwait(false);
+        var migration = snapshot.Migration;
+        if (!migration.HasPendingContractScripts && migration.PendingContractScripts.Count == 0)
+        {
+            return;
+        }
+
+        var subject = new OpsFindingSubject();
+        var pending = migration.PendingContractScripts;
+        var evidence = new List<string> { "GET /api/v1/admin/deploy/preflight?includeDiagnostics=true" };
+        evidence.AddRange(pending.Select(script => $"contract-script:{script}"));
+
+        findings.Add(new OpsFinding
+        {
+            Id = OpsFindingId.Create(RulePendingContractMigrations, subject),
+            Rule = RulePendingContractMigrations,
+            Severity = OpsFindingSeverity.Warning,
+            Title = "Pending contract migrations block coordinated deploy",
+            Explanation = $"{pending.Count} contract migration script(s) are pending, which holds coordinated-deploy readiness. Under the expand -> deploy -> migrate -> contract discipline, contract steps run only after the new code is fully rolled out and the prior schema is no longer read; run the pending contract migrations once the deploy is complete and verified. This is informational: contracting is an operator-sequenced step, not an automatic action.",
+            DetectedAt = now,
+            Subject = subject,
+            EvidenceRefs = evidence,
+            RecommendedAction = null,
+        });
+    }
+
+    // Rule (d): GP queue depth sustained above threshold. Informational — surfaces a scale hint; there
+    // is no safe automatic scale action to route in this slice.
+    private async Task EvaluateGpQueueDepthAsync(DateTimeOffset now, OpsFindingsOptions options, List<OpsFinding> findings, CancellationToken cancellationToken)
+    {
+        if (_jobStore is null)
+        {
+            return;
+        }
+
+        var activeJobs = await _jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        var queueDepth = ControlPlaneTelemetry.ComputeQueueDepth(activeJobs);
+        var totalActive = queueDepth.Sum(entry => entry.Count);
+        if (totalActive < options.GpQueueDepthThreshold)
+        {
+            return;
+        }
+
+        var subject = new OpsFindingSubject();
+        var breakdown = string.Join(", ", queueDepth.Select(entry => $"{entry.Status}/{entry.Backend}={entry.Count}"));
+
+        findings.Add(new OpsFinding
+        {
+            Id = OpsFindingId.Create(RuleGpQueueDepth, subject),
+            Rule = RuleGpQueueDepth,
+            Severity = OpsFindingSeverity.Warning,
+            Title = "Geoprocessing queue depth is high",
+            Explanation = $"Active geoprocessing job depth is {totalActive} (queued/provisioning/running), at or above the configured threshold of {options.GpQueueDepthThreshold}. Breakdown by status/backend: {breakdown}. Consider scaling execution-worker capacity for the busiest backend; no automatic action is taken.",
+            DetectedAt = now,
+            Subject = subject,
+            EvidenceRefs = ["metric:honua.execution.queue.depth"],
+            RecommendedAction = null,
+        });
+    }
+
+    // Rule (e): deploy operation stuck in ManualInterventionRequired. Critical. Offers a rollback
+    // recommended action ONLY when a safe rollback target revision is derivable (the operation records
+    // the revision it was moving away from); otherwise it is informational and says so.
+    private async Task EvaluateDeployManualInterventionAsync(DateTimeOffset now, List<OpsFinding> findings, CancellationToken cancellationToken)
+    {
+        if (_workflowStore is null)
+        {
+            return;
+        }
+
+        var active = await _workflowStore.ListActiveAsync(WorkflowOperationKind.Deploy, cancellationToken).ConfigureAwait(false);
+        foreach (var operation in active)
+        {
+            if (operation.Status != WorkflowOperationStatus.ManualInterventionRequired)
+            {
+                continue;
+            }
+
+            var deploy = operation.Deploy;
+            var subject = new OpsFindingSubject
+            {
+                OperationId = operation.OperationId,
+                TargetId = deploy?.TargetId,
+            };
+            var evidence = new List<string>
+            {
+                $"operation:{operation.OperationId}",
+                $"GET /api/v1/admin/deploy/operations/{operation.OperationId}",
+            };
+
+            // A robustly-derivable rollback target is the revision the operation was moving away from
+            // (Deploy.CurrentRevision). When it is unknown we cannot craft a safe payload, so the
+            // finding is informational.
+            var canRollback = deploy is not null && !string.IsNullOrWhiteSpace(deploy.CurrentRevision);
+            OpsFindingRecommendedAction? action = null;
+            if (canRollback)
+            {
+                var rollbackPayload = new DeployExecutionPayload
+                {
+                    TargetId = deploy!.TargetId,
+                    DesiredRevision = deploy.CurrentRevision!,
+                    CurrentRevision = deploy.DesiredRevision,
+                }.Serialize();
+
+                action = new OpsFindingRecommendedAction
+                {
+                    Kind = OperationClass.Deploy,
+                    Summary = $"Roll back deploy target '{deploy.TargetId}' to revision '{deploy.CurrentRevision}'.",
+                    ExecutionPayload = rollbackPayload,
+                    Reason = $"Deploy operation {operation.OperationId} requires manual intervention; roll back to the prior revision.",
+                };
+            }
+
+            var explanation = canRollback
+                ? $"Deploy operation '{operation.OperationId}' for target '{deploy!.TargetId}' is stuck in ManualInterventionRequired. A rollback to the prior revision '{deploy.CurrentRevision}' is proposable through the approval gateway."
+                : $"Deploy operation '{operation.OperationId}' is stuck in ManualInterventionRequired, but no rollback action is offered: the prior (rollback-target) revision is not recorded on the operation, so a safe rollback payload cannot be derived. Investigate and remediate manually.";
+
+            findings.Add(new OpsFinding
+            {
+                Id = OpsFindingId.Create(RuleDeployManualIntervention, subject),
+                Rule = RuleDeployManualIntervention,
+                Severity = OpsFindingSeverity.Critical,
+                Title = "Deploy operation requires manual intervention",
+                Explanation = explanation,
+                DetectedAt = now,
+                Subject = subject,
+                EvidenceRefs = evidence,
+                RecommendedAction = action,
+            });
+        }
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Alerts;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Composes the consolidated admin ops-health snapshot from the shared health/monitoring seams.
+/// Introduced so the endpoint handler stays a thin adapter (one dependency) while this service holds
+/// the several collaborators the snapshot fuses.
+/// </summary>
+internal interface IOpsHealthSnapshotService
+{
+    /// <summary>
+    /// Builds the consolidated ops-health snapshot.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The composed ops-health snapshot response.</returns>
+    Task<OpsHealthSnapshotResponse> GetAsync(CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
+{
+    private readonly HealthCheckService _healthCheckService;
+    private readonly IDeployPreflightProbe _deployProbe;
+    private readonly IOptionsMonitor<ControlPlaneOptions> _controlPlaneOptions;
+    private readonly IAlertDispatchHealth _alertHealth;
+    private readonly ProductionMetricsCollector _metricsCollector;
+    private readonly IExecutionJobStore? _jobStore;
+
+    public OpsHealthSnapshotService(
+        HealthCheckService healthCheckService,
+        IDeployPreflightProbe deployProbe,
+        IOptionsMonitor<ControlPlaneOptions> controlPlaneOptions,
+        IAlertDispatchHealth alertHealth,
+        ProductionMetricsCollector metricsCollector,
+        IExecutionJobStore? jobStore = null)
+    {
+        _healthCheckService = healthCheckService;
+        _deployProbe = deployProbe;
+        _controlPlaneOptions = controlPlaneOptions;
+        _alertHealth = alertHealth;
+        _metricsCollector = metricsCollector;
+        _jobStore = jobStore;
+    }
+
+    public async Task<OpsHealthSnapshotResponse> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var healthReport = await _healthCheckService.CheckHealthAsync(cancellationToken).ConfigureAwait(false);
+        var deploySnapshot = await _deployProbe.ProbeAsync(cancellationToken).ConfigureAwait(false);
+        var gpQueue = await BuildGpQueueViewAsync(cancellationToken).ConfigureAwait(false);
+        var healthMetrics = _metricsCollector.GetHealthMetrics();
+
+        return new OpsHealthSnapshotResponse
+        {
+            GeneratedAt = DateTimeOffset.UtcNow,
+            OverallStatus = healthReport.Status.ToString(),
+            Health = BuildHealthView(healthReport),
+            ServingLatency = BuildServingLatencyView(),
+            Geoprocessing = gpQueue,
+            AlertDispatch = BuildAlertDispatchView(),
+            Deploy = BuildDeployView(deploySnapshot),
+            Database = new OpsDatabaseView
+            {
+                ConnectionPoolUtilization = healthMetrics.HasDatabaseConnectionPoolUtilization
+                    ? healthMetrics.DatabaseConnectionPoolUtilization
+                    : null,
+                HasConnectionPoolData = healthMetrics.HasDatabaseConnectionPoolUtilization,
+                ActiveConnections = healthMetrics.ActiveConnections,
+                ConnectionAcquisitionTimeouts = healthMetrics.ConnectionAcquisitionTimeouts,
+                ConnectionAcquisitionFailures = healthMetrics.ConnectionAcquisitionFailures,
+                CacheHitRatio = healthMetrics.CacheHitRatio,
+                ErrorRate = healthMetrics.ErrorRate,
+            },
+        };
+    }
+
+    private static OpsHealthChecksView BuildHealthView(HealthReport report)
+    {
+        var entries = report.Entries
+            .Select(entry => new OpsHealthCheckEntryView
+            {
+                Name = entry.Key,
+                Status = entry.Value.Status.ToString(),
+                Description = entry.Value.Description,
+                DurationMs = entry.Value.Duration.TotalMilliseconds,
+            })
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
+            .ToList();
+
+        return new OpsHealthChecksView
+        {
+            Status = report.Status.ToString(),
+            TotalDurationMs = report.TotalDuration.TotalMilliseconds,
+            Entries = entries,
+        };
+    }
+
+    private static OpsServingLatencyView BuildServingLatencyView()
+    {
+        var snapshot = HonuaTelemetry.GetServingLatencySnapshot();
+        var protocols = snapshot.Protocols
+            .Select(protocol => new OpsServingLatencyProtocolView
+            {
+                Protocol = protocol.Protocol,
+                RequestCount = protocol.RequestCount,
+                ErrorCount = protocol.ErrorCount,
+                ErrorRate = protocol.ErrorRate,
+                P50Ms = protocol.P50Ms,
+                P95Ms = protocol.P95Ms,
+                P99Ms = protocol.P99Ms,
+                MaxMs = protocol.MaxMs,
+            })
+            .ToList();
+
+        return new OpsServingLatencyView
+        {
+            WindowSeconds = snapshot.WindowSeconds,
+            Protocols = protocols,
+        };
+    }
+
+    private async Task<OpsGpQueueView> BuildGpQueueViewAsync(CancellationToken cancellationToken)
+    {
+        if (_jobStore is null)
+        {
+            return new OpsGpQueueView { TotalActive = 0, Available = false, Buckets = [] };
+        }
+
+        var activeJobs = await _jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        var queueDepth = ControlPlaneTelemetry.ComputeQueueDepth(activeJobs);
+        var buckets = queueDepth
+            .Select(entry => new OpsGpQueueBucketView
+            {
+                Status = entry.Status,
+                Backend = entry.Backend,
+                Count = entry.Count,
+            })
+            .OrderBy(bucket => bucket.Status, StringComparer.Ordinal)
+            .ThenBy(bucket => bucket.Backend, StringComparer.Ordinal)
+            .ToList();
+
+        return new OpsGpQueueView
+        {
+            TotalActive = buckets.Sum(bucket => bucket.Count),
+            Available = true,
+            Buckets = buckets,
+        };
+    }
+
+    private OpsAlertDispatchView BuildAlertDispatchView()
+    {
+        var backlog = _alertHealth.LastBacklog;
+        return new OpsAlertDispatchView
+        {
+            DispatcherRunning = _alertHealth.IsDispatcherRunning,
+            DispatcherEnabled = _alertHealth.IsDispatcherEnabled,
+            StoragePollFailing = _alertHealth.IsStoragePollFailing,
+            LastPollAt = _alertHealth.LastPollAt,
+            PendingCount = backlog?.PendingCount,
+            DeadLetteredCount = backlog?.DeadLetteredCount,
+        };
+    }
+
+    private OpsDeployReadinessView BuildDeployView(DeployPreflightSnapshot snapshot)
+    {
+        var skew = PlatformReleaseSkewProjector.Build(_controlPlaneOptions.CurrentValue);
+        return new OpsDeployReadinessView
+        {
+            Status = snapshot.Status,
+            ReadyForCoordinatedDeploy = snapshot.ReadyForCoordinatedDeploy,
+            PendingMigrationsCount = snapshot.Migration.PendingScripts.Count,
+            PendingContractScriptsCount = snapshot.Migration.PendingContractScripts.Count,
+            PlatformRelease = new OpsPlatformReleaseView
+            {
+                ReleaseVersion = skew.ReleaseVersion,
+                ReleaseDeclared = skew.ReleaseDeclared,
+                IsCoVersioned = skew.IsCoVersioned,
+                SkewedIds = skew.SkewedIds,
+            },
+        };
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityJsonContext.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityJsonContext.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Source-generated JSON context for the admin ops-health snapshot and ops-findings responses.
+/// AOT-safe: no reflection-based serialization.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(OpsHealthSnapshotResponse))]
+[JsonSerializable(typeof(OpsFindingsListResponse))]
+[JsonSerializable(typeof(OpsFindingProposeResponse))]
+internal sealed partial class OpsObservabilityJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
@@ -1,0 +1,386 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Consolidated operational-health snapshot returned by
+/// <c>GET /api/v{version}/admin/observability/ops-health</c>. Composes the comprehensive
+/// health-check roll-up, in-process serving latency, GP queue depth, alert-dispatch backlog,
+/// deploy readiness, and database/cache utilization into one admin payload for the console.
+/// </summary>
+public sealed class OpsHealthSnapshotResponse
+{
+    /// <summary>Gets the UTC time the snapshot was produced.</summary>
+    [JsonPropertyName("generatedAt")]
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Gets the overall status roll-up (<c>Healthy</c>/<c>Degraded</c>/<c>Unhealthy</c>) from the health report.</summary>
+    [JsonPropertyName("overallStatus")]
+    public required string OverallStatus { get; init; }
+
+    /// <summary>Gets the comprehensive health-check roll-up, including the alert-dispatch check.</summary>
+    [JsonPropertyName("health")]
+    public required OpsHealthChecksView Health { get; init; }
+
+    /// <summary>Gets the in-process serving-latency snapshot (per-protocol percentiles + error rate).</summary>
+    [JsonPropertyName("servingLatency")]
+    public required OpsServingLatencyView ServingLatency { get; init; }
+
+    /// <summary>Gets the geoprocessing queue depth by status/backend plus the active total.</summary>
+    [JsonPropertyName("geoprocessing")]
+    public required OpsGpQueueView Geoprocessing { get; init; }
+
+    /// <summary>Gets the alert-dispatch backlog / dead-letter summary.</summary>
+    [JsonPropertyName("alertDispatch")]
+    public required OpsAlertDispatchView AlertDispatch { get; init; }
+
+    /// <summary>Gets the coordinated-deploy readiness summary and platform-release skew.</summary>
+    [JsonPropertyName("deploy")]
+    public required OpsDeployReadinessView Deploy { get; init; }
+
+    /// <summary>Gets the database connection-pool utilization and cache/error metrics.</summary>
+    [JsonPropertyName("database")]
+    public required OpsDatabaseView Database { get; init; }
+}
+
+/// <summary>Comprehensive health-check roll-up view.</summary>
+public sealed class OpsHealthChecksView
+{
+    /// <summary>Gets the aggregate health status string.</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>Gets the total health-check evaluation duration in milliseconds.</summary>
+    [JsonPropertyName("totalDurationMs")]
+    public required double TotalDurationMs { get; init; }
+
+    /// <summary>Gets the individual health-check entries.</summary>
+    [JsonPropertyName("entries")]
+    public required IReadOnlyList<OpsHealthCheckEntryView> Entries { get; init; }
+}
+
+/// <summary>A single health-check entry.</summary>
+public sealed class OpsHealthCheckEntryView
+{
+    /// <summary>Gets the registered health-check name.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>Gets the check status string.</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>Gets the operator-facing description, when the check provides one.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>Gets the check duration in milliseconds.</summary>
+    [JsonPropertyName("durationMs")]
+    public required double DurationMs { get; init; }
+}
+
+/// <summary>In-process serving-latency snapshot view.</summary>
+public sealed class OpsServingLatencyView
+{
+    /// <summary>Gets the rolling window length in seconds.</summary>
+    [JsonPropertyName("windowSeconds")]
+    public required double WindowSeconds { get; init; }
+
+    /// <summary>Gets the per-protocol latency entries.</summary>
+    [JsonPropertyName("protocols")]
+    public required IReadOnlyList<OpsServingLatencyProtocolView> Protocols { get; init; }
+}
+
+/// <summary>Per-protocol serving latency entry.</summary>
+public sealed class OpsServingLatencyProtocolView
+{
+    /// <summary>Gets the protocol family.</summary>
+    [JsonPropertyName("protocol")]
+    public required string Protocol { get; init; }
+
+    /// <summary>Gets the in-window request count.</summary>
+    [JsonPropertyName("requestCount")]
+    public required long RequestCount { get; init; }
+
+    /// <summary>Gets the in-window server-error count (HTTP status &gt;= 500).</summary>
+    [JsonPropertyName("errorCount")]
+    public required long ErrorCount { get; init; }
+
+    /// <summary>Gets the server-error rate over the window (0.0 to 1.0).</summary>
+    [JsonPropertyName("errorRate")]
+    public required double ErrorRate { get; init; }
+
+    /// <summary>Gets the 50th-percentile duration in milliseconds.</summary>
+    [JsonPropertyName("p50Ms")]
+    public required double P50Ms { get; init; }
+
+    /// <summary>Gets the 95th-percentile duration in milliseconds.</summary>
+    [JsonPropertyName("p95Ms")]
+    public required double P95Ms { get; init; }
+
+    /// <summary>Gets the 99th-percentile duration in milliseconds.</summary>
+    [JsonPropertyName("p99Ms")]
+    public required double P99Ms { get; init; }
+
+    /// <summary>Gets the maximum duration in milliseconds.</summary>
+    [JsonPropertyName("maxMs")]
+    public required double MaxMs { get; init; }
+}
+
+/// <summary>Geoprocessing queue-depth view.</summary>
+public sealed class OpsGpQueueView
+{
+    /// <summary>Gets the total active jobs (queued + provisioning + running).</summary>
+    [JsonPropertyName("totalActive")]
+    public required int TotalActive { get; init; }
+
+    /// <summary>Gets a value indicating whether GP queue telemetry is available (an execution-job store is registered).</summary>
+    [JsonPropertyName("available")]
+    public required bool Available { get; init; }
+
+    /// <summary>Gets the active-job counts bucketed by status and backend.</summary>
+    [JsonPropertyName("buckets")]
+    public required IReadOnlyList<OpsGpQueueBucketView> Buckets { get; init; }
+}
+
+/// <summary>A single GP queue-depth bucket.</summary>
+public sealed class OpsGpQueueBucketView
+{
+    /// <summary>Gets the non-terminal job status (Queued/Provisioning/Running).</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>Gets the batch-compute backend identifier.</summary>
+    [JsonPropertyName("backend")]
+    public required string Backend { get; init; }
+
+    /// <summary>Gets the active-job count in this status/backend bucket.</summary>
+    [JsonPropertyName("count")]
+    public required int Count { get; init; }
+}
+
+/// <summary>Alert-dispatch backlog / dead-letter summary view.</summary>
+public sealed class OpsAlertDispatchView
+{
+    /// <summary>Gets a value indicating whether the dispatcher loop is running.</summary>
+    [JsonPropertyName("dispatcherRunning")]
+    public required bool DispatcherRunning { get; init; }
+
+    /// <summary>Gets a value indicating whether the alert pipeline is enabled by configuration.</summary>
+    [JsonPropertyName("dispatcherEnabled")]
+    public required bool DispatcherEnabled { get; init; }
+
+    /// <summary>Gets a value indicating whether the most recent dispatch pass failed to reach the backlog store.</summary>
+    [JsonPropertyName("storagePollFailing")]
+    public required bool StoragePollFailing { get; init; }
+
+    /// <summary>Gets the timestamp of the most recent successful dispatch pass, when known.</summary>
+    [JsonPropertyName("lastPollAt")]
+    public DateTimeOffset? LastPollAt { get; init; }
+
+    /// <summary>Gets the pending backlog count, when a backlog snapshot is available.</summary>
+    [JsonPropertyName("pendingCount")]
+    public long? PendingCount { get; init; }
+
+    /// <summary>Gets the dead-lettered count, when a backlog snapshot is available.</summary>
+    [JsonPropertyName("deadLetteredCount")]
+    public long? DeadLetteredCount { get; init; }
+}
+
+/// <summary>Coordinated-deploy readiness and platform-release skew summary view.</summary>
+public sealed class OpsDeployReadinessView
+{
+    /// <summary>Gets the preflight status string (<c>ready</c>/<c>blocked</c>).</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>Gets a value indicating whether the instance is ready for a coordinated deploy.</summary>
+    [JsonPropertyName("readyForCoordinatedDeploy")]
+    public required bool ReadyForCoordinatedDeploy { get; init; }
+
+    /// <summary>Gets the count of pending (non-contract) migration scripts.</summary>
+    [JsonPropertyName("pendingMigrationsCount")]
+    public required int PendingMigrationsCount { get; init; }
+
+    /// <summary>Gets the count of pending contract migration scripts (which hold coordinated-deploy readiness).</summary>
+    [JsonPropertyName("pendingContractScriptsCount")]
+    public required int PendingContractScriptsCount { get; init; }
+
+    /// <summary>Gets the platform-release skew summary.</summary>
+    [JsonPropertyName("platformRelease")]
+    public required OpsPlatformReleaseView PlatformRelease { get; init; }
+}
+
+/// <summary>Platform-release co-versioning summary view.</summary>
+public sealed class OpsPlatformReleaseView
+{
+    /// <summary>Gets the declared release version, when any.</summary>
+    [JsonPropertyName("releaseVersion")]
+    public string? ReleaseVersion { get; init; }
+
+    /// <summary>Gets a value indicating whether a platform release is declared.</summary>
+    [JsonPropertyName("releaseDeclared")]
+    public required bool ReleaseDeclared { get; init; }
+
+    /// <summary>Gets a value indicating whether all planes are co-versioned with the release.</summary>
+    [JsonPropertyName("isCoVersioned")]
+    public required bool IsCoVersioned { get; init; }
+
+    /// <summary>Gets the identifiers of planes skewed from the declared release.</summary>
+    [JsonPropertyName("skewedIds")]
+    public required IReadOnlyList<string> SkewedIds { get; init; }
+}
+
+/// <summary>Database connection-pool + cache/error utilization view.</summary>
+public sealed class OpsDatabaseView
+{
+    /// <summary>Gets the connection-pool utilization ratio (0.0 to 1.0), when available.</summary>
+    [JsonPropertyName("connectionPoolUtilization")]
+    public double? ConnectionPoolUtilization { get; init; }
+
+    /// <summary>Gets a value indicating whether connection-pool utilization telemetry is available.</summary>
+    [JsonPropertyName("hasConnectionPoolData")]
+    public required bool HasConnectionPoolData { get; init; }
+
+    /// <summary>Gets the number of active database connections.</summary>
+    [JsonPropertyName("activeConnections")]
+    public required int ActiveConnections { get; init; }
+
+    /// <summary>Gets the connection acquisition timeout count.</summary>
+    [JsonPropertyName("connectionAcquisitionTimeouts")]
+    public required long ConnectionAcquisitionTimeouts { get; init; }
+
+    /// <summary>Gets the connection acquisition failure count.</summary>
+    [JsonPropertyName("connectionAcquisitionFailures")]
+    public required long ConnectionAcquisitionFailures { get; init; }
+
+    /// <summary>Gets the cache hit ratio (0.0 to 1.0).</summary>
+    [JsonPropertyName("cacheHitRatio")]
+    public required double CacheHitRatio { get; init; }
+
+    /// <summary>Gets the live HTTP server error rate (0.0 to 1.0).</summary>
+    [JsonPropertyName("errorRate")]
+    public required double ErrorRate { get; init; }
+}
+
+/// <summary>Response for <c>GET /api/v{version}/admin/observability/findings</c>.</summary>
+public sealed class OpsFindingsListResponse
+{
+    /// <summary>Gets the UTC time the findings were evaluated.</summary>
+    [JsonPropertyName("generatedAt")]
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Gets the active findings, ordered by descending severity.</summary>
+    [JsonPropertyName("findings")]
+    public required IReadOnlyList<OpsFindingView> Findings { get; init; }
+}
+
+/// <summary>Wire view of a single deterministic ops finding.</summary>
+public sealed class OpsFindingView
+{
+    /// <summary>Gets the deterministic finding identifier (used to propose its action).</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Gets the kebab-case rule identifier.</summary>
+    [JsonPropertyName("rule")]
+    public required string Rule { get; init; }
+
+    /// <summary>Gets the severity (<c>Info</c>/<c>Warning</c>/<c>Critical</c>).</summary>
+    [JsonPropertyName("severity")]
+    public required string Severity { get; init; }
+
+    /// <summary>Gets the short title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>Gets the plain-language explanation.</summary>
+    [JsonPropertyName("explanation")]
+    public required string Explanation { get; init; }
+
+    /// <summary>Gets the detection (evaluation) time.</summary>
+    [JsonPropertyName("detectedAt")]
+    public required DateTimeOffset DetectedAt { get; init; }
+
+    /// <summary>Gets the subject identifiers.</summary>
+    [JsonPropertyName("subject")]
+    public required OpsFindingSubjectView Subject { get; init; }
+
+    /// <summary>Gets the supporting evidence references.</summary>
+    [JsonPropertyName("evidenceRefs")]
+    public required IReadOnlyList<string> EvidenceRefs { get; init; }
+
+    /// <summary>Gets the recommended action summary, or <c>null</c> when the finding is informational.</summary>
+    [JsonPropertyName("recommendedAction")]
+    public OpsFindingActionView? RecommendedAction { get; init; }
+}
+
+/// <summary>Subject identifiers a finding pins to.</summary>
+public sealed class OpsFindingSubjectView
+{
+    /// <summary>Gets the deploy target identifier, when applicable.</summary>
+    [JsonPropertyName("targetId")]
+    public string? TargetId { get; init; }
+
+    /// <summary>Gets the execution workload identifier, when applicable.</summary>
+    [JsonPropertyName("workloadId")]
+    public string? WorkloadId { get; init; }
+
+    /// <summary>Gets the notification channel identifier, when applicable.</summary>
+    [JsonPropertyName("channel")]
+    public string? Channel { get; init; }
+
+    /// <summary>Gets the workflow/deploy operation identifier, when applicable.</summary>
+    [JsonPropertyName("operationId")]
+    public string? OperationId { get; init; }
+
+    /// <summary>Gets the platform release version, when applicable.</summary>
+    [JsonPropertyName("releaseVersion")]
+    public string? ReleaseVersion { get; init; }
+}
+
+/// <summary>
+/// Wire view of a finding's recommended action. The opaque execution payload is intentionally not
+/// surfaced — the console proposes the action by finding id, and the server materializes the payload.
+/// </summary>
+public sealed class OpsFindingActionView
+{
+    /// <summary>Gets the operation class the action routes through (<c>AdminConfigChange</c>/<c>Deploy</c>/<c>MetadataRelease</c>/<c>Seed</c>).</summary>
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    /// <summary>Gets the plain-language action summary.</summary>
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    /// <summary>Gets the operator-facing reason recorded on the proposal.</summary>
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+}
+
+/// <summary>Response for <c>POST /api/v{version}/admin/observability/findings/{findingId}/propose</c>.</summary>
+public sealed class OpsFindingProposeResponse
+{
+    /// <summary>Gets the finding identifier that was proposed.</summary>
+    [JsonPropertyName("findingId")]
+    public required string FindingId { get; init; }
+
+    /// <summary>Gets the proposal outcome status (<c>Executed</c>/<c>ProposalCreated</c>/<c>Blocked</c>/<c>NotSupported</c>).</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>Gets the created proposal identifier when the gateway required approval.</summary>
+    [JsonPropertyName("proposalId")]
+    public string? ProposalId { get; init; }
+
+    /// <summary>Gets the executed operation identifier when the gateway executed directly.</summary>
+    [JsonPropertyName("executionOperationId")]
+    public string? ExecutionOperationId { get; init; }
+
+    /// <summary>Gets an operator-facing message describing the outcome, when available.</summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/PlatformReleaseSkewProjector.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/PlatformReleaseSkewProjector.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Projects the configured control-plane deploy targets and execution workloads against the declared
+/// platform release into a co-versioning skew snapshot. Shared by the ops-health composer and the
+/// ops-findings platform-release-skew rule so both derive skew identically from configuration.
+/// </summary>
+internal static class PlatformReleaseSkewProjector
+{
+    /// <summary>
+    /// Builds the platform-release skew snapshot from the current control-plane options.
+    /// </summary>
+    /// <param name="options">The control-plane options carrying the release, deploy targets, and workloads.</param>
+    /// <returns>The skew snapshot (release version, co-versioning flag, and skewed plane ids).</returns>
+    public static PlatformReleaseSkewSnapshot Build(ControlPlaneOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var servingEntries = BuildEntries(
+            options.DeployTargets.Select(target => (target.TargetId, target.RuntimeProfile, target.ArtifactReference)));
+        var executionEntries = BuildEntries(
+            options.ExecutionWorkloads.Select(workload => (workload.WorkloadId, workload.RuntimeProfile, workload.ArtifactReference)));
+
+        return PlatformReleaseProjection.BuildSkewSnapshot(
+            options.PlatformRelease.ToDefinition(),
+            servingEntries,
+            executionEntries);
+    }
+
+    private static PlatformReleasePlaneEntry[] BuildEntries(
+        IEnumerable<(string Id, string? RuntimeProfile, string? ArtifactReference)> entries)
+        => entries
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Id))
+            .Select(entry => new PlatformReleasePlaneEntry
+            {
+                Id = entry.Id,
+                RuntimeProfile = entry.RuntimeProfile,
+                ExplicitArtifactReference = entry.ArtifactReference,
+            })
+            .ToArray();
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -1309,6 +1309,9 @@ app.MapControlPlaneEventEndpoints();
 // Console approval surface for agent-proposed operations (#1694).
 app.MapProposalEndpoints();
 
+// Consolidated ops-health snapshot + deterministic ops-findings engine (ADR-0060 WS4 / #2457).
+app.MapOpsObservabilityEndpoints();
+
 // Configure admin layer style endpoints
 app.MapAdminLayerStyleEndpoints();
 app.MapAdminLayerFieldConfigurationEndpoints();

--- a/src/Honua.ServiceDefaults/Extensions.cs
+++ b/src/Honua.ServiceDefaults/Extensions.cs
@@ -133,6 +133,9 @@ public static partial class Extensions
             tracingOptions.ExportExceptionDetails,
             tracingOptions.ExportExceptionDetails && tracingOptions.RecordExceptionStackTraces,
             tracingOptions.MaxExceptionDetailLength);
+        HonuaTelemetry.ConfigureServingLatency(
+            TimeSpan.FromSeconds(tracingOptions.ServingLatencyWindowSeconds),
+            tracingOptions.ServingLatencySamplesPerProtocol);
 
         // Bind Prometheus scraping options
         builder.Services.Configure<PrometheusOptions>(builder.Configuration.GetSection(PrometheusOptions.SectionName));

--- a/src/Honua.ServiceDefaults/HonuaTelemetry.cs
+++ b/src/Honua.ServiceDefaults/HonuaTelemetry.cs
@@ -77,6 +77,16 @@ public static class HonuaTelemetry
 
     private const int DefaultMaxExceptionDetailLength = 256;
 
+    // Serving-latency rolling-window aggregation defaults (Part 1, #2463).
+    private const int DefaultServingLatencyWindowSeconds = 300; // 5 minutes
+    private const int DefaultServingLatencySamplesPerProtocol = 4096;
+
+    // Volatile so a startup ConfigureServingLatency swap is visible to concurrent recorders.
+    // Bounded, lock-minimal per-protocol reservoirs; see ServingLatencyAggregator.
+    private static volatile ServingLatencyAggregator _servingLatency = new(
+        TimeSpan.FromSeconds(DefaultServingLatencyWindowSeconds),
+        DefaultServingLatencySamplesPerProtocol);
+
     // Serving-plane HTTP status boundaries for the coarse status_class tag.
     private const int HttpStatusClientErrorFloor = 400;
     private const int HttpStatusRedirectFloor = 300;
@@ -127,6 +137,27 @@ public static class HonuaTelemetry
         _includeExceptionStackTraces = includeStackTraces;
         _maxExceptionDetailLength = maxDetailLength > 0 ? maxDetailLength : DefaultMaxExceptionDetailLength;
     }
+
+    /// <summary>
+    /// Reconfigures the in-process serving-latency rolling-window aggregation. Invoked once at
+    /// startup from bound configuration; replacing the aggregator discards prior samples.
+    /// </summary>
+    /// <param name="window">The rolling window length (falls back to the 5-minute default when non-positive).</param>
+    /// <param name="samplesPerProtocol">The per-protocol reservoir capacity (falls back to the default when non-positive).</param>
+    public static void ConfigureServingLatency(TimeSpan window, int samplesPerProtocol)
+    {
+        var effectiveWindow = window > TimeSpan.Zero ? window : TimeSpan.FromSeconds(DefaultServingLatencyWindowSeconds);
+        var effectiveSamples = samplesPerProtocol > 0 ? samplesPerProtocol : DefaultServingLatencySamplesPerProtocol;
+        _servingLatency = new ServingLatencyAggregator(effectiveWindow, effectiveSamples);
+    }
+
+    /// <summary>
+    /// Returns a point-in-time snapshot of per-protocol serving latency (p50/p95/p99 plus
+    /// request/error counts) over the configured rolling window. Consumed by the admin
+    /// ops-health snapshot; the underlying histogram remains the source for OTLP/Prometheus.
+    /// </summary>
+    /// <returns>The current serving latency snapshot.</returns>
+    public static ServingLatencySnapshot GetServingLatencySnapshot() => _servingLatency.GetSnapshot();
 
     /// <summary>
     /// Records telemetry for a single produced error envelope. This is the one
@@ -206,6 +237,11 @@ public static class HonuaTelemetry
             { "status_class", ClassifyStatus(statusCode) },
         };
         ServingRequestDuration.Record(durationMs, tags);
+
+        // Also feed the in-process rolling-window aggregation that backs the admin
+        // ops-health snapshot (per-protocol p50/p95/p99 + error rate). Allocation-free
+        // hot path after the first sample per protocol; see ServingLatencyAggregator.
+        _servingLatency.Record(protocol, durationMs, statusCode);
     }
 
     private static string ClassifyStatus(int statusCode) => statusCode switch

--- a/src/Honua.ServiceDefaults/ServingLatencyAggregator.cs
+++ b/src/Honua.ServiceDefaults/ServingLatencyAggregator.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Honua.ServiceDefaults;
+
+/// <summary>
+/// In-process, bounded-memory rolling aggregation of serving-plane request latency,
+/// partitioned by GIS protocol. Each observed protocol keeps a fixed-size ring reservoir
+/// of the most recent duration samples tagged with a monotonic timestamp; a read computes
+/// per-protocol p50/p95/p99 plus request/error counts over the configured window.
+/// </summary>
+/// <remarks>
+/// The hot path (<see cref="Record"/>) is allocation-free after the first sample per
+/// protocol: it takes a short per-protocol lock and writes three primitives into
+/// pre-allocated arrays. Memory is bounded by <c>samplesPerProtocol × observedProtocols</c>;
+/// under sustained throughput above the ring capacity the effective window shrinks to the
+/// most recent <c>samplesPerProtocol</c> samples, so the reported count reflects the actual
+/// number of in-window samples retained rather than total traffic. Timestamps are
+/// <see cref="Stopwatch"/> ticks (monotonic, unaffected by wall-clock changes); the
+/// timestamp source is injectable for deterministic testing.
+/// </remarks>
+public sealed class ServingLatencyAggregator
+{
+    private readonly ConcurrentDictionary<string, Reservoir> _reservoirs = new(StringComparer.Ordinal);
+    private readonly int _samplesPerProtocol;
+    private readonly long _windowTicks;
+    private readonly TimeSpan _window;
+    private readonly Func<long> _timestamp;
+
+    /// <summary>
+    /// Serving-plane HTTP status floor that classifies a request as a server error for the
+    /// window error rate. Client errors (4xx) are counted as requests but not errors.
+    /// </summary>
+    private const int ServerErrorFloor = 500;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServingLatencyAggregator"/> class.
+    /// </summary>
+    /// <param name="window">The rolling window length. Samples older than this are excluded from snapshots.</param>
+    /// <param name="samplesPerProtocol">The fixed reservoir capacity per protocol (bounds memory).</param>
+    /// <param name="timestampProvider">
+    /// Optional monotonic timestamp source in <see cref="Stopwatch"/>-tick units; defaults to
+    /// <see cref="Stopwatch.GetTimestamp"/>. Supplied by tests to simulate window expiry.
+    /// </param>
+    public ServingLatencyAggregator(TimeSpan window, int samplesPerProtocol, Func<long>? timestampProvider = null)
+    {
+        if (window <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(window), window, "Window must be positive.");
+        }
+
+        if (samplesPerProtocol <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(samplesPerProtocol), samplesPerProtocol, "Sample capacity must be positive.");
+        }
+
+        _window = window;
+        _samplesPerProtocol = samplesPerProtocol;
+        _timestamp = timestampProvider ?? Stopwatch.GetTimestamp;
+        _windowTicks = Math.Max(1L, (long)(window.TotalSeconds * Stopwatch.Frequency));
+    }
+
+    /// <summary>
+    /// Records a completed serving-plane request. No-op for a blank protocol or negative duration.
+    /// </summary>
+    /// <param name="protocol">The GIS protocol family (bounded cardinality from the fixed protocol set).</param>
+    /// <param name="durationMs">The elapsed request duration in milliseconds.</param>
+    /// <param name="statusCode">The HTTP status code; <c>&gt;= 500</c> counts toward the error rate.</param>
+    public void Record(string protocol, double durationMs, int statusCode)
+    {
+        if (string.IsNullOrWhiteSpace(protocol) || durationMs < 0 || double.IsNaN(durationMs))
+        {
+            return;
+        }
+
+        var reservoir = _reservoirs.GetOrAdd(protocol, static (_, capacity) => new Reservoir(capacity), _samplesPerProtocol);
+        reservoir.Add(_timestamp(), durationMs, statusCode >= ServerErrorFloor);
+    }
+
+    /// <summary>
+    /// Computes a point-in-time snapshot of per-protocol latency percentiles and counts over the window.
+    /// </summary>
+    /// <returns>The serving latency snapshot; protocol entries are ordered by protocol name.</returns>
+    public ServingLatencySnapshot GetSnapshot()
+    {
+        var now = _timestamp();
+        var minTimestamp = now - _windowTicks;
+
+        var protocols = new List<ServingLatencyProtocolSnapshot>(_reservoirs.Count);
+        foreach (var pair in _reservoirs)
+        {
+            var (durations, errorCount) = pair.Value.CopyInWindow(minTimestamp);
+            if (durations.Length == 0)
+            {
+                continue;
+            }
+
+            Array.Sort(durations);
+            protocols.Add(new ServingLatencyProtocolSnapshot
+            {
+                Protocol = pair.Key,
+                RequestCount = durations.Length,
+                ErrorCount = errorCount,
+                ErrorRate = (double)errorCount / durations.Length,
+                P50Ms = Percentile(durations, 50),
+                P95Ms = Percentile(durations, 95),
+                P99Ms = Percentile(durations, 99),
+                MaxMs = durations[^1],
+            });
+        }
+
+        protocols.Sort(static (a, b) => string.CompareOrdinal(a.Protocol, b.Protocol));
+
+        return new ServingLatencySnapshot
+        {
+            WindowSeconds = _window.TotalSeconds,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Protocols = protocols,
+        };
+    }
+
+    // Nearest-rank percentile over an ascending-sorted, non-empty sample set.
+    private static double Percentile(double[] sortedAscending, double percentile)
+    {
+        var length = sortedAscending.Length;
+        var rank = (int)Math.Ceiling(percentile / 100.0 * length);
+        rank = Math.Clamp(rank, 1, length);
+        return sortedAscending[rank - 1];
+    }
+
+    private sealed class Reservoir
+    {
+        private readonly object _gate = new();
+        private readonly long[] _timestamps;
+        private readonly double[] _durations;
+        private readonly bool[] _errors;
+        private int _next;
+        private int _count;
+
+        public Reservoir(int capacity)
+        {
+            _timestamps = new long[capacity];
+            _durations = new double[capacity];
+            _errors = new bool[capacity];
+        }
+
+        public void Add(long timestamp, double durationMs, bool isError)
+        {
+            lock (_gate)
+            {
+                _timestamps[_next] = timestamp;
+                _durations[_next] = durationMs;
+                _errors[_next] = isError;
+                _next = (_next + 1) % _timestamps.Length;
+                if (_count < _timestamps.Length)
+                {
+                    _count++;
+                }
+            }
+        }
+
+        public (double[] Durations, long ErrorCount) CopyInWindow(long minTimestamp)
+        {
+            lock (_gate)
+            {
+                if (_count == 0)
+                {
+                    return (Array.Empty<double>(), 0);
+                }
+
+                var durations = new double[_count];
+                var written = 0;
+                long errorCount = 0;
+                for (var i = 0; i < _count; i++)
+                {
+                    if (_timestamps[i] < minTimestamp)
+                    {
+                        continue;
+                    }
+
+                    durations[written++] = _durations[i];
+                    if (_errors[i])
+                    {
+                        errorCount++;
+                    }
+                }
+
+                if (written == durations.Length)
+                {
+                    return (durations, errorCount);
+                }
+
+                var trimmed = new double[written];
+                Array.Copy(durations, trimmed, written);
+                return (trimmed, errorCount);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Point-in-time snapshot of serving-plane latency, aggregated per protocol over a rolling window.
+/// </summary>
+public sealed record ServingLatencySnapshot
+{
+    /// <summary>Gets the rolling window length, in seconds, over which the percentiles are computed.</summary>
+    public required double WindowSeconds { get; init; }
+
+    /// <summary>Gets the UTC timestamp at which the snapshot was produced.</summary>
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Gets the per-protocol latency entries (only protocols with in-window samples), ordered by protocol name.</summary>
+    public required IReadOnlyList<ServingLatencyProtocolSnapshot> Protocols { get; init; }
+}
+
+/// <summary>
+/// Per-protocol serving latency percentiles and request/error counts over the aggregation window.
+/// </summary>
+public sealed record ServingLatencyProtocolSnapshot
+{
+    /// <summary>Gets the GIS protocol family this entry describes.</summary>
+    public required string Protocol { get; init; }
+
+    /// <summary>Gets the number of in-window samples retained for this protocol.</summary>
+    public required long RequestCount { get; init; }
+
+    /// <summary>Gets the number of retained samples that were server errors (HTTP status &gt;= 500).</summary>
+    public required long ErrorCount { get; init; }
+
+    /// <summary>Gets the server-error rate over the retained samples (0.0 to 1.0).</summary>
+    public required double ErrorRate { get; init; }
+
+    /// <summary>Gets the 50th-percentile (median) request duration in milliseconds.</summary>
+    public required double P50Ms { get; init; }
+
+    /// <summary>Gets the 95th-percentile request duration in milliseconds.</summary>
+    public required double P95Ms { get; init; }
+
+    /// <summary>Gets the 99th-percentile request duration in milliseconds.</summary>
+    public required double P99Ms { get; init; }
+
+    /// <summary>Gets the maximum retained request duration in milliseconds.</summary>
+    public required double MaxMs { get; init; }
+}

--- a/src/Honua.ServiceDefaults/TracingOptions.cs
+++ b/src/Honua.ServiceDefaults/TracingOptions.cs
@@ -53,6 +53,20 @@ public sealed class TracingOptions
     public int MaxExceptionDetailLength { get; set; } = 256;
 
     /// <summary>
+    /// Gets or sets the rolling window, in seconds, over which the in-process serving-latency
+    /// snapshot (per-protocol p50/p95/p99 + error rate, surfaced by the admin ops-health endpoint)
+    /// is aggregated. Default is 300 (5 minutes).
+    /// </summary>
+    public int ServingLatencyWindowSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Gets or sets the per-protocol reservoir capacity for the in-process serving-latency snapshot.
+    /// Bounds aggregation memory; under throughput above this rate the effective window shrinks to the
+    /// most recent samples. Default is 4096.
+    /// </summary>
+    public int ServingLatencySamplesPerProtocol { get; set; } = 4096;
+
+    /// <summary>
     /// Gets or sets the maximum number of attributes per span.
     /// </summary>
     public int MaxAttributesPerSpan { get; set; } = 128;

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// Integration tests for the admin ops-health snapshot and ops-findings endpoints
+/// (ADR-0060 WS4 / epic #2457). Compile locally; the full assertions run in CI (Testcontainers).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.HealthCheck)]
+public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
+{
+    private const string AdminPassword = "ops-observability-admin-key";
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public OpsObservabilityEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(client => client.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/ops-health")]
+    public async Task GetOpsHealth_WithAdminAuth_ReturnsComposedSnapshot()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/observability/ops-health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+        root.TryGetProperty("generatedAt", out _).Should().BeTrue();
+        root.GetProperty("overallStatus").GetString().Should().NotBeNullOrWhiteSpace();
+        root.GetProperty("health").TryGetProperty("entries", out var entries).Should().BeTrue();
+        entries.ValueKind.Should().Be(JsonValueKind.Array);
+        root.TryGetProperty("servingLatency", out var latency).Should().BeTrue();
+        latency.TryGetProperty("windowSeconds", out _).Should().BeTrue();
+        root.GetProperty("geoprocessing").TryGetProperty("totalActive", out _).Should().BeTrue();
+        root.TryGetProperty("alertDispatch", out _).Should().BeTrue();
+        root.GetProperty("deploy").TryGetProperty("readyForCoordinatedDeploy", out _).Should().BeTrue();
+        root.GetProperty("database").TryGetProperty("cacheHitRatio", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/ops-health")]
+    public async Task GetOpsHealth_WithoutAdminAuth_IsUnauthorized()
+    {
+        using var anonymous = _fixture.CreateClient();
+
+        var response = await anonymous.GetAsync("/api/v1/admin/observability/ops-health");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/findings")]
+    public async Task GetFindings_WithAdminAuth_ReturnsFindingsEnvelope()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/observability/findings");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.TryGetProperty("generatedAt", out _).Should().BeTrue();
+        json.RootElement.GetProperty("findings").ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/findings")]
+    public async Task GetFindings_WithoutAdminAuth_IsUnauthorized()
+    {
+        using var anonymous = _fixture.CreateClient();
+
+        var response = await anonymous.GetAsync("/api/v1/admin/observability/findings");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/observability/findings/{findingId}/propose")]
+    public async Task ProposeFinding_UnknownId_Returns404()
+    {
+        var response = await _client.PostAsync(
+            "/api/v1/admin/observability/findings/does-not-exist/propose",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/observability/findings/{findingId}/propose")]
+    public async Task ProposeFinding_WithoutAdminAuth_IsUnauthorized()
+    {
+        using var anonymous = _fixture.CreateClient();
+
+        var response = await anonymous.PostAsync(
+            "/api/v1/admin/observability/findings/does-not-exist/propose",
+            content: null);
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
@@ -1,0 +1,375 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Alerts;
+using Honua.ControlPlane;
+using Honua.Core.Features.Alerts.Domain;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Observability.Domain;
+using Honua.Infrastructure.Monitoring;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Unit tests for the deterministic ops-findings rule set (<see cref="OpsFindingsService"/>), one
+/// rule at a time against fake seams.
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class OpsFindingsServiceTests
+{
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_AlertDispatchDeadLetters_ProducesCriticalFindingWithNoAction()
+    {
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            IsDispatcherRunning = true,
+            LastBacklog = new AlertDispatchBacklog { PendingCount = 3, DeadLetteredCount = 2 },
+        };
+        var service = CreateService(alertHealth: alertHealth);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog);
+        Assert.Equal(OpsFindingSeverity.Critical, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
+        Assert.Equal("alert-dispatch", finding.Subject.Channel);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_AlertDispatchBelowThresholds_ProducesNoFinding()
+    {
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            LastBacklog = new AlertDispatchBacklog { PendingCount = 1, DeadLetteredCount = 0 },
+        };
+        var service = CreateService(alertHealth: alertHealth);
+
+        var findings = await service.EvaluateAsync();
+
+        Assert.DoesNotContain(findings, f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_PlatformReleaseSkew_ProducesInformationalWarningWithNoAction()
+    {
+        var controlPlane = new ControlPlaneOptions
+        {
+            PlatformRelease = new PlatformReleaseOptions
+            {
+                Version = "2026.07.0",
+                ServingArtifactReference = "registry/honua-serving:2026.07.0",
+            },
+            DeployTargets =
+            [
+                new DeployTargetOptions { TargetId = "serving-a", ArtifactReference = "registry/honua-serving:OLD" },
+            ],
+        };
+        var service = CreateService(controlPlaneOptions: controlPlane);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RulePlatformReleaseSkew);
+        Assert.Equal(OpsFindingSeverity.Warning, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
+        Assert.Equal("2026.07.0", finding.Subject.ReleaseVersion);
+        Assert.Contains(finding.EvidenceRefs, e => e.Contains("serving-a", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_PendingContractMigrations_ProducesWarningWithNoAction()
+    {
+        var probe = new FakeDeployPreflightProbe(BuildDeploySnapshot(
+            hasPendingContractScripts: true,
+            pendingContractScripts: ["V42__contract_drop_legacy.sql"]));
+        var service = CreateService(deployProbe: probe);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RulePendingContractMigrations);
+        Assert.Equal(OpsFindingSeverity.Warning, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
+        Assert.Contains(finding.EvidenceRefs, e => e.Contains("V42__contract_drop_legacy.sql", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_GpQueueDepthAboveThreshold_ProducesWarningWithNoAction()
+    {
+        var jobStore = Substitute.For<IExecutionJobStore>();
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<ExecutionJobRecord>
+            {
+                BuildJob("j1", ExecutionJobStatus.Queued, "aws-batch"),
+                BuildJob("j2", ExecutionJobStatus.Running, "aws-batch"),
+                BuildJob("j3", ExecutionJobStatus.Provisioning, "k8s"),
+            });
+        var options = new OpsFindingsOptions { GpQueueDepthThreshold = 2 };
+        var service = CreateService(jobStore: jobStore, options: options);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleGpQueueDepth);
+        Assert.Equal(OpsFindingSeverity.Warning, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
+        Assert.Contains("3", finding.Explanation, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_DeployManualInterventionWithPriorRevision_ProducesCriticalFindingWithRollbackAction()
+    {
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        workflowStore.ListActiveAsync(Arg.Any<WorkflowOperationKind?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<WorkflowOperationRecord>
+            {
+                BuildDeployOperation("op-1", WorkflowOperationStatus.ManualInterventionRequired, currentRevision: "rev-9", desiredRevision: "rev-10"),
+            });
+        var service = CreateService(workflowStore: workflowStore);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleDeployManualIntervention);
+        Assert.Equal(OpsFindingSeverity.Critical, finding.Severity);
+        Assert.Equal("op-1", finding.Subject.OperationId);
+        Assert.NotNull(finding.RecommendedAction);
+        Assert.Equal(OperationClass.Deploy, finding.RecommendedAction!.Kind);
+        // The rollback payload must target the prior revision (rev-9), not the failing desired revision.
+        Assert.Contains("rev-9", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+        Assert.Contains("\"targetId\":\"target-op-1\"", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_DeployManualInterventionWithoutPriorRevision_ProducesInformationalFinding()
+    {
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        workflowStore.ListActiveAsync(Arg.Any<WorkflowOperationKind?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<WorkflowOperationRecord>
+            {
+                BuildDeployOperation("op-2", WorkflowOperationStatus.ManualInterventionRequired, currentRevision: null, desiredRevision: "rev-10"),
+            });
+        var service = CreateService(workflowStore: workflowStore);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleDeployManualIntervention);
+        Assert.Equal(OpsFindingSeverity.Critical, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_HealthyInstance_ProducesNoFindings()
+    {
+        var service = CreateService();
+
+        var findings = await service.EvaluateAsync();
+
+        Assert.Empty(findings);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_FindingIds_AreDeterministicAcrossEvaluations()
+    {
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            LastBacklog = new AlertDispatchBacklog { PendingCount = 1, DeadLetteredCount = 5 },
+        };
+        var service = CreateService(alertHealth: alertHealth);
+
+        var first = await service.EvaluateAsync();
+        var second = await service.EvaluateAsync();
+
+        Assert.Equal(
+            first.Single(f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog).Id,
+            second.Single(f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog).Id);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Propose_UnknownFinding_ReturnsFindingNotFound()
+    {
+        var service = CreateService();
+
+        var result = await service.ProposeAsync("does-not-exist");
+
+        Assert.Equal(OpsFindingProposalStatus.FindingNotFound, result.Status);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Propose_InformationalFinding_ReturnsNoRecommendedAction()
+    {
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            LastBacklog = new AlertDispatchBacklog { PendingCount = 1, DeadLetteredCount = 5 },
+        };
+        var service = CreateService(alertHealth: alertHealth);
+        var finding = (await service.EvaluateAsync()).Single(f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog);
+
+        var result = await service.ProposeAsync(finding.Id);
+
+        Assert.Equal(OpsFindingProposalStatus.NoRecommendedAction, result.Status);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Propose_ActionableFinding_RoutesThroughGatewayKeyedOnFindingId()
+    {
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        workflowStore.ListActiveAsync(Arg.Any<WorkflowOperationKind?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<WorkflowOperationRecord>
+            {
+                BuildDeployOperation("op-7", WorkflowOperationStatus.ManualInterventionRequired, currentRevision: "rev-1", desiredRevision: "rev-2"),
+            });
+
+        var gateway = Substitute.For<IOperationGateway>();
+        gateway.RouteAsync(Arg.Any<OperationGatewayRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new OperationGatewayResult
+            {
+                Outcome = OperationGatewayOutcome.ProposalCreated,
+                Decision = new GuardrailDecision(GuardrailTier.RequiresApproval, OperationClass.Deploy, HonuaEdition.Pro, "test"),
+                ProposalId = "proposal-42",
+            });
+
+        var service = CreateService(workflowStore: workflowStore, gateway: gateway);
+        var finding = (await service.EvaluateAsync()).Single(f => f.Rule == OpsFindingsService.RuleDeployManualIntervention);
+
+        var result = await service.ProposeAsync(finding.Id);
+
+        Assert.Equal(OpsFindingProposalStatus.ProposalCreated, result.Status);
+        Assert.Equal("proposal-42", result.ProposalId);
+        await gateway.Received(1).RouteAsync(
+            Arg.Is<OperationGatewayRequest>(r =>
+                r.Kind == OperationClass.Deploy &&
+                r.RequestedByAgent == OpsFindingsService.RequestedByAgent &&
+                r.IdempotencyKey == finding.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static OpsFindingsService CreateService(
+        OpsFindingsOptions? options = null,
+        ControlPlaneOptions? controlPlaneOptions = null,
+        FakeAlertDispatchHealth? alertHealth = null,
+        FakeDeployPreflightProbe? deployProbe = null,
+        IOperationGateway? gateway = null,
+        IWorkflowOperationStore? workflowStore = null,
+        IExecutionJobStore? jobStore = null)
+        => new(
+            new StaticOptionsMonitor<OpsFindingsOptions>(options ?? new OpsFindingsOptions()),
+            new StaticOptionsMonitor<ControlPlaneOptions>(controlPlaneOptions ?? new ControlPlaneOptions()),
+            alertHealth ?? new FakeAlertDispatchHealth(),
+            deployProbe ?? new FakeDeployPreflightProbe(BuildDeploySnapshot()),
+            gateway ?? Substitute.For<IOperationGateway>(),
+            workflowStore,
+            jobStore);
+
+    private static DeployPreflightSnapshot BuildDeploySnapshot(
+        bool hasPendingContractScripts = false,
+        IReadOnlyList<string>? pendingContractScripts = null)
+        => new()
+        {
+            Status = "ready",
+            ReadyForCoordinatedDeploy = true,
+            Message = "ready",
+            Readiness = new DeployPreflightReadinessSnapshot { IsReady = true, StatusCode = 200, Message = "ok" },
+            Migration = new DeployPreflightMigrationSnapshot
+            {
+                LifecycleStatus = "succeeded",
+                PlanAvailable = true,
+                HasPendingContractScripts = hasPendingContractScripts,
+                PendingContractScripts = pendingContractScripts ?? Array.Empty<string>(),
+            },
+        };
+
+    private static ExecutionJobRecord BuildJob(string id, ExecutionJobStatus status, string backend)
+        => new()
+        {
+            OperationId = id,
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Spec = new ExecutionJobSpec
+            {
+                TargetKind = BatchComputeTargetKind.AwsBatch,
+                Backend = backend,
+                Kind = ExecutionJobKind.Geoprocessing,
+                WorkloadName = "test-workload",
+            },
+        };
+
+    private static WorkflowOperationRecord BuildDeployOperation(
+        string operationId,
+        WorkflowOperationStatus status,
+        string? currentRevision,
+        string desiredRevision)
+        => new()
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.Deploy,
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = $"target-{operationId}",
+                TargetKind = DeployTargetKind.Kubernetes,
+                Backend = "k8s",
+                Environment = "prod",
+                TargetName = "serving",
+                CurrentRevision = currentRevision,
+                DesiredRevision = desiredRevision,
+            },
+        };
+
+    private sealed class FakeAlertDispatchHealth : IAlertDispatchHealth
+    {
+        public bool IsDispatcherRunning { get; set; }
+
+        public bool IsDispatcherEnabled { get; set; }
+
+        public DateTimeOffset? LastPollAt { get; set; }
+
+        public AlertDispatchBacklog? LastBacklog { get; set; }
+
+        public bool IsStoragePollFailing { get; set; }
+    }
+
+    private sealed class FakeDeployPreflightProbe : IDeployPreflightProbe
+    {
+        private readonly DeployPreflightSnapshot _snapshot;
+
+        public FakeDeployPreflightProbe(DeployPreflightSnapshot snapshot) => _snapshot = snapshot;
+
+        public Task<DeployPreflightSnapshot> ProbeAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_snapshot);
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+        where T : class
+    {
+        public StaticOptionsMonitor(T value) => CurrentValue = value;
+
+        public T CurrentValue { get; }
+
+        public T Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/ServingLatencyAggregatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/ServingLatencyAggregatorTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using Honua.ServiceDefaults;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Unit tests for the in-process serving-latency rolling-window aggregation
+/// (<see cref="ServingLatencyAggregator"/>).
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class ServingLatencyAggregatorTests
+{
+    private static readonly long TicksPerSecond = Stopwatch.Frequency;
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void GetSnapshot_EmptyWindow_ReturnsNoProtocols()
+    {
+        var aggregator = new ServingLatencyAggregator(TimeSpan.FromMinutes(5), samplesPerProtocol: 16, timestampProvider: () => 0);
+
+        var snapshot = aggregator.GetSnapshot();
+
+        Assert.Empty(snapshot.Protocols);
+        Assert.Equal(300d, snapshot.WindowSeconds);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void GetSnapshot_ComputesNearestRankPercentiles()
+    {
+        long now = 1_000 * TicksPerSecond;
+        var aggregator = new ServingLatencyAggregator(TimeSpan.FromMinutes(5), samplesPerProtocol: 256, timestampProvider: () => now);
+
+        // 1..100 ms across 100 requests; all 2xx.
+        for (var ms = 1; ms <= 100; ms++)
+        {
+            aggregator.Record("FeatureServer", ms, statusCode: 200);
+        }
+
+        var entry = Assert.Single(aggregator.GetSnapshot().Protocols);
+        Assert.Equal("FeatureServer", entry.Protocol);
+        Assert.Equal(100, entry.RequestCount);
+        Assert.Equal(0, entry.ErrorCount);
+        Assert.Equal(0d, entry.ErrorRate);
+        // Nearest-rank: p50 => ceil(0.50*100)=50th sample = 50ms; p95 => 95ms; p99 => 99ms.
+        Assert.Equal(50d, entry.P50Ms);
+        Assert.Equal(95d, entry.P95Ms);
+        Assert.Equal(99d, entry.P99Ms);
+        Assert.Equal(100d, entry.MaxMs);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void GetSnapshot_CountsServerErrorsForErrorRate()
+    {
+        long now = 500 * TicksPerSecond;
+        var aggregator = new ServingLatencyAggregator(TimeSpan.FromMinutes(5), samplesPerProtocol: 64, timestampProvider: () => now);
+
+        aggregator.Record("OGC-Features", 10, statusCode: 200);
+        aggregator.Record("OGC-Features", 20, statusCode: 404); // client error: request, not error
+        aggregator.Record("OGC-Features", 30, statusCode: 500); // server error
+        aggregator.Record("OGC-Features", 40, statusCode: 503); // server error
+
+        var entry = Assert.Single(aggregator.GetSnapshot().Protocols);
+        Assert.Equal(4, entry.RequestCount);
+        Assert.Equal(2, entry.ErrorCount);
+        Assert.Equal(0.5d, entry.ErrorRate);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void GetSnapshot_ExcludesSamplesOutsideWindow()
+    {
+        long now = 0;
+        var aggregator = new ServingLatencyAggregator(TimeSpan.FromSeconds(60), samplesPerProtocol: 128, timestampProvider: () => now);
+
+        // Old sample at t=0.
+        aggregator.Record("WFS-2.0", 999, statusCode: 200);
+
+        // Advance 120s (> 60s window) and record fresh samples.
+        now = 120 * TicksPerSecond;
+        aggregator.Record("WFS-2.0", 10, statusCode: 200);
+        aggregator.Record("WFS-2.0", 20, statusCode: 200);
+
+        var entry = Assert.Single(aggregator.GetSnapshot().Protocols);
+        Assert.Equal(2, entry.RequestCount); // the t=0 sample expired out of the window
+        Assert.Equal(20d, entry.MaxMs);
+
+        // Advance far beyond the window: everything expires and the protocol drops out.
+        now = 1_000 * TicksPerSecond;
+        Assert.Empty(aggregator.GetSnapshot().Protocols);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void Record_RingReservoir_BoundsRetainedSamples()
+    {
+        long now = 10 * TicksPerSecond;
+        var aggregator = new ServingLatencyAggregator(TimeSpan.FromMinutes(5), samplesPerProtocol: 8, timestampProvider: () => now);
+
+        // Write 20 samples into an 8-slot ring; only the most recent 8 survive.
+        for (var i = 1; i <= 20; i++)
+        {
+            aggregator.Record("MapServer", i, statusCode: 200);
+        }
+
+        var entry = Assert.Single(aggregator.GetSnapshot().Protocols);
+        Assert.Equal(8, entry.RequestCount); // only the most recent 8 of 20 survive
+        Assert.Equal(20d, entry.MaxMs); // last written sample retained
+        // Retained set sorted ascending is [13,14,15,16,17,18,19,20];
+        // nearest-rank p50 => ceil(0.50*8)=4th sample => 16ms.
+        Assert.Equal(16d, entry.P50Ms);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void Record_InvalidInputs_AreIgnored()
+    {
+        long now = 5 * TicksPerSecond;
+        var aggregator = new ServingLatencyAggregator(TimeSpan.FromMinutes(5), samplesPerProtocol: 16, timestampProvider: () => now);
+
+        aggregator.Record("", 10, statusCode: 200);
+        aggregator.Record("  ", 10, statusCode: 200);
+        aggregator.Record("FeatureServer", -1, statusCode: 200);
+        aggregator.Record("FeatureServer", double.NaN, statusCode: 200);
+
+        Assert.Empty(aggregator.GetSnapshot().Protocols);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Record_ConcurrentWriters_DoNotThrowAndRetainConsistentCounts()
+    {
+        long now = 42 * TicksPerSecond;
+        var aggregator = new ServingLatencyAggregator(TimeSpan.FromMinutes(5), samplesPerProtocol: 100_000, timestampProvider: () => now);
+
+        const int writers = 8;
+        const int perWriter = 5_000;
+        var tasks = new Task[writers];
+        for (var w = 0; w < writers; w++)
+        {
+            tasks[w] = Task.Run(() =>
+            {
+                for (var i = 0; i < perWriter; i++)
+                {
+                    aggregator.Record("FeatureServer", 1 + (i % 50), statusCode: 200);
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks);
+
+        var entry = Assert.Single(aggregator.GetSnapshot().Protocols);
+        Assert.Equal(writers * perWriter, entry.RequestCount);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void Constructor_RejectsInvalidArguments()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ServingLatencyAggregator(TimeSpan.Zero, 16));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ServingLatencyAggregator(TimeSpan.FromMinutes(1), 0));
+    }
+}


### PR DESCRIPTION
Related to #2463 and #2457 (ADR-0060 WS4 console-health slice + ops-copilot foundation, console #193 direction).

## Summary

Two related server slices in one PR, per the agent-first console direction: the consolidated ops-health snapshot the console's at-a-glance view needs, and the deterministic ops-findings engine whose recommended fixes flow through the existing proposal/approval gateway — the productized detection half of the ops copilot (reasoning stays client-side per ADR-0028; no model calls server-side).

**`GET /api/v1/admin/observability/ops-health`** composes in one payload what previously required stitching five surfaces plus parsing Prometheus text: health-check roll-up (incl. alert-dispatch), per-protocol serving latency percentiles (new bounded in-process reservoir fed by the existing middleware metric — allocation-free hot path, ~68 KB/protocol, configurable window), GP queue depth by status×backend, alert dispatch backlog/dead-letters, deploy readiness (pending migrations, pending contract scripts) with the platform-release skew summary, and DB pool/cache/error-rate vitals.

**`GET /api/v1/admin/observability/findings`** evaluates a deterministic rule set on demand — alert-dispatch backlog/dead-letters, platform-release skew, pending contract migrations, GP queue depth, deploy stuck in ManualInterventionRequired — each finding carrying a plain-language explanation and evidence references. **`POST /findings/{id}/propose`** materializes a finding's recommended action as an `OperationGatewayRequest` through `IOperationGateway`, so any fix lands as a proposal in the existing approval inbox (separation of duties, audit, live updates — all inherited). Only the stuck-deploy rule carries an action (rollback to the recorded prior revision, and only when that revision is known); the rest are deliberately informational.

## Changes Made

- `ServingLatencyAggregator` (bounded per-protocol reservoir) wired into `HonuaTelemetry.RecordServingRequest`; `Tracing:ServingLatencyWindowSeconds`/`SamplesPerProtocol` options
- `IOpsHealthSnapshotService` composer + `/admin/observability/ops-health` endpoint (source-gen JSON, EndpointRegistry, integration tests)
- `IOpsFindingsService` + `OpsFinding` domain (deterministic ids), five unit-tested rules, `Observability:OpsFindings` thresholds
- `/admin/observability/findings` + `/findings/{id}/propose` endpoints routing through the operation gateway
- Shared `PlatformReleaseSkewProjector`; feature catalog regenerated

## Breaking Changes

None. All additive; new endpoints admin-gated.

## Gate Impact

- [x] No gate-tier changes

## Testing

- [x] 20 new unit tests green (aggregator percentiles/window/concurrency; every finding rule positive+negative; propose not-found/no-action/routes-through-gateway)
- [x] Architecture suite green (EndpointRegistry drift, API surface coverage, feature-catalog drift, DI limits)
- [x] Release build (warnings-as-errors) green; format clean
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Endpoint integration tests are Testcontainers-gated and validated in CI.
