### PR TITLE
fix: provision temp/file-storage dirs so rendered-image exports work under read-only root FS (#2311)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,10 +138,21 @@ RUN addgroup -g 1001 -S honua && \
 WORKDIR /app
 COPY --from=build --chown=1001:1001 /app .
 
-# Security: Create runtime directories with proper permissions
-RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics && \
-    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics && \
-    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics
+# Security: Create runtime directories with proper permissions.
+# This set MUST include every writable directory the default configuration writes
+# to at runtime. Under the read-only root filesystem this image is built for
+# (security.read-only-root="true"), any path not provisioned here — and not backed
+# by a writable volume mount by the deployment — is read-only, so a write attempt
+# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /tmp/honua-storage
+# (FileStorage:LocalStorage:BasePath) back the map-image export href/f=json responses
+# (MapServer export, ImageServer exportImage, OGC API Maps); omitting them here made
+# every rendered-image export fail with a 500 while inline f=image responses (which
+# never touch temp storage) still succeeded. Keep this list in sync with the default
+# storage directories in appsettings.json — DockerfileWritableStorageDirectoryTests
+# enforces it.
+RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
+    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
+    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage
 
 # Security: Remove unnecessary setuid/setgid binaries
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true

--- a/tests/dotnet/Honua.Architecture.Tests/DockerfileWritableStorageDirectoryTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/DockerfileWritableStorageDirectoryTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.Architecture.Tests;
+
+/// <summary>
+/// Guards the demo-render contract (honua-server#2311): the runtime image is built for a
+/// read-only root filesystem (<c>security.read-only-root="true"</c>), so every directory the
+/// default configuration writes to at runtime MUST be provisioned as a writable runtime
+/// directory in the Dockerfile. When the two file-storage directories were omitted, inline
+/// map-image responses (<c>f=image</c>, which stream bytes directly) still worked while every
+/// <c>href</c>/<c>f=json</c> export response — MapServer <c>export</c>, ImageServer
+/// <c>exportImage</c>, OGC API Maps — failed with a 500, because persisting the rendered image
+/// to <c>TemporaryFiles:StorageDirectory</c> threw on the read-only path. This test keeps the
+/// Dockerfile's provisioned writable directories in sync with the default storage directories
+/// declared in appsettings.json so that regression cannot recur silently.
+/// </summary>
+[Trait("Category", "Architecture")]
+public sealed class DockerfileWritableStorageDirectoryTests
+{
+    private const string DockerfileRelativePath = "Dockerfile";
+    private const string AppSettingsRelativePath = "src/Honua.Server/appsettings.json";
+
+    [ArchitectureTest]
+    public void Dockerfile_ProvisionsEveryDefaultLocalStorageDirectory()
+    {
+        var repositoryRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var dockerfilePath = Path.Combine(repositoryRoot, DockerfileRelativePath);
+        var appSettingsPath = Path.Combine(
+            repositoryRoot,
+            AppSettingsRelativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        File.Exists(dockerfilePath).Should().BeTrue(
+            "the runtime Dockerfile must exist at the canonical path: {0}", dockerfilePath);
+        File.Exists(appSettingsPath).Should().BeTrue(
+            "the server appsettings.json must exist at the canonical path: {0}", appSettingsPath);
+
+        var dockerfile = File.ReadAllText(dockerfilePath);
+        using var appSettings = JsonDocument.Parse(File.ReadAllText(appSettingsPath));
+        var root = appSettings.RootElement;
+
+        var requiredDirectories = new List<(string ConfigPath, string Directory)>();
+
+        if (TryReadStringPath(root, out var tempDir, "TemporaryFiles", "StorageDirectory") &&
+            IsLocalContainerPath(tempDir))
+        {
+            requiredDirectories.Add(("TemporaryFiles:StorageDirectory", tempDir));
+        }
+
+        if (TryReadStringPath(root, out var storageBasePath, "FileStorage", "LocalStorage", "BasePath") &&
+            IsLocalContainerPath(storageBasePath))
+        {
+            requiredDirectories.Add(("FileStorage:LocalStorage:BasePath", storageBasePath));
+        }
+
+        requiredDirectories.Should().NotBeEmpty(
+            "appsettings.json must declare the default local storage directories this test protects.");
+
+        foreach (var (configPath, directory) in requiredDirectories)
+        {
+            IsProvisionedInDockerfile(dockerfile, directory).Should().BeTrue(
+                "the default storage directory '{0}' ({1}) must be provisioned as a writable runtime " +
+                "directory in the Dockerfile (mkdir -p + chown to the runtime user). The image runs with " +
+                "a read-only root filesystem, so any unprovisioned path is read-only and every rendered " +
+                "map-image export (href/f=json) that persists to it fails with a 500 (honua-server#2311).",
+                directory,
+                configPath);
+        }
+    }
+
+    // A path is provisioned when it appears both in a `mkdir -p` invocation and a `chown`
+    // invocation in the Dockerfile. Matching on the raw path token (surrounded by whitespace or
+    // line boundaries) is sufficient because these directories are absolute and unique.
+    private static bool IsProvisionedInDockerfile(string dockerfile, string directory)
+    {
+        var createdDirectories = CollectTokensFromDirective(dockerfile, "mkdir");
+        var ownedDirectories = CollectTokensFromDirective(dockerfile, "chown");
+        return createdDirectories.Contains(directory) && ownedDirectories.Contains(directory);
+    }
+
+    private static HashSet<string> CollectTokensFromDirective(string dockerfile, string directive)
+    {
+        var tokens = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var rawLine in dockerfile.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            var directiveIndex = line.IndexOf(directive, StringComparison.Ordinal);
+            if (directiveIndex < 0)
+            {
+                continue;
+            }
+
+            foreach (var token in line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (token.StartsWith("/tmp/", StringComparison.Ordinal))
+                {
+                    tokens.Add(token);
+                }
+            }
+        }
+
+        return tokens;
+    }
+
+    private static bool IsLocalContainerPath(string? value)
+        => !string.IsNullOrWhiteSpace(value) && value.StartsWith("/tmp/", StringComparison.Ordinal);
+
+    private static bool TryReadStringPath(JsonElement root, out string value, params string[] path)
+    {
+        value = string.Empty;
+        var current = root;
+        foreach (var segment in path)
+        {
+            if (current.ValueKind != JsonValueKind.Object ||
+                !current.TryGetProperty(segment, out current))
+            {
+                return false;
+            }
+        }
+
+        if (current.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = current.GetString() ?? string.Empty;
+        return true;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2311

## Summary
Rendered map-image exports on the live demo (demo.honua.io) fail with a 500 across MapServer `export?f=json` and ImageServer `exportImage?f=json`, which guts every "see the map draw" beat. Root cause: the runtime image is built for a read-only root filesystem (`security.read-only-root="true"`), but the Dockerfile only provisions three writable runtime directories (`/tmp/honua-logs`, `/tmp/honua-cache`, `/tmp/dotnet-diagnostics`) and omits the two the default configuration actually writes to — `TemporaryFiles:StorageDirectory` (`/tmp/honua-temp`) and `FileStorage:LocalStorage:BasePath` (`/tmp/honua-storage`).

Inline `f=image` responses stream bytes directly and never touch temp storage, so they keep working (verified live: 200 + valid PNG). The `href`/`f=json` responses persist the rendered image via `ITemporaryFileService.StoreTemporaryFileAsync` first; on the read-only path that write throws and the handler returns a generic 500. Metadata/identify `f=json` (no temp write) return 200 live, and the rendering engine, Skia native libs, fonts (`fontconfig`), CRS, and styling are all confirmed healthy — the failure is isolated to persisting the image.

This provisions the two missing directories in the Dockerfile alongside the existing writable runtime dirs and adds an architecture guard test that keeps the Dockerfile's provisioned writable directories in sync with the default storage directories declared in `appsettings.json`, so this regression cannot recur silently.

Note: full resolution of the *live* demo also requires the deployment to make these paths writable (a writable volume/tmpfs mount under `readOnlyRootFilesystem`, or a correctly-configured shared cloud `FileStorage` provider). That deploy-side coordination is documented in a remediation comment on #2311 for honua-devops.

## Changes Made
- Provision `/tmp/honua-temp` and `/tmp/honua-storage` as writable runtime directories in the Dockerfile (mkdir + chown to uid 1001 + chmod 750), matching the default storage directories in `appsettings.json`.
- Add `DockerfileWritableStorageDirectoryTests` (Honua.Architecture.Tests): asserts the Dockerfile provisions every default local storage directory declared in `appsettings.json` (`TemporaryFiles:StorageDirectory`, `FileStorage:LocalStorage:BasePath`). Fails before the Dockerfile change, passes after.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes
- [x] Requires environment variable or secret changes

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
