### PR TITLE
Feature bug-hunt Round 7 (final seal): 9 S1s — class-gaps + security/resource

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -6076,6 +6076,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesAuthorizationTests.JobList_WithoutAuth_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.JobList_NegativeLimit_Returns400",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.JobList_ReturnsJobListObjectOrServiceUnavailable",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.JobList_WithPositiveLimit_AcceptsLimitParameterAndReturnsValidResponse",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.JobList_ZeroLimit_Returns400"
       ],
       "proof_ledger_surface": "ogc-api-processes",
@@ -8261,6 +8262,7 @@
         "Honua.Server.Tests.FeatureServerEndpointTests.QueryFeatures_WithValidWhereClause_ReturnsFilteredFeatures",
         "Honua.Server.Tests.FeatureServerQueryValidationEdgeCaseTests.Query_GroupByKnownColumn_Succeeds",
         "Honua.Server.Tests.FeatureServerQueryValidationEdgeCaseTests.Query_GroupByUnknownColumn_Returns400",
+        "Honua.Server.Tests.FeatureServerQueryValidationEdgeCaseTests.Query_OutStatisticsGroupByWithCap_ReturnsGroupedResultsWithinLimit",
         "Honua.Server.Tests.FeatureServerStatisticsHavingTests.QueryStatistics_WithHavingPredicate_FiltersAggregatedGroups",
         "Honua.Server.Tests.FeatureServerStatisticsHavingTests.QueryStatistics_WithoutHaving_ReturnsAllGroups",
         "Honua.Server.Tests.Features.Admin.FieldMaskPolicyEndpointsTests.FieldMaskPolicy_MasksColumn_ForRestrictedRoleOnly",
@@ -9155,6 +9157,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithExplicitlyRejectedXmlAccept_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithTextXmlRejectedAndWildcardAllowed_ReturnsNotAcceptable",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithUnsupportedAcceptAndWildcardFallback_ReturnsXml",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_BboxExtendingOutsideCrsBoundsButIntersecting_DoesNotReject400",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_DuplicateLayerWithFilter_Returns200NotCrash",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_FiltersInternalAttributes",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetFeatureInfo_ReturnsPlainText",
@@ -10263,19 +10266,6 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Sharing.SharingOAuth2CallbackE2ETests.Callback_FullIdpRoundTrip_IssuesArcGisCodeAndMintsToken",
         "Honua.Server.Tests.Features.Sharing.SharingOAuth2Tests.Callback_WhenNoOidcProviderConfigured_Returns404"
-      ],
-      "proof_ledger_surface": "arcgis-portal-sharing",
-      "maturity": "implemented"
-    },
-    {
-      "id": "get-sharing-rest-oauth2-token",
-      "route": "/sharing/rest/oauth2/token",
-      "method": "GET",
-      "family": "ArcGIS Portal Sharing",
-      "protocol": "http-route-family",
-      "code_location": "src/Honua.Server/EndpointRegistry.cs",
-      "proving_tests": [
-        "Honua.Server.Tests.Features.Sharing.SharingOAuth2Tests.Token_AuthorizationCodeGrantViaQueryString_ReturnsAccessToken"
       ],
       "proof_ledger_surface": "arcgis-portal-sharing",
       "maturity": "implemented"
@@ -17408,6 +17398,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Sharing.SharingOAuth2Tests.Token_AuthorizationCodeGrantViaGetQueryString_Returns405MethodNotAllowed",
         "Honua.Server.Tests.Features.Sharing.SharingOAuth2Tests.Token_AuthorizationCodeGrantWithPkce_ReturnsAccessTokenAndRefreshToken",
         "Honua.Server.Tests.Features.Sharing.SharingOAuth2Tests.Token_AuthorizationCodeWithMismatchedRedirectUri_ReturnsInvalidGrant",
         "Honua.Server.Tests.Features.Sharing.SharingOAuth2Tests.Token_AuthorizationCodeWithWrongPkceVerifier_ReturnsInvalidGrant",

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Honua. All rights reserved.
+// Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.ControlPlane.Domain;
@@ -192,10 +192,18 @@ public interface IExecutionJobStore : IOperationStore
     /// Lists active execution jobs, optionally filtered by job kind.
     /// </summary>
     /// <param name="kind">Optional execution job kind filter.</param>
+    /// <param name="limit">
+    /// Optional upper bound on the number of records materialised before authorization
+    /// filtering. When null the store returns all active jobs. Callers that display a
+    /// bounded page should supply <c>effectiveLimit</c> plus a small overfetch budget
+    /// so per-job authorization filters can discard some records without starving the
+    /// page (BH7-009).
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Active execution jobs.</returns>
     Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(
         ExecutionJobKind? kind = null,
+        int? limit = null,
         CancellationToken cancellationToken = default);
 }
 

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/ExecutionAdmissionEvaluator.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/ExecutionAdmissionEvaluator.cs
@@ -95,7 +95,7 @@ internal sealed class ExecutionAdmissionEvaluator : IExecutionAdmissionEvaluator
 
         if (_jobStore != null)
         {
-            var active = await _jobStore.ListActiveAsync(kind: null, cancellationToken)
+            var active = await _jobStore.ListActiveAsync(kind: null, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             activeGlobal = active.Count;
 
@@ -134,7 +134,7 @@ internal sealed class ExecutionAdmissionEvaluator : IExecutionAdmissionEvaluator
             _logger, request.JobKind.ToString(), partitionTag,
             activeInPartition, activeGlobal, submissionsInWindow, activeCostWeightInPartition);
 
-        // 1. Backpressure — cheapest short-circuit when the system is saturated.
+        // 1. Backpressure â€” cheapest short-circuit when the system is saturated.
         if (options.MaxConcurrentJobsGlobal > 0 && activeGlobal >= options.MaxConcurrentJobsGlobal)
         {
             return Deny(
@@ -145,7 +145,7 @@ internal sealed class ExecutionAdmissionEvaluator : IExecutionAdmissionEvaluator
                 snapshot, request, activity, partitionTag, principalTag);
         }
 
-        // 2. Concurrency — per-partition active jobs for this kind.
+        // 2. Concurrency â€” per-partition active jobs for this kind.
         if (options.MaxConcurrentJobsPerPartition > 0 && activeInPartition >= options.MaxConcurrentJobsPerPartition)
         {
             return Deny(
@@ -156,7 +156,7 @@ internal sealed class ExecutionAdmissionEvaluator : IExecutionAdmissionEvaluator
                 snapshot, request, activity, partitionTag, principalTag);
         }
 
-        // 3. Rate — per-principal sliding-window submissions.
+        // 3. Rate â€” per-principal sliding-window submissions.
         // Claim a slot so concurrent requests from the same principal cannot both pass.
         if (options.MaxSubmissionsPerWindow > 0 && !string.IsNullOrWhiteSpace(request.PrincipalId))
         {
@@ -175,7 +175,7 @@ internal sealed class ExecutionAdmissionEvaluator : IExecutionAdmissionEvaluator
             snapshot = snapshot with { SubmissionsInWindow = postClaimCount };
         }
 
-        // 4. Cost — aggregate cost weight within the partition.
+        // 4. Cost â€” aggregate cost weight within the partition.
         if (options.MaxCostWeightPerPartition > 0)
         {
             var requestCost = ResolveCostWeight(request);

--- a/src/Honua.Jobs/Features/ControlPlane/ExecutionJobReconciler.cs
+++ b/src/Honua.Jobs/Features/ControlPlane/ExecutionJobReconciler.cs
@@ -598,7 +598,7 @@ internal sealed class ExecutionJobReconcilerBackgroundService(
         {
             try
             {
-                var activeJobs = await jobStore.ListActiveAsync(kind: null, stoppingToken).ConfigureAwait(false);
+                var activeJobs = await jobStore.ListActiveAsync(kind: null, cancellationToken: stoppingToken).ConfigureAwait(false);
                 foreach (var job in activeJobs)
                 {
                     stoppingToken.ThrowIfCancellationRequested();

--- a/src/Honua.Jobs/Features/ControlPlane/ExecutionQueueDepthCollectorBackgroundService.cs
+++ b/src/Honua.Jobs/Features/ControlPlane/ExecutionQueueDepthCollectorBackgroundService.cs
@@ -28,7 +28,7 @@ internal sealed partial class ExecutionQueueDepthCollectorBackgroundService(
         {
             try
             {
-                var activeJobs = await jobStore.ListActiveAsync(kind: null, stoppingToken).ConfigureAwait(false);
+                var activeJobs = await jobStore.ListActiveAsync(kind: null, cancellationToken: stoppingToken).ConfigureAwait(false);
                 var snapshot = ControlPlaneTelemetry.ComputeQueueDepth(activeJobs);
                 ControlPlaneTelemetry.UpdateQueueDepth(snapshot);
             }

--- a/src/Honua.Jobs/Features/ControlPlane/RedisExecutionJobStore.cs
+++ b/src/Honua.Jobs/Features/ControlPlane/RedisExecutionJobStore.cs
@@ -305,6 +305,7 @@ internal sealed partial class RedisExecutionJobStore(
 
     public async Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(
         ExecutionJobKind? kind = null,
+        int? limit = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -312,9 +313,20 @@ internal sealed partial class RedisExecutionJobStore(
         var activeKey = kind.HasValue ? GetKindActiveKey(kind.Value) : ActiveJobsKey;
         var jobIds = await _database.SetMembersAsync(activeKey).ConfigureAwait(false);
 
-        var validIds = new List<RedisValue>(jobIds.Length);
+        // BH7-009: When a limit is supplied, cap the number of IDs we materialise.
+        // Apply a 2x overfetch so per-job authorization filters can discard some
+        // records without starving the requested page. Redis Sets have no stable
+        // order; the subset is best-effort.
+        var maxIds = limit.HasValue ? limit.Value * 2 : int.MaxValue;
+
+        var validIds = new List<RedisValue>(Math.Min(jobIds.Length, maxIds));
         foreach (var jobId in jobIds)
         {
+            if (validIds.Count >= maxIds)
+            {
+                break;
+            }
+
             if (jobId.HasValue)
             {
                 validIds.Add(jobId);

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureDataAccess.Edits.cs
@@ -278,6 +278,14 @@ internal sealed partial class FeatureDataAccess
 
         var preconditions = BuildPreconditionMap(editBatch);
 
+        // BH7-021: hoist partial-result accumulators outside the try so the outer catch for
+        // the non-transactional path can report already-committed rows as successes rather than
+        // re-marking them as failures (which drives clients to re-submit, creating duplicates).
+        var partialCreatedIds = ImmutableArray<long>.Empty;
+        var partialCreateResults = ImmutableArray<EditOperationResult>.Empty;
+        var partialUpdateResults = ImmutableArray<EditOperationResult>.Empty;
+        var partialDeleteResults = ImmutableArray<EditOperationResult>.Empty;
+
         try
         {
             if (!editBatch.Operations.IsDefaultOrEmpty)
@@ -297,6 +305,8 @@ internal sealed partial class FeatureDataAccess
                 connection,
                 transaction,
                 cancellationToken);
+            partialCreatedIds = createdIds;
+            partialCreateResults = createResults;
 
             var (updatedCount, updateResults) = await ProcessUpdatesWithResultsAsync(
                 layerId,
@@ -305,6 +315,7 @@ internal sealed partial class FeatureDataAccess
                 transaction,
                 preconditions,
                 cancellationToken);
+            partialUpdateResults = updateResults;
 
             var (deletedCount, deleteResults) = await ProcessDeletesWithResultsAsync(
                 layerId,
@@ -313,6 +324,7 @@ internal sealed partial class FeatureDataAccess
                 transaction,
                 preconditions,
                 cancellationToken);
+            partialDeleteResults = deleteResults;
 
             var hasErrors = System.Linq.Enumerable.Any(createResults, r => !r.IsSuccess) ||
                             System.Linq.Enumerable.Any(updateResults, r => !r.IsSuccess) ||
@@ -377,17 +389,41 @@ internal sealed partial class FeatureDataAccess
                 return FeatureEditResult.Rollback(createResults, updateResults, deleteResults);
             }
 
-            var (failedCreateResults, failedUpdateResults, failedDeleteResults) =
-                CreateFailedOperationResults(editBatch, "Edit batch failed.");
+            // BH7-021: for the non-transactional path the partial accumulators above capture
+            // every result that was recorded before the exception. Only operations that did
+            // not yet produce a result (the unprocessed tail) should be reported as failed.
+            // Reporting all as failed previously drove clients to re-submit already-committed
+            // rows, creating duplicates.
+            var tailCreateFailures = editBatch.Creates.Length > partialCreateResults.Length
+                ? System.Linq.Enumerable
+                    .Repeat(EditOperationResult.Failure("Edit batch failed."), editBatch.Creates.Length - partialCreateResults.Length)
+                    .ToImmutableArray()
+                : ImmutableArray<EditOperationResult>.Empty;
+            var tailUpdateFailures = editBatch.Updates.Length > partialUpdateResults.Length
+                ? editBatch.Updates
+                    .Skip(partialUpdateResults.Length)
+                    .Select(f => EditOperationResult.Failure("Edit batch failed.", objectId: f.Id))
+                    .ToImmutableArray()
+                : ImmutableArray<EditOperationResult>.Empty;
+            var tailDeleteFailures = editBatch.Deletes.Length > partialDeleteResults.Length
+                ? editBatch.Deletes
+                    .Skip(partialDeleteResults.Length)
+                    .Select(id => EditOperationResult.Failure("Edit batch failed.", objectId: id))
+                    .ToImmutableArray()
+                : ImmutableArray<EditOperationResult>.Empty;
+
+            var finalCreateResults = partialCreateResults.AddRange(tailCreateFailures);
+            var finalUpdateResults = partialUpdateResults.AddRange(tailUpdateFailures);
+            var finalDeleteResults = partialDeleteResults.AddRange(tailDeleteFailures);
 
             return FeatureEditResult.Success(
-                0,
-                0,
-                0,
-                ImmutableArray<long>.Empty,
-                failedCreateResults,
-                failedUpdateResults,
-                failedDeleteResults,
+                System.Linq.Enumerable.Count(finalCreateResults, r => r.IsSuccess),
+                System.Linq.Enumerable.Count(finalUpdateResults, r => r.IsSuccess),
+                System.Linq.Enumerable.Count(finalDeleteResults, r => r.IsSuccess),
+                partialCreatedIds,
+                finalCreateResults,
+                finalUpdateResults,
+                finalDeleteResults,
                 wasRolledBack: false);
         }
     }
@@ -1021,6 +1057,12 @@ internal sealed partial class FeatureDataAccess
                 createdIds.Add(created.Id);
                 results.Add(EditOperationResult.Success(created.Id, feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // BH7-020: propagate cancellation so the server stops executing remaining
+                // batch items after a client abort, mirroring the update/delete path fixes.
+                throw;
+            }
             catch (Exception ex)
             {
                 results.Add(EditOperationResult.Failure(GetSafeEditOperationError(ex, "Create")));
@@ -1228,6 +1270,13 @@ internal sealed partial class FeatureDataAccess
                 updatedCount++;
                 results.Add(EditOperationResult.Success(updated.Id, feature.Attributes.GetValueOrDefault("globalId")?.ToString()));
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // BH7-020: propagate cancellation so the server stops executing the remaining
+                // batch items after a client abort. Swallowing this was wasting CPU/connections
+                // and misreporting any committed row as a failure.
+                throw;
+            }
             catch (FeatureEditPreconditionFailedException)
             {
                 results.Add(EditOperationResult.PreconditionFailed(feature.Id));
@@ -1297,6 +1346,12 @@ internal sealed partial class FeatureDataAccess
                 {
                     results.Add(EditOperationResult.Failure($"Feature {featureId} not found", objectId: featureId));
                 }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // BH7-020: propagate cancellation so the server stops executing remaining
+                // batch items after a client abort, mirroring the update path fix.
+                throw;
             }
             catch (FeatureEditPreconditionFailedException)
             {

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
@@ -166,7 +166,7 @@ internal sealed partial class FeatureServerQueryHandler(
 
         // Per-operation RBAC grants are consulted first (#1375); the coarse
         // AccessPolicy seam is the fallback when no grant matches. This is the
-        // enforced read path wired to the resolver for this PR — the remaining
+        // enforced read path wired to the resolver for this PR â€” the remaining
         // protocol adapters are re-wired in #1376.
         var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
             context,
@@ -318,7 +318,7 @@ internal sealed partial class FeatureServerQueryHandler(
             }
 
             // BH2-001: Reject returnDistinctValues when the resultOffset exceeds the safe in-memory
-            // scan threshold (10 × MaxRecordCount). Serving a high-offset distinct page requires
+            // scan threshold (10 Ã— MaxRecordCount). Serving a high-offset distinct page requires
             // loading every row up to the offset before deduplication, making the effective scan
             // size proportional to the offset regardless of the requested page size.
             if (validatedParams.ReturnDistinctValues && (query.Value.Offset ?? 0) > queryLimits.MaxRecordCount * 10)
@@ -497,7 +497,7 @@ internal sealed partial class FeatureServerQueryHandler(
 
             // returnCountOnly/returnIdsOnly/returnExtentOnly produce scalar/structural results,
             // not a GeoJSON FeatureCollection. The format validator allow-lists geojson for the
-            // query operation, but these secondary modes cannot honor it — return a clean 400
+            // query operation, but these secondary modes cannot honor it â€” return a clean 400
             // rather than silently downgrading to an Esri-JSON 200 (#1824).
             if (string.Equals(format, "geojson", StringComparison.OrdinalIgnoreCase) &&
                 (validatedParams.ReturnCountOnly || validatedParams.ReturnIdsOnly || validatedParams.ReturnExtentOnly))
@@ -670,12 +670,16 @@ internal sealed partial class FeatureServerQueryHandler(
                     havingConditions = parsedHaving;
                 }
 
+                // BH7-003: Apply the configured MaxRecordCount as an upper bound on
+                // statistics group rows. Without this cap a groupByFieldsForStatistics
+                // on a high-cardinality column (e.g. objectId) forces the server to
+                // materialise every row from the database — an OOM/DoS vector.
                 var statisticsQuery = query with
                 {
                     OutStatistics = statisticsDefs,
                     GroupByFields = groupByFields,
                     Having = havingConditions,
-                    Limit = null,
+                    Limit = queryLimits.MaxRecordCount,
                     Offset = null,
                     OrderBy = null,
                     Distinct = false
@@ -988,7 +992,7 @@ internal sealed partial class FeatureServerQueryHandler(
 
                 // PARQUET/ARROW are encoded entirely in managed code from the
                 // materialized QueryResult<Feature> (GeoParquetFeatureWriter /
-                // GeoArrow formatter), NOT by a store-native encoder — so unlike
+                // GeoArrow formatter), NOT by a store-native encoder â€” so unlike
                 // FGB/GEOBUF they do not depend on the resolved store implementing
                 // IFlatGeobufFeatureStore. Every IFeatureReader can materialize
                 // features (QueryWithValidationAsync below), so gating parquet/arrow
@@ -1019,7 +1023,7 @@ internal sealed partial class FeatureServerQueryHandler(
                 var shouldApplyDistinct = validatedParams.ReturnDistinctValues && outFields is { Length: > 0 };
 
                 // BH2-001: Reject returnDistinctValues when the resultOffset exceeds the safe in-memory
-                // scan threshold (10 × MaxRecordCount). Serving a high-offset distinct page requires
+                // scan threshold (10 Ã— MaxRecordCount). Serving a high-offset distinct page requires
                 // loading every row up to the offset before deduplication, making the effective scan
                 // size proportional to the offset regardless of the requested page size.
                 if (shouldApplyDistinct && (query.Offset ?? 0) > queryLimits.MaxRecordCount * 10)
@@ -2420,7 +2424,7 @@ internal sealed partial class FeatureServerQueryHandler(
         return double.IsFinite(metersPerUnit) && metersPerUnit > 0;
     }
 
-    // Parameters that change *result semantics* — rejecting them is correct because
+    // Parameters that change *result semantics* â€” rejecting them is correct because
     // silently ignoring would return output that differs from what the client asked for.
     //
     // Compatibility parameters that ArcGIS clients routinely send by default
@@ -2582,8 +2586,8 @@ internal sealed partial class FeatureServerQueryHandler(
     }
 
     // Parses a GeoServices `having` expression into structured aggregate
-    // conditions. The grammar is deliberately narrow — `AGG(field) OP number`
-    // terms joined by AND — so the provider can rebuild a fully parameterized
+    // conditions. The grammar is deliberately narrow â€” `AGG(field) OP number`
+    // terms joined by AND â€” so the provider can rebuild a fully parameterized
     // HAVING clause without ever concatenating client text into SQL. Each
     // aggregate must already be declared in outStatistics, mirroring the Esri
     // contract and reusing the same field-type hints as the SELECT aggregates.
@@ -2821,7 +2825,7 @@ internal sealed partial class FeatureServerQueryHandler(
     }
 
     // A SQL "data exception" (SQLSTATE class 22) is raised by the database when a
-    // value in the executed statement is malformed or out of range — division/mod by
+    // value in the executed statement is malformed or out of range â€” division/mod by
     // zero (22012/22020), numeric overflow (22003), invalid argument to LOG/POWER/SQRT
     // (2201E/2201F/2201G), bad text-to-number CAST (22P02), etc. For a read query these
     // are always driven by client `where`/arithmetic input, so they are client errors
@@ -2890,7 +2894,7 @@ internal sealed partial class FeatureServerQueryHandler(
     // BH2-001: Cap at MaxRecordCount * 2 + 1 so a caller with a very large
     // resultOffset cannot force a multi-million-row materialization. A request
     // whose offset+limit window exceeds this cap will still see a valid (possibly
-    // empty) page plus exceededTransferLimit=true — it cannot force an OOM.
+    // empty) page plus exceededTransferLimit=true â€” it cannot force an OOM.
     private static int ComputeDistinctScanLimit(FeatureQuery query, QueryLimits queryLimits)
     {
         var requestedWindow = Math.Max(0, query.Offset ?? 0) + Math.Max(0, query.Limit ?? 0);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Edits.cs
@@ -615,6 +615,19 @@ internal static partial class FeatureServerEndpoints
             };
         }
 
+        // BH7-016: rollbackOnFailure=true on a multi-layer request is semantically un-atomic.
+        // Each layer's edits run in its own independent transaction; there is no way to roll
+        // back a layer that has already committed when a later layer fails. Fail-closed here
+        // rather than partially committing and misrepresenting the operation as rolled back.
+        if (sharedOptions.RollbackOnFailure && orderedLayerIds.Count > 1)
+        {
+            return StandardErrorHelpers.CreateBadRequest(context,
+                "rollbackOnFailure=true is not supported for multi-layer service applyEdits",
+                ["rollbackOnFailure=true only provides intra-layer atomicity. " +
+                 "Multi-layer service-level edits cannot be rolled back atomically across layers. " +
+                 "Set rollbackOnFailure=false (or omit it) to allow partial commits, or submit each layer separately."]);
+        }
+
         var results = new ServiceLayerEditResult[orderedLayerIds.Count];
 
         // BH2-013: Track whether any non-first layer returned an error response so the

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/ApplyEditsIdempotencyStore.cs
@@ -202,15 +202,13 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
             }
         }
 
-        if (_cache == null)
-        {
-            // In-process fallback: ConcurrentDictionary.TryAdd is atomic - only one concurrent
-            // caller wins; the loser sees false and should return 409.
-            return _fallback.TryAdd(key, new FallbackEntry(PendingSentinel, now.Add(ReservationWindow)));
-        }
-
-        // Non-Redis IDistributedCache has no set-if-absent; fall open.
-        return true;
+        // In-process fallback: ConcurrentDictionary.TryAdd is atomic — only one concurrent
+        // caller wins; the loser sees false and should return 409.
+        // This covers both the no-cache path (_cache == null) and the non-Redis
+        // IDistributedCache path: a MemoryDistributedCache / SQL-session-store / Memcached
+        // cache has no set-if-absent primitive, so treating it the same as no-cache
+        // gives us a single process-level mutex via ConcurrentDictionary. (BH7-002)
+        return _fallback.TryAdd(key, new FallbackEntry(PendingSentinel, now.Add(ReservationWindow)));
     }
 
     public async Task SetAsync(
@@ -258,6 +256,12 @@ internal sealed class DistributedApplyEditsIdempotencyStore : IApplyEditsIdempot
             // Best-effort: failing to record the response must not fail an already-applied edit.
             FeatureServerLog.ApplyEditsIdempotencyStoreUnavailable(_logger, scope.ServiceId, scope.LayerId, ex);
         }
+
+        // TryReserveAsync uses _fallback for the non-Redis IDistributedCache path (BH7-002).
+        // Replace the pending reservation sentinel with the committed response so it does not
+        // linger for the full ReservationWindow, and trigger CleanupFallback to bound growth.
+        _fallback[key] = new FallbackEntry(payload, now.Add(DedupeWindow));
+        CleanupFallback(now);
     }
 
     private static string BuildKey(ApplyEditsIdempotencyScope scope)

--- a/src/Honua.Protocols.GeoServices/Sharing/SharingOAuth2Endpoints.cs
+++ b/src/Honua.Protocols.GeoServices/Sharing/SharingOAuth2Endpoints.cs
@@ -14,7 +14,7 @@ namespace Honua.Protocols.GeoServices.Sharing;
 /// <summary>
 /// ArcGIS-compatible <c>/sharing/rest/oauth2</c> named-user endpoints (#1242):
 /// <c>authorize</c>, <c>callback</c>, and <c>token</c>. Per ADR-0049 this is a thin
-/// bridge over the shared OIDC identity core and <c>IPortalTokenIssuer</c> — it does
+/// bridge over the shared OIDC identity core and <c>IPortalTokenIssuer</c> â€” it does
 /// not introduce a parallel user or token store. The interactive
 /// authorization-code+PKCE leg is delegated to the operator's configured OIDC
 /// provider through <see cref="PortalOAuthBroker"/>; the access token returned to
@@ -52,21 +52,16 @@ internal static class SharingOAuth2Endpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status404NotFound);
 
+        // RFC 6749 §4.1.3: the token endpoint MUST be reached via POST only.
+        // A GET registration would expose auth codes, client_secret, and
+        // refresh tokens as URL query-string parameters — logged verbatim by
+        // every proxy, CDN, and access-log middleware in the chain (CWE-598).
+        // BH7-001: GET registration removed; POST-only enforced.
         endpoints.MapPost(PortalOAuthRoutes.TokenPath, HandleTokenAsync)
             .WithDisplayName("ArcGIS Portal OAuth2 Token")
             .WithName("SharingRestOAuth2TokenPost")
             .WithSummary("Exchange an authorization code or refresh token for a portal access token")
-            .WithDescription("Returns the Esri-shaped { access_token, expires_in, refresh_token? } envelope; access_token is minted via IPortalTokenIssuer.")
-            .WithTags("GeoServices Sharing")
-            .AllowAnonymous()
-            .Produces<OAuth2TokenResponse>(StatusCodes.Status200OK, JsonContentType)
-            .Produces<OAuth2ErrorResponse>(StatusCodes.Status400BadRequest, JsonContentType)
-            .Produces(StatusCodes.Status404NotFound);
-
-        endpoints.MapGet(PortalOAuthRoutes.TokenPath, HandleTokenAsync)
-            .WithDisplayName("ArcGIS Portal OAuth2 Token (GET)")
-            .WithName("SharingRestOAuth2TokenGet")
-            .WithSummary("Exchange an authorization code or refresh token via query parameters")
+            .WithDescription("Returns the Esri-shaped { access_token, expires_in, refresh_token? } envelope; access_token is minted via IPortalTokenIssuer. POST-only per RFC 6749 §4.1.3.")
             .WithTags("GeoServices Sharing")
             .AllowAnonymous()
             .Produces<OAuth2TokenResponse>(StatusCodes.Status200OK, JsonContentType)
@@ -77,7 +72,7 @@ internal static class SharingOAuth2Endpoints
             .WithDisplayName("ArcGIS Portal OAuth2 Token Revocation")
             .WithName("SharingRestOAuth2Revoke")
             .WithSummary("RFC 7009 per-token revocation for opaque and JWT access tokens and refresh tokens")
-            .WithDescription("Immediately invalidates the presented access or refresh token so it fails every subsequent authorization check. Per RFC 7009 §2.2 a revocation request always returns 200, even for an unknown or already-revoked token. The presented token value is the authorization to revoke it (#2155).")
+            .WithDescription("Immediately invalidates the presented access or refresh token so it fails every subsequent authorization check. Per RFC 7009 Â§2.2 a revocation request always returns 200, even for an unknown or already-revoked token. The presented token value is the authorization to revoke it (#2155).")
             .WithTags("GeoServices Sharing")
             .AllowAnonymous()
             .Produces(StatusCodes.Status200OK)
@@ -133,7 +128,7 @@ internal static class SharingOAuth2Endpoints
 
         await revocationService.RevokeAsync(token, tokenTypeHint, context.RequestAborted).ConfigureAwait(false);
 
-        // RFC 7009 §2.2: the authorization server responds with HTTP 200 for a
+        // RFC 7009 Â§2.2: the authorization server responds with HTTP 200 for a
         // successful revocation as well as for an unknown/already-revoked token, so a
         // caller can never probe token validity through this endpoint.
         return Results.Ok();
@@ -146,7 +141,7 @@ internal static class SharingOAuth2Endpoints
         [FromServices] ILogger<SharingRestLog> logger)
     {
         // The whole introspection surface is off by default; when disabled it 404s
-        // so it is never a silent discovery surface (RFC 7662 §4: the endpoint must
+        // so it is never a silent discovery surface (RFC 7662 Â§4: the endpoint must
         // be protected, and Honua keeps it absent unless explicitly enabled).
         if (!tokenOptions.Value.Enabled || !introspectionService.IntrospectionEnabled)
         {
@@ -171,7 +166,7 @@ internal static class SharingOAuth2Endpoints
 
         var result = await introspectionService.IntrospectAsync(token, context.RequestAborted).ConfigureAwait(false);
 
-        // RFC 7662 §2.2: an inactive token returns only { "active": false } — no
+        // RFC 7662 Â§2.2: an inactive token returns only { "active": false } â€” no
         // other detail is leaked, regardless of whether it was unknown, expired,
         // revoked, or a forged JWT.
         if (result is null)
@@ -227,7 +222,7 @@ internal static class SharingOAuth2Endpoints
 
         // Open-redirect mitigation (#1484): the redirect_uri must be registered in
         // the per-deployment allow-list. A non-allow-listed redirect_uri is rejected
-        // with a direct 400 and is NEVER redirected to (RFC 6749 §4.1.2.1) so the
+        // with a direct 400 and is NEVER redirected to (RFC 6749 Â§4.1.2.1) so the
         // bridge cannot be used to bounce an authorization code to a hostile host.
         if (!PortalOAuthRedirectUriValidator.IsAllowed(redirectUri, tokenOptions.Value.OAuth2.AllowedRedirectUris))
         {
@@ -237,7 +232,7 @@ internal static class SharingOAuth2Endpoints
 
         // response_type is validated only after the redirect_uri allow-list check so
         // the error redirect below can never target an unvalidated URI (RFC 6749
-        // §4.1.2.1 requires validating redirect_uri before redirecting errors to it).
+        // Â§4.1.2.1 requires validating redirect_uri before redirecting errors to it).
         var responseType = ReadFirst(query["response_type"]);
         if (responseType is not null && !string.Equals(responseType, "code", StringComparison.Ordinal))
         {
@@ -395,7 +390,7 @@ internal static class SharingOAuth2Endpoints
             scope = ReadFirst(query["scope"]);
         }
 
-        // RFC 6749 §2.3.1: a confidential client MAY present its credentials via HTTP
+        // RFC 6749 Â§2.3.1: a confidential client MAY present its credentials via HTTP
         // Basic auth instead of the request body. When present and the body omitted
         // them, use the Basic-auth client_id/client_secret (body values win when both
         // are supplied, matching the existing body-first parsing above).
@@ -467,7 +462,7 @@ internal static class SharingOAuth2Endpoints
 
     private static IResult OAuth2Error(string error, string description)
     {
-        // OAuth2 (RFC 6749 §5.2) error responses are 400 with a JSON
+        // OAuth2 (RFC 6749 Â§5.2) error responses are 400 with a JSON
         // { error, error_description } body.
         var response = new OAuth2ErrorResponse
         {

--- a/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.ChangeSet.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.ChangeSet.cs
@@ -37,7 +37,15 @@ internal sealed partial class ODataBatchHandler
         // and the batch write would otherwise be silently overwritten (TOCTOU).
         var preconditionsByLayer = new Dictionary<int, List<FeatureEditPrecondition>>();
         var writeLayerIds = new HashSet<int>();
-        var layerCache = new Dictionary<int, ODataBatchLayerContext>();
+        // BH7-012: key by (layerId, normalizedMethod) so each distinct operation on the
+        // same layer triggers its own per-operation RBAC check via ResolveBatchLayerContextAsync.
+        // Caching only by layerId would let the second+ sub-request on the same layer skip the
+        // MapMethodToOperation / RequireResourceDataEditorAsync authorization check.
+        var layerCache = new Dictionary<(int layerId, string normalizedMethod), ODataBatchLayerContext>();
+        // Separate metadata-only cache keyed by layerId for the write-execution phase below,
+        // where we need the context but not per-operation auth (the per-request check above
+        // already enforced it, and the feature writer enforces data-write access server-side).
+        var layerMetaCache = new Dictionary<int, ODataBatchLayerContext>();
 
         foreach (var request in requests)
         {
@@ -112,7 +120,13 @@ internal sealed partial class ODataBatchHandler
                     continue;
                 }
                 var objectId = parsed.ObjectId;
-                if (!layerCache.TryGetValue(layerId.Value, out var layer))
+                // BH7-012: look up by (layerId, normalizedMethod) so each distinct operation
+                // on the same layer is authorized independently. The first POST-Insert is cached
+                // under ("POST"); a later DELETE-Delete on the same layer does NOT hit the cache
+                // and instead calls ResolveBatchLayerContextAsync with "DELETE" so
+                // MapMethodToOperation / RequireResourceDataEditorAsync runs again.
+                var normalizedMethod = request.Method.ToUpperInvariant();
+                if (!layerCache.TryGetValue((layerId.Value, normalizedMethod), out var layer))
                 {
                     var resolvedLayer = await ResolveBatchLayerContextAsync(
                         context,
@@ -132,10 +146,12 @@ internal sealed partial class ODataBatchHandler
                     }
 
                     layer = resolvedLayer.Layer;
-                    layerCache[layerId.Value] = layer;
+                    layerCache[(layerId.Value, normalizedMethod)] = layer;
+                    // Also populate the metadata cache for the write-execution phase.
+                    layerMetaCache.TryAdd(layerId.Value, layer);
                 }
 
-                switch (request.Method.ToUpperInvariant())
+                switch (normalizedMethod)
                 {
                     case "GET":
                         rollback = true;
@@ -484,7 +500,7 @@ internal sealed partial class ODataBatchHandler
 
             foreach (var layerId in layerIds)
             {
-                if (!layerCache.TryGetValue(layerId, out var layer))
+                if (!layerMetaCache.TryGetValue(layerId, out var layer))
                 {
                     continue;
                 }

--- a/src/Honua.Protocols.OgcApi/Features/OgcFeaturesUtilities.cs
+++ b/src/Honua.Protocols.OgcApi/Features/OgcFeaturesUtilities.cs
@@ -172,7 +172,16 @@ internal static class OgcFeaturesUtilities
     {
         if (string.IsNullOrWhiteSpace(crs))
         {
-            definition = supportedCrs[Crs84Uri];
+            // BH7-008: Use TryGetValue to guard against a degraded CRS registry where
+            // CRS84 was not successfully resolved at startup (PROJ misconfiguration,
+            // transient registry error). The previous indexer access threw
+            // KeyNotFoundException which propagated as a misleading HTTP 400.
+            if (!supportedCrs.TryGetValue(Crs84Uri, out definition))
+            {
+                error = "Default CRS (CRS84) is not available for this collection.";
+                return false;
+            }
+
             error = null;
             return true;
         }

--- a/src/Honua.Protocols.OgcApi/Processes/JobEndpoints.cs
+++ b/src/Honua.Protocols.OgcApi/Processes/JobEndpoints.cs
@@ -120,11 +120,16 @@ internal static class JobEndpoints
             return JobStoreUnavailableResult();
         }
 
+        // BH7-009: Compute the effective limit before fetching so the store can
+        // apply a server-side cap. The 2x budget accommodates per-job authorization
+        // filters that may discard some records without starving the page.
+        var effectiveLimit = limit ?? options.Value.DefaultJobLimit;
+
         var jobs = await jobStore.ListActiveAsync(
             ExecutionJobKind.Geoprocessing,
+            effectiveLimit,
             context.RequestAborted).ConfigureAwait(false);
 
-        var effectiveLimit = limit ?? options.Value.DefaultJobLimit;
 
         var baseUrl = BaseUrlResolver.GetBaseUrl(context);
         var statusInfosBuilder = ImmutableArray.CreateBuilder<OgcStatusInfo>();
@@ -406,7 +411,7 @@ internal static class JobEndpoints
             return ProcessEndpoints.FormatOgcAuthError(authDecision);
         }
 
-        // Already dismissed — reconcile side effects and return current status
+        // Already dismissed â€” reconcile side effects and return current status
         if (job.Status == ExecutionJobStatus.Cancelled)
         {
             if (jobQueue != null)
@@ -453,7 +458,7 @@ internal static class JobEndpoints
                 StatusCodes.Status409Conflict);
         }
 
-        // Dismissing a running job is a destructive action — require approval.
+        // Dismissing a running job is a destructive action â€” require approval.
         // Evaluated after state checks so not-found, idempotent, and terminal paths
         // remain reachable regardless of approval policy, matching CancelJobAsync.
         var approval = gate.CheckApproval(context.User, new OperatorAuthorizationRequest
@@ -540,7 +545,7 @@ internal static class JobEndpoints
 
                         // Stamp CancellationRequestedAt before the remote cancel so a
                         // concurrent dismiss that races ahead and sees the provider job
-                        // already gone maps NotFound → Cancelled rather than Failed.
+                        // already gone maps NotFound â†’ Cancelled rather than Failed.
                         var stampResult = await ExecutionJobCancellationHelper.TryStampRemoteCancelRequestedAtAsync(
                             jobStore, latest, cancellationToken: context.RequestAborted).ConfigureAwait(false);
                         switch (stampResult.Outcome)

--- a/src/Honua.Server/EndpointRegistry.Portal.cs
+++ b/src/Honua.Server/EndpointRegistry.Portal.cs
@@ -25,7 +25,7 @@ public static partial class EndpointRegistry
         new("GET", "/sharing/rest/oauth2/authorize"),
         new("GET", "/sharing/rest/oauth2/callback"),
         new("POST", "/sharing/rest/oauth2/token"),
-        new("GET", "/sharing/rest/oauth2/token"),
+        // GET /sharing/rest/oauth2/token removed (BH7-001): RFC 6749 §4.1.3 requires POST-only token exchange; GET exposed credentials in URLs/logs (CWE-598).
 
         // OAuth2 RFC 7662 token introspection (#1890).
         new("POST", "/sharing/rest/oauth2/introspect"),

--- a/src/Honua.Server/Features/Admin/OperateFixtures/PostgresOperateFixtureExecutionStore.cs
+++ b/src/Honua.Server/Features/Admin/OperateFixtures/PostgresOperateFixtureExecutionStore.cs
@@ -252,6 +252,7 @@ internal sealed partial class PostgresOperateFixtureExecutionStore(
 
     public async Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(
         ExecutionJobKind? kind = null,
+        int? limit = null,
         CancellationToken cancellationToken = default)
     {
         await using var lease = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -273,6 +274,15 @@ internal sealed partial class PostgresOperateFixtureExecutionStore(
         }
 
         sql.Append(" ORDER BY updated_at DESC, operation_id DESC");
+
+        // BH7-009: apply a 2x overfetch cap when a limit is supplied so this store
+        // does not load unbounded rows before the caller applies a page window.
+        if (limit.HasValue)
+        {
+            sql.Append(" LIMIT @row_cap");
+            command.Parameters.Add(Parameter("row_cap", NpgsqlDbType.Integer, limit.Value * 2));
+        }
+
         command.CommandText = sql.ToString();
 
         var rows = new List<ExecutionJobRecord>();

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneEventHandler.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneEventHandler.cs
@@ -8,7 +8,7 @@ namespace Honua.ControlPlane;
 
 /// <summary>
 /// Event entrypoint that drives a single control-plane reconcile from an external state-change
-/// event instead of a poll cycle. This is what an AWS Lambda — triggered by an EventBridge rule —
+/// event instead of a poll cycle. This is what an AWS Lambda â€” triggered by an EventBridge rule â€”
 /// invokes: resolve the event to the durable operation id, then reconcile that one operation
 /// exactly once and exit.
 /// <para>
@@ -34,7 +34,7 @@ namespace Honua.ControlPlane;
 /// </list>
 /// <para>
 /// The handler is intentionally loop-free and never trusts the event payload as authoritative
-/// state. A malformed, duplicate, or out-of-order event therefore cannot corrupt state — at worst it
+/// state. A malformed, duplicate, or out-of-order event therefore cannot corrupt state â€” at worst it
 /// triggers a redundant reconcile that the lease/CAS + terminal guards inside each reconciler make a
 /// no-op.
 /// </para>
@@ -105,12 +105,12 @@ internal sealed partial class ControlPlaneEventHandler(
     /// <list type="bullet">
     ///   <item><description>
     ///     <b>ECS Task State Change</b> and <b>CodeDeploy DeploymentStateChange</b> for the
-    ///     <c>AwsEcsAlbDeployBackend</c> — the provider id is the CodeDeploy deployment id /
+    ///     <c>AwsEcsAlbDeployBackend</c> â€” the provider id is the CodeDeploy deployment id /
     ///     ECS service-deployment id recorded as the operation's <c>ProviderOperationId</c>.
     ///   </description></item>
     ///   <item><description>
     ///     <b>Lambda-alias</b> routing-config change events for the
-    ///     <c>AwsLambdaGitOpsDeployBackend</c> — the provider id is the alias/version recorded as
+    ///     <c>AwsLambdaGitOpsDeployBackend</c> â€” the provider id is the alias/version recorded as
     ///     the operation's <c>ProviderOperationId</c>.
     ///   </description></item>
     /// </list>
@@ -171,7 +171,7 @@ internal sealed partial class ControlPlaneEventHandler(
     /// These reconcilers advance exactly one stage per call. Under event mode there is no 5s poll
     /// loop to re-enter and drive the next stage, so after a stage persists the reconciler enqueues a
     /// "continue" signal (a custom EventBridge event) that this handler consumes to reconcile the
-    /// same operation again — advancing the next stage. The chain terminates naturally when the
+    /// same operation again â€” advancing the next stage. The chain terminates naturally when the
     /// operation reaches a terminal status, because the reconciler's terminal guard makes any further
     /// reconcile a no-op. The backstop is the safety net if a continue signal is dropped.
     /// </para>
@@ -203,7 +203,7 @@ internal sealed partial class ControlPlaneEventHandler(
         string providerOperationId,
         CancellationToken cancellationToken)
     {
-        var active = await jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        var active = await jobStore.ListActiveAsync(kind: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         foreach (var job in active)
         {
             if (string.Equals(job.ProviderOperationId, providerOperationId, StringComparison.Ordinal))

--- a/src/Honua.Server/Features/ControlPlane/ExecutionJobBackstopSweepService.cs
+++ b/src/Honua.Server/Features/ControlPlane/ExecutionJobBackstopSweepService.cs
@@ -74,7 +74,7 @@ internal sealed partial class ExecutionJobBackstopSweepService(
     /// </summary>
     internal async Task SweepOnceAsync(TimeSpan staleThreshold, CancellationToken cancellationToken)
     {
-        var active = await jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        var active = await jobStore.ListActiveAsync(kind: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         var cutoff = DateTimeOffset.UtcNow - staleThreshold;
 
         foreach (var job in active)

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
@@ -231,7 +231,7 @@ internal sealed class OpsFindingsService : IOpsFindingsService
             return;
         }
 
-        var activeJobs = await _jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        var activeJobs = await _jobStore.ListActiveAsync(kind: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         var queueDepth = ControlPlaneTelemetry.ComputeQueueDepth(activeJobs);
         var totalActive = queueDepth.Sum(entry => entry.Count);
         if (totalActive < options.GpQueueDepthThreshold)

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
@@ -134,7 +134,7 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
             return new OpsGpQueueView { TotalActive = 0, Available = false, Buckets = [] };
         }
 
-        var activeJobs = await _jobStore.ListActiveAsync(kind: null, cancellationToken).ConfigureAwait(false);
+        var activeJobs = await _jobStore.ListActiveAsync(kind: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         var queueDepth = ControlPlaneTelemetry.ComputeQueueDepth(activeJobs);
         var buckets = queueDepth
             .Select(entry => new OpsGpQueueBucketView

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ApplyEditsIdempotencyStoreTests.cs
@@ -114,6 +114,41 @@ public sealed class ApplyEditsIdempotencyStoreTests
         replay.Should().BeNull("the same key on a different layer is a distinct edit");
     }
 
+    // ─── BH7-002 regression ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// BH7-002: concurrent TryReserveAsync on a non-Redis IDistributedCache (e.g.
+    /// MemoryDistributedCache — the default deployment) must still produce exactly one
+    /// winner per key.  The store must fall through to the in-process ConcurrentDictionary
+    /// path instead of returning true for every caller (the previous "fall-open" bug).
+    /// </summary>
+    [UnitTest]
+    [Operation(Operations.ApplyEdits)]
+    public async Task TryReserveAsync_ConcurrentSameScope_NonRedisCache_ExactlyOneWins()
+    {
+        // Arrange: MemoryDistributedCache configured but no IConnectionMultiplexer.
+        // Prior to the fix TryReserveAsync returned true unconditionally here.
+        var store = new DistributedApplyEditsIdempotencyStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLogger<DistributedApplyEditsIdempotencyStore>.Instance);
+
+        var scope = Scope(key: "bh7-002-race");
+
+        // Act: 10 concurrent reservations for the same scope.
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => store.TryReserveAsync(scope))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        // Assert: exactly one winner (BH7-002).
+        results.Count(static r => r).Should().Be(1,
+            "ConcurrentDictionary.TryAdd is the fallback for non-Redis IDistributedCache; " +
+            "exactly one concurrent caller must win the reservation so only one edit executes");
+        results.Count(static r => !r).Should().Be(9,
+            "all other concurrent callers must lose the reservation and return 409");
+    }
+
     [UnitTest]
     [Operation(Operations.ApplyEdits)]
     public void TryResolveKey_NoHeader_ReturnsNullKeyWithoutError()

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
@@ -381,7 +381,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/execute")]
     public async Task ExecutePost_AsyncOnlyTask_Returns400WithCapabilityMessage()
     {
-        // analytics.cluster is NOT in GPServerExecutionPolicy.SyncEligibleProcessIds —
+        // analytics.cluster is NOT in GPServerExecutionPolicy.SyncEligibleProcessIds â€”
         // the synchronous /execute path must surface a capability error rather
         // than try to run a long-running task inline.
         using var content = new FormUrlEncodedContent(new Dictionary<string, string>
@@ -838,7 +838,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var created = await jobStore!.TryCreateAsync(jobRecord);
         created.Should().BeTrue("the binding-validation fixture job must be created");
 
-        // Query status under a different service — should be rejected
+        // Query status under a different service â€” should be rejected
         var statusResponse = await _client.GetAsync(
             $"/rest/services/OtherService/GPServer/BufferAnalysis/jobs/{jobId}?f=json");
 
@@ -877,7 +877,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var created = await jobStore!.TryCreateAsync(jobRecord);
         created.Should().BeTrue("the binding-validation fixture job must be created");
 
-        // Query status under a different task — should be rejected
+        // Query status under a different task â€” should be rejected
         var statusResponse = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/DifferentTask/jobs/{jobId}?f=json");
 
@@ -1015,7 +1015,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var created = await jobStore!.TryCreateAsync(jobRecord);
         created.Should().BeTrue("the cross-protocol fixture job must be created");
 
-        // Access via GPServer route — should be rejected (no GPServer binding metadata)
+        // Access via GPServer route â€” should be rejected (no GPServer binding metadata)
         var response = await _client.GetAsync(
             $"/rest/services/AnyService/GPServer/AnyTask/jobs/{jobId}?f=json");
 
@@ -1051,7 +1051,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
     [Endpoint("POST /rest/services/{serviceId}/GPServer/{taskName}/submitJob")]
     public async Task SubmitJobPost_WithEnvInQueryString_ReturnsBadRequest()
     {
-        // POST with form body but env control in query string — the query-string
+        // POST with form body but env control in query string â€” the query-string
         // parameter must still be read and rejected (not silently dropped).
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
@@ -1087,7 +1087,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
     [Endpoint("GET /rest/services/{serviceId}/GPServer/{taskName}/jobs/{jobId}")]
     public async Task JobStatus_WithMissingJobId_ReturnsBadRequestOrNotFound()
     {
-        // Empty jobId in the route — the routing framework will either 404 or match
+        // Empty jobId in the route â€” the routing framework will either 404 or match
         var response = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/?f=json");
 
@@ -1191,7 +1191,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             var response = await client.PostAsync(
                 $"/rest/services/{ServiceId}/GPServer/geometry.buffer/submitJob", content);
 
-            // Auth must be checked before parameter validation — expect 401 not 400.
+            // Auth must be checked before parameter validation â€” expect 401 not 400.
             response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
                 "auth must be checked before env-control rejection per IGeoprocessingJobService contract");
         }
@@ -1695,6 +1695,7 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
 
         public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(
             ExecutionJobKind? kind = null,
+            int? limit = null,
             CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values
                 .Where(job => !kind.HasValue || job.Spec.Kind == kind.Value)

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcCrsResolverTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcCrsResolverTests.cs
@@ -89,4 +89,37 @@ public sealed class OgcCrsResolverTests
         definition.Srid.Should().Be(26910);
         definition.AxisOrder.Should().Be(AxisOrder.EastNorth);
     }
+
+    // BH7-008 regression: when the CRS registry is degraded and the default CRS84
+    // entry is absent, TryResolveCrs must return false with a descriptive error
+    // rather than throwing KeyNotFoundException (which was previously silently
+    // swallowed as a misleading HTTP 400 "Invalid filter parameters").
+    [UnitTest]
+    public void TryResolveCrs_WithNullCrs_WhenCrs84Absent_ReturnsFalseWithError()
+    {
+        // Simulate a degraded CRS registry that did not resolve CRS84 at startup
+        // (e.g., PROJ misconfiguration or transient registry error).
+        var supportedCrs = new Dictionary<string, CrsDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        // Must not throw and must return false with a descriptive error.
+        var succeeded = OgcFeaturesUtilities.TryResolveCrs(null, supportedCrs, out _, out var error);
+
+        succeeded.Should().BeFalse("CRS84 is absent from a degraded registry");
+        error.Should().NotBeNullOrWhiteSpace("a descriptive error must be returned");
+        error.Should().Contain("CRS84", "the error must identify the missing default CRS");
+    }
+
+    [UnitTest]
+    public void TryResolveCrs_WithEmptyCrs_WhenCrs84Absent_ReturnsFalseWithError()
+    {
+        // Same degraded-registry scenario but triggered by an empty string (equivalent
+        // to null — the common case when a client sends no crs= parameter).
+        var supportedCrs = new Dictionary<string, CrsDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        var succeeded = OgcFeaturesUtilities.TryResolveCrs(string.Empty, supportedCrs, out _, out var error);
+
+        succeeded.Should().BeFalse();
+        error.Should().NotBeNullOrWhiteSpace();
+        error.Should().Contain("CRS84");
+    }
 }

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Processes/OgcProcessesDismissJobTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Processes/OgcProcessesDismissJobTests.cs
@@ -62,7 +62,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
             .Returns(queuedJob, (ExecutionJobRecord?)null);
         _jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        _jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        _jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
 
         _cancellationNotifier.Cancel(JobId).Returns(false);
@@ -238,7 +238,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
         jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(remoteQueued, terminal);
         jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
 
         var fixture = new WebAppFixture()
@@ -311,7 +311,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
         jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(remoteQueued);
         jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
 
         var fixture = new WebAppFixture()
@@ -393,7 +393,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
         jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(retryAwaitingResubmission);
         jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
 
         var fixture = new WebAppFixture()
@@ -476,7 +476,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
             .Returns(remoteQueued, remoteQueued, runningRecord);
         jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
         jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
             .Returns(false);
@@ -558,7 +558,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
             Arg.Any<TimeSpan?>(),
             Arg.Any<CancellationToken>());
 
-        // Queue should NOT have been cleaned up — worker owns terminal state.
+        // Queue should NOT have been cleaned up â€” worker owns terminal state.
         await _jobQueue.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
@@ -605,7 +605,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
         jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(remoteRunning);
         jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
 
         var fixture = new WebAppFixture()
@@ -693,7 +693,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
         jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(remoteRunning);
         jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
 
         var fixture = new WebAppFixture()
@@ -763,7 +763,7 @@ public sealed class OgcProcessesDismissJobTests : IAsyncLifetime
         jobStore.GetAsync(JobId, Arg.Any<CancellationToken>()).Returns(remoteRunning);
         jobStore.GetAsync(Arg.Is<string>(id => id != JobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
 
         var fixture = new WebAppFixture()

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Processes/OgcProcessesEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Processes/OgcProcessesEndpointsTests.cs
@@ -485,7 +485,7 @@ public sealed class OgcProcessesEndpointsTests : IClassFixture<WebAppFixture>
         using var request = new HttpRequestMessage(HttpMethod.Post,
             "/ogc/processes/processes/honua-geoprocessing/execution");
         request.Headers.Add("Prefer", "respond-async");
-        // queryFeatures is a non-geoprocess kind — catalog validation skips it,
+        // queryFeatures is a non-geoprocess kind â€” catalog validation skips it,
         // so this request exercises only response-mode handling, not catalog checks.
         request.Content = new StringContent(
             """{"inputs":{"plan":{"planId":"p1","steps":[{"stepId":"s1","kind":"queryFeatures"}]}},"response":"document"}""",
@@ -493,7 +493,7 @@ public sealed class OgcProcessesEndpointsTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.SendAsync(request);
 
-        // Either 201 (job created) or 503 (no Redis) — not 501
+        // Either 201 (job created) or 503 (no Redis) â€” not 501
         response.StatusCode.Should().BeOneOf(HttpStatusCode.Created, HttpStatusCode.ServiceUnavailable);
     }
 
@@ -592,7 +592,7 @@ public sealed class OgcProcessesEndpointsTests : IClassFixture<WebAppFixture>
             using var request = new HttpRequestMessage(HttpMethod.Post,
                 "/ogc/processes/processes/honua-geoprocessing/execution");
             request.Headers.Add("Prefer", "respond-async");
-            // queryFeatures is a non-geoprocess step kind — catalog validation skips it
+            // queryFeatures is a non-geoprocess step kind â€” catalog validation skips it
             // and the destructive classifier sees no Geoprocess step, so the submission
             // should not trigger the IsDestructive branch of the evaluator.
             request.Content = new StringContent(
@@ -601,7 +601,7 @@ public sealed class OgcProcessesEndpointsTests : IClassFixture<WebAppFixture>
 
             var response = await client.SendAsync(request);
 
-            // Either 201 (job created) or 503 (no Redis) — never 403 (approval required),
+            // Either 201 (job created) or 503 (no Redis) â€” never 403 (approval required),
             // since the plan is non-destructive and the evaluator only gates destructive plans.
             response.StatusCode.Should().BeOneOf(HttpStatusCode.Created, HttpStatusCode.ServiceUnavailable);
         }
@@ -706,7 +706,7 @@ public sealed class OgcProcessesEndpointsTests : IClassFixture<WebAppFixture>
 
         if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
         {
-            // No Redis — 503 with problem document
+            // No Redis â€” 503 with problem document
             var err = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
             err.RootElement.GetProperty("status").GetInt32().Should().Be(503);
             return;
@@ -769,5 +769,36 @@ public sealed class OgcProcessesEndpointsTests : IClassFixture<WebAppFixture>
     {
         var response = await _fixture.Client.DeleteAsync("/ogc/processes/jobs/nonexistent-job-id");
         response.StatusCode.Should().BeOneOf(HttpStatusCode.NotFound, HttpStatusCode.ServiceUnavailable);
+    }
+
+    // -----------------------------------------------------------------------
+    // Job list — BH7-009 resource-cap regression
+    // -----------------------------------------------------------------------
+
+    // BH7-009 regression: before the fix, ListActiveAsync was called with no limit,
+    // so all active jobs were loaded into memory before applying the effectiveLimit
+    // break. The fix passes effectiveLimit to ListActiveAsync so the store applies
+    // a server-side cap. This test verifies that a positive limit= parameter is
+    // accepted and the response shape is valid (or 503 without Redis).
+    [IntegrationTest]
+    [Operation(Operations.JobStatus)]
+    [Endpoint("GET /ogc/processes/jobs")]
+    public async Task JobList_WithPositiveLimit_AcceptsLimitParameterAndReturnsValidResponse()
+    {
+        var response = await _fixture.Client.GetAsync("/ogc/processes/jobs?limit=5");
+
+        if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+        {
+            // No Redis in this test environment; 503 is expected.
+            var err = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            err.RootElement.GetProperty("status").GetInt32().Should().Be(503);
+            return;
+        }
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        json.RootElement.TryGetProperty("jobs", out var jobs).Should().BeTrue();
+        // With limit=5 and no active jobs in the test store, the array is empty.
+        jobs.GetArrayLength().Should().BeLessOrEqualTo(5, "the effective limit must be honoured");
     }
 }

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Processes/OgcProcessesJobKindFilterTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Processes/OgcProcessesJobKindFilterTests.cs
@@ -136,7 +136,7 @@ public sealed class OgcProcessesJobKindFilterTestsFixture : IAsyncLifetime
             .Returns(GeoJob);
         mockJobStore.GetAsync(Arg.Is<string>(id => id != EtlJobId && id != GeoJobId), Arg.Any<CancellationToken>())
             .Returns((ExecutionJobRecord?)null);
-        mockJobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        mockJobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExecutionJobRecord> { GeoJob });
 
         App = new WebAppFixture()

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerQueryValidationEdgeCaseTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerQueryValidationEdgeCaseTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using FluentAssertions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
 using Honua.TestKit.Helpers;
+using System.Text.Json;
 
 namespace Honua.Server.Tests;
 
@@ -134,5 +136,36 @@ public sealed class FeatureServerQueryValidationEdgeCaseTests : IAsyncLifetime
             "&f=json");
 
         response.Be200Ok();
+    }
+
+    // BH7-003 regression: outStatistics with groupByFieldsForStatistics must apply
+    // the configured MaxRecordCount cap (not null) so a high-cardinality groupBy
+    // cannot exhaust server memory. With few test rows the cap is never hit; the
+    // test guards the code path and verifies no regression in the normal case.
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task Query_OutStatisticsGroupByWithCap_ReturnsGroupedResultsWithinLimit()
+    {
+        var outStatistics = Uri.EscapeDataString(
+            "[{\"statisticType\":\"count\",\"onStatisticField\":\"objectid\",\"outStatisticFieldName\":\"feature_count\"}]");
+
+        // Each of the two seeded features has a distinct name, so the groupBy produces
+        // one statistics row per name — well within the MaxRecordCount cap.
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query" +
+            "?where=1%3D1" +
+            "&groupByFieldsForStatistics=name" +
+            $"&outStatistics={outStatistics}" +
+            "&f=json");
+
+        // Must succeed — the cap must not break valid queries below the threshold.
+        response.Be200Ok();
+
+        var body = await response.Content.ReadAsStringAsync();
+        var doc = System.Text.Json.JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("features", out var features).Should().BeTrue();
+        // Two distinct names -> two groups; both within the default MaxRecordCount cap.
+        features.GetArrayLength().Should().Be(2);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/Jobs/ConsoleJobEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/Jobs/ConsoleJobEndpointsTests.cs
@@ -611,7 +611,7 @@ public sealed class ConsoleJobEndpointsTests : IAsyncLifetime
             });
         }
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values.ToArray());
 
         private static bool MatchesParameter(ExecutionJobRecord job, string key, string? expected)

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OperationsProgressEndpointsTests.cs
@@ -660,7 +660,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
             jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
                 .Returns(jobRecord);
-            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
                 .Returns(Array.Empty<ExecutionJobRecord>());
 
             var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-never-submitted");
@@ -749,7 +749,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
             jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
                 .Returns(jobRecord);
-            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
                 .Returns(Array.Empty<ExecutionJobRecord>());
 
             var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-retry-backoff");
@@ -836,7 +836,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
             jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
                 .Returns(jobRecord, runningRecord);
-            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
                 .Returns(Array.Empty<ExecutionJobRecord>());
             jobStore.TrySetAsync(Arg.Any<ExecutionJobRecord>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
                 .Returns(false);
@@ -907,7 +907,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
             jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
                 .Returns(jobRecord);
-            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
                 .Returns(Array.Empty<ExecutionJobRecord>());
 
             var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-nonterminal");
@@ -989,7 +989,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
             jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
                 .Returns(jobRecord);
-            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
                 .Returns(Array.Empty<ExecutionJobRecord>());
 
             var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-terminal-race");
@@ -1058,7 +1058,7 @@ public sealed class OperationsProgressEndpointsTests : IAsyncLifetime
 
             jobStore.GetAsync(operationId, Arg.Any<CancellationToken>())
                 .Returns(jobRecord);
-            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
                 .Returns(Array.Empty<ExecutionJobRecord>());
 
             var progress = GeoprocessingProgress.CreateForSubmittedJob(operationId, "admin-cancel-failed-race");

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/Share/ShareAdminEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/Share/ShareAdminEndpointsTests.cs
@@ -376,7 +376,7 @@ public sealed class ShareAdminEndpointsTests : IAsyncLifetime
         retryResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
         (await _jobStore.GetAsync(jobRunId))!.Status.Should().Be(ExecutionJobStatus.Cancelled);
 
-        // And the Share run must remain Cancelled — the rejected retry must not have reopened it.
+        // And the Share run must remain Cancelled â€” the rejected retry must not have reopened it.
         var detail = await _client.GetAsync($"/api/v1/admin/share/exports/{exportId}/runs/{runId}");
         detail.StatusCode.Should().Be(HttpStatusCode.OK);
         using (var doc = await ReadJsonAsync(detail))
@@ -725,7 +725,7 @@ public sealed class ShareAdminEndpointsTests : IAsyncLifetime
                 NextCursor = null
             });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(
                 _jobs.Values.Where(job => !kind.HasValue || job.Spec.Kind == kind.Value).ToArray());
     }
@@ -992,7 +992,7 @@ public sealed class ShareExportDispatchFailureTests : IAsyncLifetime
         public Task<ExecutionJobPage> QueryAsync(ExecutionJobQuery query, CancellationToken cancellationToken = default)
             => Task.FromResult(new ExecutionJobPage { Items = _jobs.Values.ToArray(), NextCursor = null });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values.ToArray());
     }
 }
@@ -1190,7 +1190,7 @@ public sealed class ShareExportRunPersistFailureTests : IAsyncLifetime
         public Task<ExecutionJobPage> QueryAsync(ExecutionJobQuery query, CancellationToken cancellationToken = default)
             => Task.FromResult(new ExecutionJobPage { Items = _jobs.Values.ToArray(), NextCursor = null });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values.ToArray());
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/TileCacheJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/TileCacheJobServiceTests.cs
@@ -276,7 +276,7 @@ public sealed class TileCacheJobServiceTests
         public Task<ExecutionJobPage> QueryAsync(ExecutionJobQuery query, CancellationToken cancellationToken = default)
             => Task.FromResult(new ExecutionJobPage { Items = _records.Values.ToArray() });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_records.Values.ToArray());
 
         public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ExecutionAdmissionEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geoprocessing/ExecutionAdmissionEvaluatorTests.cs
@@ -29,7 +29,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     public ExecutionAdmissionEvaluatorTests()
     {
         _jobStore
-            .ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            .ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<ExecutionJobRecord>());
     }
 
@@ -58,7 +58,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     }
 
     // -----------------------------------------------------------------------
-    // Backpressure — system-wide global limit
+    // Backpressure â€” system-wide global limit
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -82,7 +82,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     }
 
     // -----------------------------------------------------------------------
-    // Concurrency — per-partition + kind limit
+    // Concurrency â€” per-partition + kind limit
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -125,7 +125,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     }
 
     // -----------------------------------------------------------------------
-    // Rate — per-principal sliding window
+    // Rate â€” per-principal sliding window
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -158,10 +158,10 @@ public sealed class ExecutionAdmissionEvaluatorTests
 
         (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
 
-        // Within the window — throttled.
+        // Within the window â€” throttled.
         (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Throttled);
 
-        // After the window — admitted again.
+        // After the window â€” admitted again.
         _time.Advance(TimeSpan.FromSeconds(31));
         (await sut.EvaluateAsync(CreateRequest())).Outcome.Should().Be(ExecutionAdmissionOutcome.Admitted);
     }
@@ -188,7 +188,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     }
 
     // -----------------------------------------------------------------------
-    // Cost — aggregate cost weight per partition
+    // Cost â€” aggregate cost weight per partition
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -225,7 +225,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     }
 
     // -----------------------------------------------------------------------
-    // Short-circuit evaluation order: Backpressure → Concurrency → Rate → Cost
+    // Short-circuit evaluation order: Backpressure â†’ Concurrency â†’ Rate â†’ Cost
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -280,7 +280,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     }
 
     // -----------------------------------------------------------------------
-    // Job store missing — do not crash, skip concurrency/cost gates
+    // Job store missing â€” do not crash, skip concurrency/cost gates
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -334,7 +334,7 @@ public sealed class ExecutionAdmissionEvaluatorTests
     private void SeedActiveJobs(params ExecutionJobRecord[] jobs)
     {
         _jobStore
-            .ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+            .ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(jobs);
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneTriggerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneTriggerTests.cs
@@ -255,7 +255,7 @@ public sealed class ControlPlaneTriggerTests
         public Task<ExecutionJobPage> QueryAsync(ExecutionJobQuery query, CancellationToken cancellationToken = default)
             => Task.FromResult(new ExecutionJobPage { Items = _jobs.Values.ToArray() });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values.ToArray());
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ExecutionJobCancellationHelperTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ExecutionJobCancellationHelperTests.cs
@@ -56,7 +56,7 @@ public sealed class ExecutionJobCancellationHelperTests
         result.Job.Should().BeSameAs(job,
             "identical nonterminal observations must preserve the original record reference");
         jobStore.TrySetInvocations.Should().Be(0,
-            "no-op observations must not touch the durable store — otherwise UpdatedAt gets refreshed");
+            "no-op observations must not touch the durable store â€” otherwise UpdatedAt gets refreshed");
 
         var stored = await jobStore.GetAsync("job-noop");
         stored!.UpdatedAt.Should().Be(updatedAt,
@@ -222,7 +222,7 @@ public sealed class ExecutionJobCancellationHelperTests
     public async Task TryStampRemoteCancelRequestedAtAsync_AlreadyStamped_ReturnsAlreadyStampedWithoutWrite()
     {
         // Idempotent: a repeat remote cancel on a record that already has
-        // CancellationRequestedAt set must not refresh UpdatedAt — the reconciler's
+        // CancellationRequestedAt set must not refresh UpdatedAt â€” the reconciler's
         // missing-registration grace window relies on an unchanged UpdatedAt for
         // repeated idempotent cancel observations.
         var updatedAt = DateTimeOffset.UtcNow.AddMinutes(-2);
@@ -303,7 +303,7 @@ public sealed class ExecutionJobCancellationHelperTests
     {
         // The exact race the stamp protects against: a concurrent caller stamps
         // CancellationRequestedAt first. The losing CAS must re-read, see the stamp,
-        // and fall through as AlreadyStamped — not retry-and-overwrite. This is what
+        // and fall through as AlreadyStamped â€” not retry-and-overwrite. This is what
         // makes the downstream backend.CancelAsync see CancellationRequestedAt set
         // and map NotFound -> Cancelled instead of Failed.
         var stale = CreateJobRecord("job-race-stamped", ExecutionJobStatus.Running);
@@ -320,7 +320,7 @@ public sealed class ExecutionJobCancellationHelperTests
         result.Outcome.Should().Be(RemoteCancelStampOutcome.AlreadyStamped);
         result.Job!.CancellationRequestedAt.Should().Be(concurrentlyStamped.CancellationRequestedAt);
         result.Job.Status.Should().Be(ExecutionJobStatus.Running,
-            "the losing caller must not terminalize the record — only surface the durable intent");
+            "the losing caller must not terminalize the record â€” only surface the durable intent");
     }
 
     [Fact]
@@ -346,7 +346,7 @@ public sealed class ExecutionJobCancellationHelperTests
         var merged = ExecutionJobCancellationHelper.MergeBackendCancelObservation(job, observation, now);
 
         merged.Should().BeSameAs(job,
-            "the merge must return the same reference when all observable fields match — callers rely on ReferenceEquals to detect no-ops");
+            "the merge must return the same reference when all observable fields match â€” callers rely on ReferenceEquals to detect no-ops");
     }
 
     private static (MeterListener Listener, List<(string? Status, string? PreviousStatus)> Events) ListenForTransitions(string expectedBackend)
@@ -472,7 +472,7 @@ public sealed class ExecutionJobCancellationHelperTests
                     .ToArray()
             });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values.ToArray());
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ExecutionJobReconcilerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ExecutionJobReconcilerTests.cs
@@ -1472,9 +1472,9 @@ public sealed class ExecutionJobReconcilerTests
             {
                 setCallCount++;
                 var record = (ExecutionJobRecord)call[0];
-                // 1st call: Provisioning transition → succeed.
-                // 2nd call: Post-start update → simulated CAS conflict (winner raced in).
-                // 3rd call: Merge-provenance CAS over the fetched winner → succeed.
+                // 1st call: Provisioning transition â†’ succeed.
+                // 2nd call: Post-start update â†’ simulated CAS conflict (winner raced in).
+                // 3rd call: Merge-provenance CAS over the fetched winner â†’ succeed.
                 if (setCallCount == 2)
                 {
                     return false;
@@ -1541,7 +1541,7 @@ public sealed class ExecutionJobReconcilerTests
         // The reconciler dispatches the retry; the Kubernetes adapter creates a fresh
         // "...-a2" Job. Before the post-start CAS fires, a concurrent cancellation-
         // request writer stamps the record, winning the CAS. The merge helper must
-        // still advance AttemptCount (1→2) and clear NextRetryAt on the winner,
+        // still advance AttemptCount (1â†’2) and clear NextRetryAt on the winner,
         // otherwise the Kubernetes adapter's ResolveCoordinates would resolve the Job
         // name against the stale AttemptCount=1 and target the prior attempt's Job
         // (which no longer exists) instead of the "...-a2" Job it just created.
@@ -2045,7 +2045,7 @@ public sealed class ExecutionJobReconcilerTests
                     .ToArray()
             });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
         {
             var jobs = _jobs.Values
                 .Where(job => !kind.HasValue || job.Spec.Kind == kind.Value)
@@ -2083,7 +2083,7 @@ public sealed class ExecutionJobReconcilerTests
                     .Take(query.Limit)
                     .ToArray()
             });
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values.ToArray());
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Observability/LocalOperateEventFeedTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Observability/LocalOperateEventFeedTests.cs
@@ -854,7 +854,7 @@ public sealed class LocalOperateEventFeedTests
             return Task.FromResult(new ExecutionJobPage { Items = page, NextCursor = nextCursor });
         }
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_records.Values.ToArray());
 
         private static bool MatchesParameter(ExecutionJobRecord job, string key, string? expected)

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Coverages/Multidimensional/MultidimensionalCoverageEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Coverages/Multidimensional/MultidimensionalCoverageEndpointTests.cs
@@ -403,7 +403,7 @@ public class MultidimensionalCoverageEndpointTests : IAsyncLifetime
                 NextCursor = null
             });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(
                 _jobs.Values.Where(job => !kind.HasValue || job.Spec.Kind == kind.Value).ToArray());
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Provisioner/ProvisionerBuildJobServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Provisioner/ProvisionerBuildJobServiceTests.cs
@@ -22,7 +22,7 @@ namespace Honua.Server.Tests.Features.Provisioner;
 /// cancellation. Exercises the canonical submission flow against the in-process
 /// <see cref="LocalBatchComputeBackend"/> (durable record + queue enqueue) and a remote
 /// stub backend (provider submission with the AWS Batch coordinates wired), plus
-/// cancellation and rollback — all with the Batch backend mocked, no live AWS.
+/// cancellation and rollback â€” all with the Batch backend mocked, no live AWS.
 /// </summary>
 public sealed class ProvisionerBuildJobServiceTests
 {
@@ -268,7 +268,7 @@ public sealed class ProvisionerBuildJobServiceTests
         public Task<ExecutionJobPage> QueryAsync(ExecutionJobQuery query, CancellationToken cancellationToken = default)
             => Task.FromResult(new ExecutionJobPage { Items = _records.Values.ToArray() });
 
-        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_records.Values.ToArray());
 
         public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2Tests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2Tests.cs
@@ -363,17 +363,18 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Security)]
-    [Endpoint("GET /sharing/rest/oauth2/token")]
-    public async Task Token_AuthorizationCodeGrantViaQueryString_ReturnsAccessToken()
+    [Endpoint("POST /sharing/rest/oauth2/token")]
+    public async Task Token_AuthorizationCodeGrantViaGetQueryString_Returns405MethodNotAllowed()
     {
+        // BH7-001: The token endpoint must be POST-only per RFC 6749 §4.1.3.
+        // A GET registration exposed auth codes, client_secret, and refresh
+        // tokens in URL query strings — logged by proxies/CDN/access logs (CWE-598).
+        // Verify that GET requests are rejected with 405 Method Not Allowed.
         var verifier = "query-string-grant-verifier-value-abcdefghijklmnop";
         var challenge = WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
         var code = await SeedAuthorizationCodeAsync(challenge, "S256");
 
         using var client = _fixture.CreateClient();
-        // Use the literal route path (not the TokenEndpoint const) so the
-        // endpoint-registry governance scanner recognises this as a same-method
-        // (GET) HTTP request that backs GET /sharing/rest/oauth2/token.
         var url = QueryHelpers.AddQueryString("/sharing/rest/oauth2/token", new Dictionary<string, string?>
         {
             ["grant_type"] = "authorization_code",
@@ -384,9 +385,8 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
         });
         using var response = await client.GetAsync(url);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var payload = await ReadTokenAsync(response);
-        payload.AccessToken.Should().NotBeNullOrWhiteSpace();
+        // GET must be rejected — credentials must never travel in the URL.
+        response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
     }
 
     [IntegrationTest]
@@ -437,7 +437,7 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
     {
         // RFC 7662 introspection (#1890) is off by default; opt in and drive the real
         // admin-guarded endpoint. An unknown/forged token must introspect as
-        // { active: false } per RFC 7662 §2.2 — no other detail is leaked.
+        // { active: false } per RFC 7662 Â§2.2 â€” no other detail is leaked.
         var fixture = new WebAppFixture()
             .ConfigureWebHost(builder =>
             {
@@ -478,7 +478,7 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
     public async Task Introspect_WhenDisabled_Returns404()
     {
         // The introspection surface is absent (404) unless explicitly enabled, so it is
-        // never a silent discovery surface (RFC 7662 §4). The default fixture does not
+        // never a silent discovery surface (RFC 7662 Â§4). The default fixture does not
         // enable it; the admin-authenticated request still 404s.
         using var client = _fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
         using var response = await client.PostAsync(
@@ -605,7 +605,7 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
     [Endpoint("POST /sharing/rest/oauth2/revoke")]
     public async Task Revoke_UnknownToken_Returns200()
     {
-        // RFC 7009 §2.2: a revocation request for an unknown/already-revoked token still
+        // RFC 7009 Â§2.2: a revocation request for an unknown/already-revoked token still
         // returns 200, so the endpoint can never be used to probe token validity.
         using var client = _fixture.CreateClient();
         using var response = await PostRevokeAsync(client, ("token", "00000000000000000000000000000000"));

--- a/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/WorkflowPackages/WorkflowPackageEndpointsTests.cs
@@ -56,7 +56,7 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
                 services.AddSingleton<IExecutionJobStore>(_jobStore);
                 services.AddSingleton<IUniversalProgressStore>(_progressStore);
                 services.AddSingleton<IJobQueue>(_jobQueue);
-                // Capture the publish→metadata-release bridge deterministically without requiring an
+                // Capture the publishâ†’metadata-release bridge deterministically without requiring an
                 // active Metadata v2 snapshot in the test environment (#2176).
                 services.AddSingleton<IMetadataReleaseService>(_releaseService);
             })
@@ -629,7 +629,7 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
         => JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
     /// <summary>
-    /// Records workflow release-package emissions from the publish path so the publish→
+    /// Records workflow release-package emissions from the publish path so the publishâ†’
     /// metadata-release bridge can be asserted without an active Metadata v2 snapshot (#2176).
     /// All other release-service operations are unused by these tests.
     /// </summary>
@@ -780,6 +780,7 @@ public sealed class WorkflowPackageEndpointsTests : IAsyncLifetime
 
         public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(
             ExecutionJobKind? kind = null,
+            int? limit = null,
             CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<ExecutionJobRecord>>(_jobs.Values
                 .Where(job => !kind.HasValue || job.Spec.Kind == kind.Value)

--- a/tests/dotnet/Honua.TestKit/Helpers/InMemoryJobExecution.cs
+++ b/tests/dotnet/Honua.TestKit/Helpers/InMemoryJobExecution.cs
@@ -10,7 +10,7 @@ namespace Honua.TestKit.Helpers;
 /// Functional in-memory <see cref="IExecutionJobStore"/> for integration tests. Production only
 /// registers a durable execution-job store when Redis (<c>IConnectionMultiplexer</c>) is present
 /// (see GeoprocessingServiceCollectionExtensions), and the <see cref="WebAppFixture"/> runs without
-/// Redis — so the durable-operation endpoint tests register this store to exercise the durable
+/// Redis â€” so the durable-operation endpoint tests register this store to exercise the durable
 /// cancel/retry paths (the endpoints resolve <see cref="IExecutionJobStore"/> optionally and take
 /// the durable path when it is present). State is a plain dictionary; not thread-optimised, but the
 /// per-test server is single-caller.
@@ -81,13 +81,20 @@ public sealed class InMemoryExecutionJobStore : IExecutionJobStore
         }
     }
 
-    public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<ExecutionJobRecord>> ListActiveAsync(ExecutionJobKind? kind = null, int? limit = null, CancellationToken cancellationToken = default)
     {
         lock (_gate)
         {
-            IReadOnlyList<ExecutionJobRecord> items = _jobs.Values
-                .Where(job => !kind.HasValue || job.Spec.Kind == kind.Value)
-                .ToArray();
+            var query = _jobs.Values
+                .Where(job => !kind.HasValue || job.Spec.Kind == kind.Value);
+            // BH7-009: apply 2x overfetch budget when a limit is supplied (mirrors
+            // the Redis store behaviour; authorization filters may discard some records).
+            if (limit.HasValue)
+            {
+                query = query.Take(limit.Value * 2);
+            }
+
+            IReadOnlyList<ExecutionJobRecord> items = query.ToArray();
             return Task.FromResult(items);
         }
     }


### PR DESCRIPTION
Final seal round. 62 raw → 33 survivors (0 S0, 9 S1, 24 S2). Composition confirmed the classes are structurally sealed — remaining S1s were niche class-gaps + isolated. S2 → backlog.

## Class-fix gap-closers (final)
- **Idempotency** — TryReserveAsync no longer falls open on a non-Redis IDistributedCache (the DEFAULT no-Redis deployment): concurrent same-key applyEdits now use the atomic in-process reserve → exactly one create (10-concurrent test).
- **Per-op authz** — OData $batch changeset now authorizes EVERY sub-request per (layer, method), not just the first.
- **Multi-layer atomicity** — service-level applyEdits with rollbackOnFailure=true now fail-closed rejects the un-atomic cross-layer case (mirrors the WFS-T fix).
- **Cancellation** — OperationCanceledException propagates in non-transactional edit loops; already-committed ops reported accurately (not blanket-failed).

## Security + resource (isolated)
- **OAuth2 token endpoint POST-only** — removed the GET registration (auth codes/secrets/refresh tokens no longer leakable via URL/logs; CWE-598).
- outStatistics result cap (OOM), OGC CRS84 crash fix, bounded job-list query.

Consolidated build 0/0. (Fixed 2 `ListActiveAsync` callers trunk added after the branch cut.)
EOF
)