### PR TITLE
test(cert): live ECS/ALB weighted-cutover certification cell

### DIFF
--- a/.github/workflows/real-aws-certification.yml
+++ b/.github/workflows/real-aws-certification.yml
@@ -12,8 +12,9 @@ name: Real AWS Certification
 #               `cert` GitHub environment so it matches the honua-iac OIDC role's subject pin
 #               (repo:honua-io/honua-server:environment:cert).
 #   * Budgeted — each certification cell is tiny and short-lived (a register/deregister smoke, two
-#               smallest-tier Batch jobs, one small S3 object, a no-op Lambda alias flip) and every
-#               resource is torn down; the reaper sweeps any crash-orphaned leftover.
+#               smallest-tier Batch jobs, one small S3 object, a no-op Lambda alias flip, one
+#               same-revision ECS/ALB weighted cutover on a standing smallest-Fargate service) and
+#               every resource is torn down; the reaper sweeps any crash-orphaned leftover.
 #   * Teardown — every cell namespaces its resources honua-cert-* and tags them honua-cert-run=<runId>
 #               and tears them down in a finally block; a dedicated always() reaper step then reaps
 #               any honua-cert-run-tagged resource older than the TTL, so no standing resources remain.
@@ -38,11 +39,11 @@ name: Real AWS Certification
 #   cert_artifact_bucket       REALAWS_CERT_ARTIFACT_BUCKET               HONUA_REALAWS_CERT_ARTIFACT_BUCKET
 #   (cert Lambda function)     REALAWS_CERT_LAMBDA_FUNCTION               HONUA_REALAWS_CERT_LAMBDA_FUNCTION
 #   (cert Lambda alias)        REALAWS_CERT_LAMBDA_ALIAS                  HONUA_REALAWS_CERT_LAMBDA_ALIAS
-#   (cert ECS cluster)         REALAWS_CERT_ECS_CLUSTER                   HONUA_REALAWS_CERT_ECS_CLUSTER          (deferred cell)
-#   (cert ECS service)         REALAWS_CERT_ECS_SERVICE                   HONUA_REALAWS_CERT_ECS_SERVICE          (deferred cell)
-#   (cert ALB listener)        REALAWS_CERT_ALB_LISTENER_ARN              HONUA_REALAWS_CERT_ALB_LISTENER_ARN     (deferred cell)
-#   (cert canary target group) REALAWS_CERT_CANARY_TARGET_GROUP_ARN       HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN (deferred cell)
-#   (cert stable target group) REALAWS_CERT_STABLE_TARGET_GROUP_ARN       HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN (deferred cell)
+#   (cert ECS cluster)         REALAWS_CERT_ECS_CLUSTER                   HONUA_REALAWS_CERT_ECS_CLUSTER          (ECS/ALB cell)
+#   (cert ECS service)         REALAWS_CERT_ECS_SERVICE                   HONUA_REALAWS_CERT_ECS_SERVICE          (ECS/ALB cell)
+#   (cert ALB listener)        REALAWS_CERT_ALB_LISTENER_ARN              HONUA_REALAWS_CERT_ALB_LISTENER_ARN     (ECS/ALB cell)
+#   (cert canary target group) REALAWS_CERT_CANARY_TARGET_GROUP_ARN       HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN (ECS/ALB cell)
+#   (cert stable target group) REALAWS_CERT_STABLE_TARGET_GROUP_ARN       HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN (ECS/ALB cell)
 #
 # The Batch execution cell submits against the smallest-tier job definition, which the maintainer
 # must provision (in the cert stack) as a trivially- and quickly-succeeding container (e.g. busybox

--- a/docs/internal/contributor/testkit.md
+++ b/docs/internal/contributor/testkit.md
@@ -642,7 +642,9 @@ teardown-guaranteed:
   absent, so the lane degrades cell-by-cell and forks / credential-less runs never fail.
 - **Budgeted** — each cell is tiny and short-lived: a register/deregister smoke, two smallest-tier
   Batch jobs (one polled to `SUCCEEDED` under a hard <8-minute budget, one cancelled), one small S3
-  object, and a no-op Lambda alias flip.
+  object, a no-op Lambda alias flip, and one same-revision ECS/ALB weighted cutover (shift → observe
+  → promote → rollback) against the standing smallest-Fargate cert service under a hard <5-minute
+  convergence budget, with the listener rule restored to `stable=100/canary=0` in a `finally`.
 - **Isolated + torn down** — `RealAwsCertificationFixture` mints a unique `honua-cert-{runId}`
   prefix and a `honua-cert-run=<runId>` tag; every cell tears its resources down in a `finally`
   block. A dedicated `always()` reaper step (`CertificationResourceReaper`, filtered by
@@ -656,13 +658,20 @@ teardown-guaranteed:
 `AwsBatchComputeBackend` + `AwsSdkBatchJobClient`), `S3ArtifactRealCertificationTests` (artifact
 round-trip through the production S3 client seam against `cert_artifact_bucket`), and
 `AwsLambdaAliasRealCertificationTests` (read→no-op-flip→restore through the production
-`AwsSdkLambdaAliasClient`, certifying the alias-flip primitive that cutover/rollback ride).
+`AwsSdkLambdaAliasClient`, certifying the alias-flip primitive that cutover/rollback ride), and
+`AwsEcsAlbRealCertificationTests` (weighted-cutover cell — drives the real `AwsEcsAlbDeployBackend`
+with its production `AwsSdkAlbClient` + `AwsSdkEcsClient` seams: resolves the listener's default rule,
+`StartAsync` shifts a 25% canary share, `ObserveAsync` polls to `PromotionRecommended`, `PromoteAsync`
+cuts to `canary=100/stable=0`, then `RollbackAsync` restores `stable=100/canary=0` and `ObserveAsync`
+settles `RolledBack`). It deploys the service's **current** task definition as the desired revision
+(same-revision) so ECS converges immediately and the cell certifies traffic-shift + convergence +
+rollback mechanics, not an image roll; it drives `StartAsync` directly (skipping `PlanAsync`, whose
+`telemetry.connection` gate is a workflow-orchestration concern the backend's unit tests cover); and
+it snapshots + restores the standing listener rule and task definition in a `finally` so the
+substrate stays pristine.
 
 **Deferred (`DeferredRealCertificationPlaceholders`, explicit skipped placeholders):** live
-failure-of-failure / double-fault certification (#2161 — covered today by reconciler unit tests),
-and the ECS/ALB weighted-cutover cell (ALB weight mechanics are heavily unit-tested and already have
-a Terraform-gated live path via `AwsEcsAlbDeployBackendLiveTests`; a live cutover in this lane needs
-standing ALB + dual target-group + ECS-service infrastructure).
+failure-of-failure / double-fault certification (#2161 — covered today by reconciler unit tests).
 
 **Stack-output → repo-variable → env-var contract** (set repo Actions *variables* from the
 `honua-iac examples/aws-cert` Terraform outputs; every input is optional/dormant-safe):
@@ -679,7 +688,7 @@ standing ALB + dual target-group + ECS-service infrastructure).
 | `cert_artifact_bucket` | `REALAWS_CERT_ARTIFACT_BUCKET` | `HONUA_REALAWS_CERT_ARTIFACT_BUCKET` |
 | (cert Lambda function) | `REALAWS_CERT_LAMBDA_FUNCTION` | `HONUA_REALAWS_CERT_LAMBDA_FUNCTION` |
 | (cert Lambda alias) | `REALAWS_CERT_LAMBDA_ALIAS` | `HONUA_REALAWS_CERT_LAMBDA_ALIAS` |
-| (cert ECS/ALB set — deferred cell) | `REALAWS_CERT_ECS_CLUSTER`, `REALAWS_CERT_ECS_SERVICE`, `REALAWS_CERT_ALB_LISTENER_ARN`, `REALAWS_CERT_CANARY_TARGET_GROUP_ARN`, `REALAWS_CERT_STABLE_TARGET_GROUP_ARN` | `HONUA_REALAWS_CERT_ECS_CLUSTER`, `HONUA_REALAWS_CERT_ECS_SERVICE`, `HONUA_REALAWS_CERT_ALB_LISTENER_ARN`, `HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN`, `HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN` |
+| (cert ECS/ALB set) | `REALAWS_CERT_ECS_CLUSTER`, `REALAWS_CERT_ECS_SERVICE`, `REALAWS_CERT_ALB_LISTENER_ARN`, `REALAWS_CERT_CANARY_TARGET_GROUP_ARN`, `REALAWS_CERT_STABLE_TARGET_GROUP_ARN` | `HONUA_REALAWS_CERT_ECS_CLUSTER`, `HONUA_REALAWS_CERT_ECS_SERVICE`, `HONUA_REALAWS_CERT_ALB_LISTENER_ARN`, `HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN`, `HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN` |
 
 **Maintainer bootstrap:** (1) apply `honua-iac examples/aws-cert`; (2) set `REALAWS_CERT_ROLE_ARN`
 to its `github_oidc_role_arn` output and the per-cell variables above from the matching outputs;

--- a/tests/dotnet/Honua.CloudIntegration.Tests/AwsEcsAlbRealCertificationTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/AwsEcsAlbRealCertificationTests.cs
@@ -1,0 +1,351 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using Amazon;
+using Amazon.ElasticLoadBalancingV2;
+using Amazon.ElasticLoadBalancingV2.Model;
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Honua.CloudIntegration.Tests;
+
+/// <summary>
+/// Real-AWS certification lane (#2164) — the ECS/ALB weighted-cutover cell. Drives the REAL
+/// <see cref="AwsEcsAlbDeployBackend"/> wired with its PRODUCTION seams (<see cref="AwsSdkAlbClient"/>
+/// and <see cref="AwsSdkEcsClient"/> — the exact clients production injects) against the standing
+/// certification substrate (honua-iac <c>examples/aws-cert</c>): a smallest-Fargate ECS service
+/// attached to both target groups behind an internal ALB whose listener default rule is a weighted
+/// forward action (stable=100/canary=0). It certifies the weighted-cutover control-plane MECHANICS
+/// the deploy controller rides — shift → observe convergence → promote → rollback → settle — end to
+/// end through live ELBv2 <c>ModifyRule</c>/<c>DescribeRules</c> and ECS <c>UpdateService</c>/
+/// <c>DescribeServices</c> calls.
+///
+/// SAME-REVISION BY DESIGN (documented rationale): the cell resolves the service's CURRENT task
+/// definition ARN and submits THAT as the desired revision. A genuine two-revision upgrade would need
+/// a freshly-built/pushed container image and a second task-definition registration on every weekly
+/// run, which mutates production-relevant artifacts and adds standing build infrastructure for no
+/// extra coverage of the traffic-shifting seam. Deploying the same revision means ECS is already at
+/// steady state on the desired task definition, so <c>UpdateService</c> converges immediately and the
+/// observe/promote/rollback assertions exercise the ALB weight primitive and the convergence-decision
+/// logic without waiting on an image roll. The cell therefore certifies weighted-cutover +
+/// convergence + rollback mechanics, NOT a functional application upgrade.
+///
+/// PLANASYNC IS BYPASSED (documented decision): <see cref="AwsEcsAlbDeployBackend.PlanAsync"/> blocks
+/// any canary-weighted submit on a <c>telemetry.connection</c> parameter so the production workflow
+/// can auto-promote/roll-back from telemetry — a workflow-orchestration concern with no bearing on the
+/// SDK cutover mechanics this cell certifies, and one the backend's unit tests already cover
+/// (<c>AwsEcsAlbDeployBackendTests.PlanAsync_*</c>). Like the other certification cells, which drive
+/// their backends directly, this cell calls <c>StartAsync</c> without a telemetry connection and
+/// performs the promotion decision itself.
+///
+/// TEARDOWN INVARIANT: the listener rule is a STANDING resource (not created here), so there is
+/// nothing to tag or reap — correctness is a guaranteed restore. The original default-rule weights and
+/// the original service task definition are snapshotted at test start and restored UNCONDITIONALLY in
+/// a <c>finally</c> block, even when an assertion above throws, so every weekly run leaves the
+/// substrate pristine (stable=100/canary=0) for the next one.
+///
+/// SAFETY: OFF unless <see cref="RealAwsCertificationFixture.EcsAlbConfigured"/>; the single fact
+/// <c>[SkippableFact]</c>-skips otherwise (forks, PRs without secrets, ordinary local runs).
+/// </summary>
+[Trait(CloudIntegrationTraits.Category, CloudIntegrationTraits.RealAwsCertification)]
+public sealed class AwsEcsAlbRealCertificationTests : IClassFixture<RealAwsCertificationFixture>
+{
+    // Hard wall-clock budget for the shift→PromotionRecommended poll. A same-revision deploy converges
+    // fast; this ceiling keeps a misconfigured substrate from burning the workflow's 30-minute timeout.
+    private static readonly TimeSpan ConvergenceBudget = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan RollbackSettleBudget = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(10);
+
+    // Partial canary share the cutover shifts to before promotion. Between 1 and 99 (the backend's
+    // valid canary-weight range) so the observe path lands on PromotionRecommended, not Succeeded.
+    private const int CanaryShare = 25;
+
+    private readonly RealAwsCertificationFixture _cert;
+
+    public AwsEcsAlbRealCertificationTests(RealAwsCertificationFixture cert)
+    {
+        _cert = cert;
+    }
+
+    [SkippableFact]
+    public async Task WeightedCutover_ShiftObservePromoteRollback_ThroughProductionBackend()
+    {
+        Skip.IfNot(
+            _cert.EcsAlbConfigured,
+            "Real-AWS ECS/ALB cell not configured (needs HONUA_REALAWS_CERT_ENABLED=true, "
+            + "HONUA_REALAWS_CERT_ECS_CLUSTER, HONUA_REALAWS_CERT_ECS_SERVICE, "
+            + "HONUA_REALAWS_CERT_ALB_LISTENER_ARN, HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN, "
+            + "HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN with credentials present).");
+
+        var region = _cert.Region;
+        var cluster = _cert.EcsCluster!;
+        var service = _cert.EcsService!;
+        var canaryTargetGroup = _cert.CanaryTargetGroupArn!;
+        var stableTargetGroup = _cert.StableTargetGroupArn!;
+
+        // The production seams, wired exactly as production wires the backend.
+        using var albClient = new AwsSdkAlbClient();
+        using var ecsClient = new AwsSdkEcsClient();
+
+        // Resolve the listener's DEFAULT rule (the weighted forward action the backend mutates). The
+        // substrate hands us a LISTENER ARN; the backend operates on a RULE ARN, so derive it live.
+        var listenerRuleArn = await ResolveDefaultRuleArnAsync(_cert.AlbListenerArn!, region);
+
+        // Same-revision deploy: the desired revision IS the service's current task definition, so ECS
+        // is already converged and the cell certifies the traffic-shift mechanics, not an image roll.
+        var currentService = await ecsClient.DescribeServiceAsync(cluster, service, region);
+        var currentTaskDefinition = currentService.TaskDefinitionArn;
+        currentTaskDefinition.Should().NotBeNullOrWhiteSpace(
+            "the certification ECS service must resolve to a concrete task definition to deploy");
+
+        // Snapshot the pre-test state so the finally can restore the substrate exactly, even on failure.
+        var originalRuleState = await albClient.GetListenerRuleWeightsAsync(listenerRuleArn, region);
+
+        var backend = new AwsEcsAlbDeployBackend(albClient, ecsClient, NullLogger<AwsEcsAlbDeployBackend>.Instance);
+        var operation = BuildOperation(
+            cluster,
+            service,
+            listenerRuleArn,
+            canaryTargetGroup,
+            stableTargetGroup,
+            region,
+            currentTaskDefinition!);
+
+        try
+        {
+            // 1) Shift a partial canary share and roll the (same) task definition.
+            var submission = await backend.StartAsync(operation);
+            submission.Status.Should().Be(
+                WorkflowOperationStatus.Submitted,
+                "the production ECS/ALB backend must accept the weighted cutover");
+
+            var afterShift = ReadShares(await albClient.GetListenerRuleWeightsAsync(listenerRuleArn, region));
+            afterShift.Canary.Should().Be(
+                CanaryShare, "StartAsync must actually shift the live ALB canary weight");
+            afterShift.Stable.Should().Be(
+                100 - CanaryShare, "StartAsync must actually shift the live ALB stable weight");
+
+            // 2) Observe until the rollout is holding the partial share and is promotable. On a
+            //    same-revision deploy ECS is already at steady state, so this settles quickly.
+            var recommended = await PollForPromotionAsync(backend, operation);
+            recommended.Should().BeTrue(
+                "a converged partial canary must reach PromotionRecommended within the budget");
+
+            // 3) Promote → canary target group takes 100% of traffic.
+            var promotion = await backend.PromoteAsync(operation);
+            promotion.Status.Should().Be(
+                WorkflowOperationStatus.Succeeded, "promotion must complete the cutover");
+            promotion.ObservedRevision.Should().Be(
+                currentTaskDefinition, "promotion must report the promoted task definition");
+
+            var afterPromote = ReadShares(await albClient.GetListenerRuleWeightsAsync(listenerRuleArn, region));
+            afterPromote.Canary.Should().Be(100, "promotion must move the canary weight to 100");
+            afterPromote.Stable.Should().Be(0, "promotion must move the stable weight to 0");
+
+            // 4) Rollback → stable target group restored to 100%, then Observe settles RolledBack.
+            var rollback = await backend.RollbackAsync(operation);
+            rollback.Status.Should().Be(
+                WorkflowOperationStatus.RollbackRequested,
+                "rollback shifts traffic back to stable and then settles on subsequent observes");
+
+            var afterRollback = ReadShares(await albClient.GetListenerRuleWeightsAsync(listenerRuleArn, region));
+            afterRollback.Canary.Should().Be(0, "rollback must move the canary weight to 0");
+            afterRollback.Stable.Should().Be(100, "rollback must restore the stable weight to 100");
+
+            // Drive the backend's terminal rollback settlement (Observe requires RollbackRequested).
+            var rollingBack = operation with { Status = WorkflowOperationStatus.RollbackRequested };
+            var settled = await PollForRolledBackAsync(backend, rollingBack);
+            settled.Should().Be(
+                WorkflowOperationStatus.RolledBack,
+                "the ECS/ALB rollout must settle to RolledBack once stable serves 100% and the canary is idle");
+        }
+        finally
+        {
+            // Guaranteed restore of the STANDING substrate: original default-rule weights + original
+            // task definition, so the next weekly run starts from stable=100/canary=0 regardless of any
+            // assertion failure above. Best-effort — a transient restore blip must not mask a primary
+            // assertion, and the task-definition restore is a no-op on the same-revision happy path.
+            await BestEffortRestoreAsync(
+                albClient,
+                ecsClient,
+                listenerRuleArn,
+                originalRuleState.TargetGroupWeights,
+                cluster,
+                service,
+                currentTaskDefinition!,
+                region);
+        }
+    }
+
+    private static async Task<bool> PollForPromotionAsync(
+        AwsEcsAlbDeployBackend backend,
+        WorkflowOperationRecord operation)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < ConvergenceBudget)
+        {
+            var observation = await backend.ObserveAsync(operation);
+
+            // Reconciling + PromotionRecommended is the converged-partial endpoint. A fully-converged
+            // 100% share (Succeeded) is accepted defensively but should not occur at a partial weight.
+            if (observation.PromotionRecommended || observation.Status == WorkflowOperationStatus.Succeeded)
+            {
+                return true;
+            }
+
+            observation.Status.Should().Be(
+                WorkflowOperationStatus.Reconciling,
+                "a partial canary that is not yet promotable must remain Reconciling, not fail");
+
+            await Task.Delay(PollInterval);
+        }
+
+        return false;
+    }
+
+    private static async Task<WorkflowOperationStatus> PollForRolledBackAsync(
+        AwsEcsAlbDeployBackend backend,
+        WorkflowOperationRecord rollingBack)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var latest = WorkflowOperationStatus.RollbackRequested;
+        while (stopwatch.Elapsed < RollbackSettleBudget)
+        {
+            var observation = await backend.ObserveAsync(rollingBack);
+            latest = observation.Status;
+            if (latest == WorkflowOperationStatus.RolledBack)
+            {
+                return latest;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        return latest;
+    }
+
+    private static async Task BestEffortRestoreAsync(
+        AwsSdkAlbClient albClient,
+        AwsSdkEcsClient ecsClient,
+        string listenerRuleArn,
+        IReadOnlyList<AwsAlbTargetGroupWeight> originalWeights,
+        string cluster,
+        string service,
+        string originalTaskDefinition,
+        string region)
+    {
+        try
+        {
+            await albClient.UpdateListenerRuleWeightsAsync(listenerRuleArn, originalWeights, region);
+        }
+        catch
+        {
+            // Best-effort: the substrate default is stable=100/canary=0 and a failed rollout already
+            // shifts traffic back to stable, so a transient restore failure does not strand traffic.
+        }
+
+        try
+        {
+            await ecsClient.UpdateServiceTaskDefinitionAsync(cluster, service, originalTaskDefinition, region);
+        }
+        catch
+        {
+            // Best-effort: same-revision deploys never change the service task definition, so this is a
+            // defensive no-op that must not mask the primary assertion outcome.
+        }
+    }
+
+    private static async Task<string> ResolveDefaultRuleArnAsync(string listenerArn, string region)
+    {
+        using var elb = string.IsNullOrWhiteSpace(region)
+            ? new AmazonElasticLoadBalancingV2Client()
+            : new AmazonElasticLoadBalancingV2Client(RegionEndpoint.GetBySystemName(region));
+
+        var response = await elb.DescribeRulesAsync(new DescribeRulesRequest { ListenerArn = listenerArn });
+        var defaultRule = response.Rules?.FirstOrDefault(rule => rule.IsDefault == true)
+            ?? throw new InvalidOperationException(
+                $"Listener '{listenerArn}' has no default rule to certify weighted cutover against.");
+
+        if (string.IsNullOrWhiteSpace(defaultRule.RuleArn))
+        {
+            throw new InvalidOperationException(
+                $"Listener '{listenerArn}' default rule did not resolve to a rule ARN.");
+        }
+
+        return defaultRule.RuleArn;
+    }
+
+    private (int Canary, int Stable) ReadShares(AwsAlbListenerRuleState state)
+    {
+        var canary = 0;
+        var stable = 0;
+        foreach (var weight in state.TargetGroupWeights)
+        {
+            if (string.Equals(weight.TargetGroupArn, _cert.CanaryTargetGroupArn, StringComparison.OrdinalIgnoreCase))
+            {
+                canary = weight.Weight;
+            }
+            else if (string.Equals(weight.TargetGroupArn, _cert.StableTargetGroupArn, StringComparison.OrdinalIgnoreCase))
+            {
+                stable = weight.Weight;
+            }
+        }
+
+        return (canary, stable);
+    }
+
+    private static WorkflowOperationRecord BuildOperation(
+        string cluster,
+        string service,
+        string listenerRuleArn,
+        string canaryTargetGroup,
+        string stableTargetGroup,
+        string region,
+        string desiredTaskDefinition)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["aws.region"] = region,
+            ["aws.ecs.cluster"] = cluster,
+            ["aws.ecs.canary_service"] = service,
+            ["aws.alb.listener_rule_arn"] = listenerRuleArn,
+            ["aws.alb.canary_target_group_arn"] = canaryTargetGroup,
+            ["aws.alb.stable_target_group_arn"] = stableTargetGroup,
+            // Partial canary weight — the backend shifts this share to the canary target group on
+            // StartAsync and treats the converged partial as PromotionRecommended.
+            ["aws.ecs.canary_weight_percentage"] = CanaryShare.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+
+        var now = DateTimeOffset.UtcNow;
+        return new WorkflowOperationRecord
+        {
+            OperationId = $"cert-ecs-alb-{Guid.NewGuid():N}",
+            Kind = WorkflowOperationKind.Deploy,
+            Status = WorkflowOperationStatus.Submitted,
+            CreatedAt = now.AddMinutes(-1),
+            UpdatedAt = now,
+            CurrentPhase = "Certification",
+            Audit = new OperationAuditInfo(),
+            Concurrency = new OperationConcurrencyPolicy
+            {
+                PartitionKey = $"cert-ecs-alb:{service}",
+                RequiresExclusiveLease = true,
+            },
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = "cert-ecs-alb",
+                TargetKind = DeployTargetKind.AwsEcs,
+                Backend = AwsEcsAlbDeployBackend.AdapterBackendName,
+                Environment = "cert",
+                TargetName = service,
+                CurrentRevision = desiredTaskDefinition,
+                DesiredRevision = desiredTaskDefinition,
+                Parameters = parameters,
+            },
+        };
+    }
+}

--- a/tests/dotnet/Honua.CloudIntegration.Tests/DeferredRealCertificationPlaceholders.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/DeferredRealCertificationPlaceholders.cs
@@ -31,25 +31,4 @@ public sealed class DeferredRealCertificationPlaceholders
             + "not implemented; the reconciliation paths are unit/integration-tested. This placeholder "
             + "reserves the cell and documents the deferral.");
     }
-
-    /// <summary>
-    /// DEFERRED: ECS/ALB weighted-cutover certification. The ALB weight mechanics are heavily unit-
-    /// tested (<c>AwsEcsAlbDeployBackendTests</c>) and already have a Terraform-gated live path keyed
-    /// off the separate <c>HONUA_LIVE_ECS_ALB_*</c> variables (<c>AwsEcsAlbDeployBackendLiveTests</c>).
-    /// Folding a live weighted cutover into THIS lane needs standing ALB + dual target-group + running
-    /// ECS service infrastructure and a canary-promotion decision, which is a deliberate
-    /// infrastructure/cost decision deferred out of the initial cert tier. Reserved here so the live
-    /// matrix records the deferral; the fixture already surfaces the ECS/ALB inputs
-    /// (<c>HONUA_REALAWS_CERT_ECS_*</c> / <c>_ALB_*</c> / <c>_TARGET_GROUP_ARN</c>) for when it lands.
-    /// </summary>
-    [SkippableFact]
-    public void EcsAlbWeightedCutover_Certification_IsDeferred()
-    {
-        Skip.If(
-            true,
-            "Deferred: live ECS/ALB weighted-cutover certification needs standing ALB + dual "
-            + "target-group + ECS-service infrastructure. The weight mechanics are unit-tested and a "
-            + "Terraform-gated live path already exists (AwsEcsAlbDeployBackendLiveTests). This "
-            + "placeholder reserves the cell and documents the deferral.");
-    }
 }

--- a/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/Honua.CloudIntegration.Tests.csproj
@@ -61,6 +61,9 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="AWSSDK.Batch" />
+    <!-- The ECS/ALB weighted-cutover cell (#2164) resolves the cert listener's default rule ARN
+         directly (DescribeRules by ListenerArn) before driving the production AwsSdkAlbClient seam. -->
+    <PackageReference Include="AWSSDK.ElasticLoadBalancingV2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.CloudIntegration.Tests/RealAwsCertificationFixture.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/RealAwsCertificationFixture.cs
@@ -34,7 +34,7 @@ namespace Honua.CloudIntegration.Tests;
 ///   <item><term>gp_execution_role_arn</term><description><c>HONUA_REALAWS_CERT_EXECUTION_ROLE_ARN</c></description></item>
 ///   <item><term>cert_artifact_bucket</term><description><c>HONUA_REALAWS_CERT_ARTIFACT_BUCKET</c> (required for the S3 cell)</description></item>
 ///   <item><term>(cert stack Lambda)</term><description><c>HONUA_REALAWS_CERT_LAMBDA_FUNCTION</c> + <c>HONUA_REALAWS_CERT_LAMBDA_ALIAS</c> (required for the Lambda cell)</description></item>
-///   <item><term>(cert stack ECS/ALB)</term><description><c>HONUA_REALAWS_CERT_ECS_CLUSTER</c>, <c>HONUA_REALAWS_CERT_ECS_SERVICE</c>, <c>HONUA_REALAWS_CERT_ALB_LISTENER_ARN</c>, <c>HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN</c>, <c>HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN</c> (ECS/ALB cell — deferred placeholder)</description></item>
+///   <item><term>(cert stack ECS/ALB)</term><description><c>HONUA_REALAWS_CERT_ECS_CLUSTER</c>, <c>HONUA_REALAWS_CERT_ECS_SERVICE</c>, <c>HONUA_REALAWS_CERT_ALB_LISTENER_ARN</c>, <c>HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN</c>, <c>HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN</c> (required for the ECS/ALB weighted-cutover cell)</description></item>
 /// </list>
 /// </summary>
 public sealed class RealAwsCertificationFixture : IAsyncLifetime
@@ -75,19 +75,22 @@ public sealed class RealAwsCertificationFixture : IAsyncLifetime
     /// <summary>Cert-stack Lambda alias name the alias-flip cell reads, flips, and restores.</summary>
     public const string LambdaAliasEnvVar = "HONUA_REALAWS_CERT_LAMBDA_ALIAS";
 
-    /// <summary>Cert-stack ECS cluster (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    /// <summary>Cert-stack ECS cluster the ECS/ALB weighted-cutover cell drives.</summary>
     public const string EcsClusterEnvVar = "HONUA_REALAWS_CERT_ECS_CLUSTER";
 
-    /// <summary>Cert-stack ECS service (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    /// <summary>Cert-stack ECS service the ECS/ALB weighted-cutover cell drives.</summary>
     public const string EcsServiceEnvVar = "HONUA_REALAWS_CERT_ECS_SERVICE";
 
-    /// <summary>Cert-stack ALB listener ARN (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    /// <summary>
+    /// Cert-stack ALB listener ARN. The ECS/ALB weighted-cutover cell resolves this listener's
+    /// DEFAULT rule (the weighted forward action the backend mutates) at test start.
+    /// </summary>
     public const string AlbListenerArnEnvVar = "HONUA_REALAWS_CERT_ALB_LISTENER_ARN";
 
-    /// <summary>Cert-stack canary target group ARN (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    /// <summary>Cert-stack canary target group ARN the ECS/ALB weighted-cutover cell shifts weight to.</summary>
     public const string CanaryTargetGroupArnEnvVar = "HONUA_REALAWS_CERT_CANARY_TARGET_GROUP_ARN";
 
-    /// <summary>Cert-stack stable target group ARN (ECS/ALB weighted-cutover cell — deferred placeholder).</summary>
+    /// <summary>Cert-stack stable target group ARN the ECS/ALB weighted-cutover cell shifts weight to.</summary>
     public const string StableTargetGroupArnEnvVar = "HONUA_REALAWS_CERT_STABLE_TARGET_GROUP_ARN";
 
     /// <summary>
@@ -192,6 +195,20 @@ public sealed class RealAwsCertificationFixture : IAsyncLifetime
     /// <summary>True when the lane is enabled AND both the Lambda function and alias are present.</summary>
     public bool LambdaAliasConfigured
         => Enabled && !string.IsNullOrWhiteSpace(LambdaFunctionName) && !string.IsNullOrWhiteSpace(LambdaAliasName);
+
+    /// <summary>
+    /// True when the lane is enabled AND every ECS/ALB weighted-cutover input is present: the ECS
+    /// cluster + service, the ALB listener whose default rule is mutated, and both the canary and
+    /// stable target group ARNs. The cell resolves the listener's default rule ARN from
+    /// <see cref="AlbListenerArn"/> at test start, so no separate rule-ARN input is required.
+    /// </summary>
+    public bool EcsAlbConfigured
+        => Enabled
+            && !string.IsNullOrWhiteSpace(EcsCluster)
+            && !string.IsNullOrWhiteSpace(EcsService)
+            && !string.IsNullOrWhiteSpace(AlbListenerArn)
+            && !string.IsNullOrWhiteSpace(CanaryTargetGroupArn)
+            && !string.IsNullOrWhiteSpace(StableTargetGroupArn);
 
     /// <summary>
     /// The per-run resource-tag set: <see cref="RunTagKey"/>=<see cref="RunId"/> plus a


### PR DESCRIPTION
Related to #2164 (real-AWS certification tier — ECS/ALB weighted-cutover cell; #2161 failure-of-failure remains the last deferred cell).

## Summary

Replaces the deferred ECS/ALB placeholder with a live certification cell driving the production `AwsEcsAlbDeployBackend` through its real SDK seams against the standing cert substrate (companion substrate PR in honua-iac): resolve the listener's default weighted rule and the service's current task definition, `StartAsync` at canary=25 (weights verified by reading the ALB back), `ObserveAsync` to `PromotionRecommended`, `PromoteAsync` to canary=100/`Succeeded`, then `RollbackAsync` and observe to `RolledBack` with weights restored. A same-revision deploy keeps the cell image-free and fast-converging — it certifies the traffic-shift, convergence-detection, and rollback mechanics, which is what #2164's matrix cell asks of the executor. Snapshotted rule weights + task definition are restored unconditionally in `finally`, so every weekly run leaves the substrate at stable=100/canary=0.

`PlanAsync` is deliberately bypassed: it gates canary submits on a telemetry connection, which is workflow-orchestration policy already covered by its unit tests, not SDK cutover mechanics; the cell drives `StartAsync` directly like the other certification cells (documented in the class summary).

## Changes Made

- `AwsEcsAlbRealCertificationTests` (new live cell, `[SkippableFact]` gated on the five ECS/ALB fixture inputs)
- Fixture: `EcsAlbConfigured` gate; ECS/ALB env-input docs de-deferred (the five inputs already existed and were already passed through the workflow)
- Placeholder removed (ECS/ALB only; #2161 kept); workflow header annotations flipped to active; testkit doc updated
- Explicit `AWSSDK.ElasticLoadBalancingV2` test reference for default-rule resolution

## Breaking Changes

None (tests + workflow annotations + docs only).

## Gate Impact

- [x] Extends the dormant weekly certification lane; zero effect on PR/trunk gates

## Testing

- [x] Release build (warnings-as-errors) green; `--filter Category=RealAwsCertification` skips cleanly locally (8 skipped/0 failed); format clean; workflow YAML parses
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Live proof comes from the certification workflow once the substrate toggle is applied.
