### PR TITLE
fix: update ListActiveAsync mock for new limit parameter (Trunk Sanity red)

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
@@ -109,7 +109,7 @@ public sealed class OpsFindingsServiceTests
     public async Task Evaluate_GpQueueDepthAboveThreshold_ProducesWarningWithNoAction()
     {
         var jobStore = Substitute.For<IExecutionJobStore>();
-        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<CancellationToken>())
+        jobStore.ListActiveAsync(Arg.Any<ExecutionJobKind?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(new List<ExecutionJobRecord>
             {
                 BuildJob("j1", ExecutionJobStatus.Queued, "aws-batch"),


### PR DESCRIPTION
## Issue Link
Related to #2311 follow-up work (trunk health); no dedicated issue — Trunk Sanity compile break.

## Summary
Trunk Sanity has been failing since ~18:18 UTC today: `OpsFindingsServiceTests.cs(112)` fails Release build with CS1503 because `IExecutionJobStore.ListActiveAsync` gained a middle `int? limit` parameter (BH7-009) and the NSubstitute mock still passed `(kind, cancellationToken)`, binding the token to `int?`.

## Changes Made
- Add `Arg.Any<int?>()` for the new `limit` parameter in the `ListActiveAsync` mock setup (line 112). The other `ListActiveAsync` mocks in the file target the unchanged `WorkflowOperationRecord` store and are untouched.

## Breaking Changes
None

## Gate Impact
- [x] No gate-tier impact (test-only compile fix restoring trunk build)

## Testing
- [x] `dotnet build tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors (was CS1503)
- [x] Ran scripts/ci/pre-pr-check.sh equivalent (Release build of affected project with warnings-as-errors; change is a one-line test mock fix)
