### PR TITLE
feat: add pagination + count/no-geometry modes to honua_query_features MCP tool

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
@@ -117,6 +117,27 @@ internal sealed class McpQueryFeaturesArgument
     [JsonPropertyName("limit")]
     public int? Limit { get; set; }
 
+    /// <summary>
+    /// Number of matching features to skip before returning results (pagination).
+    /// Threads into the canonical query pipeline's <c>ResultOffset</c>.
+    /// </summary>
+    [JsonPropertyName("resultOffset")]
+    public int? ResultOffset { get; set; }
+
+    /// <summary>
+    /// When <see langword="false"/>, features are returned without geometry
+    /// (attribute-only rows). Defaults to <see langword="true"/>.
+    /// </summary>
+    [JsonPropertyName("returnGeometry")]
+    public bool? ReturnGeometry { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, only the matching feature count is returned
+    /// and no features. Defaults to <see langword="false"/>.
+    /// </summary>
+    [JsonPropertyName("returnCountOnly")]
+    public bool? ReturnCountOnly { get; set; }
+
     [JsonPropertyName("outSrid")]
     public int? OutSrid { get; set; }
 }
@@ -139,12 +160,34 @@ internal sealed class McpQueryFeaturesOutput
     [JsonPropertyName("limit")]
     public int Limit { get; set; }
 
+    /// <summary>
+    /// Offset applied to this request (the <c>resultOffset</c> argument, defaulting to 0).
+    /// </summary>
+    [JsonPropertyName("resultOffset")]
+    public int ResultOffset { get; set; }
+
     [JsonPropertyName("exceededTransferLimit")]
     public bool ExceededTransferLimit { get; set; }
 
-    /// <summary>RFC 7946 GeoJSON <c>FeatureCollection</c> for the returned features.</summary>
+    /// <summary>
+    /// When <see cref="ExceededTransferLimit"/> is <see langword="true"/>, the
+    /// <c>resultOffset</c> the caller should send on the next request to fetch the
+    /// following page (<c>resultOffset + returnedCount</c>). Omitted (null) when the
+    /// last page has been returned.
+    /// </summary>
+    [JsonPropertyName("nextOffset")]
+    public int? NextOffset { get; set; }
+
+    /// <summary>
+    /// Matching feature count. Populated only when <c>returnCountOnly=true</c>
+    /// (features are omitted in that mode); otherwise null.
+    /// </summary>
+    [JsonPropertyName("count")]
+    public long? Count { get; set; }
+
+    /// <summary>RFC 7946 GeoJSON <c>FeatureCollection</c> for the returned features. Omitted when <c>returnCountOnly=true</c>.</summary>
     [JsonPropertyName("geojson")]
-    public McpGeoJsonFeatureCollection GeoJson { get; set; } = new();
+    public McpGeoJsonFeatureCollection? GeoJson { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
@@ -81,6 +81,22 @@ internal static class MapToolSchemas
               "default": 100,
               "description": "Maximum number of features to return (capped at 1000)."
             },
+            "resultOffset": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "Number of matching features to skip before returning results (pagination). Pair with limit to page mechanically through large result sets: when a response reports exceededTransferLimit=true, re-issue the same query with resultOffset set to the returned nextOffset until exceededTransferLimit is false."
+            },
+            "returnGeometry": {
+              "type": "boolean",
+              "default": true,
+              "description": "When false, features are returned without geometry (attribute-only rows). Use for attribute scans where returning geometry would waste the response/context budget."
+            },
+            "returnCountOnly": {
+              "type": "boolean",
+              "default": false,
+              "description": "When true, return only the matching feature count and no features. Use for cheap cardinality checks before deciding whether/how to page."
+            },
             "outSrid": {
               "type": "integer",
               "default": 4326,

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
@@ -48,7 +48,9 @@ internal sealed class QueryFeaturesTool : IMcpTool
     {
         Name = ToolName,
         Title = "Query features",
-        Description = "Query features from a published layer (by serviceId/layerId) with an optional attribute WHERE clause, bbox, outFields, and result limit. Returns a GeoJSON FeatureCollection.",
+        Description = "Query features from a published layer (by serviceId/layerId) with an optional attribute WHERE clause, bbox, outFields, and result limit. Returns a GeoJSON FeatureCollection. "
+            + "Paging: results are capped at 'limit' (default 100, max 1000). When the response reports exceededTransferLimit=true there are more matching features; page through them mechanically by re-issuing the SAME query with resultOffset set to the returned nextOffset, repeating until exceededTransferLimit=false. "
+            + "Set returnCountOnly=true to get just the matching {count} (no features) for a cheap cardinality check, and returnGeometry=false to return attribute-only rows (geometry omitted) when scanning attributes.",
         InputSchema = MapToolSchemas.QueryFeaturesArgumentSchema,
         OutputSchema = McpToolOutputSchemas.QueryFeaturesOutputSchema,
         Annotations = McpToolAnnotationSets.ReadOnly("Query features")
@@ -74,6 +76,9 @@ internal sealed class QueryFeaturesTool : IMcpTool
         var layer = MapToolLayerResolver.Resolve(snapshot, argument.ServiceId, argument.LayerId);
 
         var limit = ResolveLimit(argument.Limit);
+        var offset = ResolveOffset(argument.ResultOffset);
+        var returnGeometry = argument.ReturnGeometry ?? true;
+        var returnCountOnly = argument.ReturnCountOnly ?? false;
         var outSrid = argument.OutSrid ?? 4326;
         if (outSrid <= 0)
         {
@@ -87,18 +92,39 @@ internal sealed class QueryFeaturesTool : IMcpTool
         {
             OutFields = ToOutFields(argument.OutFields),
             Limit = limit,
+            ResultOffset = offset,
             OutputSrid = outSrid,
             SqlFilter = BuildAttributeFilter(filterService, argument.Where, layer),
             SpatialFilter = BuildBboxFilter(geometryService, argument.Bbox, argument.BboxSrid)
         };
 
         var reader = httpContext.RequestServices.GetRequiredService<IFeatureReader>();
+
+        // returnCountOnly: adapt to the canonical count seam and return {count}
+        // with no features (a cheap cardinality check that never buffers geometry).
+        if (returnCountOnly)
+        {
+            var count = await reader.CountAsync(layer.StorageLayerId, query, cancellationToken).ConfigureAwait(false);
+            var countOutput = new McpQueryFeaturesOutput
+            {
+                ServiceId = layer.Service.Metadata.Id,
+                LayerId = argument.LayerId!.Value,
+                ReturnedCount = 0,
+                Limit = limit,
+                ResultOffset = offset,
+                ExceededTransferLimit = false,
+                Count = count
+            };
+
+            return McpToolHelpers.SuccessResult(countOutput, MapToolJsonContext.Default.McpQueryFeaturesOutput);
+        }
+
         var result = await reader.QueryAsync(layer.StorageLayerId, query, cancellationToken).ConfigureAwait(false);
 
         var features = new List<JsonNode>(result.Items.Length);
         foreach (var feature in result.Items)
         {
-            features.Add(ToGeoJsonFeature(feature, geometryService));
+            features.Add(ToGeoJsonFeature(feature, geometryService, returnGeometry));
         }
 
         var output = new McpQueryFeaturesOutput
@@ -107,7 +133,11 @@ internal sealed class QueryFeaturesTool : IMcpTool
             LayerId = argument.LayerId!.Value,
             ReturnedCount = features.Count,
             Limit = limit,
+            ResultOffset = offset,
             ExceededTransferLimit = result.HasMoreResults,
+            // When more results remain, hand the agent the exact offset to page
+            // mechanically: the next page starts after everything returned so far.
+            NextOffset = result.HasMoreResults ? offset + features.Count : null,
             GeoJson = new McpGeoJsonFeatureCollection { Features = features }
         };
 
@@ -123,6 +153,17 @@ internal sealed class QueryFeaturesTool : IMcpTool
         }
 
         return Math.Min(limit, MapToolSchemas.MaxFeatureLimit);
+    }
+
+    private static int ResolveOffset(int? requested)
+    {
+        var offset = requested ?? 0;
+        if (offset < 0)
+        {
+            throw new GeoprocessingValidationException("'resultOffset' must be zero or a positive integer.");
+        }
+
+        return offset;
     }
 
     private static ImmutableArray<string>? ToOutFields(IReadOnlyList<string>? outFields)
@@ -219,10 +260,14 @@ internal sealed class QueryFeaturesTool : IMcpTool
             envelopeMaxY: maxY);
     }
 
-    private static JsonObject ToGeoJsonFeature(Feature feature, IGeometryService geometryService)
+    private static JsonObject ToGeoJsonFeature(Feature feature, IGeometryService geometryService, bool returnGeometry)
     {
-        var geometryJson = geometryService.ConvertWkbToGeoJson(feature.Geometry);
-        JsonNode? geometryNode = geometryJson is null ? null : JsonNode.Parse(geometryJson);
+        JsonNode? geometryNode = null;
+        if (returnGeometry)
+        {
+            var geometryJson = geometryService.ConvertWkbToGeoJson(feature.Geometry);
+            geometryNode = geometryJson is null ? null : JsonNode.Parse(geometryJson);
+        }
 
         var properties = new JsonObject();
         foreach (var pair in feature.Attributes)

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -321,16 +321,31 @@ internal static class McpToolOutputSchemas
         """
         {
           "type": "object",
-          "required": ["serviceId", "layerId", "returnedCount", "limit", "exceededTransferLimit", "geojson"],
+          "required": ["serviceId", "layerId", "returnedCount", "limit", "resultOffset", "exceededTransferLimit"],
           "properties": {
             "serviceId": { "type": "string" },
             "layerId": { "type": "integer" },
             "returnedCount": { "type": "integer" },
             "limit": { "type": "integer" },
-            "exceededTransferLimit": { "type": "boolean" },
+            "resultOffset": {
+              "type": "integer",
+              "description": "The resultOffset applied to this request (defaults to 0)."
+            },
+            "exceededTransferLimit": {
+              "type": "boolean",
+              "description": "True when more matching features exist beyond this page. When true, re-issue the same query with resultOffset=nextOffset to fetch the next page."
+            },
+            "nextOffset": {
+              "type": "integer",
+              "description": "Present only when exceededTransferLimit is true: the resultOffset to send on the next request (resultOffset + returnedCount) to page mechanically. Absent on the last page."
+            },
+            "count": {
+              "type": "integer",
+              "description": "Matching feature count. Present only when returnCountOnly=true; features are omitted in that mode."
+            },
             "geojson": {
               "type": "object",
-              "description": "RFC 7946 GeoJSON FeatureCollection.",
+              "description": "RFC 7946 GeoJSON FeatureCollection. Omitted when returnCountOnly=true. When returnGeometry=false each feature's geometry is null.",
               "properties": {
                 "type": { "type": "string", "const": "FeatureCollection" },
                 "features": { "type": "array", "items": { "type": "object" } }

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
@@ -8,7 +8,10 @@ Honua's live `/mcp` advertised tool input schemas and resource payload shapes
 implementation.
 
 - Source: `geospatial-mcp` `spec/schemas/` (branch `feat/json-schemas-conformance`,
-  PR honua-io/geospatial-mcp#21).
+  PR honua-io/geospatial-mcp#21). `tools/query_features.schema.json` (and the
+  paired paging fixture) were re-vendored from PR honua-io/geospatial-mcp#46,
+  which adds the optional `resultOffset` / `returnGeometry` / `returnCountOnly`
+  params.
 - Do not hand-edit. Re-vendor when the upstream schemas change.
 - Files are copied to the test output directory (`CopyToOutputDirectory`) and
   loaded at test time.

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/query_features/query_features_paging.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/query_features/query_features_paging.json
@@ -1,0 +1,17 @@
+{
+  "id": "query_features.paging_and_count",
+  "schemaRef": "tools/query_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "serviceId": "county_parcels",
+    "layerId": 0,
+    "where": "zoning = 'R1'",
+    "limit": 100,
+    "resultOffset": 100,
+    "returnGeometry": false,
+    "returnCountOnly": false,
+    "outSrid": 4326
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/query_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/query_features.schema.json
@@ -45,6 +45,22 @@
       "default": 100,
       "description": "Maximum number of features to return (capped at 1000)."
     },
+    "resultOffset": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 0,
+      "description": "Number of matching features to skip before returning results (pagination). Pair with limit to page mechanically through large result sets: when a response reports exceededTransferLimit=true, re-issue the same query with resultOffset set to the returned nextOffset until exceededTransferLimit is false."
+    },
+    "returnGeometry": {
+      "type": "boolean",
+      "default": true,
+      "description": "When false, features are returned without geometry (attribute-only rows). Use for attribute scans where returning geometry would waste the response/context budget."
+    },
+    "returnCountOnly": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, return only the matching feature count and no features. Use for cheap cardinality checks before deciding whether/how to page."
+    },
     "outSrid": {
       "type": "integer",
       "default": 4326,

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
@@ -147,6 +147,194 @@ public sealed class McpMapToolTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_query_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public void Describe_QueryFeatures_AdvertisesPagingAndCountParameters()
+    {
+        var descriptor = new QueryFeaturesTool(_jobService, NullLogger<QueryFeaturesTool>.Instance).Describe();
+
+        var inputProps = descriptor.InputSchema.GetProperty("properties");
+        inputProps.TryGetProperty("resultOffset", out var resultOffset).Should().BeTrue();
+        resultOffset.GetProperty("type").GetString().Should().Be("integer");
+        resultOffset.GetProperty("minimum").GetInt32().Should().Be(0);
+        inputProps.TryGetProperty("returnGeometry", out var returnGeometry).Should().BeTrue();
+        returnGeometry.GetProperty("type").GetString().Should().Be("boolean");
+        inputProps.TryGetProperty("returnCountOnly", out var returnCountOnly).Should().BeTrue();
+        returnCountOnly.GetProperty("type").GetString().Should().Be("boolean");
+
+        descriptor.OutputSchema.Should().NotBeNull();
+        var outputProps = descriptor.OutputSchema!.Value.GetProperty("properties");
+        outputProps.TryGetProperty("nextOffset", out _).Should().BeTrue();
+        outputProps.TryGetProperty("count", out _).Should().BeTrue();
+        outputProps.TryGetProperty("resultOffset", out _).Should().BeTrue();
+
+        descriptor.Description.Should().Contain("nextOffset",
+            "the tool description must teach the mechanical paging loop");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_query_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_QueryFeatures_WithResultOffset_PagesDisjointResultsUsingNextOffset()
+    {
+        // A 250-row layer paged at limit=100 must be traversed in exactly three
+        // calls: offset 0 -> 100 -> 200, each page disjoint, driven only by the
+        // returned nextOffset until exceededTransferLimit flips false.
+        const int total = 250;
+        const int pageSize = 100;
+
+        var reader = Substitute.For<IFeatureReader>();
+        reader.QueryAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var query = callInfo.ArgAt<FeatureQuery>(1);
+                var offset = query.ResultOffset ?? 0;
+                var limit = query.Limit ?? pageSize;
+                var take = Math.Min(limit, Math.Max(0, total - offset));
+                var items = Enumerable.Range(offset, take)
+                    .Select(id => new Feature
+                    {
+                        Id = id,
+                        Geometry = [0x01],
+                        Attributes = ImmutableDictionary<string, object?>.Empty.Add("idx", id)
+                    })
+                    .ToImmutableArray();
+                return new QueryResult<Feature>
+                {
+                    TotalCount = total,
+                    HasMoreResults = offset + take < total,
+                    Items = items
+                };
+            });
+
+        var geometryService = Substitute.For<IGeometryService>();
+        geometryService.ConvertWkbToGeoJson(Arg.Any<byte[]?>())
+            .Returns("""{"type":"Point","coordinates":[1,2]}""");
+
+        var surface = BuildSurface();
+        var services = BuildServices(reader: reader, geometryService: geometryService);
+
+        var seenIds = new List<long>();
+        int? offsetArg = null;
+        var calls = 0;
+
+        while (true)
+        {
+            calls++;
+            var offsetJson = offsetArg is { } o ? $",\"resultOffset\":{o}" : string.Empty;
+            var response = await surface.DispatchAsync(
+                AuthenticatedContext(services),
+                ToolCall($"page-{calls}", QueryFeaturesTool.ToolName, $$"""
+                    {"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"limit":{{pageSize}}{{offsetJson}}}
+                    """),
+                CancellationToken.None);
+
+            response!.Error.Should().BeNull();
+            var structured = response.Result!.Value.GetProperty("structuredContent");
+
+            foreach (var feature in structured.GetProperty("geojson").GetProperty("features").EnumerateArray())
+            {
+                seenIds.Add(feature.GetProperty("id").GetInt64());
+            }
+
+            if (structured.GetProperty("exceededTransferLimit").GetBoolean())
+            {
+                structured.TryGetProperty("nextOffset", out var nextOffset).Should().BeTrue(
+                    "a non-final page must advertise nextOffset so the agent can page mechanically");
+                offsetArg = nextOffset.GetInt32();
+            }
+            else
+            {
+                structured.TryGetProperty("nextOffset", out _).Should().BeFalse(
+                    "the final page must not advertise nextOffset");
+                break;
+            }
+
+            calls.Should().BeLessThan(10, "paging must terminate");
+        }
+
+        calls.Should().Be(3, "a 250-row layer at limit=100 pages in exactly three calls");
+        seenIds.Should().HaveCount(total);
+        seenIds.Should().OnlyHaveUniqueItems("pages must be disjoint");
+        seenIds.Should().BeEquivalentTo(Enumerable.Range(0, total).Select(i => (long)i));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_query_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_QueryFeatures_ReturnCountOnly_ReturnsCountWithoutFeatures()
+    {
+        var reader = Substitute.For<IFeatureReader>();
+        reader.CountAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(250L);
+
+        var surface = BuildSurface();
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices(reader: reader)),
+            ToolCall("count-1", QueryFeaturesTool.ToolName, $$"""
+                {"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"returnCountOnly":true}
+                """),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var structured = response.Result!.Value.GetProperty("structuredContent");
+        structured.GetProperty("count").GetInt64().Should().Be(250);
+        structured.GetProperty("returnedCount").GetInt32().Should().Be(0);
+        structured.TryGetProperty("geojson", out _).Should().BeFalse(
+            "returnCountOnly must omit the feature collection");
+
+        await reader.Received(1).CountAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>());
+        await reader.DidNotReceive().QueryAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_query_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_QueryFeatures_ReturnGeometryFalse_OmitsGeometry()
+    {
+        var reader = Substitute.For<IFeatureReader>();
+        reader.QueryAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new QueryResult<Feature>
+            {
+                TotalCount = 1,
+                HasMoreResults = false,
+                Items =
+                [
+                    new Feature
+                    {
+                        Id = 7,
+                        Geometry = [0x01],
+                        Attributes = ImmutableDictionary<string, object?>.Empty.Add("name", "Lot 7")
+                    }
+                ]
+            });
+
+        var geometryService = Substitute.For<IGeometryService>();
+
+        var surface = BuildSurface();
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices(reader: reader, geometryService: geometryService)),
+            ToolCall("nogeom-1", QueryFeaturesTool.ToolName, $$"""
+                {"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"returnGeometry":false}
+                """),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var structured = response.Result!.Value.GetProperty("structuredContent");
+        structured.GetProperty("returnedCount").GetInt32().Should().Be(1);
+        var feature = structured.GetProperty("geojson").GetProperty("features")[0];
+        feature.GetProperty("geometry").ValueKind.Should().Be(JsonValueKind.Null,
+            "returnGeometry=false yields attribute-only rows with null geometry");
+        feature.GetProperty("properties").GetProperty("name").GetString().Should().Be("Lot 7");
+
+        geometryService.DidNotReceive().ConvertWkbToGeoJson(Arg.Any<byte[]?>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     [Endpoint("POST /mcp tools/call honua_render_map")]
     [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
     public async Task ToolsCall_RenderMap_ReturnsImageContentBlock()


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1948

## Summary
Adds pagination and count/no-geometry modes to the `honua_query_features` MCP tool. Previously the tool had a result limit (default 100, cap 1000) but no offset/cursor, so an agent that hit `exceededTransferLimit` could only re-issue with a tighter WHERE/bbox — it could not page. There was also no count-only or geometry-free mode, so counting or attribute scans blew the context window with geometry. The tool is a thin adapter over the shared canonical query pipeline, and all three new params thread into it (`FeatureQuery.ResultOffset`, `IFeatureReader.CountAsync`) rather than opening a parallel path.

## Changes Made
- Add optional input params to `honua_query_features`: `resultOffset` (int >=0, default 0), `returnGeometry` (bool, default true → attribute-only rows when false), `returnCountOnly` (bool, default false → returns `{count}` with no features via the canonical count seam).
- Output now surfaces `resultOffset` and, when `exceededTransferLimit` is true, `nextOffset` (`resultOffset + returnedCount`) so an agent can page mechanically; `count` is emitted in count-only mode and the feature collection is omitted.
- Update the tool description and output schema to teach the paging loop explicitly ("if exceededTransferLimit, re-issue with resultOffset=nextOffset").
- Standard-first: re-vendored `ConformanceSchemas/geospatial-mcp/tools/query_features.schema.json` (+ a paging conformance fixture) from the companion standard PR honua-io/geospatial-mcp#46, which adds the same optional params; README source note updated.
- Tests: schema-surface assertions for the new params, a tool-level test proving offset paging returns disjoint pages across exactly 3 calls for a 250-row layer via `nextOffset`, `returnCountOnly` returns count without features, and `returnGeometry=false` yields null geometry without invoking the geometry service.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos

## Breaking Changes
None. All three params are optional with backward-compatible defaults; existing `honua_query_features` calls behave identically.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
