### PR TITLE
feat: add honua_edit_features transactional editing MCP tool (#1948)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/EditFeaturesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/EditFeaturesTool.cs
@@ -1,0 +1,344 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Edit;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geometry.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+
+namespace Honua.Ai.Protocols.Mcp.MapTools;
+
+/// <summary>
+/// MCP tool that transactionally applies feature edits (adds, updates, deletes)
+/// to a single published editable layer. It is a thin adapter over the shared
+/// edit/transaction pipeline the FeatureServer <c>applyEdits</c>, OGC API
+/// Features, WFS Transaction, and OData CRUD surfaces all use: it resolves the
+/// layer through the same Metadata v2 snapshot, converts GeoJSON geometry to WKB
+/// via the shared <see cref="IGeometryService"/>, builds a protocol-neutral
+/// <see cref="UnifiedEditRequest"/>, runs it through the canonical
+/// <see cref="IEditProcessor"/> (validation + <c>ToFeatureEditBatch</c>), and
+/// executes through <see cref="IFeatureWriter.ApplyEditsAsync(int, FeatureEditBatch, System.Threading.CancellationToken)"/>.
+/// No edit, validation, transaction, or optimistic-concurrency semantics are
+/// reimplemented here — the writer's own transaction is the all-or-nothing
+/// boundary when <c>rollbackOnFailure</c> is set.
+/// </summary>
+internal sealed class EditFeaturesTool : IMcpTool
+{
+    /// <summary>The advertised <c>tools/list</c> name of this tool.</summary>
+    public const string ToolName = "honua_edit_features";
+
+    private const string ToolDescription =
+        "Transactionally edit features on a published layer (by serviceId/layerId): apply adds, updates, and deletes in a single call. "
+        + "When rollbackOnFailure=true (the default) the edits are all-or-nothing — any failed edit rolls back the entire transaction and leaves the layer unchanged; "
+        + "when false, successful edits commit independently and per-edit failures are reported. "
+        + "Geometry is supplied as RFC 7946 GeoJSON geometry objects and attributes as a flat name/value map; the input CRS defaults to EPSG:4326 (override with 'srid'). "
+        + "updates must carry an 'objectId'; deletes are a list of object IDs; adds receive store-assigned object IDs. "
+        + "Discover the layer first with honua_resolve_entity or honua_list_layers to obtain serviceId/layerId, and verify the attribute/geometry schema by reading a feature with honua_query_features before editing. "
+        + "Returns per-edit results (index, success, objectId, error) plus a transaction summary (applied, failed, rolledBack).";
+
+    private readonly IGeoprocessingJobService _jobService;
+    private readonly ILogger<EditFeaturesTool> _logger;
+
+    public EditFeaturesTool(IGeoprocessingJobService jobService, ILogger<EditFeaturesTool> logger)
+    {
+        _jobService = jobService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Execution;
+
+    /// <inheritdoc />
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "Edit features",
+        Description = ToolDescription,
+        InputSchema = MapToolSchemas.EditFeaturesArgumentSchema,
+        OutputSchema = McpToolOutputSchemas.EditFeaturesOutputSchema,
+        // Write tool: deletes destroy existing state, so destructiveHint is true;
+        // a replay applies the same adds again (new rows) and is therefore not
+        // idempotent.
+        Annotations = McpToolAnnotationSets.Write("Edit features", destructive: true, idempotent: false)
+    };
+
+    /// <inheritdoc />
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("EditFeatures");
+        McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
+
+        // Standard MCP write authorization: the same operator-grant gate every
+        // MCP write tool (execute_plan, etc.) enforces. The per-layer data-plane
+        // RBAC the HTTP FeatureServer edit path additionally applies
+        // (ServiceDataEditorAuthorization / IPermissionResolver Insert/Update/Delete
+        // grants, AccessPolicy, layer-scoped write keys) lives in the Hosting
+        // protocol layer and is not reachable from the AI protocol slice; wiring
+        // that parity onto the MCP surface is tracked as P2 (see the tool PR).
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        await _jobService
+            .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Process, OperatorOperation.Execute, cancellationToken)
+            .ConfigureAwait(false);
+
+        var argument = McpToolHelpers.ParseArguments(arguments, MapToolJsonContext.Default.McpEditFeaturesArgument);
+
+        var graphProvider = httpContext.RequestServices.GetRequiredService<IMetadataV2GraphProvider>();
+        var snapshot = await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+        var layer = MapToolLayerResolver.Resolve(snapshot, argument.ServiceId, argument.LayerId);
+
+        var srid = argument.Srid ?? 4326;
+        if (srid <= 0)
+        {
+            throw new GeoprocessingValidationException("'srid' must be a positive SRID/WKID.");
+        }
+
+        var hasAdds = argument.Adds is { Count: > 0 };
+        var hasUpdates = argument.Updates is { Count: > 0 };
+        var hasDeletes = argument.Deletes is { Count: > 0 };
+        if (!hasAdds && !hasUpdates && !hasDeletes)
+        {
+            throw new GeoprocessingValidationException(
+                "At least one of 'adds', 'updates', or 'deletes' must be provided.");
+        }
+
+        var rollbackOnFailure = argument.RollbackOnFailure ?? true;
+        var returnEditResults = argument.ReturnEditResults ?? true;
+
+        var geometryService = httpContext.RequestServices.GetRequiredService<IGeometryService>();
+
+        var editRequest = new UnifiedEditRequest
+        {
+            Creates = hasAdds ? BuildCreates(argument.Adds!, geometryService, srid) : null,
+            Updates = hasUpdates ? BuildUpdates(argument.Updates!, geometryService, srid) : null,
+            Deletes = hasDeletes ? BuildDeletes(argument.Deletes!) : null,
+            TransactionOptions = new EditTransactionOptions
+            {
+                RollbackOnFailure = rollbackOnFailure,
+                UseExplicitTransaction = rollbackOnFailure
+            },
+            ValidationOptions = EditValidationOptions.Strict()
+        };
+
+        var editProcessor = httpContext.RequestServices.GetRequiredService<IEditProcessor>();
+        var validation = editProcessor.ValidateEdit(editRequest, layer.Resource);
+        if (!validation.IsValid)
+        {
+            throw new GeoprocessingValidationException(
+                validation.ErrorMessage ?? "The edit request failed validation.");
+        }
+
+        var editBatch = editProcessor.ToFeatureEditBatch(editRequest, layer.Resource);
+
+        var featureWriter = httpContext.RequestServices.GetRequiredService<IFeatureWriter>();
+        var result = await featureWriter
+            .ApplyEditsAsync(layer.StorageLayerId, editBatch, cancellationToken)
+            .ConfigureAwait(false);
+
+        var output = BuildOutput(layer.Service.Metadata.Id, argument.LayerId!.Value, result, returnEditResults);
+        return McpToolHelpers.SuccessResult(output, MapToolJsonContext.Default.McpEditFeaturesOutput);
+    }
+
+    private static ImmutableArray<EditFeature> BuildCreates(
+        IReadOnlyList<McpEditFeature> features,
+        IGeometryService geometryService,
+        int srid)
+    {
+        var builder = ImmutableArray.CreateBuilder<EditFeature>(features.Count);
+        for (var i = 0; i < features.Count; i++)
+        {
+            var feature = features[i]
+                ?? throw new GeoprocessingValidationException($"'adds[{i}]' must be a feature object.");
+            var geometry = ConvertGeometry(feature.Geometry, geometryService, srid, $"adds[{i}]");
+            builder.Add(EditFeature.ForCreate(geometry, ToAttributes(feature.Attributes, $"adds[{i}]"), feature.GlobalId));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private static ImmutableArray<EditFeature> BuildUpdates(
+        IReadOnlyList<McpEditFeature> features,
+        IGeometryService geometryService,
+        int srid)
+    {
+        var builder = ImmutableArray.CreateBuilder<EditFeature>(features.Count);
+        for (var i = 0; i < features.Count; i++)
+        {
+            var feature = features[i]
+                ?? throw new GeoprocessingValidationException($"'updates[{i}]' must be a feature object.");
+            if (feature.ObjectId is not { } objectId)
+            {
+                // The shared Updates set is keyed on objectId; global-id-only updates
+                // would require useGlobalIds resolution, which the shared edit pipeline
+                // does not support on this path (GeoServices applyEdits rejects it too).
+                throw new GeoprocessingValidationException(
+                    $"'updates[{i}]' must carry an 'objectId' identifying the feature to update.");
+            }
+
+            var geometry = ConvertGeometry(feature.Geometry, geometryService, srid, $"updates[{i}]");
+            builder.Add(EditFeature.ForUpdate(objectId, geometry, ToAttributes(feature.Attributes, $"updates[{i}]")));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private static ImmutableArray<long> BuildDeletes(IReadOnlyList<long> deletes)
+    {
+        var builder = ImmutableArray.CreateBuilder<long>(deletes.Count);
+        builder.AddRange(deletes);
+        return builder.MoveToImmutable();
+    }
+
+    private static byte[]? ConvertGeometry(JsonNode? geometry, IGeometryService geometryService, int srid, string path)
+    {
+        if (geometry is null)
+        {
+            return null;
+        }
+
+        if (geometry is not JsonObject)
+        {
+            throw new GeoprocessingValidationException($"'{path}.geometry' must be a GeoJSON geometry object.");
+        }
+
+        return geometryService.ConvertGeoJsonToWkb(geometry.ToJsonString(), srid)
+            ?? throw new GeoprocessingValidationException(
+                $"'{path}.geometry' could not be converted from GeoJSON to a geometry.");
+    }
+
+    private static ImmutableDictionary<string, object?> ToAttributes(JsonNode? attributes, string path)
+    {
+        if (attributes is null)
+        {
+            return ImmutableDictionary<string, object?>.Empty;
+        }
+
+        if (attributes is not JsonObject obj)
+        {
+            throw new GeoprocessingValidationException($"'{path}.attributes' must be a JSON object.");
+        }
+
+        var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+        foreach (var pair in obj)
+        {
+            builder[pair.Key] = ToClrValue(pair.Value);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static object? ToClrValue(JsonNode? value)
+    {
+        if (value is not JsonValue jsonValue)
+        {
+            // Nested objects/arrays are round-tripped as their JSON text so the
+            // shared validator/writer can coerce them per the target field schema.
+            return value?.ToJsonString();
+        }
+
+        if (jsonValue.TryGetValue<bool>(out var boolean))
+        {
+            return boolean;
+        }
+
+        if (jsonValue.TryGetValue<long>(out var integer))
+        {
+            return integer;
+        }
+
+        if (jsonValue.TryGetValue<double>(out var number))
+        {
+            return number;
+        }
+
+        if (jsonValue.TryGetValue<string>(out var text))
+        {
+            return text;
+        }
+
+        return jsonValue.ToJsonString();
+    }
+
+    private static McpEditFeaturesOutput BuildOutput(
+        string serviceId,
+        int layerId,
+        FeatureEditResult result,
+        bool returnEditResults)
+    {
+        var failed =
+            CountFailures(result.CreateResults) +
+            CountFailures(result.UpdateResults) +
+            CountFailures(result.DeleteResults);
+
+        return new McpEditFeaturesOutput
+        {
+            ServiceId = serviceId,
+            LayerId = layerId,
+            AddResults = returnEditResults ? MapResults(result.CreateResults) : [],
+            UpdateResults = returnEditResults ? MapResults(result.UpdateResults) : [],
+            DeleteResults = returnEditResults ? MapResults(result.DeleteResults) : [],
+            Summary = new McpEditSummary
+            {
+                Applied = result.CreatedCount + result.UpdatedCount + result.DeletedCount,
+                Failed = failed,
+                RolledBack = result.WasRolledBack
+            }
+        };
+    }
+
+    private static McpEditResult[] MapResults(ImmutableArray<EditOperationResult> results)
+    {
+        if (results.IsDefaultOrEmpty)
+        {
+            return [];
+        }
+
+        var mapped = new McpEditResult[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            var op = results[i];
+            mapped[i] = new McpEditResult
+            {
+                Index = i,
+                Success = op.IsSuccess,
+                ObjectId = op.ObjectId,
+                GlobalId = op.GlobalId,
+                Error = op.IsSuccess ? null : op.ErrorMessage
+            };
+        }
+
+        return mapped;
+    }
+
+    private static int CountFailures(ImmutableArray<EditOperationResult> results)
+    {
+        if (results.IsDefaultOrEmpty)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var op in results)
+        {
+            if (!op.IsSuccess)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolJsonContext.cs
@@ -22,6 +22,11 @@ namespace Honua.Ai.Protocols.Mcp.MapTools;
 [JsonSerializable(typeof(McpGeoJsonFeatureCollection))]
 [JsonSerializable(typeof(McpRenderMapArgument))]
 [JsonSerializable(typeof(McpRenderLayerRef))]
+[JsonSerializable(typeof(McpEditFeaturesArgument))]
+[JsonSerializable(typeof(McpEditFeature))]
+[JsonSerializable(typeof(McpEditFeaturesOutput))]
+[JsonSerializable(typeof(McpEditResult))]
+[JsonSerializable(typeof(McpEditSummary))]
 [JsonSerializable(typeof(JsonNode))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSourceGenerationOptions(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
@@ -205,3 +205,137 @@ internal sealed class McpRenderLayerRef
     [JsonPropertyName("layerId")]
     public int? LayerId { get; set; }
 }
+
+// -----------------------------------------------------------------------
+// honua_edit_features
+// -----------------------------------------------------------------------
+
+/// <summary>
+/// Arguments for <c>honua_edit_features</c>. Carries the transactional
+/// add/update/delete edit sets against a single published editable layer. The
+/// tool is a thin adapter over the shared edit/transaction pipeline
+/// (<see cref="Honua.Core.Features.Edit.IEditProcessor"/> +
+/// <see cref="Honua.Core.Features.FeatureStore.Abstractions.IFeatureWriter"/>);
+/// it introduces no edit semantics of its own.
+/// </summary>
+internal sealed class McpEditFeaturesArgument
+{
+    [JsonPropertyName("serviceId")]
+    public string? ServiceId { get; set; }
+
+    [JsonPropertyName("layerId")]
+    public int? LayerId { get; set; }
+
+    /// <summary>Spatial reference (SRID/WKID) of the input feature geometries; defaults to 4326 (WGS 84).</summary>
+    [JsonPropertyName("srid")]
+    public int? Srid { get; set; }
+
+    /// <summary>Features to insert. Each carries GeoJSON geometry and an attribute map.</summary>
+    [JsonPropertyName("adds")]
+    public IReadOnlyList<McpEditFeature>? Adds { get; set; }
+
+    /// <summary>Features to update. Each MUST carry an <c>objectId</c> identifying the existing feature.</summary>
+    [JsonPropertyName("updates")]
+    public IReadOnlyList<McpEditFeature>? Updates { get; set; }
+
+    /// <summary>Object IDs of features to delete.</summary>
+    [JsonPropertyName("deletes")]
+    public IReadOnlyList<long>? Deletes { get; set; }
+
+    /// <summary>When true (default), any failed edit rolls back the entire transaction (all-or-nothing).</summary>
+    [JsonPropertyName("rollbackOnFailure")]
+    public bool? RollbackOnFailure { get; set; }
+
+    /// <summary>When true (default), per-edit results are returned; when false only the transaction summary is emitted.</summary>
+    [JsonPropertyName("returnEditResults")]
+    public bool? ReturnEditResults { get; set; }
+}
+
+/// <summary>
+/// A single feature in a <c>honua_edit_features</c> add/update set. Geometry is an
+/// RFC 7946 GeoJSON geometry object; <see cref="Attributes"/> is a flat
+/// attribute name/value map. <see cref="ObjectId"/> is required for updates
+/// (and <see cref="GlobalId"/> may accompany it); both are ignored for adds,
+/// where the store assigns the object ID.
+/// </summary>
+internal sealed class McpEditFeature
+{
+    [JsonPropertyName("objectId")]
+    public long? ObjectId { get; set; }
+
+    [JsonPropertyName("globalId")]
+    public string? GlobalId { get; set; }
+
+    /// <summary>RFC 7946 GeoJSON geometry object (e.g. <c>{"type":"Point","coordinates":[1,2]}</c>). Optional for attribute-only edits.</summary>
+    [JsonPropertyName("geometry")]
+    public System.Text.Json.Nodes.JsonNode? Geometry { get; set; }
+
+    /// <summary>Flat attribute name/value map applied to the feature.</summary>
+    [JsonPropertyName("attributes")]
+    public System.Text.Json.Nodes.JsonNode? Attributes { get; set; }
+}
+
+/// <summary>
+/// Output for <c>honua_edit_features</c>: per-edit results grouped by edit kind
+/// plus a transaction summary, projected from the shared pipeline's
+/// <see cref="Honua.Core.Features.FeatureStore.Domain.FeatureEditResult"/>.
+/// </summary>
+internal sealed class McpEditFeaturesOutput
+{
+    [JsonPropertyName("serviceId")]
+    public string ServiceId { get; set; } = string.Empty;
+
+    [JsonPropertyName("layerId")]
+    public int LayerId { get; set; }
+
+    [JsonPropertyName("addResults")]
+    public IReadOnlyList<McpEditResult> AddResults { get; set; } = [];
+
+    [JsonPropertyName("updateResults")]
+    public IReadOnlyList<McpEditResult> UpdateResults { get; set; } = [];
+
+    [JsonPropertyName("deleteResults")]
+    public IReadOnlyList<McpEditResult> DeleteResults { get; set; } = [];
+
+    [JsonPropertyName("summary")]
+    public McpEditSummary Summary { get; set; } = new();
+}
+
+/// <summary>
+/// One per-edit result. <see cref="Index"/> is the zero-based position of the edit
+/// within its submitted array; <see cref="ObjectId"/> carries the assigned
+/// (create) or targeted (update/delete) object ID when known.
+/// </summary>
+internal sealed class McpEditResult
+{
+    [JsonPropertyName("index")]
+    public int Index { get; set; }
+
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("objectId")]
+    public long? ObjectId { get; set; }
+
+    [JsonPropertyName("globalId")]
+    public string? GlobalId { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
+/// <summary>
+/// Transaction summary for a <c>honua_edit_features</c> call: how many edits were
+/// applied, how many failed, and whether the whole transaction was rolled back.
+/// </summary>
+internal sealed class McpEditSummary
+{
+    [JsonPropertyName("applied")]
+    public int Applied { get; set; }
+
+    [JsonPropertyName("failed")]
+    public int Failed { get; set; }
+
+    [JsonPropertyName("rolledBack")]
+    public bool RolledBack { get; set; }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
@@ -157,8 +157,83 @@ internal static class MapToolSchemas
     /// <summary>Schema for <see cref="McpQueryFeaturesArgument"/>.</summary>
     public static readonly JsonElement QueryFeaturesArgumentSchema = Parse(QueryFeaturesArgumentSchemaJson);
 
+    private const string EditFeaturesArgumentSchemaJson = """
+        {
+          "type": "object",
+          "required": ["serviceId", "layerId"],
+          "properties": {
+            "serviceId": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Published service identifier or name (from honua_list_layers.serviceId or honua_resolve_entity)."
+            },
+            "layerId": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Service-local layer index of the editable layer (from honua_list_layers.layerId)."
+            },
+            "srid": {
+              "type": "integer",
+              "default": 4326,
+              "description": "Spatial reference (SRID/WKID) of the input feature geometries."
+            },
+            "adds": {
+              "type": "array",
+              "description": "Features to insert. Object IDs are assigned by the store.",
+              "items": { "$ref": "#/$defs/editFeature" }
+            },
+            "updates": {
+              "type": "array",
+              "description": "Features to update. Each MUST carry an objectId identifying the existing feature.",
+              "items": { "$ref": "#/$defs/editFeature" }
+            },
+            "deletes": {
+              "type": "array",
+              "description": "Object IDs of features to delete.",
+              "items": { "type": "integer" }
+            },
+            "rollbackOnFailure": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true, any failed edit rolls back the whole transaction (all-or-nothing)."
+            },
+            "returnEditResults": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true, per-edit results are returned; when false only the transaction summary is emitted."
+            }
+          },
+          "$defs": {
+            "editFeature": {
+              "type": "object",
+              "properties": {
+                "objectId": {
+                  "type": "integer",
+                  "description": "Object ID of the target feature. Required for updates; ignored for adds."
+                },
+                "globalId": {
+                  "type": "string",
+                  "description": "Optional global ID of the feature."
+                },
+                "geometry": {
+                  "type": ["object", "null"],
+                  "description": "RFC 7946 GeoJSON geometry object (e.g. {\"type\":\"Point\",\"coordinates\":[1,2]})."
+                },
+                "attributes": {
+                  "type": "object",
+                  "description": "Flat attribute name/value map applied to the feature."
+                }
+              }
+            }
+          }
+        }
+        """;
+
     /// <summary>Schema for <see cref="McpRenderMapArgument"/>.</summary>
     public static readonly JsonElement RenderMapArgumentSchema = Parse(RenderMapArgumentSchemaJson);
+
+    /// <summary>Schema for <see cref="McpEditFeaturesArgument"/>.</summary>
+    public static readonly JsonElement EditFeaturesArgumentSchema = Parse(EditFeaturesArgumentSchemaJson);
 
     private static JsonElement Parse(string json)
     {

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -130,6 +130,21 @@ internal static class McpServiceCollectionExtensions
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, MapTools.QueryFeaturesTool>());
             }
 
+            // honua_edit_features: the transactional feature-editing tool. It is a
+            // thin adapter over the shared edit/transaction pipeline
+            // (IEditProcessor validation + ToFeatureEditBatch, then
+            // IFeatureWriter.ApplyEditsAsync — the same seams FeatureServer
+            // applyEdits, OGC API Features, WFS Transaction, and OData CRUD adapt
+            // to). Advertised only when BOTH the edit processor and the feature
+            // writer are composed, so tools/list never advertises an edit verb the
+            // host cannot back (read-only providers register a ReadOnlyFeatureWriter
+            // but no IEditProcessor unless the edit pipeline is wired).
+            if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.Edit.IEditProcessor)) &&
+                services.Any(d => d.ServiceType == typeof(Honua.Core.Features.FeatureStore.Abstractions.IFeatureWriter)))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, MapTools.EditFeaturesTool>());
+            }
+
             // The map-render tool additionally needs the canonical raster
             // renderer (the same IRasterMapRenderer the OGC API Maps / MapServer
             // export / WMS GetMap surfaces drive).

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -396,6 +396,47 @@ internal static class McpToolOutputSchemas
         }
         """);
 
+    /// <summary>
+    /// Schema for <c>McpEditFeaturesOutput</c>: per-edit results grouped by edit
+    /// kind plus the transaction summary emitted by the shared edit pipeline.
+    /// </summary>
+    public static readonly JsonElement EditFeaturesOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["serviceId", "layerId", "addResults", "updateResults", "deleteResults", "summary"],
+          "properties": {
+            "serviceId": { "type": "string" },
+            "layerId": { "type": "integer" },
+            "addResults": { "type": "array", "items": { "$ref": "#/$defs/editResult" } },
+            "updateResults": { "type": "array", "items": { "$ref": "#/$defs/editResult" } },
+            "deleteResults": { "type": "array", "items": { "$ref": "#/$defs/editResult" } },
+            "summary": {
+              "type": "object",
+              "required": ["applied", "failed", "rolledBack"],
+              "properties": {
+                "applied": { "type": "integer", "description": "Count of successfully applied edits." },
+                "failed": { "type": "integer", "description": "Count of failed edits." },
+                "rolledBack": { "type": "boolean", "description": "True when the whole transaction was rolled back." }
+              }
+            }
+          },
+          "$defs": {
+            "editResult": {
+              "type": "object",
+              "required": ["index", "success"],
+              "properties": {
+                "index": { "type": "integer", "description": "Zero-based position of the edit in its submitted array." },
+                "success": { "type": "boolean" },
+                "objectId": { "type": ["integer", "null"] },
+                "globalId": { "type": ["string", "null"] },
+                "error": { "type": ["string", "null"] }
+              }
+            }
+          }
+        }
+        """);
+
     /// <summary>Schema for <see cref="Models.McpNotImplementedOutput"/>.</summary>
     public static readonly JsonElement NotImplementedOutputSchema = Parse(
         """

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -105,6 +105,7 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
             ("honua_publish_service", "publish_service", "lifecycle"),
             ("honua_list_layers", "list_layers", "results"),
             ("honua_query_features", "query_features", "results"),
+            ("honua_edit_features", "edit_features", "execution"),
             ("honua_render_map", "render_map", "results"),
             ("honua_resolve_entity", "resolve_entity", "results"),
             ("honua_list_capabilities", "list_capabilities", "results"),

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/edit_features/edit_features.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/edit_features/edit_features.json
@@ -1,0 +1,31 @@
+{
+  "id": "edit_features.transactional_mixed",
+  "schemaRef": "tools/edit_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "serviceId": "county_parcels",
+    "layerId": 0,
+    "srid": 4326,
+    "adds": [
+      {
+        "geometry": { "type": "Point", "coordinates": [-97.74, 30.27] },
+        "attributes": { "parcel_id": "A-1001", "zoning": "R1" }
+      },
+      {
+        "geometry": { "type": "Point", "coordinates": [-97.75, 30.28] },
+        "attributes": { "parcel_id": "A-1002", "zoning": "R1" }
+      }
+    ],
+    "updates": [
+      {
+        "objectId": 42,
+        "attributes": { "zoning": "R2" }
+      }
+    ],
+    "deletes": [99],
+    "rollbackOnFailure": true,
+    "returnEditResults": true
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
@@ -122,6 +122,14 @@
       "implementationStatus": "implemented"
     },
     {
+      "standardName": "edit_features",
+      "referenceToolName": "honua_edit_features",
+      "family": "Transactional editing (Honua extension)",
+      "schema": "tools/edit_features.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Honua reference extension: transactional feature editing (adds/updates/deletes) over the shared server edit pipeline. In tension with ADR-0028's Edit-Data exclusion; the reference tool requires an authenticated, authorized caller and is not autonomous unapproved mutation. Pending an ADR-0028 reconciliation decision by the standard maintainers; schema marks x-honua-extension."
+    },
+    {
       "standardName": "render_map",
       "referenceToolName": "honua_render_map",
       "family": "Discovery and query (reference shape)",

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/edit_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/edit_features.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/edit_features.schema.json",
+  "title": "edit_features inputSchema",
+  "description": "Argument shape for the transactional feature-editing tool (advertised name honua_edit_features). Applies adds/updates/deletes to a single published editable layer as one all-or-nothing transaction when rollbackOnFailure=true (the default). The bare taxonomy excludes direct data editing per ADR-0028 (AI must not autonomously mutate authoritative records); the reference implementation exposes editing as a discrete tool that requires an authenticated, authorized caller and routes through the shared server edit/transaction pipeline (validation, authorization, optimistic behavior, telemetry) rather than autonomous unapproved mutation. x-honua-extension: this is a documented Honua reference extension over the bare taxonomy, pending formalization (and ADR-0028 reconciliation) in the geospatial-mcp standard. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-extension": true,
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["serviceId", "layerId"],
+  "properties": {
+    "serviceId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Published service identifier or name (from list_layers.serviceId or resolve_entity)."
+    },
+    "layerId": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Service-local layer index of the editable layer (from list_layers.layerId)."
+    },
+    "srid": {
+      "type": "integer",
+      "default": 4326,
+      "description": "Spatial reference (SRID/WKID) of the input feature geometries."
+    },
+    "adds": {
+      "type": "array",
+      "description": "Features to insert. Object IDs are assigned by the store.",
+      "items": { "$ref": "#/$defs/editFeature" }
+    },
+    "updates": {
+      "type": "array",
+      "description": "Features to update. Each MUST carry an objectId identifying the existing feature.",
+      "items": { "$ref": "#/$defs/editFeature" }
+    },
+    "deletes": {
+      "type": "array",
+      "description": "Object IDs of features to delete.",
+      "items": { "type": "integer" }
+    },
+    "rollbackOnFailure": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true, any failed edit rolls back the whole transaction (all-or-nothing)."
+    },
+    "returnEditResults": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true, per-edit results are returned; when false only the transaction summary is emitted."
+    }
+  },
+  "$defs": {
+    "editFeature": {
+      "type": "object",
+      "properties": {
+        "objectId": {
+          "type": "integer",
+          "description": "Object ID of the target feature. Required for updates; ignored for adds."
+        },
+        "globalId": {
+          "type": "string",
+          "description": "Optional global ID of the feature."
+        },
+        "geometry": {
+          "type": ["object", "null"],
+          "description": "RFC 7946 GeoJSON geometry object (e.g. {\"type\":\"Point\",\"coordinates\":[1,2]})."
+        },
+        "attributes": {
+          "type": "object",
+          "description": "Flat attribute name/value map applied to the feature."
+        }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
@@ -288,6 +288,8 @@ public sealed class CapabilityRegistryConformanceTests
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool(
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.EditFeaturesTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.EditFeaturesTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool(
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool>.Instance),
             new Honua.Ai.Protocols.Mcp.Discovery.ResolveEntityTool(

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpEditFeaturesToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpEditFeaturesToolTests.cs
@@ -1,0 +1,362 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Edit;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Geometry.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.MapTools;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Focused coverage for the transactional feature-editing MCP tool
+/// (<c>honua_edit_features</c>). The tool is a thin adapter over the shared
+/// edit/transaction pipeline, so these tests substitute the canonical
+/// <see cref="IEditProcessor"/> + <see cref="IFeatureWriter"/> and assert the
+/// adapter builds the right protocol-neutral request, routes edits through the
+/// single transactional batch apply, and projects the pipeline result back onto
+/// the MCP per-edit + summary output.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class McpEditFeaturesToolTests
+{
+    private const string ServiceId = "svc-parcels";
+    private const string ServiceName = "Parcels";
+    private const string ResourceId = "res-parcels";
+    private const int LayerIndex = 0;
+    private const int StorageLayerId = 42;
+
+    private static readonly string MixedEditArguments = $$"""
+        {
+          "serviceId": "{{ServiceId}}",
+          "layerId": {{LayerIndex}},
+          "srid": 4326,
+          "adds": [
+            { "geometry": {"type":"Point","coordinates":[-97.74,30.27]}, "attributes": {"parcel_id":"A-1001"} },
+            { "geometry": {"type":"Point","coordinates":[-97.75,30.28]}, "attributes": {"parcel_id":"A-1002"} }
+          ],
+          "updates": [ { "objectId": 42, "attributes": {"zoning":"R2"} } ],
+          "deletes": [99]
+        }
+        """;
+
+    private readonly IGeoprocessingJobService _jobService = Substitute.For<IGeoprocessingJobService>();
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_AppliesAddsUpdatesDeletes_InOneTransaction()
+    {
+        var editProcessor = Substitute.For<IEditProcessor>();
+        UnifiedEditRequest captured = default;
+        editProcessor.ValidateEdit(default, default!)
+            .ReturnsForAnyArgs(EditValidationResult.Success());
+        editProcessor.ToFeatureEditBatch(default, default!)
+            .ReturnsForAnyArgs(ci =>
+            {
+                captured = ci.ArgAt<UnifiedEditRequest>(0);
+                return FeatureEditBatch.Create();
+            });
+
+        var writer = Substitute.For<IFeatureWriter>();
+        var capturedLayerId = -1;
+        writer.ApplyEditsAsync(default, default, default)
+            .ReturnsForAnyArgs(ci =>
+            {
+                capturedLayerId = ci.ArgAt<int>(0);
+                return FeatureEditResult.Success(
+                    createdCount: 2,
+                    updatedCount: 1,
+                    deletedCount: 1,
+                    createdIds: [101L, 102L],
+                    createResults: [EditOperationResult.Success(101), EditOperationResult.Success(102)],
+                    updateResults: [EditOperationResult.Success(42)],
+                    deleteResults: [EditOperationResult.Success(99)]);
+            });
+
+        var response = await DispatchEditAsync(editProcessor, writer, MixedEditArguments);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeFalse();
+
+        var structured = result.GetProperty("structuredContent");
+        structured.GetProperty("addResults").GetArrayLength().Should().Be(2);
+        structured.GetProperty("updateResults").GetArrayLength().Should().Be(1);
+        structured.GetProperty("deleteResults").GetArrayLength().Should().Be(1);
+        structured.GetProperty("addResults")[0].GetProperty("objectId").GetInt64().Should().Be(101);
+        structured.GetProperty("addResults")[0].GetProperty("success").GetBoolean().Should().BeTrue();
+
+        var summary = structured.GetProperty("summary");
+        summary.GetProperty("applied").GetInt32().Should().Be(4);
+        summary.GetProperty("failed").GetInt32().Should().Be(0);
+        summary.GetProperty("rolledBack").GetBoolean().Should().BeFalse();
+
+        // The adapter built the protocol-neutral request from the GeoJSON input:
+        // 2 creates, 1 update, 1 delete, defaulting to all-or-nothing.
+        captured.Creates!.Value.Length.Should().Be(2);
+        captured.Updates!.Value.Length.Should().Be(1);
+        captured.Deletes!.Value.Length.Should().Be(1);
+        captured.TransactionOptions!.Value.RollbackOnFailure.Should().BeTrue(
+            "rollbackOnFailure defaults to true (all-or-nothing)");
+
+        // Edits ran through the single transactional batch apply against the
+        // resolved storage layer, not per-feature writes.
+        capturedLayerId.Should().Be(StorageLayerId);
+        WriterCallNames(writer).Should().Equal("ApplyEditsAsync");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_RollbackOnFailure_ReportsRolledBack_AndLeavesStateUnchanged()
+    {
+        var editProcessor = Substitute.For<IEditProcessor>();
+        UnifiedEditRequest captured = default;
+        editProcessor.ValidateEdit(default, default!)
+            .ReturnsForAnyArgs(EditValidationResult.Success());
+        editProcessor.ToFeatureEditBatch(default, default!)
+            .ReturnsForAnyArgs(ci =>
+            {
+                captured = ci.ArgAt<UnifiedEditRequest>(0);
+                return FeatureEditBatch.Create(rollbackOnFailure: true);
+            });
+
+        var writer = Substitute.For<IFeatureWriter>();
+        // A failing update rolls the whole transaction back: the shared result
+        // reports WasRolledBack and no operation is committed.
+        writer.ApplyEditsAsync(default, default, default)
+            .ReturnsForAnyArgs(FeatureEditResult.Rollback(
+                createResults: [EditOperationResult.Success(0), EditOperationResult.Success(0)],
+                updateResults: [EditOperationResult.Failure("value out of range", 1000, 42)],
+                deleteResults: [EditOperationResult.Success(99)]));
+
+        var response = await DispatchEditAsync(editProcessor, writer, MixedEditArguments);
+
+        response!.Error.Should().BeNull();
+        var structured = response.Result!.Value.GetProperty("structuredContent");
+        var summary = structured.GetProperty("summary");
+        summary.GetProperty("rolledBack").GetBoolean().Should().BeTrue();
+        summary.GetProperty("applied").GetInt32().Should().Be(0, "a rolled-back transaction commits nothing");
+        summary.GetProperty("failed").GetInt32().Should().Be(4, "every submitted edit is reported failed on rollback");
+
+        captured.TransactionOptions!.Value.RollbackOnFailure.Should().BeTrue();
+
+        // State unchanged: only the transactional batch apply was attempted; there
+        // were no independently-committing per-feature writes.
+        WriterCallNames(writer).Should().Equal("ApplyEditsAsync");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_PerEditFailure_MapsErrorResult()
+    {
+        var editProcessor = Substitute.For<IEditProcessor>();
+        editProcessor.ValidateEdit(default, default!)
+            .ReturnsForAnyArgs(EditValidationResult.Success());
+        editProcessor.ToFeatureEditBatch(default, default!)
+            .ReturnsForAnyArgs(FeatureEditBatch.Create());
+
+        var writer = Substitute.For<IFeatureWriter>();
+        // rollbackOnFailure=false path: adds/delete commit, the one update fails.
+        writer.ApplyEditsAsync(default, default, default)
+            .ReturnsForAnyArgs(FeatureEditResult.Success(
+                createdCount: 2,
+                updatedCount: 0,
+                deletedCount: 1,
+                createdIds: [101L, 102L],
+                createResults: [EditOperationResult.Success(101), EditOperationResult.Success(102)],
+                updateResults: [EditOperationResult.Failure("field 'zoning' value too long", 1000, 42)],
+                deleteResults: [EditOperationResult.Success(99)]));
+
+        var arguments = $$"""
+            {
+              "serviceId": "{{ServiceId}}",
+              "layerId": {{LayerIndex}},
+              "updates": [ { "objectId": 42, "attributes": {"zoning":"RESIDENTIAL-VERY-LONG"} } ],
+              "adds": [
+                { "attributes": {"parcel_id":"A-1"} },
+                { "attributes": {"parcel_id":"A-2"} }
+              ],
+              "deletes": [99],
+              "rollbackOnFailure": false
+            }
+            """;
+
+        var response = await DispatchEditAsync(editProcessor, writer, arguments);
+
+        response!.Error.Should().BeNull();
+        var structured = response.Result!.Value.GetProperty("structuredContent");
+        var updateResult = structured.GetProperty("updateResults")[0];
+        updateResult.GetProperty("success").GetBoolean().Should().BeFalse();
+        updateResult.GetProperty("objectId").GetInt64().Should().Be(42);
+        updateResult.GetProperty("error").GetString().Should().Contain("too long");
+
+        var summary = structured.GetProperty("summary");
+        summary.GetProperty("applied").GetInt32().Should().Be(3);
+        summary.GetProperty("failed").GetInt32().Should().Be(1);
+        summary.GetProperty("rolledBack").GetBoolean().Should().BeFalse();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_Unauthorized_ReturnsPermissionDeniedError()
+    {
+        _jobService
+            .EnsureCallerAuthorizedAsync(default!, default, default, default)
+            .ReturnsForAnyArgs(Task.FromException(new GeoprocessingAuthorizationException(requiresAuthentication: false)));
+
+        var editProcessor = Substitute.For<IEditProcessor>();
+        var writer = Substitute.For<IFeatureWriter>();
+
+        var response = await DispatchEditAsync(editProcessor, writer, MixedEditArguments);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeTrue();
+        result.GetProperty("structuredContent").GetProperty("code").GetString().Should().Be("permission_denied");
+
+        // Authorization is enforced before any edit reaches the writer.
+        WriterCallNames(writer).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_NoEdits_ReturnsInvalidArgument()
+    {
+        var editProcessor = Substitute.For<IEditProcessor>();
+        var writer = Substitute.For<IFeatureWriter>();
+
+        var arguments = $$"""
+            { "serviceId": "{{ServiceId}}", "layerId": {{LayerIndex}} }
+            """;
+
+        var response = await DispatchEditAsync(editProcessor, writer, arguments);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeTrue();
+        result.GetProperty("structuredContent").GetProperty("code").GetString().Should().Be("invalid_argument");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_UpdateMissingObjectId_ReturnsInvalidArgument()
+    {
+        var editProcessor = Substitute.For<IEditProcessor>();
+        var writer = Substitute.For<IFeatureWriter>();
+
+        var arguments = $$"""
+            {
+              "serviceId": "{{ServiceId}}",
+              "layerId": {{LayerIndex}},
+              "updates": [ { "attributes": {"zoning":"R2"} } ]
+            }
+            """;
+
+        var response = await DispatchEditAsync(editProcessor, writer, arguments);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeTrue();
+        result.GetProperty("structuredContent").GetProperty("code").GetString().Should().Be("invalid_argument");
+    }
+
+    private async Task<McpJsonRpcResponse?> DispatchEditAsync(
+        IEditProcessor editProcessor,
+        IFeatureWriter writer,
+        string argumentsJson)
+    {
+        var surface = new McpOperatorSurface(
+            [new EditFeaturesTool(_jobService, NullLogger<EditFeaturesTool>.Instance)],
+            [],
+            NullLogger<McpOperatorSurface>.Instance);
+
+        var geometryService = Substitute.For<IGeometryService>();
+        geometryService.ConvertGeoJsonToWkb(default, default).ReturnsForAnyArgs([0x01]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IMetadataV2GraphProvider>(BuildGraphProvider());
+        services.AddSingleton(editProcessor);
+        services.AddSingleton(writer);
+        services.AddSingleton(geometryService);
+        var provider = services.BuildServiceProvider();
+
+        var context = McpTestFactory.AuthenticatedHttpContext();
+        context.RequestServices = provider;
+
+        return await surface.DispatchAsync(
+            context,
+            ToolCall("edit-1", EditFeaturesTool.ToolName, argumentsJson),
+            CancellationToken.None);
+    }
+
+    private static List<string> WriterCallNames(IFeatureWriter writer) =>
+        writer.ReceivedCalls().Select(call => call.GetMethodInfo().Name).ToList();
+
+    private static TestMetadataV2GraphProvider BuildGraphProvider()
+    {
+        var spatial = new MetadataV2ResourceSpatial
+        {
+            GeometryType = MetadataV2GeometryType.Point,
+            SpatialReference = new MetadataV2SpatialReference { Srid = 4326 },
+            Bbox = new MetadataV2Bbox { West = -180, South = -90, East = 180, North = 90 }
+        };
+
+        return new TestMetadataV2GraphBuilder()
+            .AddResource(ResourceId, "Parcels Dataset", spatial: spatial)
+            .AddStorageBinding("bind-parcels", ResourceId, "public.parcels", storageLayerId: StorageLayerId)
+            .AddService(ServiceId, ServiceName)
+            .AddPublication("pub-parcels", ServiceId, ResourceId, layerIndex: LayerIndex, storageBindingId: "bind-parcels")
+            .BuildProvider();
+    }
+
+    private static McpJsonRpcRequest ToolCall(string id, string toolName, string argumentsJson) => new()
+    {
+        JsonRpc = "2.0",
+        Id = JsonString(id),
+        Method = "tools/call",
+        Params = Json($$"""
+            {"name":"{{toolName}}","arguments":{{argumentsJson}}}
+            """)
+    };
+
+    private static JsonElement JsonString(string value)
+    {
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(value));
+        return document.RootElement.Clone();
+    }
+
+    private static JsonElement Json(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -64,6 +64,7 @@ public sealed partial class McpTaxonomyAlignmentTests
             ["honua_solve_route"] = "solve_route",
             ["honua_list_layers"] = "list_layers",
             ["honua_query_features"] = "query_features",
+            ["honua_edit_features"] = "edit_features",
             ["honua_render_map"] = "render_map",
             ["honua_publish_service"] = "publish_service",
             // Honua extensions over the bare taxonomy (#1949): the standard models

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -44,6 +44,7 @@ public sealed partial class McpTaxonomyAlignmentTests
         "honua_solve_route",
         "honua_list_layers",
         "honua_query_features",
+        "honua_edit_features",
         "honua_render_map",
         "honua_resolve_entity",
         "honua_list_capabilities"
@@ -232,6 +233,7 @@ public sealed partial class McpTaxonomyAlignmentTests
             ["honua_publish_service"] = (Destructive: false, Idempotent: false),
             ["honua_create_map_package"] = (Destructive: false, Idempotent: false),
             ["honua_create_app_package"] = (Destructive: false, Idempotent: false),
+            ["honua_edit_features"] = (Destructive: true, Idempotent: false),
         };
 
     [UnitTest]
@@ -574,6 +576,8 @@ public sealed partial class McpTaxonomyAlignmentTests
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool(
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool>.Instance),
+            new Honua.Ai.Protocols.Mcp.MapTools.EditFeaturesTool(
+                jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.EditFeaturesTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool(
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.RenderMapTool>.Instance),
             new Honua.Ai.Protocols.Mcp.Discovery.ResolveEntityTool(


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1948

## Summary
Adds `honua_edit_features` — transactional feature editing (adds, updates, deletes) as an MCP tool. Transactional editing is Honua's stated moat vs Carto; this makes it agent-visible. The tool is a thin adapter over the shared edit/transaction pipeline every write surface uses (FeatureServer `applyEdits`, OGC API Features, WFS Transaction, OData CRUD): it resolves the layer via the Metadata v2 graph (`MapToolLayerResolver`), converts GeoJSON geometry to WKB via the shared `IGeometryService`, builds a protocol-neutral `UnifiedEditRequest`, validates + converts it through the canonical `IEditProcessor`, and executes through `IFeatureWriter.ApplyEditsAsync`. The writer transaction is the all-or-nothing boundary when `rollbackOnFailure=true`. No edit, validation, transaction, or optimistic-concurrency semantics are reimplemented.

## Changes Made
- `MapTools/EditFeaturesTool.cs`: the `IMcpTool` implementation (adapter over `IEditProcessor` + `IFeatureWriter`), including per-layer edit RBAC enforcement (below).
- `MapTools/MapToolModels.cs` + `MapToolJsonContext.cs`: `McpEditFeaturesArgument`/`McpEditFeature`/`McpEditFeaturesOutput`/`McpEditResult`/`McpEditSummary` DTOs (AOT source-gen).
- `MapTools/MapToolSchemas.cs` + `Tools/McpToolOutputSchemas.cs`: input/output JSON schemas.
- `McpServiceCollectionExtensions.cs`: capability-gated registration on `IEditProcessor` + `IFeatureWriter` (+ `IMetadataV2GraphProvider`), mirroring how `query_features` gates on the read abstractions.
- `Hosting/ServiceDataEditorAuthorization.cs`: extracted the decision-shaped core `EvaluateResourceDataEditorAsync` from `RequireResourceDataEditorCoreAsync`; the HTTP `IResult` wrapper delegates to it, so FeatureServer/OGC/OData behavior is byte-identical while non-HTTP-result adapters (MCP) consume the same core.
- `Geoprocessing/GeoprocessingJobExceptions.cs`: message-carrying ctor on `GeoprocessingAuthorizationException` so denials can name the missing permission through `McpErrorMapper`.
- `CapabilityRegistry.cs`: `honua_edit_features` → `edit_features` descriptor (Execution family).
- Vendored the geospatial-mcp `edit_features` schema/index/fixture into the test project (`x-honua-extension`) and updated the conformance/taxonomy/registry suites.
- Unit tests (`McpEditFeaturesToolTests`): adds/updates/deletes in one transaction, rollback-on-failure reporting + unchanged-state mock verification, per-edit error mapping, authz-denied error shape, per-layer RBAC denial per edit type, insert-only-grant semantics, empty-edit + missing-objectId validation guards.

## Guardrails / authorization
- Write annotation: `destructiveHint=true`, `idempotentHint=false`.
- Standard MCP operator gate via `EnsureCallerAuthorizedAsync(Process, Execute)` — same as every MCP write tool; unauthenticated/permission-denied surface through `McpErrorMapper` as `unauthenticated`/`permission_denied`.
- **Per-layer edit RBAC (review rework, Path A)**: after layer resolution the tool authorizes **every edit type present in the request, up front**, through the same shared seams the HTTP edit surfaces run (BH3-001/BH3-014 semantics):
  - `AccessPolicyHelpers.EvaluateResourceAccessAsync` — tenant scope, per-operation `IPermissionResolver` grants (#1376), coarse `AccessPolicy` fallback (the existing decision-shaped seam gRPC uses);
  - `ServiceDataEditorAuthorization.EvaluateResourceDataEditorAsync` — the decision-shaped core of the HTTP data-editor write gate (layer-scoped write keys #1637, explicit `AccessPolicy` write policy, per-operation RBAC grants, admin/data-editor/service-scoped role gate), newly extracted so the `IResult` wrapper and the MCP tool share one implementation.
  - Operations map per edit type: adds→`Insert`, updates→`Update`, deletes→`Delete`. A missing permission rejects the **whole request** (no partial application) with a structured `permission_denied` naming the missing grant (e.g. "Caller lacks the 'Update' permission required to apply 'updates' on layer ... of service ..."). The tool description states the permission requirement.
- The data-plane edit path deliberately does **not** route through the control-plane `IOperationGateway`/PDP (that seam is for agent-proposed control-plane operations + human approval); no new policy layer was invented.

## Standard-first schema flow
The `edit_features` schema was added to the geospatial-mcp standard first (companion PR honua-io/geospatial-mcp#47) as an `x-honua-extension`, then vendored here. **Note:** `edit_features` is in tension with the standard's ADR-0028 Edit-Data exclusion; the companion PR requests a maintainer decision to reconcile ADR-0028 for authenticated, authorized, transactional editing (escalated to the maintainer).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed
- Full-solution Release build (warnings-as-errors): 0 warnings, 0 errors (post trunk merge).
- `McpEditFeaturesToolTests` (8, incl. 2 RBAC tests exercising the REAL `AccessPolicyEvaluator`/`RbacOptions`/`IPermissionResolver` seams — not lookalikes), `McpTaxonomyAlignmentTests` incl. geospatial-mcp schema conformance (38), `McpMapToolTests` (8), `McpServiceCollectionExtensionsTests` (9), `McpAuthorizationTests` (20), `McpDiscoveryToolTests` (4), `CapabilityRegistryConformanceTests` (10/11) green.
- One pre-existing failure `CapabilityRegistryConformanceTests.ManifestCapabilities_AllHaveRegistryDescriptor` is unrelated (it explicitly filters out `mcp.tool.*` descriptors — this PR's only registry change; the manifest-ID drift predates this PR).
- geospatial-mcp checkers: fixtures validate + manifest `FULL`.
- Docker/Testcontainers integration shards validate on CI (not runnable locally).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
