### PR TITLE
fix(alerts): stop ops events crashing event reads + rendering as GIS junk; idempotency, backlog retention

### DIFF
--- a/src/Honua.Core/Features/Alerts/Abstractions/IAlertDataStores.cs
+++ b/src/Honua.Core/Features/Alerts/Abstractions/IAlertDataStores.cs
@@ -259,6 +259,21 @@ public interface IAlertDispatchStore
     /// <returns>Backlog snapshot.</returns>
     Task<AlertDispatchBacklog> GetBacklogAsync(
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Purges delivered dispatch rows whose delivery timestamp is older than
+    /// <paramref name="deliveredBefore"/>, up to <paramref name="batchLimit"/> rows.
+    /// Retention keeps the outbox bounded (delivered rows are otherwise never removed)
+    /// so backlog counts stay cheap.
+    /// </summary>
+    /// <param name="deliveredBefore">Delete delivered rows with <c>delivered_at</c> before this cutoff.</param>
+    /// <param name="batchLimit">Maximum rows to delete in this pass.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Number of rows deleted.</returns>
+    Task<int> PurgeDeliveredAsync(
+        DateTimeOffset deliveredBefore,
+        int batchLimit,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Alerts/Domain/AlertLifecycleModels.cs
+++ b/src/Honua.Core/Features/Alerts/Domain/AlertLifecycleModels.cs
@@ -102,9 +102,11 @@ public sealed record AlertEventSummary
     public required long EventId { get; init; }
 
     /// <summary>
-    /// Source rule identifier.
+    /// Source rule identifier, or <see langword="null"/> for operations
+    /// notifications (deploy/job terminal events) that reuse the alert outbox
+    /// but are not linked to an alert rule (#2427).
     /// </summary>
-    public required long RuleId { get; init; }
+    public required long? RuleId { get; init; }
 
     /// <summary>
     /// Source rule name when available.

--- a/src/Honua.Core/Features/Alerts/Domain/AlertOptions.cs
+++ b/src/Honua.Core/Features/Alerts/Domain/AlertOptions.cs
@@ -149,11 +149,20 @@ public sealed class AlertDispatchOptions
     public TimeSpan IdleDelay { get; init; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
-    /// Maximum outbound notifications delivered per channel per rolling minute.
-    /// When a channel exceeds this cap, further claimed dispatches for that channel
-    /// are rescheduled (not dead-lettered) until the window frees. Set to <c>0</c> to
-    /// disable the cap. Defaults to a generous 120/minute/channel.
+    /// Maximum outbound notifications delivered per channel per rolling minute,
+    /// enforced <b>per replica</b>. When a channel exceeds this cap, further claimed
+    /// dispatches for that channel are rescheduled (not dead-lettered) until the
+    /// window frees. Set to <c>0</c> to disable the cap. Defaults to a generous
+    /// 120/minute/channel.
     /// </summary>
+    /// <remarks>
+    /// The cap is enforced by a process-local, in-memory sliding window. The alert
+    /// dispatch worker is deliberately multi-consumer (every replica claims work via
+    /// <c>FOR UPDATE SKIP LOCKED</c> for throughput) and is <b>not</b> leader-elected,
+    /// so this cap is best-effort per replica: the effective cluster-wide ceiling is
+    /// approximately <c>value × replicaCount</c>. Size the value against a single
+    /// replica's budget and rely on downstream provider rate limits for hard caps.
+    /// </remarks>
     [Range(0, 1_000_000)]
     public int MaxNotificationsPerMinutePerChannel { get; init; } = 120;
 
@@ -170,6 +179,33 @@ public sealed class AlertDispatchOptions
     /// </summary>
     [Range(1, int.MaxValue)]
     public int UnhealthyDeadLetterThreshold { get; init; } = 1;
+
+    /// <summary>
+    /// Minimum interval between dispatch-backlog recomputations. The backlog count is
+    /// a full aggregate over the outbox, so it is refreshed at most once per interval
+    /// (and always after a non-empty claim batch) rather than on every idle poll.
+    /// </summary>
+    public TimeSpan BacklogRefreshInterval { get; init; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Retention window for delivered (status = delivered) dispatch rows. A periodic
+    /// sweep purges delivered rows older than this so the outbox does not grow
+    /// unbounded and backlog counts stay cheap. Set to <see cref="TimeSpan.Zero"/> or
+    /// negative to disable purging.
+    /// </summary>
+    public TimeSpan DeliveredRetention { get; init; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Minimum interval between delivered-row retention sweeps.
+    /// </summary>
+    public TimeSpan RetentionSweepInterval { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Maximum delivered rows deleted per retention sweep pass (bounded delete to avoid
+    /// long-running transactions).
+    /// </summary>
+    [Range(1, 1_000_000)]
+    public int RetentionBatchSize { get; init; } = 1_000;
 
     /// <summary>
     /// Digest delivery settings.

--- a/src/Honua.Postgres/Features/Alerts/AlertLog.cs
+++ b/src/Honua.Postgres/Features/Alerts/AlertLog.cs
@@ -58,4 +58,12 @@ internal static partial class AlertLog
     public static partial void DispatchDeadLettered(
         ILogger logger,
         long dispatchId);
+
+    [LoggerMessage(
+        EventId = 5607,
+        Level = LogLevel.Debug,
+        Message = "Purged {DeletedCount} delivered alert-dispatch rows past the retention window")]
+    public static partial void DispatchDeliveredPurged(
+        ILogger logger,
+        int deletedCount);
 }

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
@@ -233,11 +233,15 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
     {
         // Pending backlog = rows awaiting delivery: pending (0), in-flight/claimed (1),
         // and retriable-failed (3). Dead-lettered (4) rows are counted separately.
+        // The `status <> 2` predicate lets the planner serve the count from the
+        // partial ix_alert_dispatch_active index and skip delivered rows entirely,
+        // so this stays cheap even before retention has purged old delivered rows.
         const string sql = """
             SELECT
                 COUNT(*) FILTER (WHERE status IN (0, 1, 3)) AS pending,
                 COUNT(*) FILTER (WHERE status = 4) AS dead_lettered
             FROM honua.alert_dispatch
+            WHERE status <> 2
             """;
 
         await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -254,5 +258,45 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
             PendingCount = reader.IsDBNull(0) ? 0 : reader.GetInt64(0),
             DeadLetteredCount = reader.IsDBNull(1) ? 0 : reader.GetInt64(1)
         };
+    }
+
+    public async Task<int> PurgeDeliveredAsync(
+        DateTimeOffset deliveredBefore,
+        int batchLimit,
+        CancellationToken cancellationToken = default)
+    {
+        if (batchLimit <= 0)
+        {
+            return 0;
+        }
+
+        // Bounded delete of delivered (status = 2) rows older than the retention
+        // cutoff. The ix_alert_dispatch_delivered partial index serves the victim
+        // selection; the LIMIT keeps each sweep's transaction short.
+        const string sql = """
+            WITH victims AS (
+                SELECT dispatch_id
+                FROM honua.alert_dispatch
+                WHERE status = 2 AND delivered_at < @delivered_before
+                ORDER BY delivered_at
+                LIMIT @limit
+            )
+            DELETE FROM honua.alert_dispatch d
+            USING victims v
+            WHERE d.dispatch_id = v.dispatch_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("delivered_before", NpgsqlDbType.TimestampTz, deliveredBefore);
+        command.Parameters.AddWithValue("limit", NpgsqlDbType.Integer, batchLimit);
+
+        var deleted = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        if (deleted > 0)
+        {
+            AlertLog.DispatchDeliveredPurged(_logger, deleted);
+        }
+
+        return deleted;
     }
 }

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertEventQuery.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertEventQuery.cs
@@ -131,7 +131,7 @@ internal sealed class PostgresAlertEventQuery : IAlertEventQuery
         return new AlertEventSummary
         {
             EventId = reader.GetInt64(0),
-            RuleId = reader.GetInt64(1),
+            RuleId = reader.IsDBNull(1) ? null : reader.GetInt64(1),
             RuleName = reader.IsDBNull(2) ? null : reader.GetString(2),
             ZoneId = reader.IsDBNull(3) ? null : reader.GetInt64(3),
             ServiceId = reader.GetString(4),

--- a/src/Honua.Server/Features/Admin/Models/ObservabilityAlertModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/ObservabilityAlertModels.cs
@@ -11,8 +11,8 @@ internal sealed class ObservabilityAlertEventResponse
     /// <summary>Event identifier.</summary>
     public required long EventId { get; init; }
 
-    /// <summary>Source rule identifier.</summary>
-    public required long RuleId { get; init; }
+    /// <summary>Source rule identifier, or <see langword="null"/> for operations notifications not linked to an alert rule.</summary>
+    public required long? RuleId { get; init; }
 
     /// <summary>Source rule name when available.</summary>
     public string? RuleName { get; init; }

--- a/src/Honua.Server/Features/Alerts/AlertDispatchBackgroundService.cs
+++ b/src/Honua.Server/Features/Alerts/AlertDispatchBackgroundService.cs
@@ -65,6 +65,8 @@ internal sealed partial class AlertDispatchBackgroundService : BackgroundService
         }
 
         _isRunning = true;
+        var lastBacklogRefresh = DateTimeOffset.MinValue;
+        var lastRetentionSweep = DateTimeOffset.MinValue;
         try
         {
             while (!stoppingToken.IsCancellationRequested)
@@ -85,7 +87,27 @@ internal sealed partial class AlertDispatchBackgroundService : BackgroundService
                         await ProcessItemAsync(dispatchStore, eventStore, item, stoppingToken).ConfigureAwait(false);
                     }
 
-                    await RefreshBacklogAsync(dispatchStore, stoppingToken).ConfigureAwait(false);
+                    // The backlog count is a full outbox aggregate; recompute it after a
+                    // non-empty batch (state changed) or at most once per refresh interval
+                    // instead of on every idle poll.
+                    if (batch.Count > 0 || now - lastBacklogRefresh >= _options.Dispatch.BacklogRefreshInterval)
+                    {
+                        await RefreshBacklogAsync(dispatchStore, stoppingToken).ConfigureAwait(false);
+                        lastBacklogRefresh = now;
+                    }
+                    else
+                    {
+                        _storagePollFailing = false;
+                    }
+
+                    // Periodically purge delivered rows past the retention window so the
+                    // outbox stays bounded and backlog counts remain cheap.
+                    if (now - lastRetentionSweep >= _options.Dispatch.RetentionSweepInterval)
+                    {
+                        await PurgeDeliveredAsync(dispatchStore, now, stoppingToken).ConfigureAwait(false);
+                        lastRetentionSweep = now;
+                    }
+
                     Interlocked.Exchange(ref _lastPollAtTicks, now.UtcTicks);
 
                     if (batch.Count == 0)
@@ -117,6 +139,27 @@ internal sealed partial class AlertDispatchBackgroundService : BackgroundService
         Volatile.Write(ref _lastBacklog, backlog);
         _storagePollFailing = false;
         AlertPipelineMetrics.RecordBacklog(backlog.PendingCount, backlog.DeadLetteredCount);
+    }
+
+    private async Task PurgeDeliveredAsync(
+        IAlertDispatchStore dispatchStore,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var retention = _options.Dispatch.DeliveredRetention;
+        if (retention <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        var cutoff = now - retention;
+        var deleted = await dispatchStore
+            .PurgeDeliveredAsync(cutoff, _options.Dispatch.RetentionBatchSize, cancellationToken)
+            .ConfigureAwait(false);
+        if (deleted > 0)
+        {
+            LogDeliveredPurged(_logger, deleted);
+        }
     }
 
     private async Task ProcessItemAsync(
@@ -195,4 +238,7 @@ internal sealed partial class AlertDispatchBackgroundService : BackgroundService
 
     [LoggerMessage(EventId = 9424, Level = LogLevel.Information, Message = "Alert dispatch {DispatchId} for {ChannelType} deferred by the per-channel notification rate cap ({MaxPerMinute}/min).")]
     private static partial void LogRateCapped(ILogger logger, long dispatchId, AlertChannelType channelType, int maxPerMinute);
+
+    [LoggerMessage(EventId = 9425, Level = LogLevel.Debug, Message = "Purged {DeletedCount} delivered alert-dispatch rows past the retention window.")]
+    private static partial void LogDeliveredPurged(ILogger logger, int deletedCount);
 }

--- a/src/Honua.Server/Features/Alerts/AlertDispatchHealthCheck.cs
+++ b/src/Honua.Server/Features/Alerts/AlertDispatchHealthCheck.cs
@@ -9,12 +9,15 @@ using Microsoft.Extensions.Options;
 namespace Honua.Alerts;
 
 /// <summary>
-/// Surfaces alert delivery-outbox backlog and dead-letter accumulation to
-/// readiness/health endpoints so operators see delivery stalls before they become
-/// silent notification loss. Reads the cached snapshot the dispatcher publishes after
-/// each pass (no per-probe database query). Modeled on the feature-change outbox
-/// health check. Reports Healthy (with a note) when the pipeline is disabled — a
-/// disabled dispatcher is an operating choice, not a fault.
+/// Surfaces alert delivery-outbox backlog and dead-letter accumulation through the
+/// <see cref="HealthCheckService"/> roll-up (and the ops-health snapshot's
+/// <c>overallStatus</c>) so operators see delivery stalls before they become silent
+/// notification loss. Note this runs via the IHealthCheck registry, not the
+/// <c>/healthz/ready</c> readiness probe (which uses <c>ReadinessCheckService</c> and
+/// never executes registered health checks). Reads the cached snapshot the dispatcher
+/// publishes after each pass (no per-probe database query). Modeled on the
+/// feature-change outbox health check. Reports Healthy (with a note) when the pipeline
+/// is disabled — a disabled dispatcher is an operating choice, not a fault.
 /// </summary>
 internal sealed class AlertDispatchHealthCheck : IHealthCheck
 {

--- a/src/Honua.Server/Features/Alerts/AlertNotificationRateLimiter.cs
+++ b/src/Honua.Server/Features/Alerts/AlertNotificationRateLimiter.cs
@@ -11,9 +11,16 @@ namespace Honua.Alerts;
 /// notifications to <see cref="AlertDispatchOptions.MaxNotificationsPerMinutePerChannel"/>
 /// per rolling minute. The dispatch worker checks it BEFORE calling a delivery sink;
 /// a capped dispatch is rescheduled (retry budget untouched), never dead-lettered.
-/// A cap of <c>0</c> disables limiting. The limiter is process-local, matching the
-/// single-leader dispatcher model.
+/// A cap of <c>0</c> disables limiting.
 /// </summary>
+/// <remarks>
+/// The limiter is process-local. Unlike the alert <i>evaluation</i> service, the
+/// dispatch worker is deliberately multi-consumer (every replica claims work via
+/// <c>FOR UPDATE SKIP LOCKED</c> for throughput) and is <b>not</b> leader-elected, so
+/// this cap is best-effort <b>per replica</b>: the effective cluster-wide ceiling is
+/// approximately <c>cap × replicaCount</c>. It is a fairness/burst guard, not a hard
+/// cluster-wide quota; rely on downstream provider rate limits for hard ceilings.
+/// </remarks>
 internal sealed class AlertNotificationRateLimiter
 {
     private static readonly TimeSpan Window = TimeSpan.FromMinutes(1);

--- a/src/Honua.Server/Features/Alerts/EmailAlertDeliverySink.cs
+++ b/src/Honua.Server/Features/Alerts/EmailAlertDeliverySink.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Net;
 using System.Net.Mail;
+using Honua.Alerts.Ops;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
 using Microsoft.Extensions.Options;
@@ -49,16 +51,21 @@ internal sealed class EmailAlertDeliverySink : IAlertDeliverySink
 
         try
         {
+            var content = BuildContent(alertEvent);
             using var message = new MailMessage
             {
                 From = new MailAddress(emailOptions.FromAddress, emailOptions.FromName),
-                Subject = $"[Honua Alert] {alertEvent.Severity}: {alertEvent.TriggerType} on layer {alertEvent.LayerId}",
-                Body = alertEvent.PayloadJson,
+                Subject = content.Subject,
+                Body = content.Body,
                 IsBodyHtml = false
             };
             message.To.Add(new MailAddress(recipient));
 
-            message.Headers.Add("X-Honua-Alert-Rule", alertEvent.RuleId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            if (content.RuleHeader is not null)
+            {
+                message.Headers.Add("X-Honua-Alert-Rule", content.RuleHeader);
+            }
+
             message.Headers.Add("X-Honua-Alert-Event", alertEvent.DedupeKey);
 
             using var client = new SmtpClient(emailOptions.SmtpHost, emailOptions.SmtpPort)
@@ -111,4 +118,39 @@ internal sealed class EmailAlertDeliverySink : IAlertDeliverySink
             };
         }
     }
+
+    /// <summary>
+    /// Builds the email subject, body, and rule header for an alert event. Ops
+    /// notifications render their human-readable title/body/attributes; the rule
+    /// header is omitted (they are not linked to an alert rule). GIS alerts keep the
+    /// existing subject/body/rule-header formatting.
+    /// </summary>
+    internal static EmailAlertContent BuildContent(AlertEventEnvelope alertEvent)
+    {
+        if (OpsNotificationPresentation.TryResolve(alertEvent) is { } ops)
+        {
+            var body = ops.Body;
+            var attributes = OpsNotificationPresentation.FormatAttributes(ops.Attributes, "\n");
+            if (attributes.Length > 0)
+            {
+                body = string.IsNullOrWhiteSpace(body) ? attributes : $"{body}\n\n{attributes}";
+            }
+
+            return new EmailAlertContent(
+                Subject: $"[Honua Ops] {alertEvent.Severity}: {ops.Title}",
+                Body: body,
+                RuleHeader: null);
+        }
+
+        return new EmailAlertContent(
+            Subject: $"[Honua Alert] {alertEvent.Severity}: {alertEvent.TriggerType} on layer {alertEvent.LayerId}",
+            Body: alertEvent.PayloadJson,
+            RuleHeader: alertEvent.RuleId.ToString(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Rendered email content for an alert event.</summary>
+    /// <param name="Subject">Email subject line.</param>
+    /// <param name="Body">Plain-text email body.</param>
+    /// <param name="RuleHeader">Value for the <c>X-Honua-Alert-Rule</c> header, or null to omit it (ops events).</param>
+    internal readonly record struct EmailAlertContent(string Subject, string Body, string? RuleHeader);
 }

--- a/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
@@ -152,6 +152,6 @@ internal sealed partial class NotifyingWorkflowOperationStore : IWorkflowOperati
     public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
         => _inner.ReleaseLeaseAsync(operationId, ownerId, cancellationToken);
 
-    [LoggerMessage(EventId = 9434, Level = LogLevel.Warning, Message = "Ops notification for terminal deploy {OperationId} could not be enqueued.")]
+    [LoggerMessage(EventId = 9454, Level = LogLevel.Warning, Message = "Ops notification for terminal deploy {OperationId} could not be enqueued.")]
     private static partial void LogNotifyFailed(ILogger logger, string operationId, Exception exception);
 }

--- a/src/Honua.Server/Features/Alerts/Ops/OpsJobTerminalCallback.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/OpsJobTerminalCallback.cs
@@ -77,6 +77,6 @@ internal sealed partial class OpsJobTerminalCallback : IJobTerminalCallback
         }
     }
 
-    [LoggerMessage(EventId = 9433, Level = LogLevel.Warning, Message = "Ops notification for failed job {OperationId} could not be enqueued.")]
+    [LoggerMessage(EventId = 9453, Level = LogLevel.Warning, Message = "Ops notification for failed job {OperationId} could not be enqueued.")]
     private static partial void LogNotifyFailed(ILogger logger, string operationId, Exception exception);
 }

--- a/src/Honua.Server/Features/Alerts/Ops/OpsNotificationPresentation.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/OpsNotificationPresentation.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Alerts.Domain;
+
+namespace Honua.Alerts.Ops;
+
+/// <summary>
+/// Resolves the human-readable presentation of an ops notification carried on a
+/// shared alert-delivery envelope. Operations notifications (deploy/job terminal
+/// events) reuse the GIS alert outbox but persist their meaningful title/body in
+/// <see cref="AlertEventEnvelope.PayloadJson"/> while the rule/zone/layer/object/
+/// trigger scalars are inert placeholders (#2427). Human-readable sinks (Slack,
+/// Teams, Email) must render ops events from this payload rather than the GIS
+/// scalars, which would otherwise post meaningless "Rule: 0, Layer: 0" text.
+/// </summary>
+internal static class OpsNotificationPresentation
+{
+    /// <summary>
+    /// Returns the parsed ops payload when <paramref name="alertEvent"/> is an
+    /// operations notification (<see cref="AlertEventSources.Ops"/>); otherwise
+    /// <see langword="null"/> so callers fall back to GIS formatting.
+    /// </summary>
+    public static OpsAlertPayload? TryResolve(AlertEventEnvelope alertEvent)
+    {
+        if (alertEvent is null ||
+            !string.Equals(alertEvent.Source, AlertEventSources.Ops, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize(
+                alertEvent.PayloadJson,
+                OpsNotificationJsonContext.Default.OpsAlertPayload);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Formats ops attributes (operationId, workload, status, phase, …) as a stable,
+    /// key-ordered string joined by <paramref name="separator"/>. Empty when there
+    /// are no attributes.
+    /// </summary>
+    public static string FormatAttributes(
+        IReadOnlyDictionary<string, string>? attributes,
+        string separator)
+    {
+        if (attributes is null || attributes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return string.Join(
+            separator,
+            attributes
+                .OrderBy(static pair => pair.Key, StringComparer.Ordinal)
+                .Select(static pair => $"{pair.Key}: {pair.Value}"));
+    }
+
+    /// <summary>
+    /// Severity-derived emoji used by human-readable sinks. Ops events do not carry a
+    /// meaningful incident status, so presentation keys off severity instead.
+    /// </summary>
+    public static string SeverityEmoji(AlertSeverity severity) => severity switch
+    {
+        AlertSeverity.Critical => ":red_circle:",
+        AlertSeverity.Warning => ":large_orange_circle:",
+        _ => ":information_source:"
+    };
+}

--- a/src/Honua.Server/Features/Alerts/Ops/OpsNotificationService.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/OpsNotificationService.cs
@@ -134,12 +134,12 @@ internal sealed partial class OpsNotificationService
         };
     }
 
-    [LoggerMessage(EventId = 9430, Level = LogLevel.Debug, Message = "Ops notification from {Source} ({Severity}) skipped: below minimum severity {MinSeverity}.")]
+    [LoggerMessage(EventId = 9450, Level = LogLevel.Debug, Message = "Ops notification from {Source} ({Severity}) skipped: below minimum severity {MinSeverity}.")]
     private static partial void LogBelowMinSeverity(ILogger logger, string source, AlertSeverity severity, AlertSeverity minSeverity);
 
-    [LoggerMessage(EventId = 9431, Level = LogLevel.Warning, Message = "Ops notification channel {ChannelType} for {Source} is not allowed by edition {Edition}; skipping that channel.")]
+    [LoggerMessage(EventId = 9451, Level = LogLevel.Warning, Message = "Ops notification channel {ChannelType} for {Source} is not allowed by edition {Edition}; skipping that channel.")]
     private static partial void LogChannelNotAllowed(ILogger logger, string source, AlertChannelType channelType, AlertEdition edition);
 
-    [LoggerMessage(EventId = 9432, Level = LogLevel.Information, Message = "Ops notification from {Source} ({Severity}) enqueued to {ChannelCount} channel(s) (dedupe {DedupeIdentifier}).")]
+    [LoggerMessage(EventId = 9452, Level = LogLevel.Information, Message = "Ops notification from {Source} ({Severity}) enqueued to {ChannelCount} channel(s) (dedupe {DedupeIdentifier}).")]
     private static partial void LogEnqueued(ILogger logger, string source, AlertSeverity severity, int channelCount, string dedupeIdentifier);
 }

--- a/src/Honua.Server/Features/Alerts/SlackAlertDeliverySink.cs
+++ b/src/Honua.Server/Features/Alerts/SlackAlertDeliverySink.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json;
+using Honua.Alerts.Ops;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Configuration;
@@ -67,30 +68,12 @@ internal sealed class SlackAlertDeliverySink : IAlertDeliverySink
                 _ => "#17a2b8"
             };
 
-            var statusEmoji = alertEvent.IncidentStatus switch
-            {
-                AlertIncidentStatus.Started => ":red_circle:",
-                AlertIncidentStatus.Ongoing => ":large_orange_circle:",
-                AlertIncidentStatus.Ended => ":white_check_mark:",
-                _ => ":bell:"
-            };
+            var attachment = OpsNotificationPresentation.TryResolve(alertEvent) is { } ops
+                ? BuildOpsAttachment(alertEvent, ops, color)
+                : BuildGisAttachment(alertEvent, color);
 
             var payload = JsonSerializer.Serialize(
-                new SlackAlertPayload
-                {
-                    Attachments =
-                    [
-                        new SlackAlertAttachment
-                        {
-                            Color = color,
-                            Fallback = $"Honua Alert: {alertEvent.TriggerType} ({alertEvent.Severity})",
-                            Title = $"{statusEmoji} Honua Alert: {alertEvent.TriggerType}",
-                            Text = $"*Severity:* {alertEvent.Severity}\n*Status:* {alertEvent.IncidentStatus}\n*Rule:* {alertEvent.RuleId}\n*Layer:* {alertEvent.LayerId} / Feature: {alertEvent.ObjectId}",
-                            Footer = "Honua Alerts",
-                            Timestamp = alertEvent.OccurredAt.ToUnixTimeSeconds()
-                        }
-                    ]
-                },
+                new SlackAlertPayload { Attachments = [attachment] },
                 AlertDeliveryJsonContext.Default.SlackAlertPayload);
 
             using var request = new HttpRequestMessage(HttpMethod.Post, destinationValidation.Uri)
@@ -127,5 +110,55 @@ internal sealed class SlackAlertDeliverySink : IAlertDeliverySink
                 Error = "Slack delivery failed."
             };
         }
+    }
+
+    private static SlackAlertAttachment BuildGisAttachment(AlertEventEnvelope alertEvent, string color)
+    {
+        var statusEmoji = alertEvent.IncidentStatus switch
+        {
+            AlertIncidentStatus.Started => ":red_circle:",
+            AlertIncidentStatus.Ongoing => ":large_orange_circle:",
+            AlertIncidentStatus.Ended => ":white_check_mark:",
+            _ => ":bell:"
+        };
+
+        return new SlackAlertAttachment
+        {
+            Color = color,
+            Fallback = $"Honua Alert: {alertEvent.TriggerType} ({alertEvent.Severity})",
+            Title = $"{statusEmoji} Honua Alert: {alertEvent.TriggerType}",
+            Text = $"*Severity:* {alertEvent.Severity}\n*Status:* {alertEvent.IncidentStatus}\n*Rule:* {alertEvent.RuleId}\n*Layer:* {alertEvent.LayerId} / Feature: {alertEvent.ObjectId}",
+            Footer = "Honua Alerts",
+            Timestamp = alertEvent.OccurredAt.ToUnixTimeSeconds()
+        };
+    }
+
+    private static SlackAlertAttachment BuildOpsAttachment(
+        AlertEventEnvelope alertEvent,
+        OpsAlertPayload ops,
+        string color)
+    {
+        var text = new StringBuilder();
+        text.Append("*Severity:* ").Append(alertEvent.Severity).Append("\n*Source:* ").Append(ops.Source);
+        if (!string.IsNullOrWhiteSpace(ops.Body))
+        {
+            text.Append('\n').Append(ops.Body);
+        }
+
+        var attributes = OpsNotificationPresentation.FormatAttributes(ops.Attributes, "\n");
+        if (attributes.Length > 0)
+        {
+            text.Append('\n').Append(attributes);
+        }
+
+        return new SlackAlertAttachment
+        {
+            Color = color,
+            Fallback = $"Honua Ops: {ops.Title} ({alertEvent.Severity})",
+            Title = $"{OpsNotificationPresentation.SeverityEmoji(alertEvent.Severity)} {ops.Title}",
+            Text = text.ToString(),
+            Footer = "Honua Ops",
+            Timestamp = alertEvent.OccurredAt.ToUnixTimeSeconds()
+        };
     }
 }

--- a/src/Honua.Server/Features/Alerts/TeamsAlertDeliverySink.cs
+++ b/src/Honua.Server/Features/Alerts/TeamsAlertDeliverySink.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using Honua.Alerts.Ops;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Configuration;
@@ -68,31 +70,19 @@ internal sealed class TeamsAlertDeliverySink : IAlertDeliverySink
             };
 
             // Use Office 365 Connector card format (MessageCard) for broad compatibility.
+            var ops = OpsNotificationPresentation.TryResolve(alertEvent);
+            var summary = ops is null
+                ? $"Honua Alert: {alertEvent.TriggerType} ({alertEvent.Severity})"
+                : $"Honua Ops: {ops.Title} ({alertEvent.Severity})";
+
             var payload = JsonSerializer.Serialize(
                 new TeamsAlertPayload
                 {
                     Type = "MessageCard",
                     Context = "https://schema.org/extensions",
                     ThemeColor = themeColor,
-                    Summary = $"Honua Alert: {alertEvent.TriggerType} ({alertEvent.Severity})",
-                    Sections =
-                    [
-                        new TeamsAlertSection
-                        {
-                            ActivityTitle = $"Honua Alert: {alertEvent.TriggerType}",
-                            ActivitySubtitle = $"Incident {alertEvent.IncidentStatus}",
-                            Facts =
-                            [
-                                new TeamsAlertFact { Name = "Severity", Value = alertEvent.Severity.ToString() },
-                                new TeamsAlertFact { Name = "Status", Value = alertEvent.IncidentStatus.ToString() },
-                                new TeamsAlertFact { Name = "Rule ID", Value = alertEvent.RuleId.ToString(System.Globalization.CultureInfo.InvariantCulture) },
-                                new TeamsAlertFact { Name = "Layer", Value = alertEvent.LayerId.ToString(System.Globalization.CultureInfo.InvariantCulture) },
-                                new TeamsAlertFact { Name = "Feature", Value = alertEvent.ObjectId.ToString(System.Globalization.CultureInfo.InvariantCulture) },
-                                new TeamsAlertFact { Name = "Occurred At", Value = alertEvent.OccurredAt.ToString("O") }
-                            ],
-                            Markdown = true
-                        }
-                    ]
+                    Summary = summary,
+                    Sections = [ops is null ? BuildGisSection(alertEvent) : BuildOpsSection(alertEvent, ops)]
                 },
                 AlertDeliveryJsonContext.Default.TeamsAlertPayload);
 
@@ -130,5 +120,48 @@ internal sealed class TeamsAlertDeliverySink : IAlertDeliverySink
                 Error = "Teams delivery failed."
             };
         }
+    }
+
+    private static TeamsAlertSection BuildGisSection(AlertEventEnvelope alertEvent) => new()
+    {
+        ActivityTitle = $"Honua Alert: {alertEvent.TriggerType}",
+        ActivitySubtitle = $"Incident {alertEvent.IncidentStatus}",
+        Facts =
+        [
+            new TeamsAlertFact { Name = "Severity", Value = alertEvent.Severity.ToString() },
+            new TeamsAlertFact { Name = "Status", Value = alertEvent.IncidentStatus.ToString() },
+            new TeamsAlertFact { Name = "Rule ID", Value = alertEvent.RuleId.ToString(CultureInfo.InvariantCulture) },
+            new TeamsAlertFact { Name = "Layer", Value = alertEvent.LayerId.ToString(CultureInfo.InvariantCulture) },
+            new TeamsAlertFact { Name = "Feature", Value = alertEvent.ObjectId.ToString(CultureInfo.InvariantCulture) },
+            new TeamsAlertFact { Name = "Occurred At", Value = alertEvent.OccurredAt.ToString("O") }
+        ],
+        Markdown = true
+    };
+
+    private static TeamsAlertSection BuildOpsSection(AlertEventEnvelope alertEvent, OpsAlertPayload ops)
+    {
+        var facts = new List<TeamsAlertFact>
+        {
+            new() { Name = "Severity", Value = alertEvent.Severity.ToString() },
+            new() { Name = "Source", Value = ops.Source }
+        };
+
+        if (ops.Attributes is not null)
+        {
+            foreach (var pair in ops.Attributes.OrderBy(static p => p.Key, StringComparer.Ordinal))
+            {
+                facts.Add(new TeamsAlertFact { Name = pair.Key, Value = pair.Value });
+            }
+        }
+
+        facts.Add(new TeamsAlertFact { Name = "Occurred At", Value = alertEvent.OccurredAt.ToString("O") });
+
+        return new TeamsAlertSection
+        {
+            ActivityTitle = ops.Title,
+            ActivitySubtitle = string.IsNullOrWhiteSpace(ops.Body) ? ops.Source : ops.Body,
+            Facts = [.. facts],
+            Markdown = true
+        };
     }
 }

--- a/src/Honua.Server/Features/Alerts/WebhookAlertDeliverySink.cs
+++ b/src/Honua.Server/Features/Alerts/WebhookAlertDeliverySink.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Globalization;
 using System.Text;
+using Honua.Alerts.Ops;
 using Honua.Core.Features.Alerts.Abstractions;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Configuration;
@@ -79,7 +80,18 @@ internal sealed class WebhookAlertDeliverySink : IAlertDeliverySink
             };
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
             var signature = WebhookDeliveryHelper.ComputeSignature(_options.Dispatch.DefaultWebhookSecret, timestamp, alertEvent.PayloadJson);
-            WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Alert-Rule", alertEvent.RuleId.ToString(CultureInfo.InvariantCulture));
+
+            // Ops notifications are not linked to an alert rule; emit the ops source
+            // instead of a misleading "0" rule reference (#2427).
+            if (OpsNotificationPresentation.TryResolve(alertEvent) is { } ops)
+            {
+                WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Alert-Source", ops.Source);
+            }
+            else
+            {
+                WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Alert-Rule", alertEvent.RuleId.ToString(CultureInfo.InvariantCulture));
+            }
+
             WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Alert-Event", alertEvent.DedupeKey);
             WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Event-Timestamp", timestamp);
             WebhookDeliveryHelper.AddValidatedHeader(request.Headers, "X-Honua-Signature", $"sha256={signature}");

--- a/src/Honua.Server/Features/ControlPlane/OperationGateway.cs
+++ b/src/Honua.Server/Features/ControlPlane/OperationGateway.cs
@@ -232,10 +232,28 @@ internal sealed partial class OperationGateway : IOperationGateway
             plan = plan with { ExecutionPayload = request.ExecutionPayload };
         }
 
+        // Honor the idempotency key on the approval path: a repeated proposal (e.g.
+        // propose → refresh → propose) must fold onto the existing active proposal
+        // rather than minting a duplicate AwaitingApproval record (#1693). The
+        // proposal id is derived deterministically from the key so a concurrent
+        // duplicate TryCreate collides and we fetch-and-return the winner (race-safe).
+        var hasIdempotencyKey = !string.IsNullOrWhiteSpace(request.IdempotencyKey);
+        if (hasIdempotencyKey)
+        {
+            var existing = await FindActiveByIdempotencyKeyAsync(request.Kind, request.IdempotencyKey!, cancellationToken)
+                .ConfigureAwait(false);
+            if (existing != null)
+            {
+                return ExistingProposalResult(existing, decision, request.IdempotencyKey!);
+            }
+        }
+
         var now = DateTimeOffset.UtcNow;
         var proposal = new OperationProposal
         {
-            ProposalId = $"proposal-{Guid.NewGuid():N}",
+            ProposalId = hasIdempotencyKey
+                ? DeriveProposalId(request.Kind, request.IdempotencyKey!)
+                : $"proposal-{Guid.NewGuid():N}",
             Kind = request.Kind,
             Status = OperationProposalStatus.AwaitingApproval,
             RequestedBy = request.RequestedBy,
@@ -257,6 +275,17 @@ internal sealed partial class OperationGateway : IOperationGateway
             .ConfigureAwait(false);
         if (!created)
         {
+            // Lost a race (or an idempotent replay landed) under the same id: fetch and
+            // return the winning proposal instead of failing the caller.
+            if (hasIdempotencyKey)
+            {
+                var winner = await _proposalStore.GetAsync(proposal.ProposalId, cancellationToken).ConfigureAwait(false);
+                if (winner != null)
+                {
+                    return ExistingProposalResult(winner, decision, request.IdempotencyKey!);
+                }
+            }
+
             throw new InvalidOperationException("Failed to durably persist the operation proposal.");
         }
 
@@ -276,6 +305,37 @@ internal sealed partial class OperationGateway : IOperationGateway
             ProposalId = proposal.ProposalId,
             Message = "Proposal created and awaiting approval."
         };
+    }
+
+    private async Task<OperationProposal?> FindActiveByIdempotencyKeyAsync(
+        OperationClass kind,
+        string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        var active = await _proposalStore.ListActiveAsync(kind, cancellationToken).ConfigureAwait(false);
+        return active.FirstOrDefault(
+            proposal => string.Equals(proposal.Audit.IdempotencyKey, idempotencyKey, StringComparison.Ordinal));
+    }
+
+    private static OperationGatewayResult ExistingProposalResult(
+        OperationProposal existing,
+        GuardrailDecision decision,
+        string idempotencyKey) => new()
+        {
+            Outcome = OperationGatewayOutcome.ProposalCreated,
+            Decision = decision,
+            ProposalId = existing.ProposalId,
+            Message = $"Existing proposal returned for idempotency key '{idempotencyKey}'.",
+        };
+
+    // Derive a stable proposal id from (kind, idempotency key) so a repeated proposal
+    // maps to the same durable record. This makes TryCreate collide on a duplicate,
+    // giving the gateway a race-safe fetch-and-return instead of a second proposal.
+    private static string DeriveProposalId(OperationClass kind, string idempotencyKey)
+    {
+        var material = System.Text.Encoding.UTF8.GetBytes($"{kind}:{idempotencyKey}");
+        var hash = System.Security.Cryptography.SHA256.HashData(material);
+        return $"proposal-{Convert.ToHexString(hash)[..32].ToLowerInvariant()}";
     }
 
     private async Task PersistResolutionAsync(OperationProposal proposal, CancellationToken cancellationToken)

--- a/src/Honua.Server/Features/HealthCheck/ProductionHealthChecks.cs
+++ b/src/Honua.Server/Features/HealthCheck/ProductionHealthChecks.cs
@@ -81,7 +81,9 @@ internal static class ProductionHealthChecks
             OutboxTags);
 
         // Alert delivery outbox (#2427): surfaces dispatch backlog growth and dead-letter
-        // accumulation on the readiness endpoint so notification-delivery stalls are visible
+        // accumulation through the HealthCheckService roll-up / ops-health snapshot
+        // overallStatus (not the /healthz/ready probe, which uses ReadinessCheckService and
+        // does not run registered health checks) so notification-delivery stalls are visible
         // before they become silent loss. Reports Healthy when the pipeline is disabled.
         healthChecksBuilder.AddCheck<Honua.Alerts.AlertDispatchHealthCheck>(
             "alert-dispatch",

--- a/src/Honua.Server/Migrations/076_AddAlertDispatchRetentionIndexes.sql
+++ b/src/Honua.Server/Migrations/076_AddAlertDispatchRetentionIndexes.sql
@@ -1,0 +1,22 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 076_AddAlertDispatchRetentionIndexes.sql
+-- Description: Keeps the alert delivery outbox backlog count cheap and the outbox
+--              bounded (alerts GA follow-up, #2481). Before this, GetBacklogAsync
+--              scanned the whole honua.alert_dispatch table (the only partial index
+--              covered status IN (0,3)) every dispatch pass, and delivered (status=2)
+--              rows were never purged, so both grew without bound.
+
+-- Serve the backlog count (status IN (0,1,3) and status = 4) from a partial index that
+-- excludes delivered rows. Paired with the `WHERE status <> 2` predicate in
+-- GetBacklogAsync so the planner skips the delivered mass entirely.
+CREATE INDEX IF NOT EXISTS ix_alert_dispatch_active
+    ON honua.alert_dispatch(status)
+    WHERE status <> 2;
+
+-- Serve the retention delete of delivered rows (status = 2 AND delivered_at < cutoff)
+-- so the periodic purge does not seq-scan the delivered mass.
+CREATE INDEX IF NOT EXISTS ix_alert_dispatch_delivered
+    ON honua.alert_dispatch(delivered_at)
+    WHERE status = 2;

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertDispatchStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertDispatchStoreTests.cs
@@ -1,0 +1,260 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Alerts;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Alerts;
+
+/// <summary>
+/// Integration tests for <see cref="PostgresAlertDispatchStore"/> backlog counting and
+/// delivered-row retention (#2481). The dispatch store targets the literal
+/// <c>honua.alert_dispatch</c> table (search-path isolation does not scope it), so this
+/// suite mirrors <see cref="PostgresAlertAdminStoreTests"/>'s global-schema pattern.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
+{
+    [IntegrationTest]
+    public async Task GetBacklogAsync_ExcludesDeliveredRows_AndCountsPendingAndDeadLettered()
+    {
+        await EnsureAlertSchemaAsync();
+        await ClearAlertTablesAsync();
+
+        var eventId = await InsertRuleAndEventAsync();
+        await InsertDispatchAsync(eventId, status: 0, deliveredAt: null);              // pending
+        await InsertDispatchAsync(eventId, status: 1, deliveredAt: null);              // processing
+        await InsertDispatchAsync(eventId, status: 3, deliveredAt: null);              // failed (retriable)
+        await InsertDispatchAsync(eventId, status: 4, deliveredAt: null);              // dead-letter
+        await InsertDispatchAsync(eventId, status: 2, deliveredAt: DateTimeOffset.UtcNow); // delivered
+
+        var store = new PostgresAlertDispatchStore(
+            new TestConnectionProvider(fixture.DataSource),
+            NullLogger<PostgresAlertDispatchStore>.Instance);
+
+        var backlog = await store.GetBacklogAsync();
+
+        backlog.PendingCount.Should().Be(3, "pending, processing, and retriable-failed rows are backlog");
+        backlog.DeadLetteredCount.Should().Be(1);
+    }
+
+    [IntegrationTest]
+    public async Task PurgeDeliveredAsync_DeletesOnlyOldDeliveredRows()
+    {
+        await EnsureAlertSchemaAsync();
+        await ClearAlertTablesAsync();
+
+        var eventId = await InsertRuleAndEventAsync();
+        var now = DateTimeOffset.UtcNow;
+        await InsertDispatchAsync(eventId, status: 2, deliveredAt: now.AddHours(-48)); // old delivered → purged
+        await InsertDispatchAsync(eventId, status: 2, deliveredAt: now.AddHours(-1));  // recent delivered → kept
+        await InsertDispatchAsync(eventId, status: 0, deliveredAt: null);              // pending → kept
+        await InsertDispatchAsync(eventId, status: 4, deliveredAt: null);              // dead-letter → kept
+
+        var store = new PostgresAlertDispatchStore(
+            new TestConnectionProvider(fixture.DataSource),
+            NullLogger<PostgresAlertDispatchStore>.Instance);
+
+        var deleted = await store.PurgeDeliveredAsync(now.AddHours(-24), batchLimit: 100);
+
+        deleted.Should().Be(1, "only the delivered row older than the cutoff is purged");
+        (await CountDispatchAsync()).Should().Be(3);
+        (await CountDispatchByStatusAsync(2)).Should().Be(1, "the recent delivered row is retained");
+    }
+
+    [IntegrationTest]
+    public async Task PurgeDeliveredAsync_RespectsBatchLimit()
+    {
+        await EnsureAlertSchemaAsync();
+        await ClearAlertTablesAsync();
+
+        var eventId = await InsertRuleAndEventAsync();
+        var now = DateTimeOffset.UtcNow;
+        for (var i = 0; i < 5; i++)
+        {
+            await InsertDispatchAsync(eventId, status: 2, deliveredAt: now.AddHours(-48));
+        }
+
+        var store = new PostgresAlertDispatchStore(
+            new TestConnectionProvider(fixture.DataSource),
+            NullLogger<PostgresAlertDispatchStore>.Instance);
+
+        var deleted = await store.PurgeDeliveredAsync(now.AddHours(-24), batchLimit: 2);
+
+        deleted.Should().Be(2, "the batch limit caps the number of rows deleted per pass");
+        (await CountDispatchByStatusAsync(2)).Should().Be(3);
+    }
+
+    private async Task<long> InsertRuleAndEventAsync()
+    {
+        long eventId = 0;
+        await fixture.RunUnderSchemaMutationLockAsync(async () =>
+        {
+            await using var connection = await fixture.GetConnectionAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO honua.alert_rules (
+                    rule_id, service_id, layer_id, rule_name, trigger_type, conditions,
+                    cooldown_seconds, severity, edition_required, channels, is_active)
+                VALUES (
+                    9001, 'svc-a', 1, 'rule-9001', 1, '{}'::jsonb,
+                    0, 'warning', 1, '{}'::text[], TRUE)
+                ON CONFLICT (rule_id) DO NOTHING;
+
+                INSERT INTO honua.alert_events (
+                    dedupe_key, rule_id, service_id, layer_id, objectid, trigger_type, generation,
+                    severity, occurred_at, payload, incident_status, incident_duration_ms)
+                VALUES (
+                    @dedupe_key, 9001, 'svc-a', 1, 1, 1, 1,
+                    'warning', now(), '{}'::jsonb, 1, 0)
+                RETURNING event_id;
+                """;
+            command.Parameters.AddWithValue("dedupe_key", Guid.NewGuid().ToString("N"));
+            var result = await command.ExecuteScalarAsync();
+            eventId = Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture);
+        });
+        return eventId;
+    }
+
+    private async Task InsertDispatchAsync(long eventId, short status, DateTimeOffset? deliveredAt)
+    {
+        await fixture.ApplyGlobalSeedSqlAsync(
+            """
+            INSERT INTO honua.alert_dispatch (
+                event_id, channel_type, status, attempts, max_attempts, next_attempt_at, delivered_at)
+            VALUES (
+                @event_id, 1, @status, 0, 5, now(), @delivered_at);
+            """,
+            command =>
+            {
+                command.Parameters.AddWithValue("event_id", eventId);
+                command.Parameters.AddWithValue("status", status);
+                command.Parameters.AddWithValue("delivered_at", (object?)deliveredAt ?? DBNull.Value);
+            });
+    }
+
+    private async Task<long> CountDispatchAsync()
+    {
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM honua.alert_dispatch;";
+        return Convert.ToInt64(await command.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private async Task<long> CountDispatchByStatusAsync(short status)
+    {
+        await using var connection = await fixture.GetConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM honua.alert_dispatch WHERE status = @status;";
+        command.Parameters.AddWithValue("status", status);
+        return Convert.ToInt64(await command.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private async Task EnsureAlertSchemaAsync()
+    {
+        await fixture.ApplyGlobalSeedSqlAsync("""
+            CREATE SCHEMA IF NOT EXISTS honua;
+
+            CREATE TABLE IF NOT EXISTS honua.alert_rules (
+                rule_id BIGSERIAL PRIMARY KEY,
+                service_id TEXT NOT NULL,
+                layer_id INT NOT NULL,
+                zone_id BIGINT NULL,
+                rule_name TEXT NOT NULL,
+                trigger_type SMALLINT NOT NULL,
+                conditions JSONB NOT NULL DEFAULT '{}'::jsonb,
+                cooldown_seconds INT NOT NULL DEFAULT 0,
+                severity TEXT NOT NULL DEFAULT 'warning',
+                edition_required SMALLINT NOT NULL DEFAULT 1,
+                channels TEXT[] NOT NULL DEFAULT '{}'::text[],
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS honua.alert_events (
+                event_id BIGSERIAL PRIMARY KEY,
+                dedupe_key TEXT NOT NULL UNIQUE,
+                rule_id BIGINT NULL REFERENCES honua.alert_rules(rule_id) ON DELETE CASCADE,
+                zone_id BIGINT NULL,
+                service_id TEXT NOT NULL,
+                layer_id INT NOT NULL,
+                objectid BIGINT NOT NULL,
+                trigger_type SMALLINT NOT NULL,
+                generation BIGINT NOT NULL,
+                severity TEXT NOT NULL,
+                occurred_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+                incident_status SMALLINT NOT NULL DEFAULT 1,
+                incident_duration_ms BIGINT NOT NULL DEFAULT 0,
+                source TEXT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS honua.alert_dispatch (
+                dispatch_id BIGSERIAL PRIMARY KEY,
+                event_id BIGINT NOT NULL REFERENCES honua.alert_events(event_id) ON DELETE CASCADE,
+                channel_type SMALLINT NOT NULL,
+                destination TEXT,
+                status SMALLINT NOT NULL DEFAULT 0,
+                attempts INT NOT NULL DEFAULT 0,
+                max_attempts INT NOT NULL DEFAULT 5,
+                next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                last_attempt_at TIMESTAMPTZ,
+                delivered_at TIMESTAMPTZ,
+                last_error TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+            """);
+    }
+
+    private async Task ClearAlertTablesAsync()
+    {
+        await fixture.ApplyGlobalSeedSqlAsync("""
+            TRUNCATE TABLE
+                honua.alert_dispatch,
+                honua.alert_events,
+                honua.alert_rules
+            RESTART IDENTITY CASCADE;
+            """);
+    }
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource) : IAdoNetDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await dataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var conn = await dataSource.OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var tx = await conn.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (conn, tx);
+            }
+            catch
+            {
+                await conn.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(Func<Task> operation, CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertEventQueryTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertEventQueryTests.cs
@@ -149,6 +149,40 @@ public sealed class PostgresAlertEventQueryTests(PostgresFixture fixture)
     }
 
     [IntegrationTest]
+    public async Task ListAsync_WithOpsEventNullRuleId_DoesNotThrowAndReturnsNullRuleId()
+    {
+        // Regression: migration 075 relaxed rule_id to NULL so ops notifications
+        // (deploy/job terminal events) can reuse the alert outbox. The list mapper
+        // previously called GetInt64 unconditionally and threw InvalidCastException
+        // when an ops row (NULL rule_id) surfaced (#2427).
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresAlertEventQueryTests));
+        try
+        {
+            await EnsureSchemaAsync(schema);
+            var baseTime = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+            await InsertEventAsync(schema, ruleId: 7, severity: "warning", occurredAt: baseTime);
+            var opsEventId = await InsertOpsEventAsync(schema, severity: "critical", occurredAt: baseTime.AddSeconds(1));
+
+            var query = new PostgresAlertEventQuery(new TestConnectionProvider(fixture.DataSource, schema), schema);
+
+            var page = await query.ListAsync(new AlertEventFilter { PageSize = 10 });
+
+            page.Items.Should().HaveCount(2);
+            var opsRow = page.Items.Single(item => item.EventId == opsEventId);
+            opsRow.RuleId.Should().BeNull();
+            opsRow.Severity.Should().Be(AlertSeverity.Critical);
+
+            var single = await query.GetAsync(opsEventId);
+            single.Should().NotBeNull();
+            single!.RuleId.Should().BeNull();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
     public async Task SuppressAsync_PersistsExpiryAndAuditMetadata()
     {
         var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresAlertEventQueryTests));
@@ -314,13 +348,36 @@ public sealed class PostgresAlertEventQueryTests(PostgresFixture fixture)
         return (eventId, ruleId);
     }
 
+    private async Task<long> InsertOpsEventAsync(
+        string schema,
+        string severity,
+        DateTimeOffset occurredAt,
+        string serviceId = "deploy")
+    {
+        await using var conn = await fixture.GetConnectionAsync(schema);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $$"""
+            INSERT INTO "{{schema}}".alert_events (
+                dedupe_key, rule_id, service_id, layer_id, objectid, trigger_type, generation,
+                severity, occurred_at, payload, incident_status, incident_duration_ms, source)
+            VALUES (@dedupe, NULL, @svc, 0, 0, 1, 0, @sev, @occurred, '{}'::jsonb, 1, 0, 'ops')
+            RETURNING event_id;
+            """;
+        cmd.Parameters.AddWithValue("dedupe", Guid.NewGuid().ToString("N"));
+        cmd.Parameters.AddWithValue("svc", serviceId);
+        cmd.Parameters.AddWithValue("sev", severity);
+        cmd.Parameters.AddWithValue("occurred", occurredAt);
+
+        return (long)(await cmd.ExecuteScalarAsync())!;
+    }
+
     private async Task EnsureSchemaAsync(string schema)
     {
         await fixture.ExecuteAsync($$"""
             CREATE TABLE IF NOT EXISTS "{{schema}}".alert_events (
                 event_id BIGSERIAL PRIMARY KEY,
                 dedupe_key TEXT NOT NULL UNIQUE,
-                rule_id BIGINT NOT NULL,
+                rule_id BIGINT NULL,
                 zone_id BIGINT NULL,
                 service_id TEXT NOT NULL,
                 layer_id INT NOT NULL,
@@ -332,6 +389,7 @@ public sealed class PostgresAlertEventQueryTests(PostgresFixture fixture)
                 payload JSONB NOT NULL DEFAULT '{}'::jsonb,
                 incident_status SMALLINT NOT NULL DEFAULT 1,
                 incident_duration_ms BIGINT NOT NULL DEFAULT 0,
+                source TEXT NULL,
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             );
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Alerts/AlertTestFixtures.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Alerts/AlertTestFixtures.cs
@@ -2,8 +2,10 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Text.Json;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Alerts;
+using Honua.Alerts.Ops;
 
 namespace Honua.Server.Tests.Features.Alerts;
 
@@ -43,6 +45,48 @@ internal static class AlertTestFixtures
             PayloadJson = "{\"test\":true}",
             IncidentStatus = incidentStatus
         };
+
+    /// <summary>
+    /// Builds an operations-notification envelope (source = ops) whose meaningful
+    /// title/body/attributes live in the payload and whose rule/layer/object scalars
+    /// are inert placeholders (#2427).
+    /// </summary>
+    public static AlertEventEnvelope CreateOpsAlertEvent(
+        AlertSeverity severity = AlertSeverity.Critical,
+        string title = "Deploy prod-web failed",
+        string body = "Deployment of prod-web to production failed during migration.",
+        string source = "deploy-workflow",
+        string operationId = "op-9f3c")
+    {
+        var payload = new OpsAlertPayload
+        {
+            Source = source,
+            Severity = severity.ToString(),
+            Title = title,
+            Body = body,
+            Attributes = new Dictionary<string, string>
+            {
+                ["operationId"] = operationId,
+                ["status"] = "Failed"
+            }
+        };
+
+        return new AlertEventEnvelope
+        {
+            DedupeKey = $"ops:{source}:{operationId}",
+            RuleId = 0,
+            ServiceId = source,
+            LayerId = 0,
+            ObjectId = 0,
+            TriggerType = AlertTriggerType.Threshold,
+            Generation = 0,
+            Severity = severity,
+            OccurredAt = DateTimeOffset.UtcNow,
+            PayloadJson = JsonSerializer.Serialize(payload, OpsNotificationJsonContext.Default.OpsAlertPayload),
+            IncidentStatus = AlertIncidentStatus.Started,
+            Source = AlertEventSources.Ops
+        };
+    }
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Alerts/EmailAlertDeliverySinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Alerts/EmailAlertDeliverySinkTests.cs
@@ -79,6 +79,29 @@ public sealed class EmailAlertDeliverySinkTests
     }
 
     [UnitTest]
+    public void BuildContent_WithOpsEvent_UsesOpsTitleBodyAndOmitsRuleHeader()
+    {
+        var content = EmailAlertDeliverySink.BuildContent(AlertTestFixtures.CreateOpsAlertEvent());
+
+        Assert.Contains("[Honua Ops]", content.Subject, StringComparison.Ordinal);
+        Assert.Contains("Deploy prod-web failed", content.Subject, StringComparison.Ordinal);
+        Assert.Contains("Critical", content.Subject, StringComparison.Ordinal);
+        Assert.Contains("Deployment of prod-web", content.Body, StringComparison.Ordinal);
+        Assert.Contains("operationId: op-9f3c", content.Body, StringComparison.Ordinal);
+        // Ops events are not linked to a rule; the rule header must be omitted (not "0").
+        Assert.Null(content.RuleHeader);
+    }
+
+    [UnitTest]
+    public void BuildContent_WithGisEvent_KeepsRuleHeaderAndAlertSubject()
+    {
+        var content = EmailAlertDeliverySink.BuildContent(AlertTestFixtures.CreateAlertEvent());
+
+        Assert.Contains("[Honua Alert]", content.Subject, StringComparison.Ordinal);
+        Assert.Equal("42", content.RuleHeader);
+    }
+
+    [UnitTest]
     public void ChannelType_ReturnsEmail()
     {
         var sink = new EmailAlertDeliverySink(Options.Create(new AlertDeliveryOptions()));

--- a/tests/dotnet/Honua.Server.Tests/Features/Alerts/SlackAlertDeliverySinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Alerts/SlackAlertDeliverySinkTests.cs
@@ -88,6 +88,27 @@ public sealed class SlackAlertDeliverySinkTests
     }
 
     [UnitTest]
+    public async Task DeliverAsync_WithOpsEvent_RendersOpsTitleAndOperationIdNotRuleZero()
+    {
+        var handler = new CapturingHttpMessageHandler(HttpStatusCode.OK);
+        var client = new HttpClient(handler);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient("alerts-slack").Returns(client);
+
+        var sink = new SlackAlertDeliverySink(httpClientFactory, Options.Create(CreateOptionsWithSlack()));
+        var result = await sink.DeliverAsync(
+            AlertTestFixtures.CreateDispatchItem(AlertChannelType.Slack),
+            AlertTestFixtures.CreateOpsAlertEvent());
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(handler.LastRequestBody);
+        Assert.Contains("Deploy prod-web failed", handler.LastRequestBody, StringComparison.Ordinal);
+        Assert.Contains("op-9f3c", handler.LastRequestBody, StringComparison.Ordinal);
+        Assert.Contains("Critical", handler.LastRequestBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("Rule:", handler.LastRequestBody, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
     public void ChannelType_ReturnsSlack()
     {
         var httpClientFactory = Substitute.For<IHttpClientFactory>();

--- a/tests/dotnet/Honua.Server.Tests/Features/Alerts/TeamsAlertDeliverySinkTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Alerts/TeamsAlertDeliverySinkTests.cs
@@ -94,6 +94,27 @@ public sealed class TeamsAlertDeliverySinkTests
     }
 
     [UnitTest]
+    public async Task DeliverAsync_WithOpsEvent_RendersOpsTitleAndSourceNotRuleFacts()
+    {
+        var handler = new CapturingHttpMessageHandler(HttpStatusCode.OK);
+        var client = new HttpClient(handler);
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient("alerts-teams").Returns(client);
+
+        var sink = new TeamsAlertDeliverySink(httpClientFactory, Options.Create(CreateOptionsWithTeams()));
+        var result = await sink.DeliverAsync(
+            AlertTestFixtures.CreateDispatchItem(AlertChannelType.MicrosoftTeams),
+            AlertTestFixtures.CreateOpsAlertEvent());
+
+        Assert.True(result.Succeeded);
+        Assert.Contains("Deploy prod-web failed", handler.LastRequestBody, StringComparison.Ordinal);
+        Assert.Contains("deploy-workflow", handler.LastRequestBody, StringComparison.Ordinal);
+        Assert.Contains("op-9f3c", handler.LastRequestBody, StringComparison.Ordinal);
+        Assert.Contains("Critical", handler.LastRequestBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("Rule ID", handler.LastRequestBody, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
     public void ChannelType_ReturnsMicrosoftTeams()
     {
         var httpClientFactory = Substitute.For<IHttpClientFactory>();

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationGatewayIdempotencyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OperationGatewayIdempotencyTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Abstractions;
+using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Regression coverage for the propose idempotency gap (#1693): re-proposing an
+/// approval-tier operation with the same idempotency key previously minted a second
+/// AwaitingApproval proposal instead of folding onto the existing one.
+/// </summary>
+public sealed class OperationGatewayIdempotencyTests
+{
+    [Fact]
+    public async Task RouteAsync_ApprovalTier_SameIdempotencyKey_ReturnsSingleProposal()
+    {
+        var store = new MultiProposalStore();
+        var ladder = Substitute.For<IGuardrailLadder>();
+        ladder.Resolve(OperationClass.Deploy).Returns(
+            new GuardrailDecision(GuardrailTier.RequiresApproval, OperationClass.Deploy, HonuaEdition.Pro, "test"));
+
+        var sut = BuildGateway(store, ladder);
+
+        var request = new OperationGatewayRequest
+        {
+            Kind = OperationClass.Deploy,
+            RequestedBy = "agent",
+            IdempotencyKey = "idem-123"
+        };
+
+        var first = await sut.RouteAsync(request);
+        // Refresh-then-repropose: the caller re-issues the same request.
+        var second = await sut.RouteAsync(request);
+
+        first.Outcome.Should().Be(OperationGatewayOutcome.ProposalCreated);
+        second.Outcome.Should().Be(OperationGatewayOutcome.ProposalCreated);
+        second.ProposalId.Should().Be(first.ProposalId, "the same idempotency key must fold onto the same proposal");
+        store.Count.Should().Be(1, "re-proposing with the same idempotency key must not mint a duplicate proposal");
+        store.ActiveCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RouteAsync_ApprovalTier_DifferentIdempotencyKeys_CreateDistinctProposals()
+    {
+        var store = new MultiProposalStore();
+        var ladder = Substitute.For<IGuardrailLadder>();
+        ladder.Resolve(OperationClass.Deploy).Returns(
+            new GuardrailDecision(GuardrailTier.RequiresApproval, OperationClass.Deploy, HonuaEdition.Pro, "test"));
+
+        var sut = BuildGateway(store, ladder);
+
+        var first = await sut.RouteAsync(new OperationGatewayRequest
+        {
+            Kind = OperationClass.Deploy,
+            RequestedBy = "agent",
+            IdempotencyKey = "idem-a"
+        });
+        var second = await sut.RouteAsync(new OperationGatewayRequest
+        {
+            Kind = OperationClass.Deploy,
+            RequestedBy = "agent",
+            IdempotencyKey = "idem-b"
+        });
+
+        second.ProposalId.Should().NotBe(first.ProposalId);
+        store.Count.Should().Be(2);
+    }
+
+    private static OperationGateway BuildGateway(IOperationProposalStore store, IGuardrailLadder ladder)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IAuditLog>(_ => NullAuditLog.Instance);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        return new OperationGateway(
+            ladder,
+            store,
+            [],
+            scopeFactory,
+            Substitute.For<IProposalNotifier>(),
+            NullLogger<OperationGateway>.Instance);
+    }
+
+    /// <summary>
+    /// In-memory proposal store keyed by proposal id, able to hold multiple
+    /// proposals (unlike the single-slot store) so a duplicate-proposal regression
+    /// is observable.
+    /// </summary>
+    private sealed class MultiProposalStore : IOperationProposalStore
+    {
+        private readonly Dictionary<string, OperationProposal> _proposals = new(StringComparer.Ordinal);
+        private readonly Lock _lock = new();
+
+        public int Count
+        {
+            get { lock (_lock) { return _proposals.Count; } }
+        }
+
+        public int ActiveCount
+        {
+            get { lock (_lock) { return _proposals.Values.Count(IsActive); } }
+        }
+
+        public Task<OperationProposal?> GetAsync(string proposalId, CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(_proposals.TryGetValue(proposalId, out var proposal) ? proposal : null);
+            }
+        }
+
+        public Task<bool> TryCreateAsync(
+            OperationProposal proposal,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                if (_proposals.ContainsKey(proposal.ProposalId))
+                {
+                    return Task.FromResult(false);
+                }
+
+                _proposals[proposal.ProposalId] = proposal with { Version = 1 };
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<bool> TrySetAsync(
+            OperationProposal proposal,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                if (!_proposals.TryGetValue(proposal.ProposalId, out var current) || current.Version != proposal.Version)
+                {
+                    return Task.FromResult(false);
+                }
+
+                _proposals[proposal.ProposalId] = proposal with { Version = proposal.Version + 1 };
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<IReadOnlyList<OperationProposal>> ListActiveAsync(
+            OperationClass? kind = null,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_lock)
+            {
+                var active = _proposals.Values
+                    .Where(IsActive)
+                    .Where(proposal => kind == null || proposal.Kind == kind)
+                    .ToList();
+                return Task.FromResult<IReadOnlyList<OperationProposal>>(active);
+            }
+        }
+
+        public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        private static bool IsActive(OperationProposal proposal)
+            => proposal.Status is not (OperationProposalStatus.Succeeded
+                or OperationProposalStatus.Failed
+                or OperationProposalStatus.Rejected
+                or OperationProposalStatus.RolledBack);
+    }
+}


### PR DESCRIPTION
Related to #2468, #2481 (correctness review of Alerts GA + ops-health). Console companion: honua-io/honua-console fix/copilot-propose-outcome.

## Summary

Fixes verified defects a fresh review found in the merged alerts/observability work — two HIGH, each with a regression test proven to fail before the fix.

**HIGH — ops events crashed every unscoped alert-event read.** Migration 075 made `alert_events.rule_id` nullable and ops notifications persist NULL, but `PostgresAlertEventQuery.MapSummary` read `rule_id` with `GetInt64` and no null guard — so the first ops event (any deploy/job failure with `Alerts:Ops` enabled) threw `InvalidCastException` → 500 on the admin alert-events list, the observability-alerts endpoint, and the console Operate event feed. Fixed by mapping `rule_id` to `long?` end-to-end (`AlertEventSummary`, `ObservabilityAlertEventResponse`) — ops rows stay listable and honestly represent "no rule" rather than a misleading rule 0. The console DTO is made nullable to match (companion PR).

**HIGH — Slack/Teams/Email rendered ops notifications as garbage GIS alerts.** `OpsNotificationService` put the real title/body only in the payload and set `RuleId=0`/`Threshold`/`Layer 0`; the human-readable sinks formatted only from those scalars, so a failed deploy posted "Threshold — Rule: 0, Layer: 0". Added a shared `OpsNotificationPresentation.TryResolve` that the Slack/Teams/Email sinks prefer for ops-source events (title/body/source/severity/attributes), falling back to GIS formatting otherwise; the webhook emits `X-Honua-Alert-Source` instead of `Rule: 0`. GIS rendering unchanged.

**MED** — propose idempotency now honored (gateway derives the proposal id from the idempotency key and folds a duplicate onto the existing active proposal, so double-propose no longer clutters the inbox); per-channel rate-cap docs corrected to "best-effort per replica" (the dispatcher is deliberately multi-consumer, not single-leader); backlog `COUNT(*)` now excludes delivered rows via a new partial index (migration 076) + throttled recompute, and delivered rows are purged on a retention sweep.

**LOW** — deduplicated colliding LoggerMessage EventIds; corrected stale "readiness endpoint" health-check docs.

## Breaking Changes

`ObservabilityAlertEventResponse.RuleId` / `AlertEventSummary.RuleId` are now nullable (null for ops events). The console consumer is updated in the companion PR; any other client must tolerate null.

## Gate Impact

- [x] No gate-tier changes

## Testing

- [x] Sink ops-rendering tests, gateway idempotency test, dispatch-store backlog/retention tests, null-rule_id event-list test (proven failing pre-fix); sinks+idempotency 53, gateway 14, ops/pipeline/health 19, arch migration-safety 8 — all green
- [x] Release build (warnings-as-errors) green; format clean
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
