### PR TITLE
fix: re-land per-layer edit RBAC for honua_edit_features (lost in train squash of #2493)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/EditFeaturesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/EditFeaturesTool.cs
@@ -11,8 +11,10 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Geoprocessing;
+using Honua.Infrastructure.Authentication;
 using Honua.Ai.Protocols.Mcp.Models;
 using Honua.Ai.Protocols.Mcp.Tools;
+using AccessDecision = Honua.Core.Features.Security.Domain.AccessDecision;
 
 namespace Honua.Ai.Protocols.Mcp.MapTools;
 
@@ -28,7 +30,11 @@ namespace Honua.Ai.Protocols.Mcp.MapTools;
 /// executes through <see cref="IFeatureWriter.ApplyEditsAsync(int, FeatureEditBatch, System.Threading.CancellationToken)"/>.
 /// No edit, validation, transaction, or optimistic-concurrency semantics are
 /// reimplemented here — the writer's own transaction is the all-or-nothing
-/// boundary when <c>rollbackOnFailure</c> is set.
+/// boundary when <c>rollbackOnFailure</c> is set. Per-layer edit RBAC is
+/// enforced through the same shared authorization seams as the HTTP edit
+/// surfaces (<see cref="AccessPolicyHelpers.EvaluateResourceAccessAsync"/> and
+/// <see cref="ServiceDataEditorAuthorization.EvaluateResourceDataEditorAsync"/>),
+/// per edit type: Insert for adds, Update for updates, Delete for deletes.
 /// </summary>
 internal sealed class EditFeaturesTool : IMcpTool
 {
@@ -42,6 +48,7 @@ internal sealed class EditFeaturesTool : IMcpTool
         + "Geometry is supplied as RFC 7946 GeoJSON geometry objects and attributes as a flat name/value map; the input CRS defaults to EPSG:4326 (override with 'srid'). "
         + "updates must carry an 'objectId'; deletes are a list of object IDs; adds receive store-assigned object IDs. "
         + "Discover the layer first with honua_resolve_entity or honua_list_layers to obtain serviceId/layerId, and verify the attribute/geometry schema by reading a feature with honua_query_features before editing. "
+        + "The caller must hold per-layer edit permission for every edit type in the call (Insert for adds, Update for updates, Delete for deletes); a missing permission rejects the whole request with permission_denied before any edit is applied. "
         + "Returns per-edit results (index, success, objectId, error) plus a transaction summary (applied, failed, rolledBack).";
 
     private readonly IGeoprocessingJobService _jobService;
@@ -83,12 +90,8 @@ internal sealed class EditFeaturesTool : IMcpTool
         McpLog.ToolInvoked(_logger, ToolName, WorkflowFamily);
 
         // Standard MCP write authorization: the same operator-grant gate every
-        // MCP write tool (execute_plan, etc.) enforces. The per-layer data-plane
-        // RBAC the HTTP FeatureServer edit path additionally applies
-        // (ServiceDataEditorAuthorization / IPermissionResolver Insert/Update/Delete
-        // grants, AccessPolicy, layer-scoped write keys) lives in the Hosting
-        // protocol layer and is not reachable from the AI protocol slice; wiring
-        // that parity onto the MCP surface is tracked as P2 (see the tool PR).
+        // MCP write tool (execute_plan, etc.) enforces. Per-layer edit RBAC is
+        // enforced separately below, once the target layer is resolved.
         var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
         await _jobService
             .EnsureCallerAuthorizedAsync(principal, OperatorResourceType.Process, OperatorOperation.Execute, cancellationToken)
@@ -114,6 +117,17 @@ internal sealed class EditFeaturesTool : IMcpTool
             throw new GeoprocessingValidationException(
                 "At least one of 'adds', 'updates', or 'deletes' must be provided.");
         }
+
+        // Per-layer edit RBAC through the same shared seams the FeatureServer
+        // single-verb edit endpoints run (BH3-001/BH3-014): the operation-aware
+        // resource-access seam (tenant scope, per-operation grants, AccessPolicy)
+        // plus the data-editor write gate (layer-scoped write keys, explicit write
+        // policy, per-operation RBAC grants, admin/data-editor roles). Every edit
+        // type present in the request is authorized UP FRONT — a caller missing any
+        // required permission gets a structured permission_denied naming the missing
+        // grant and no edit is applied.
+        await EnsureLayerEditAuthorizedAsync(httpContext, layer, hasAdds, hasUpdates, hasDeletes, cancellationToken)
+            .ConfigureAwait(false);
 
         var rollbackOnFailure = argument.RollbackOnFailure ?? true;
         var returnEditResults = argument.ReturnEditResults ?? true;
@@ -150,6 +164,98 @@ internal sealed class EditFeaturesTool : IMcpTool
 
         var output = BuildOutput(layer.Service.Metadata.Id, argument.LayerId!.Value, result, returnEditResults);
         return McpToolHelpers.SuccessResult(output, MapToolJsonContext.Default.McpEditFeaturesOutput);
+    }
+
+    /// <summary>
+    /// Authorizes every edit type present in the request against the resolved
+    /// layer via the shared per-operation authorization seams: adds require
+    /// <see cref="AuthorizationOperation.Insert"/>, updates
+    /// <see cref="AuthorizationOperation.Update"/>, and deletes
+    /// <see cref="AuthorizationOperation.Delete"/>. Checks run before any edit is
+    /// built or applied, so a missing grant rejects the whole request up front
+    /// rather than partially applying it.
+    /// </summary>
+    private static async Task EnsureLayerEditAuthorizedAsync(
+        HttpContext httpContext,
+        MapToolLayerContext layer,
+        bool hasAdds,
+        bool hasUpdates,
+        bool hasDeletes,
+        CancellationToken cancellationToken)
+    {
+        if (hasAdds)
+        {
+            await RequireLayerOperationAsync(httpContext, layer, AuthorizationOperation.Insert, "adds", cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (hasUpdates)
+        {
+            await RequireLayerOperationAsync(httpContext, layer, AuthorizationOperation.Update, "updates", cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (hasDeletes)
+        {
+            await RequireLayerOperationAsync(httpContext, layer, AuthorizationOperation.Delete, "deletes", cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task RequireLayerOperationAsync(
+        HttpContext httpContext,
+        MapToolLayerContext layer,
+        AuthorizationOperation operation,
+        string editKind,
+        CancellationToken cancellationToken)
+    {
+        // 1) Operation-aware resource access (tenant scope, per-operation grants,
+        //    coarse AccessPolicy) — the same seam the FeatureServer edit endpoints
+        //    run pre-body via AccessPolicyHelpers.RequireResourceAccessAsync.
+        var decision = await AccessPolicyHelpers.EvaluateResourceAccessAsync(
+            httpContext,
+            layer.Resource,
+            layer.Service,
+            operation,
+            cancellationToken).ConfigureAwait(false);
+
+        // 2) The per-edit-type data-editor write gate (layer-scoped write keys,
+        //    explicit write policy, per-operation RBAC grants, admin/data-editor
+        //    roles) — the decision-shaped core of
+        //    ServiceDataEditorAuthorization.RequireResourceDataEditorAsync.
+        if (decision.IsAllowed)
+        {
+            decision = await ServiceDataEditorAuthorization.EvaluateResourceDataEditorAsync(
+                httpContext,
+                layer.Resource,
+                layer.Service,
+                operation,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        ThrowIfDenied(decision, layer, operation, editKind);
+    }
+
+    private static void ThrowIfDenied(
+        in AccessDecision decision,
+        in MapToolLayerContext layer,
+        AuthorizationOperation operation,
+        string editKind)
+    {
+        if (decision.IsAllowed)
+        {
+            return;
+        }
+
+        if (decision.RequiresAuthentication)
+        {
+            throw new GeoprocessingAuthorizationException(requiresAuthentication: true);
+        }
+
+        throw new GeoprocessingAuthorizationException(
+            requiresAuthentication: false,
+            $"Caller lacks the '{operation}' permission required to apply '{editKind}' on layer "
+            + $"'{layer.Resource.Metadata.Name}' of service '{layer.Service.Metadata.Name}'.");
     }
 
     private static ImmutableArray<EditFeature> BuildCreates(

--- a/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobExceptions.cs
+++ b/src/Honua.Geoprocessing/Features/Geoprocessing/GeoprocessingJobExceptions.cs
@@ -20,6 +20,19 @@ internal sealed class GeoprocessingAuthorizationException : Exception
     {
         RequiresAuthentication = requiresAuthentication;
     }
+
+    /// <summary>
+    /// Creates an authorization failure with a caller-supplied message (e.g. one
+    /// naming the specific permission the caller lacks) so structured error
+    /// contracts can surface an actionable denial.
+    /// </summary>
+    /// <param name="requiresAuthentication">Whether the caller needs authentication (vs. insufficient permissions).</param>
+    /// <param name="message">The denial message surfaced to the caller.</param>
+    public GeoprocessingAuthorizationException(bool requiresAuthentication, string message)
+        : base(message)
+    {
+        RequiresAuthentication = requiresAuthentication;
+    }
 }
 
 /// <summary>

--- a/src/Honua.Hosting/Features/Authentication/ServiceDataEditorAuthorization.cs
+++ b/src/Honua.Hosting/Features/Authentication/ServiceDataEditorAuthorization.cs
@@ -103,6 +103,36 @@ internal static class ServiceDataEditorAuthorization
         AuthorizationOperation? specificOperation,
         CancellationToken cancellationToken)
     {
+        var decision = await EvaluateResourceDataEditorAsync(
+            context, resource, service, specificOperation, cancellationToken).ConfigureAwait(false);
+        return CreateDecisionResult(context, decision);
+    }
+
+    /// <summary>
+    /// Decision-shaped core of the per-layer data-editor write gate, shared by the
+    /// HTTP <see cref="IResult"/> wrappers above and by non-HTTP-result adapters
+    /// (e.g. the MCP <c>honua_edit_features</c> tool) that surface denials through
+    /// their own error contracts. Semantics are identical to the HTTP path:
+    /// layer-scoped write keys (#1637) are authoritative for scoped principals; an
+    /// explicit <see cref="AccessPolicy"/> write restriction stays authoritative;
+    /// otherwise a per-operation RBAC write grant (#1376) on the
+    /// <c>(service, layer)</c> authorizes the mutation (narrowed to
+    /// <paramref name="specificOperation"/> when set — BH3-001/BH3-014), falling
+    /// back to the coarse admin/data-editor/service-scoped role gate.
+    /// </summary>
+    /// <param name="context">The request context.</param>
+    /// <param name="resource">The target resource (layer).</param>
+    /// <param name="service">The owning service, or <see langword="null"/>.</param>
+    /// <param name="specificOperation">The specific write operation being authorized, or <see langword="null"/> for any-write.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The access decision.</returns>
+    internal static async Task<AccessDecision> EvaluateResourceDataEditorAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        AuthorizationOperation? specificOperation,
+        CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(resource);
 
         // Layer-scoped write keys (#1637) are enforced here in the shared pipeline.
@@ -111,7 +141,7 @@ internal static class ServiceDataEditorAuthorization
         // the named layer. Out-of-scope targets are forbidden.
         if (LayerScopedWriteKey.IsScopedWritePrincipal(context.User))
         {
-            return EvaluateScopedWriteKey(context, service?.Metadata.Name, resource.Metadata.Name);
+            return EvaluateScopedWriteKeyDecision(context, service?.Metadata.Name, resource.Metadata.Name);
         }
 
         // An explicit AccessPolicy write restriction stays authoritative (a
@@ -120,7 +150,7 @@ internal static class ServiceDataEditorAuthorization
         var explicitDecision = EvaluateExplicitWritePolicy(context, resource.AccessPolicy, service?.AccessPolicy);
         if (explicitDecision is not null)
         {
-            return CreateDecisionResult(context, explicitDecision.Value);
+            return explicitDecision.Value;
         }
 
         // No explicit write policy: a per-operation RBAC write grant (#1376) on
@@ -132,32 +162,31 @@ internal static class ServiceDataEditorAuthorization
         if (service is not null &&
             await HasWriteGrantAsync(context, service.Metadata.Name, resource.Metadata.Name, cancellationToken, specificOperation).ConfigureAwait(false))
         {
-            return null;
+            return AccessDecision.Allowed();
         }
 
         if (service is null)
         {
             // No service context — fall back to the same global role gate used for
-            // service-scoped checks (admin or global data-editor role).  Returning null
-            // for any authenticated principal would allow a principal with only the
-            // default OIDC role to mutate any service-less resource, bypassing RBAC.
+            // service-scoped checks (admin or global data-editor role).  Allowing any
+            // authenticated principal here would let a principal with only the
+            // default OIDC role mutate any service-less resource, bypassing RBAC.
             if (context.User?.Identity?.IsAuthenticated != true)
             {
-                return CreateDecisionResult(context, AccessDecision.RequiresAuth("Authentication is required."));
+                return AccessDecision.RequiresAuth("Authentication is required.");
             }
 
             var options = context.RequestServices.GetRequiredService<IOptions<RbacOptions>>().Value;
             var user = context.User!; // non-null: authenticated guard above
             if (IsAdmin(user, options) || HasGlobalDataEditorRole(user, options))
             {
-                return null;
+                return AccessDecision.Allowed();
             }
 
-            return CreateDecisionResult(context, AccessDecision.Forbidden("User does not have the required data editor role."));
+            return AccessDecision.Forbidden("User does not have the required data editor role.");
         }
 
-        var decision = await EvaluateServiceAccessAsync(context, service.Metadata.Name, cancellationToken).ConfigureAwait(false);
-        return CreateDecisionResult(context, decision);
+        return await EvaluateServiceAccessAsync(context, service.Metadata.Name, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpEditFeaturesToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpEditFeaturesToolTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Security.Claims;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Authorization.Abstractions;
 using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
@@ -11,7 +13,9 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Abstractions;
 using Honua.Geoprocessing;
+using Honua.Infrastructure.Authentication;
 using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.Protocols.Mcp.MapTools;
 using Honua.Ai.Protocols.Mcp.Models;
@@ -21,6 +25,7 @@ using Honua.TestKit.Infrastructure;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 
 namespace Honua.Server.Tests.Features.Protocols.Mcp;
@@ -32,7 +37,11 @@ namespace Honua.Server.Tests.Features.Protocols.Mcp;
 /// <see cref="IEditProcessor"/> + <see cref="IFeatureWriter"/> and assert the
 /// adapter builds the right protocol-neutral request, routes edits through the
 /// single transactional batch apply, and projects the pipeline result back onto
-/// the MCP per-edit + summary output.
+/// the MCP per-edit + summary output. Per-layer edit RBAC runs through the REAL
+/// shared seams (<see cref="AccessPolicyEvaluator"/>,
+/// <c>ServiceDataEditorAuthorization</c>, <see cref="IPermissionResolver"/>
+/// grants), not lookalikes, so the authorization tests exercise the same
+/// primitives the HTTP edit surfaces enforce.
 /// </summary>
 [Protocol(TestProtocols.Mcp)]
 public sealed class McpEditFeaturesToolTests
@@ -247,6 +256,108 @@ public sealed class McpEditFeaturesToolTests
     [Operation(Operations.Update)]
     [Endpoint("POST /mcp tools/call honua_edit_features")]
     [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_PrincipalWithoutEditGrants_IsPermissionDenied_ForEachEditType()
+    {
+        // An authenticated caller with NO edit roles/grants (query-only) must be
+        // denied per edit type by the shared per-layer RBAC gate — generic
+        // process-execution rights alone cannot mutate a layer.
+        var editProcessor = Substitute.For<IEditProcessor>();
+        var writer = Substitute.For<IFeatureWriter>();
+        var queryOnly = AuthenticatedPrincipal();
+
+        var cases = new (string Arguments, string ExpectedOperation)[]
+        {
+            ($$"""{"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"adds":[ {"attributes":{"parcel_id":"A-1"} } ] }""", "Insert"),
+            ($$"""{"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"updates":[ {"objectId":42,"attributes":{"zoning":"R2"} } ] }""", "Update"),
+            ($$"""{"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"deletes":[99] }""", "Delete"),
+        };
+
+        foreach (var (arguments, expectedOperation) in cases)
+        {
+            var response = await DispatchEditAsync(editProcessor, writer, arguments, principal: queryOnly);
+
+            response!.Error.Should().BeNull();
+            var result = response.Result!.Value;
+            result.GetProperty("isError").GetBoolean().Should().BeTrue(
+                $"a caller without edit grants must be denied '{expectedOperation}'");
+            var structured = result.GetProperty("structuredContent");
+            structured.GetProperty("code").GetString().Should().Be("permission_denied");
+            structured.GetProperty("message").GetString().Should().Contain(expectedOperation,
+                "the structured denial must name the missing permission");
+        }
+
+        // No edit ever reached the pipeline.
+        WriterCallNames(writer).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_EditFeatures_InsertOnlyGrant_AllowsAdds_ButRejectsMixedAddUpdateUpFront()
+    {
+        // A per-operation Insert grant (canonical IPermissionResolver, #1376)
+        // authorizes an adds-only call, but a mixed add+update call is rejected
+        // WHOLE and UP FRONT because the caller lacks the Update grant — no
+        // partial application.
+        var resolver = Substitute.For<IPermissionResolver>();
+        resolver.AuthorizeAsync(default!, default!, default!, default, default, default, default)
+            .ReturnsForAnyArgs(ci => ci.ArgAt<AuthorizationOperation>(4) == AuthorizationOperation.Insert
+                ? PermissionDecision.Allow(new PermissionGrant { Service = ServiceName, Layer = "*", Operation = "insert" })
+                : PermissionDecision.NoMatch());
+
+        var fieldCrew = AuthenticatedPrincipal("field-crew");
+
+        var editProcessor = Substitute.For<IEditProcessor>();
+        editProcessor.ValidateEdit(default, default!)
+            .ReturnsForAnyArgs(EditValidationResult.Success());
+        editProcessor.ToFeatureEditBatch(default, default!)
+            .ReturnsForAnyArgs(FeatureEditBatch.Create());
+
+        var writer = Substitute.For<IFeatureWriter>();
+        writer.ApplyEditsAsync(default, default, default)
+            .ReturnsForAnyArgs(FeatureEditResult.Success(
+                createdCount: 1,
+                updatedCount: 0,
+                deletedCount: 0,
+                createdIds: [101L],
+                createResults: [EditOperationResult.Success(101)]));
+
+        // adds-only: the Insert grant authorizes the call.
+        var addsOnly = $$"""{"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"adds":[ {"attributes":{"parcel_id":"A-1"} } ] }""";
+        var allowed = await DispatchEditAsync(editProcessor, writer, addsOnly, principal: fieldCrew, permissionResolver: resolver);
+
+        allowed!.Error.Should().BeNull();
+        allowed.Result!.Value.GetProperty("isError").GetBoolean().Should().BeFalse(
+            "an Insert grant must authorize an adds-only call");
+        WriterCallNames(writer).Should().Equal("ApplyEditsAsync");
+
+        writer.ClearReceivedCalls();
+
+        // add + update: missing Update grant rejects the whole request up front.
+        var mixed = $$"""
+            {"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},
+             "adds":[ {"attributes":{"parcel_id":"A-2"} } ],
+             "updates":[ {"objectId":42,"attributes":{"zoning":"R2"} } ] }
+            """;
+        var denied = await DispatchEditAsync(editProcessor, writer, mixed, principal: fieldCrew, permissionResolver: resolver);
+
+        denied!.Error.Should().BeNull();
+        var result = denied.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeTrue();
+        var structured = result.GetProperty("structuredContent");
+        structured.GetProperty("code").GetString().Should().Be("permission_denied");
+        structured.GetProperty("message").GetString().Should().Contain("Update",
+            "the structured denial must name the missing grant");
+
+        // Nothing was applied — not even the authorized adds.
+        WriterCallNames(writer).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Update)]
+    [Endpoint("POST /mcp tools/call honua_edit_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
     public async Task ToolsCall_EditFeatures_NoEdits_ReturnsInvalidArgument()
     {
         var editProcessor = Substitute.For<IEditProcessor>();
@@ -292,7 +403,9 @@ public sealed class McpEditFeaturesToolTests
     private async Task<McpJsonRpcResponse?> DispatchEditAsync(
         IEditProcessor editProcessor,
         IFeatureWriter writer,
-        string argumentsJson)
+        string argumentsJson,
+        ClaimsPrincipal? principal = null,
+        IPermissionResolver? permissionResolver = null)
     {
         var surface = new McpOperatorSurface(
             [new EditFeaturesTool(_jobService, NullLogger<EditFeaturesTool>.Instance)],
@@ -307,15 +420,42 @@ public sealed class McpEditFeaturesToolTests
         services.AddSingleton(editProcessor);
         services.AddSingleton(writer);
         services.AddSingleton(geometryService);
+
+        // The REAL shared authorization seams the HTTP edit surfaces run: the
+        // access-policy evaluator plus the RBAC options that drive the
+        // data-editor role gate ("data-editor" is a global data-editor role in
+        // these tests). A per-operation permission resolver is registered only
+        // when a test exercises grant-based authorization.
+        services.AddSingleton<IAccessPolicyEvaluator>(new AccessPolicyEvaluator());
+        services.AddSingleton(Options.Create(new RbacOptions { DataEditorRoles = ["data-editor"] }));
+        if (permissionResolver is not null)
+        {
+            services.AddSingleton(permissionResolver);
+        }
+
         var provider = services.BuildServiceProvider();
 
-        var context = McpTestFactory.AuthenticatedHttpContext();
-        context.RequestServices = provider;
+        var context = new DefaultHttpContext
+        {
+            RequestServices = provider,
+            User = principal ?? DataEditorPrincipal()
+        };
 
         return await surface.DispatchAsync(
             context,
             ToolCall("edit-1", EditFeaturesTool.ToolName, argumentsJson),
             CancellationToken.None);
+    }
+
+    /// <summary>Authenticated principal holding the global data-editor role.</summary>
+    private static ClaimsPrincipal DataEditorPrincipal() => AuthenticatedPrincipal("data-editor");
+
+    /// <summary>Authenticated principal with the supplied role claims.</summary>
+    private static ClaimsPrincipal AuthenticatedPrincipal(params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.Name, "test-user") };
+        claims.AddRange(roles.Select(role => new Claim(ClaimTypes.Role, role)));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
     }
 
     private static List<string> WriterCallNames(IFeatureWriter writer) =>


### PR DESCRIPTION
## Issue Link
Related to #1948

## Summary
Re-lands the per-layer edit RBAC enforcement for `honua_edit_features` that was authored on PR #2493's branch (commit 53d632c42) but did not reach trunk: the merge train squashed the PR from its queued-at-time snapshot, so the merged tree contains only the 14 purely-additive MCP files and none of the authorization changes. As merged, the tool enforces only the generic operator Process/Execute gate — any principal with process-execution rights can mutate any layer, bypassing the per-layer Insert/Update/Delete RBAC every other write surface enforces.

This is a clean cherry-pick of the reviewed rework commit onto current trunk.

## Changes Made
- Extract a decision-shaped core `EvaluateResourceDataEditorAsync` from `ServiceDataEditorAuthorization.RequireResourceDataEditorCoreAsync` (HTTP wrapper delegates to it; behavior unchanged for HTTP surfaces).
- `EditFeaturesTool` authorizes every edit type present up front (adds→Insert, updates→Update, deletes→Delete) via `AccessPolicyHelpers.EvaluateResourceAccessAsync` + the data-editor core; any denial rejects the whole request as structured `permission_denied` naming the missing grant, before any edit is applied.
- Tool description states the per-layer permission requirement.
- Tests exercise the real `AccessPolicyEvaluator`/`RbacOptions`/`IPermissionResolver` primitives: query-only principal denied per edit type; insert-only grant allows adds but rejects mixed add+update up front with zero writer calls.

## Breaking Changes
None

## Gate Impact
- [x] No gate-tier impact (authorization tightening on a tool released this week)

## Testing
- [x] Release build of Honua.Ai.Tests with TreatWarningsAsErrors=true: 0 warnings, 0 errors
- [x] McpEditFeaturesToolTests: 8/8 passed
- [x] dotnet format --verify-no-changes clean on changed files
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
