### PR TITLE
test(python): align FeatureServer integration tests with GeoServices 200 error contract (#2418)

### DIFF
--- a/tests/python/feature_server/test_apply_edits.py
+++ b/tests/python/feature_server/test_apply_edits.py
@@ -19,6 +19,7 @@ import pytest
 import httpx
 
 from shared.geometry import GeometryGenerator
+from shared.geoservices import assert_geoservices_error
 
 
 class TestApplyEditsAdd:
@@ -470,7 +471,10 @@ class TestApplyEditsErrors:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/applyEdits",
             data={"adds": "not valid json", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices REST signals errors with HTTP 200 and
+        # an {"error": {"code": N}} body. Esri still returns an error object for
+        # unparseable input, so a bare success can never satisfy this assertion.
+        assert_geoservices_error(response, body_codes={400})
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -488,7 +492,8 @@ class TestApplyEditsErrors:
             f"/rest/services/{test_service_id}/FeatureServer/99999/applyEdits",
             data={"adds": json.dumps(adds), "f": "json"},
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117 (#2418): unknown layer -> HTTP 200 + {"error": {"code": 404}}.
+        assert_geoservices_error(response, body_codes={400, 404})
 
     @pytest.mark.integration
     @pytest.mark.featureserver

--- a/tests/python/feature_server/test_attachments.py
+++ b/tests/python/feature_server/test_attachments.py
@@ -20,6 +20,7 @@ import pytest
 import httpx
 
 from shared.geometry import GeometryGenerator
+from shared.geoservices import assert_geoservices_error
 
 
 class TestQueryAttachments:
@@ -138,10 +139,14 @@ class TestAddAttachment:
             files=files,
             data={"f": "json"},
         )
-        # Should return error
+        # Should return error. PA-070/PA-117 (#2418): a not-found feature now yields
+        # HTTP 200 + {"error": {"code": 404}} per the Esri GeoServices convention;
+        # a legacy 4xx or an addAttachmentResult.success == False is also accepted.
         assert response.status_code in [400, 404] or (
-            response.status_code == 200 and
-            response.json().get("addAttachmentResult", {}).get("success") is False
+            response.status_code == 200 and (
+                isinstance(response.json().get("error"), dict) or
+                response.json().get("addAttachmentResult", {}).get("success") is False
+            )
         )
 
 
@@ -161,9 +166,14 @@ class TestUpdateAttachment:
                 "f": "json",
             },
         )
+        # PA-070/PA-117 (#2418): invalid IDs now yield HTTP 200 + {"error": {...}}
+        # per the Esri GeoServices convention; a legacy 4xx or an
+        # updateAttachmentResult.success == False is also accepted.
         assert response.status_code in [400, 404] or (
-            response.status_code == 200 and
-            response.json().get("updateAttachmentResult", {}).get("success") is False
+            response.status_code == 200 and (
+                isinstance(response.json().get("error"), dict) or
+                response.json().get("updateAttachmentResult", {}).get("success") is False
+            )
         )
 
 
@@ -211,7 +221,9 @@ class TestDownloadAttachment:
         response = http_client.get(
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/999999999/attachments/999999999"
         )
-        assert response.status_code == 404
+        # PA-070/PA-117 (#2418): a missing attachment now yields HTTP 200 +
+        # {"error": {"code": 404}} per the Esri GeoServices convention.
+        assert_geoservices_error(response, body_codes={404})
 
 
 class TestAttachmentWorkflow:

--- a/tests/python/feature_server/test_auxiliary_services.py
+++ b/tests/python/feature_server/test_auxiliary_services.py
@@ -16,6 +16,8 @@ import json
 import httpx
 import pytest
 
+from shared.geoservices import assert_geoservices_error
+
 
 class TestGeometryServer:
     @pytest.mark.integration
@@ -64,7 +66,8 @@ class TestImageServer:
             params={"f": "xml"},
         )
 
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})
 
     @pytest.mark.integration
     def test_compute_statistics_histograms_valid_request_returns_statistics(
@@ -109,4 +112,6 @@ class TestImageServer:
             },
         )
 
-        assert response.status_code == 501
+        # PA-070/PA-117 (#2418): the not-implemented signal is now HTTP 200 +
+        # {"error": {"code": 501}} rather than a bare 501 status.
+        assert_geoservices_error(response, body_codes={501})

--- a/tests/python/feature_server/test_gpserver_smoke.py
+++ b/tests/python/feature_server/test_gpserver_smoke.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from shared.geoservices import assert_geoservices_error
+
 POINT_WKB_BASE64 = "AQEAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 
@@ -75,7 +77,9 @@ class TestGPServerSmoke:
             },
         )
 
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices REST signals errors with HTTP 200 and an
+        # {"error": {"code": N}} body; the error code moved into the body, not the status.
+        assert response.status_code == 200
 
         data = response.json()
         assert data["error"]["code"] == 400
@@ -100,10 +104,12 @@ class TestGPServerSmoke:
             },
         )
 
+        # PA-070/PA-117 (#2418): the store-unavailable case now returns HTTP 200 with a
+        # {"error": {"code": 503}} body instead of a 503 status; branch on the body.
         assert response.status_code in (200, 503)
 
         data = response.json()
-        if response.status_code == 200:
+        if "error" not in data:
             assert data["jobId"]
             assert data["jobStatus"] == "esriJobSubmitted"
             return

--- a/tests/python/feature_server/test_metadata.py
+++ b/tests/python/feature_server/test_metadata.py
@@ -12,6 +12,8 @@ Endpoints:
 import pytest
 import httpx
 
+from shared.geoservices import assert_geoservices_error
+
 
 class TestServiceMetadata:
     """Tests for the FeatureServer service metadata endpoint."""
@@ -78,7 +80,9 @@ class TestServiceMetadata:
         response = http_client.get(
             "/rest/services/nonexistent_service_xyz/FeatureServer"
         )
-        assert response.status_code == 404
+        # PA-070/PA-117 (#2418): GeoServices REST signals not-found with HTTP 200 +
+        # {"error": {"code": 404}} rather than a bare 404.
+        assert_geoservices_error(response, body_codes={404})
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -209,7 +213,9 @@ class TestLayerMetadata:
         response = http_client.get(
             f"/rest/services/{test_service_id}/FeatureServer/99999"
         )
-        assert response.status_code == 404
+        # PA-070/PA-117 (#2418): GeoServices REST signals not-found with HTTP 200 +
+        # {"error": {"code": 404}} rather than a bare 404.
+        assert_geoservices_error(response, body_codes={404})
 
     @pytest.mark.integration
     @pytest.mark.featureserver

--- a/tests/python/feature_server/test_query.py
+++ b/tests/python/feature_server/test_query.py
@@ -23,6 +23,7 @@ import httpx
 from shapely.geometry import shape
 
 from shared.geometry import GeometryGenerator
+from shared.geoservices import assert_geoservices_error
 from conftest import assert_esri_feature_set
 
 
@@ -93,7 +94,8 @@ class TestQueryBasic:
             f"/rest/services/{test_service_id}/FeatureServer/99999/query",
             params={"where": "1=1", "f": "json"},
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117 (#2418): unknown layer -> HTTP 200 + {"error": {"code": 404}}.
+        assert_geoservices_error(response, body_codes={400, 404})
 
 
 class TestQueryWhereClause:
@@ -253,7 +255,8 @@ class TestQueryWhereClause:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "invalid !!! syntax", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): invalid where -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})
 
 
 class TestQuerySpatial:

--- a/tests/python/feature_server/test_query_matrix.py
+++ b/tests/python/feature_server/test_query_matrix.py
@@ -12,6 +12,7 @@ import httpx
 from pyproj import Transformer
 
 from shared.geometry import GeometryGenerator
+from shared.geoservices import assert_geoservices_error
 
 
 NON_DISTANCE_SPATIAL_RELS = [
@@ -134,7 +135,8 @@ class TestSpatialRelMatrix:
                 "f": "json",
             },
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})
 
 
 class TestGeometryTypeMatrix:
@@ -180,7 +182,8 @@ class TestNearestCount:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "1=1", "nearestCount": 3, "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -254,7 +257,8 @@ class TestInputOutputSpatialReference:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "1=1", "inSR": "invalid", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -263,4 +267,5 @@ class TestInputOutputSpatialReference:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "1=1", "outSR": "invalid", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})

--- a/tests/python/feature_server/test_related_records.py
+++ b/tests/python/feature_server/test_related_records.py
@@ -18,6 +18,8 @@ Tests cover:
 import pytest
 import httpx
 
+from shared.geoservices import assert_geoservices_error
+
 
 class TestQueryRelatedRecordsBasic:
     """Basic tests for queryRelatedRecords endpoint."""
@@ -72,9 +74,12 @@ class TestQueryRelatedRecordsBasic:
 
         if response.status_code == 200:
             data = response.json()
-            # Should have relatedRecordGroups
-            assert "relatedRecordGroups" in data
-            assert isinstance(data["relatedRecordGroups"], list)
+            # PA-070/PA-117 (#2418): a 200 may now carry a GeoServices
+            # {"error": {...}} body instead of a success payload; only assert the
+            # success structure when no error object is present.
+            if "error" not in data:
+                assert "relatedRecordGroups" in data
+                assert isinstance(data["relatedRecordGroups"], list)
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -86,7 +91,8 @@ class TestQueryRelatedRecordsBasic:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/queryRelatedRecords",
             params={"f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})
 
 
 class TestQueryRelatedRecordsObjectIds:
@@ -273,7 +279,8 @@ class TestQueryRelatedRecordsErrors:
                 "f": "json",
             },
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117 (#2418): unknown layer -> HTTP 200 + {"error": {"code": 404}}.
+        assert_geoservices_error(response, body_codes={400, 404})
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -289,4 +296,5 @@ class TestQueryRelatedRecordsErrors:
                 "f": "json",
             },
         )
-        assert response.status_code == 400
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": 400}}.
+        assert_geoservices_error(response, body_codes={400})

--- a/tests/python/feature_server/test_renderer.py
+++ b/tests/python/feature_server/test_renderer.py
@@ -10,6 +10,8 @@ Endpoint: GET /rest/services/{serviceId}/FeatureServer/{layerId}/generateRendere
 import pytest
 import httpx
 
+from shared.geoservices import assert_geoservices_error
+
 
 class TestGenerateRenderer:
     """Tests for the generateRenderer endpoint."""
@@ -111,7 +113,8 @@ class TestGenerateRenderer:
                 "f": "json",
             },
         )
-        assert response.status_code in [400, 501]
+        # PA-070/PA-117 (#2418): GeoServices errors -> HTTP 200 + {"error": {"code": N}}.
+        assert_geoservices_error(response, body_codes={400, 501})
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -126,4 +129,5 @@ class TestGenerateRenderer:
                 "f": "json",
             },
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117 (#2418): unknown layer -> HTTP 200 + {"error": {"code": 404}}.
+        assert_geoservices_error(response, body_codes={400, 404})

--- a/tests/python/feature_server/test_tiles.py
+++ b/tests/python/feature_server/test_tiles.py
@@ -10,6 +10,8 @@ Endpoint: GET /tiles/{layerId}/{z}/{x}/{y}.mvt
 import pytest
 import httpx
 
+from shared.geoservices import assert_geoservices_error
+
 
 class TestMvtTiles:
     """Tests for MVT tile endpoint."""
@@ -61,7 +63,9 @@ class TestMvtTiles:
     def test_mvt_tile_invalid_layer_returns_404(self, http_client: httpx.Client):
         """MVT tile for invalid layer should return 404."""
         response = http_client.get("/tiles/99999/0/0/0.mvt")
-        assert response.status_code == 404
+        # PA-070/PA-117 (#2418): /tiles is a GeoServices-classified path, so an
+        # unknown layer now yields HTTP 200 + {"error": {"code": 404}}.
+        assert_geoservices_error(response, body_codes={400, 404})
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -86,8 +90,9 @@ class TestMvtTiles:
         """MVT tile with out-of-bounds coordinates should return error."""
         # At zoom 0, only tile 0/0/0 exists
         response = http_client.get(f"/tiles/{test_layer_id}/0/5/5.mvt")
-        # Should return 400 (invalid) or 204 (empty)
-        assert response.status_code in [400, 204]
+        # PA-070/PA-117 (#2418): out-of-range coordinates yield either an empty tile
+        # (204) or a GeoServices error (HTTP 200 + {"error": {...}}, or legacy 4xx).
+        assert_geoservices_error(response, body_codes={400, 404}, allow_empty=True)
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -96,8 +101,9 @@ class TestMvtTiles:
     ):
         """MVT tile with negative coordinates should return error."""
         response = http_client.get(f"/tiles/{test_layer_id}/5/-1/0.mvt")
-        # Negative coordinates are invalid
-        assert response.status_code in [400, 404]
+        # Negative coordinates are invalid. PA-070/PA-117 (#2418): a GeoServices
+        # error now surfaces as HTTP 200 + {"error": {...}} (or a legacy 4xx/route 404).
+        assert_geoservices_error(response, body_codes={400, 404}, allow_empty=True)
 
     @pytest.mark.integration
     @pytest.mark.featureserver

--- a/tests/python/shared/geoservices.py
+++ b/tests/python/shared/geoservices.py
@@ -1,0 +1,72 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+"""Assertion helpers for the Esri GeoServices REST error contract.
+
+PA-070 / PA-117 (honua-server #2418) aligned the GeoServices REST surface
+(paths under ``/rest/services`` and ``/tiles``) with the Esri ArcGIS REST
+convention: operation errors are signalled with **HTTP 200** and an
+``{"error": {"code": N, ...}}`` JSON body rather than a non-2xx HTTP status.
+Modern OGC API (RFC 7807) error paths were intentionally left untouched.
+
+These helpers assert that contract while remaining tolerant of a legacy
+non-2xx status, so they keep catching real regressions (a plain success body
+where an error is expected) without re-encoding the pre-parity status codes.
+"""
+
+from __future__ import annotations
+
+from typing import Container, Optional
+
+import httpx
+
+
+def assert_geoservices_error(
+    response: httpx.Response,
+    *,
+    body_codes: Optional[Container[int]] = None,
+    allow_empty: bool = False,
+) -> None:
+    """Assert a GeoServices REST/tiles error response.
+
+    Accepts either the Esri 200 + ``{"error": {...}}`` body contract or a
+    legacy ``>= 400`` status. When the response is 200 it MUST carry an
+    ``error`` object, so a silent success body can never satisfy the
+    assertion.
+
+    Args:
+        response: the HTTP response to inspect.
+        body_codes: if provided, the ``error.code`` of a 200 body (or the HTTP
+            status of a legacy ``>= 400`` response) must be one of these.
+        allow_empty: also accept an empty ``204 No Content`` (used by tile
+            endpoints that emit an empty tile rather than an error body).
+    """
+    status = response.status_code
+
+    if allow_empty and status == 204:
+        return
+
+    if status >= 400:
+        if body_codes is not None:
+            assert status in body_codes, f"unexpected error status {status}"
+        return
+
+    assert status == 200, (
+        f"expected 200 or >= 400, got {status}: {response.text[:300]}"
+    )
+
+    try:
+        body = response.json()
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise AssertionError(
+            "expected a JSON GeoServices error body, got "
+            f"{response.headers.get('content-type')}: {response.content[:200]!r}"
+        ) from exc
+
+    error = body.get("error") if isinstance(body, dict) else None
+    assert isinstance(error, dict), (
+        "expected a GeoServices error object {'error': {...}}, "
+        f"got: {str(body)[:300]}"
+    )
+    if body_codes is not None:
+        assert error.get("code") in body_codes, error


### PR DESCRIPTION
## Issue Link
Related to #2418
Related to #2505

## Summary
`trunk`'s full matrix went red after #2418 (`573f72b3`, PA-069/PA-070/PA-117) deliberately aligned the GeoServices REST surface (paths under `/rest/services` and `/tiles`) with the Esri ArcGIS REST convention: operation errors are now signalled with **HTTP 200 + `{"error":{"code":N,...}}` body** instead of a non-2xx status. That PR flipped ~211 GeoServices *unit*-test assertions but could not run the Python integration suite locally, so its stale `4xx` assertions failed in CI.

This PR migrates the **26 affected Python FeatureServer integration tests** to the new contract. This is a **deliberate parity change**, so the fix is to update the tests, not revert the code.

## Changes Made
- Add `tests/python/shared/geoservices.py` with `assert_geoservices_error()` — accepts either `200 + {"error":{...}}` (optionally checking `error.code`) or a legacy `>=400` status, and rejects a plain success body so a missing error indication is still caught as a regression.
- Update 26 stale tests across `test_apply_edits`, `test_attachments`, `test_metadata`, `test_query`, `test_query_matrix`, `test_related_records`, `test_renderer`, `test_tiles`, `test_auxiliary_services`, `test_gpserver_smoke` to assert the new contract, each annotated with `PA-070/PA-117 (#2418)`.
- Invalid-JSON and unknown-layer/feature cases assert the error object with the expected code (Esri never returns a bare success for unparseable input).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

<!-- Note: change is Python-only (tests/python). Validated with `python3 -m py_compile`
on all edited files and a helper unit-test of assert_geoservices_error(); no .NET
source or formatting surface is touched. The remaining stale-assertion migration for
the .NET Testcontainers integration + browser/JS suites (same root cause, needs Docker
to validate) is tracked in #2505; the FeatureCatalogDriftTests drift in #2506. -->
