### PR TITLE
fix: regenerate feature-catalog.json after #2418 OGC-Processes changes

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -6151,6 +6151,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesAuthorizationTests.JobResults_WithoutAuth_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesDurableRuntimeTests.Execute_FirstSliceVectorProcess_CompletesAndReturnsDurableResultEvidence",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.JobResults_NonexistentJob_ReturnsNotFoundOrServiceUnavailable",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesFailedJobResultsTests.JobResults_FailedJob_Returns500WithRegisteredOgcExceptionType",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesJobKindFilterTests.JobResults_NonGeoprocessingJob_Returns404",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesJobResultsTests.JobResults_SucceededArtifactBackedJob_ReturnsNonEmptyResultEvidence"
       ],
@@ -6306,6 +6307,7 @@
       "protocol": "nested-standard",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Infrastructure.Errors.StandardErrorResponseFormatterTests.FormatError_WmsAliasPath_ReturnsServiceExceptionReport",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetCapabilities_WithWmsEnabledAndMapServerDisabled_ReturnsXml",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_OgcAlias_GetCapabilities_ReturnsXml"
       ],
@@ -10660,6 +10662,7 @@
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchGet_WithInvalidThreeDimensionalBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchGet_WithLimit_RespectsLimit",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchGet_WithNegativeLimit_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchGet_WithNonNumericCollectionId_IsAcceptedAndReturnsEmpty",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchGet_WithOutOfRangeBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchGet_WithPropertiesPrefixedTopLevelName_ProjectsNestedProperty",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchGet_WithRegistryBackedExplicitGeometryCrsInFilter_AcceptsNonDefaultCrs",
@@ -14805,6 +14808,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesAuthorizationTests.Execute_WithMalformedJsonWithoutAuth_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesAuthorizationTests.Execute_WithoutAuth_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesDurableRuntimeTests.Execute_FirstSliceVectorProcess_CompletesAndReturnsDurableResultEvidence",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_AsyncJobCreated_EmitsPreferenceAppliedHeader",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_CyclicDependsOn_Returns400",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_DestructivePlanWhenApprovalRequired_Returns403",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_DuplicateStepIds_Returns400",
@@ -14819,6 +14823,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_OutputsNotArray_Returns400",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_PlanEmptySteps_Returns400",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_PlanMissingPlanId_Returns400",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_PreferRespondSync_Returns422WithOgcExceptionType",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_ResponseModeDocument_IsAccepted",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_ResponseModeRaw_Returns501",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Processes.OgcProcessesEndpointsTests.Execute_StepMissingKind_Returns400",
@@ -17515,6 +17520,7 @@
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidPaginationToken_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidSortDirection_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithInvalidThreeDimensionalBbox_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithNonNumericCollectionId_IsAcceptedAndReturnsEmpty",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithOutOfRangeBbox_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithStringIds_FiltersByStacItemId",
         "Honua.Server.Tests.Features.Protocols.Stac.StacSearchTests.SearchPost_WithThreeDimensionalBbox_ReturnsItems"


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2506

## Summary
`FeatureCatalogDriftTests.CommittedCatalog_EqualsFreshlyGeneratedOutput` was red on trunk (part of the full-matrix red blocking the merge train). PR #2418's OGC-Processes exception-type work (PA-071/166/205) plus its accompanying STAC/WMS error-format tests added new `[Endpoint]`-attributed proving tests without regenerating the committed catalog, so `docs/gis/data/feature-catalog.json` drifted from the generator's output. This regenerates it via the canonical `scripts/generate-feature-catalog.sh` (the `HONUA_EMIT_FEATURE_CATALOG=1` emitter) — no hand edits.

## Changes Made
- Regenerated `docs/gis/data/feature-catalog.json` from the live API surface via `scripts/generate-feature-catalog.sh`.
- Diff is purely additive: 6 new proving-test references attached to existing catalog entries (no endpoint added/removed, no maturity change):
  - OGC Processes: `OgcProcessesFailedJobResultsTests.JobResults_FailedJob_Returns500WithRegisteredOgcExceptionType`, `OgcProcessesEndpointsTests.Execute_PreferRespondSync_Returns422WithOgcExceptionType`, `OgcProcessesEndpointsTests.Execute_AsyncJobCreated_EmitsPreferenceAppliedHeader`
  - WMS error formatting: `StandardErrorResponseFormatterTests.FormatError_WmsAliasPath_ReturnsServiceExceptionReport`
  - STAC: `StacSearchTests.SearchGet_WithNonNumericCollectionId_IsAcceptedAndReturnsEmpty`, `StacSearchTests.SearchPost_WithNonNumericCollectionId_IsAcceptedAndReturnsEmpty`

## Testing
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Notes for the merge train
- **Coordinate with open PR #2495**, which also carries a feature-catalog regen from an earlier trunk state. Whichever of #2495 / this PR merges **second** will re-drift on `feature-catalog.json` and needs a trivial re-run of `scripts/generate-feature-catalog.sh` + recommit before its drift test goes green.
- **Out of scope / still red, separate root cause:** `Honua.Ai.Tests` `McpResourceSerializationTests.FeatureCatalogResource_ServesEmbeddedEvidenceBackedCatalog` fails asserting every served entry has `maturity == "implemented"`. That assertion is stale since the `experimental` tier (#2346) added legitimately non-implemented catalog entries and the served resource is unfiltered. This is NOT proving-test drift and is not fixable via a catalog regen — it needs the test assertion relaxed to `implemented|experimental` (or the resource to filter). Flagged for a follow-up; left untouched to keep this PR a surgical regen.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
