### PR TITLE
test: accept experimental maturity tier in FeatureCatalogResource assertion

### DIFF
--- a/tests/dotnet/Honua.Ai.Tests/Source/McpResourceSerializationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpResourceSerializationTests.cs
@@ -336,13 +336,15 @@ public sealed class McpResourceSerializationTests
         entries.GetArrayLength().Should().BeGreaterThan(0);
 
         // Every served entry is evidence-backed: a route, at least one proving
-        // test, and the implemented maturity tier (slice 1 invariant, #1946).
+        // test, and a recognized maturity tier. The catalog carries both the
+        // slice-1 "implemented" tier (#1946) and the "experimental" tier
+        // introduced with #2346; the resource serves the catalog unfiltered.
         foreach (var entry in entries.EnumerateArray())
         {
             entry.GetProperty("route").GetString().Should().NotBeNullOrWhiteSpace();
             entry.GetProperty("method").GetString().Should().NotBeNullOrWhiteSpace();
             entry.GetProperty("proving_tests").GetArrayLength().Should().BeGreaterThan(0);
-            entry.GetProperty("maturity").GetString().Should().Be("implemented");
+            entry.GetProperty("maturity").GetString().Should().BeOneOf("implemented", "experimental");
         }
     }
 


### PR DESCRIPTION
## Issue Link
Related to #2506

## Summary
`McpResourceSerializationTests.FeatureCatalogResource_ServesEmbeddedEvidenceBackedCatalog` pins every served catalog entry to `maturity == "implemented"`, but the catalog legitimately contains `experimental`-tier entries since #2346 and the MCP resource serves the catalog unfiltered. The stale assertion fails the .NET Foundation lane on trunk (part of the red full matrix; identified during the #2506 investigation).

## Changes Made
- Relax the maturity assertion to `BeOneOf("implemented", "experimental")` and update the invariant comment to name both tiers.

## Breaking Changes
None

## Gate Impact
- [x] No gate-tier impact (test-only)

## Testing
- [x] Release build of Honua.Ai.Tests with TreatWarningsAsErrors=true: 0 warnings/errors
- [x] McpResourceSerializationTests: all pass including the previously failing catalog test
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
