### PR TITLE
test(geoservices): align lagging error-status assertions to the Esri-200 contract (#2418)

### DIFF
--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
@@ -60,7 +60,8 @@ public sealed class GeoservicesCatalogEndpointTests : IClassFixture<WebAppFixtur
     {
         var response = await _fixture.Client.GetAsync("/rest/services?f=xml");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerEditingEditionGateTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerEditingEditionGateTests.cs
@@ -56,7 +56,8 @@ public sealed class FeatureServerEditingEditionGateTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/applyEdits",
             new StringContent(json, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var responseBody = await response.Content.ReadAsStringAsync();
         responseBody.Should().Contain(FeatureCatalog.FeatureServerEditsKey);
     }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerExtrusionTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerExtrusionTests.cs
@@ -116,7 +116,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.HeightFieldMissing);
     }
@@ -136,7 +137,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.HeightFieldNotFound);
     }
@@ -156,7 +158,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.HeightFieldTypeInvalid);
     }
@@ -180,7 +183,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.UnitUnrecognized);
     }
@@ -201,7 +205,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.NegativeDefaultHeight);
     }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerH3TileTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerH3TileTests.cs
@@ -34,7 +34,10 @@ public sealed class FeatureServerH3TileTests : IClassFixture<WebAppFixture>
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
-            response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.mapbox-vector-tile");
+            // PA-070/PA-117: /tiles is a GeoServices REST surface, so an H3 capability error is
+            // returned as HTTP 200 with a JSON error envelope; a real tile is a vector tile.
+            response.Content.Headers.ContentType?.MediaType.Should().BeOneOf(
+                "application/vnd.mapbox-vector-tile", "application/json");
         }
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerNotImplementedOperationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerNotImplementedOperationTests.cs
@@ -103,24 +103,30 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
         // image: honest 404; this server stores no FeatureServer image resource.
         var image = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/image");
-        image.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        image.StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Invalid-service branch (404) for each GET surface.
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/queryContingentValues?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/query?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/htmlPopup?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/image"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // ----- Service-level mutation operations (POST, honest rejection) -----
@@ -133,23 +139,28 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
     public async Task ServiceLevelSharedTemplateMutations_RejectHonestlyAnd404OnMissingService()
     {
         // Valid service: honest rejection (no shared-template store).
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         (await _fixture.Client.PostAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/sharedTemplates/add",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.OK);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         (await _fixture.Client.PostAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/sharedTemplates/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Invalid service: 404 takes precedence over rejection.
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/add",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
+            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.OK);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
+            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.OK);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/delete",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
+            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // ----- Layer-level read operations (GET, spec-shaped 200) -----
@@ -196,13 +207,16 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
         // Invalid-service branch (404) for each GET surface.
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/hasAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/queryAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/cleanupAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // ----- Layer-level rejection operations (honest rejection) -----
@@ -218,29 +232,37 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
         // Valid layer: honest rejection (no asset / 3D / metadata-write surface).
         (await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/uploadAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/convert3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         (await _fixture.Client.PostAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/metadata/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Invalid service: 404 takes precedence over rejection.
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/uploadAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/convert3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
         (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/query3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/0/metadata/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
+            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -557,7 +557,8 @@ public sealed class FeatureServerQueryParameterTests : IClassFixture<WebAppFixtu
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query",
             new StringContent(payload, Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Unsupported Media Type");
     }
@@ -814,8 +815,8 @@ public sealed class FeatureServerQueryParameterTests : IClassFixture<WebAppFixtu
             "?where=1%3D1&outFields=category&returnDistinctValues=true&returnGeometry=false" +
             "&resultOffset=200000&f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "returnDistinctValues with a very large resultOffset must be rejected to prevent OOM");
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("returnDistinctValues",

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerReplicationTests.cs
@@ -121,7 +121,8 @@ public sealed class FeatureServerReplicationTests : IAsyncLifetime
                 $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/createReplica",
                 new StringContent(payload, Encoding.UTF8, "application/json"));
 
-            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             var body = await response.Content.ReadAsStringAsync();
             body.Should().Contain(FeatureCatalog.FieldOpsOfflineSyncKey);
         }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerServiceQueryTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerServiceQueryTests.cs
@@ -163,8 +163,8 @@ public sealed class FeatureServerServiceQueryTests : IClassFixture<WebAppFixture
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/query?where=1=1&f=geojson");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "f=geojson is not supported for service-level queries which always return ServiceQueryResponse JSON");
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
@@ -199,7 +199,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -215,7 +216,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -231,7 +233,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -244,7 +247,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerTemporalTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerTemporalTests.cs
@@ -513,9 +513,8 @@ public sealed class FeatureServerTemporalTests : IClassFixture<WebAppFixture>
                 $"/rest/services/{serviceId}/FeatureServer/{layerId}/query?time={encodedTime}&f=json");
 
             // Assert
-            response.StatusCode.Should().BeOneOf(
-                new[] { HttpStatusCode.BadRequest, HttpStatusCode.InternalServerError },
-                $"Invalid time format should return error: {invalidTime}");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 
@@ -560,12 +559,10 @@ public sealed class FeatureServerTemporalTests : IClassFixture<WebAppFixture>
 
         // Assert
         // Should return an appropriate error when no temporal field is available
-        response.StatusCode.Should().BeOneOf(
-            HttpStatusCode.BadRequest,
-            HttpStatusCode.NotFound,
-            HttpStatusCode.InternalServerError);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        if (response.StatusCode == HttpStatusCode.BadRequest)
+        if (response.StatusCode == HttpStatusCode.OK)
         {
             var content = await response.Content.ReadAsStringAsync();
             content.Should().ContainEquivalentOf("temporal");

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeometryValidationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeometryValidationTests.cs
@@ -483,7 +483,8 @@ public sealed class GeometryValidationTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?geometry={Uri.EscapeDataString(malformedGeometry)}&f=json");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     #endregion

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
@@ -483,8 +483,8 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
 
         // An undeclared filter field must be a clean 400, not a 500.
         var undeclaredResponse = await _fixture.Client.GetAsync(runTaggedUri);
-        undeclaredResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "an undeclared filter field is a client error, not a server 'Query execution failed' 500");
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        undeclaredResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         using (var undeclaredDocument = await ReadJsonDocumentAsync(undeclaredResponse))
         {
             undeclaredDocument.RootElement.GetProperty("error").GetProperty("code").GetInt32()

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileEndpointTests.cs
@@ -69,8 +69,8 @@ public class MvtTileEndpointTests : IClassFixture<WebAppFixture>
         foreach (var coordinate in invalidCoordinates)
         {
             var response = await _fixture.Client.GetAsync(coordinate);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-                $"coordinate {coordinate} should return BadRequest");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
@@ -173,7 +173,8 @@ public class MvtTileErrorHandlingTests : IClassFixture<WebAppFixture>
 
         // Assert - Both should return the same error response format
         mvtResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        queryResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var mvtContent = await mvtResponse.Content.ReadAsStringAsync();
         var queryContent = await queryResponse.Content.ReadAsStringAsync();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicationDurabilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicationDurabilityTests.cs
@@ -222,7 +222,8 @@ public sealed class ReplicationDurabilityTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
             new StringContent(failedUploadPayload, Encoding.UTF8, "application/json"));
 
-        failedUploadResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        failedUploadResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var afterFailure = await repo.GetAsync(replicaId);
         afterFailure.Should().NotBeNull();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerClientCompatibilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerClientCompatibilityTests.cs
@@ -122,7 +122,8 @@ public sealed class GPServerClientCompatibilityTests : IClassFixture<WebAppFixtu
             25.5,
             new KeyValuePair<string, string>("env:transferDomains", "true"));
 
-        error.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        error.StatusCode.Should().Be(HttpStatusCode.OK);
         error.Code.Should().Be(400);
         error.Message.Should().Be("Bad Request");
         error.Details.Should().Contain(detail => detail.Contains("GP environment controls are not yet supported", StringComparison.Ordinal));

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
@@ -129,7 +129,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             $"/rest/services/{ServiceId}/GPServer",
             new StringContent("""{"f":"json"}""", Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -521,7 +522,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             $"/rest/services/{ServiceId}/GPServer/geometry.buffer/submitJob",
             new StringContent("""{"f":"json"}""", Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -694,10 +696,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var response = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/nonexistent-job-id?f=json");
 
-        // Without Redis: ServiceUnavailable; With Redis: NotFound
-        response.StatusCode.Should().BeOneOf(
-            HttpStatusCode.NotFound,
-            HttpStatusCode.ServiceUnavailable);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // -----------------------------------------------------------------------
@@ -712,10 +712,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var response = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/nonexistent/results/Output?f=json");
 
-        // Without Redis: ServiceUnavailable; With Redis: NotFound
-        response.StatusCode.Should().BeOneOf(
-            HttpStatusCode.NotFound,
-            HttpStatusCode.ServiceUnavailable);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -794,10 +792,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var response = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/nonexistent/cancel?f=json");
 
-        // Without Redis: ServiceUnavailable; With Redis: NotFound
-        response.StatusCode.Should().BeOneOf(
-            HttpStatusCode.NotFound,
-            HttpStatusCode.ServiceUnavailable);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -809,9 +805,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/nonexistent/cancel",
             new FormUrlEncodedContent(new Dictionary<string, string> { ["f"] = "json" }));
 
-        response.StatusCode.Should().BeOneOf(
-            HttpStatusCode.NotFound,
-            HttpStatusCode.ServiceUnavailable);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // -----------------------------------------------------------------------
@@ -854,7 +849,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var statusResponse = await _client.GetAsync(
             $"/rest/services/OtherService/GPServer/BufferAnalysis/jobs/{jobId}?f=json");
 
-        statusResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        statusResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -893,7 +889,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var statusResponse = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/DifferentTask/jobs/{jobId}?f=json");
 
-        statusResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        statusResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // -----------------------------------------------------------------------
@@ -1108,7 +1105,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var response = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/?f=json");
 
-        response.IsSuccessStatusCode.Should().BeFalse();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.IsSuccessStatusCode.Should().BeTrue();
     }
 
     [IntegrationTest]
@@ -1131,7 +1129,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             var response = await client.GetAsync(
                 $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/slow-job?f=json");
 
-            response.StatusCode.Should().Be(HttpStatusCode.RequestTimeout);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -1159,7 +1158,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             var response = await client.GetAsync(
                 $"/rest/services/{ServiceId}/GPServer/BufferAnalysis/jobs/completed-job?f=json");
 
-            response.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -1209,8 +1209,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
                 $"/rest/services/{ServiceId}/GPServer/geometry.buffer/submitJob", content);
 
             // Auth must be checked before parameter validation â€” expect 401 not 400.
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
-                "auth must be checked before env-control rejection per IGeoprocessingJobService contract");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
@@ -63,7 +63,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Intersect_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/intersect?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -101,7 +102,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Union_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/union");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -211,7 +213,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/clip",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -220,7 +223,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Clip_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/clip?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -260,7 +264,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Difference_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/difference?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // #1308: ArcGIS clients wrap the single operating geometry as
@@ -430,7 +435,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Area_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/areasAndLengths?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -524,7 +530,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Length_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/lengths?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- Intersect: additional coverage ---
@@ -571,7 +578,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/intersect",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -597,7 +605,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/intersect",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -624,7 +633,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/intersect",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- Union: additional coverage ---
@@ -694,7 +704,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/union",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -718,7 +729,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/union",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- Difference: additional coverage ---
@@ -795,7 +807,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/difference",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -822,7 +835,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/difference",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- Area/Length: missing SR coverage ---
@@ -845,7 +859,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/areasAndLengths",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -866,7 +881,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/lengths",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -888,7 +904,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/lengths",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<ApiErrorResponse>(content);

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceBufferTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceBufferTests.cs
@@ -259,7 +259,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -282,7 +283,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var responseContent = await response.Content.ReadAsStringAsync();
         var error = JsonSerializer.Deserialize<ApiErrorResponse>(responseContent);
@@ -314,7 +316,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -340,7 +343,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
             "/rest/services/Utilities/Geometry/GeometryServer/buffer",
             new StringContent(requestBody, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("maximum of 1000 geometries");
@@ -371,7 +375,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
             "/rest/services/Utilities/Geometry/GeometryServer/buffer",
             new StringContent(requestBody, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("maximum of 1000 values");
@@ -406,7 +411,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer?inSR=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
@@ -104,7 +104,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var target = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolygon","geometries":[{"rings":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/cut?target={target}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- trimExtend ---
@@ -194,7 +195,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var polylines = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolyline","geometries":[{"paths":[[[0,0],[2,0]]]}]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/trimExtend?polylines={polylines}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- offset ---
@@ -276,7 +278,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var geometries = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolyline","geometries":[{"paths":[[[0,0],[5,0]]]}]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/offset?geometries={geometries}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- autoComplete ---
@@ -317,7 +320,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/autoComplete?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- reshape ---
@@ -359,7 +363,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var target = Uri.EscapeDataString("""{"rings":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/reshape?target={target}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- findTransformations ---
@@ -394,6 +399,7 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/findTransformations?inSR=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceGeoCoordinateStringTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceGeoCoordinateStringTests.cs
@@ -135,7 +135,8 @@ public sealed class GeometryServiceGeoCoordinateStringTests : IClassFixture<WebA
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/toGeoCoordinateString", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -148,7 +149,8 @@ public sealed class GeometryServiceGeoCoordinateStringTests : IClassFixture<WebA
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/toGeoCoordinateString", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -240,7 +242,8 @@ public sealed class GeometryServiceGeoCoordinateStringTests : IClassFixture<WebA
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/fromGeoCoordinateString", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     private static async Task<GeometryServiceToGeoCoordinateStringResponse?> DeserializeToAsync(HttpResponseMessage response)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
@@ -82,7 +82,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/distance?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // #1308: ArcGIS clients wrap geometry1/geometry2 as
@@ -199,7 +200,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/relation?geometries1={geometries1}&geometries2={geometries2}&sr=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- densify ---
@@ -247,7 +249,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/densify?geometries={geometries}&sr=3857");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -275,7 +278,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
             "/rest/services/Utilities/Geometry/GeometryServer/densify",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -355,7 +359,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/convexHull?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- generalize ---
@@ -403,7 +408,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/generalize?geometries={geometries}&sr=3857");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     // --- labelPoints ---
@@ -442,6 +448,7 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/labelPoints?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceProjectTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceProjectTests.cs
@@ -109,7 +109,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/project", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -174,7 +175,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/project?inSR=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -267,7 +269,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/project", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -290,7 +293,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/project", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceSimplifyTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceSimplifyTests.cs
@@ -132,7 +132,8 @@ public sealed class GeometryServiceSimplifyTests : IClassFixture<WebAppFixture>
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/simplify?sr=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -152,6 +153,7 @@ public sealed class GeometryServiceSimplifyTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/simplify", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerBasicTests.cs
@@ -469,9 +469,8 @@ public class ImageServerBasicTests : IClassFixture<WebAppFixture>
         {
             using var response = await fixture.Client.GetAsync("/rest/services/2024Imagery/ImageServer?f=xml");
 
-            response.StatusCode.Should().Be(
-                HttpStatusCode.BadRequest,
-                "numeric-leading service IDs should match the named ImageServer route before format validation runs");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -1023,7 +1023,8 @@ public class ImageServerEndpointsTests
             var response = await fixture.Client.GetAsync(
                 $"/rest/services/{TestLayerId}/ImageServer/measure?f=json&measureOperation=esriMensurationHeightFromBaseAndTop&geometryType=esriGeometryPoint&fromGeometry={Uri.EscapeDataString(fromGeometry)}&toGeometry={Uri.EscapeDataString(toGeometry)}");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -1135,7 +1136,8 @@ public class ImageServerEndpointsTests
             var response = await fixture.Client.GetAsync(
                 $"/rest/services/{TestLayerId}/ImageServer/measure?f=json&measureOperation=esriMensurationHeightFromBaseAndTop&geometryType=esriGeometryPoint&fromGeometry={Uri.EscapeDataString(fromGeometry)}&toGeometry={Uri.EscapeDataString(toGeometry)}");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -1925,7 +1927,8 @@ public class ImageServerEndpointsTests
                 $"/rest/services/{TestLayerId}/ImageServer/exportTiles?{query}");
 
             var content = await response.Content.ReadAsStringAsync();
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             content.Should().Contain("compact");
         }
         finally
@@ -2197,7 +2200,8 @@ public class ImageServerEndpointsTests
             var response = await fixture.Client.GetAsync(
                 $"/rest/services/{TestLayerId}/ImageServer/computeClassStatistics?f=json&classDescriptions={Uri.EscapeDataString(classDescriptions)}");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -2223,7 +2227,8 @@ public class ImageServerEndpointsTests
                 $"/rest/services/{TestLayerId}/ImageServer/computeClassStatistics",
                 content);
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerErrorHandlingTests.cs
@@ -175,7 +175,8 @@ public class ImageServerErrorHandlingTests : IClassFixture<WebAppFixture>
             $"/rest/services/{TestLayerId}/ImageServer/identify?geometry=abc,def&f=json");
 
         // Either 400 (invalid coordinates) or 404 (no rasters)
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -186,7 +187,8 @@ public class ImageServerErrorHandlingTests : IClassFixture<WebAppFixture>
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestLayerId}/ImageServer/identify?geometry=42&f=json");
 
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -197,7 +199,8 @@ public class ImageServerErrorHandlingTests : IClassFixture<WebAppFixture>
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestLayerId}/ImageServer/identify?geometry={{\"invalid\":true}}&f=json");
 
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     #endregion

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMosaicIntegrationTests.cs
@@ -141,7 +141,8 @@ public sealed class ImageServerMosaicIntegrationTests
                 $"/rest/services/{WebAppFixture.TestLayerId}/ImageServer/identify" +
                 "?geometry=1.5,1&geometryType=esriGeometryPoint&time=2024-02-15T00:00:00Z&f=json");
 
-            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRasterMetadataTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRasterMetadataTests.cs
@@ -233,11 +233,13 @@ public class ImageServerRasterMetadataTests
         {
             var invalidFormat = await fixture.Client.GetAsync(
                 $"/rest/services/{TestLayerId}/ImageServer/statistics?f=xml");
-            invalidFormat.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            invalidFormat.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var missingLayer = await fixture.Client.GetAsync(
                 "/rest/services/99999/ImageServer/histograms?f=json");
-            missingLayer.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            missingLayer.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerDynamicJoinTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerDynamicJoinTests.cs
@@ -116,7 +116,8 @@ public sealed class MapServerDynamicJoinTests
             $"&dynamicLayers={dynamicLayers}&f=json");
 
         var content = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         content.Should().Contain("inaccessible right layer");
     }
 
@@ -168,7 +169,8 @@ public sealed class MapServerDynamicJoinTests
             $"&dynamicLayers={dynamicLayers}&f=json");
 
         var content = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         content.Should().Contain("not a valid field name");
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -527,7 +527,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/exportTiles?f=json&levels=0&exportExtent=-180,-85,180,85&maxTiles=1&storageFormat=tpkx");
 
         var content = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         content.Should().Contain("compact");
     }
 
@@ -1335,7 +1336,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
 
         var invalidResponse = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/legend?f=json&size=invalid");
-        invalidResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        invalidResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1515,7 +1517,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/{WebAppFixture.TestLayerId}/query",
             new StringContent(payload, Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Unsupported Media Type");
     }
@@ -1527,7 +1530,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/find");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1537,7 +1541,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/export");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1547,7 +1552,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/identify");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1557,7 +1563,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/generateKml");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerRenderCapacityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerRenderCapacityTests.cs
@@ -90,7 +90,8 @@ public sealed class MapServerRenderCapacityTests : IClassFixture<MapServerRender
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMS?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&BBOX=-90,-180,90,180&WIDTH=256&HEIGHT=256&CRS=EPSG:4326&LAYERS={WebAppFixture.TestLayerId}&STYLES=&FORMAT=image/png");
 
         var content = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable, content);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         content.Should().Contain("NoApplicableCode");
         content.Should().Contain("Raster rendering capacity is currently exhausted");
     }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerTileEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerTileEndpointTests.cs
@@ -138,7 +138,8 @@ public sealed class MapServerTileEndpointTests : IClassFixture<WebAppFixture>
         var invalidResponse = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/tile/2/10/10");
 
-        invalidResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        invalidResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -149,7 +150,8 @@ public sealed class MapServerTileEndpointTests : IClassFixture<WebAppFixture>
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/tile/-1/0/0");
 
-        response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -155,7 +155,8 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
         foreach (var url in badCoordinates)
         {
             var response = await _fixture.Client.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, $"{url} is out of range");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
@@ -90,8 +90,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var second = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/create",
             ("versionName", "admin.dup_name_test"), ("accessPermission", "private"), ("f", "json"));
-        second.StatusCode.Should().Be(HttpStatusCode.Conflict,
-            "duplicate version name must return 409; body: {0}", await second.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using var doc = JsonDocument.Parse(await second.Content.ReadAsStringAsync());
         doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(
@@ -181,8 +181,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{Guid.NewGuid()}/startReading",
             ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
-            "an unknown version should not open a session; body: {0}", await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -226,8 +226,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{Guid.NewGuid()}/startEditing",
             ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
-            "an unknown version should not open an edit session; body: {0}", await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -252,9 +252,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var editResponse = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/startEditing",
             ("f", "json"));
-        editResponse.StatusCode.Should().Be(HttpStatusCode.Conflict,
-            "opening an edit session against a reconciling version must return 409; body: {0}",
-            await editResponse.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        editResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using (var doc = JsonDocument.Parse(await editResponse.Content.ReadAsStringAsync()))
         {
@@ -359,8 +358,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/reconcile",
             ("conflictDetection", "byPlanet"), ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "an unsupported conflictDetection mode should be rejected; body: {0}", await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -518,9 +517,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/delete",
             ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict,
-            "BH6-002: deleting a reconciling version must return 409; body: {0}",
-            await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(
@@ -543,7 +541,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
 
         var info = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}?f=json");
-        info.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        info.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // ---- helpers --------------------------------------------------------------------------------

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesErrorHandlingTests.cs
@@ -216,7 +216,8 @@ public class OgcFeaturesErrorHandlingTests : IClassFixture<OgcFeaturesErrorHandl
 
         // Assert - OGC uses RFC 7807, FeatureServer uses GeoServices
         ogcResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        fsResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 404 code is carried in the JSON body (asserted below).
+        fsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var ogcContent = await ogcResponse.Content.ReadAsStringAsync();
         var fsContent = await fsResponse.Content.ReadAsStringAsync();

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
@@ -535,7 +535,8 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _communityFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/geometries/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -669,7 +670,8 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{NoGeometrySceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/AdvancedSpatialQueryTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/AdvancedSpatialQueryTests.cs
@@ -185,7 +185,8 @@ public sealed class AdvancedSpatialQueryTests : IAsyncLifetime
             $"&f=json");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     #endregion
@@ -348,7 +349,8 @@ public sealed class AdvancedSpatialQueryTests : IAsyncLifetime
             $"&f=json");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     #endregion

--- a/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/AttachmentEndpointTests.cs
@@ -308,7 +308,8 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/addAttachment", form);
 
         // Assert
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -320,7 +321,8 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/addAttachment",
             new StringContent("objectId=1", Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Unsupported Media Type");
     }
@@ -431,7 +433,8 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/updateAttachment", form);
 
         // Assert
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -443,7 +446,8 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/updateAttachment",
             new StringContent("objectId=1&attachmentId=1", Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Unsupported Media Type");
     }
@@ -563,7 +567,8 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/deleteAttachments",
             new StringContent("objectId=1&attachmentIds=1", Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Unsupported Media Type");
     }
@@ -621,7 +626,8 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/attachments/{nonExistentAttachmentId}");
 
         // Assert
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -642,7 +648,8 @@ public sealed class AttachmentEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/{TestFeatureId}/addAttachment", form);
 
         // Assert
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.RequestEntityTooLarge);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("exceeds maximum allowed size");

--- a/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
@@ -104,7 +104,8 @@ public class ApiSurfaceComplianceTests : IAsyncLifetime
 
         // Test invalid layer ID
         var invalidResponse = await client.GetAsync("/rest/services/test/FeatureServer/999?f=json");
-        invalidResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 404 code is carried in the JSON body.
+        invalidResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     /// <summary>
@@ -189,15 +190,18 @@ public class ApiSurfaceComplianceTests : IAsyncLifetime
         var errorTestCases = new[]
         {
             // Invalid service/collection
-            ("/rest/services/invalid/FeatureServer", HttpStatusCode.NotFound, "Invalid service ID"),
+            // PA-070/PA-117: GeoServices always returns HTTP 200; the error code is carried in the JSON body.
+            ("/rest/services/invalid/FeatureServer", HttpStatusCode.OK, "Invalid service ID"),
             ("/ogc/features/collections/invalid/items", HttpStatusCode.NotFound, "Invalid collection ID"),
 
             // Invalid layer ID
-            ("/rest/services/test/FeatureServer/999", HttpStatusCode.NotFound, "Invalid layer ID"),
+            ("/rest/services/test/FeatureServer/999", HttpStatusCode.OK, "Invalid layer ID"),
+            // Non-numeric layer id fails the {layerId:int} route constraint, so routing returns 404
+            // before the GeoServices error formatter runs — this stays a real transport 404.
             ("/rest/services/test/FeatureServer/abc", HttpStatusCode.NotFound, "Non-numeric layer ID"),
 
             // Invalid query parameters
-            ("/rest/services/test/FeatureServer/0/query?where=invalid sql syntax", HttpStatusCode.BadRequest, "Invalid SQL where clause"),
+            ("/rest/services/test/FeatureServer/0/query?where=invalid sql syntax", HttpStatusCode.OK, "Invalid SQL where clause"),
             ("/ogc/features/collections/0/items?bbox=invalid", HttpStatusCode.BadRequest, "Invalid bbox format"),
             ("/ogc/features/collections/0/items?limit=-1", HttpStatusCode.BadRequest, "Negative limit"),
             // OGC API - Features Part 1 /req/core/fc-limit-definition (d): an over-maximum

--- a/tests/dotnet/Honua.Server.Tests/CrsTransformationCorrectnessTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/CrsTransformationCorrectnessTests.cs
@@ -506,10 +506,8 @@ public sealed class CrsTransformationCorrectnessTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(requestUri);
 
         // Should return appropriate error, not crash
-        response.StatusCode.Should().BeOneOf(
-            System.Net.HttpStatusCode.BadRequest,
-            System.Net.HttpStatusCode.UnprocessableEntity,
-            System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
 
         // Should not be a server error (500)
         ((int)response.StatusCode).Should().BeLessThan(500);
@@ -539,9 +537,8 @@ public sealed class CrsTransformationCorrectnessTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(requestUri);
 
         // Should validate and reject invalid coordinates
-        response.StatusCode.Should().BeOneOf(
-            System.Net.HttpStatusCode.BadRequest,
-            System.Net.HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
 
         // Should not cause server errors
         ((int)response.StatusCode).Should().BeLessThan(500);

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerEndpointTests.cs
@@ -304,7 +304,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync("/rest/services/nonexistent/FeatureServer");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -323,7 +324,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     {
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer?f=html");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
         var content = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(content);
         var details = document.RootElement.GetProperty("error").GetProperty("details")
@@ -551,7 +553,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
     {
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}?f=html");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
         var content = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(content);
         var details = document.RootElement.GetProperty("error").GetProperty("details")
@@ -615,7 +618,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/nonexistent/FeatureServer/{TestLayerId}");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -636,7 +640,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/999");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -655,8 +660,9 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         // Act
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/invalid");
 
-        // Assert - Should return 404 because 'invalid' doesn't match int route constraint
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // Assert
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -669,7 +675,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.DeleteAsync($"/rest/services/{TestServiceId}/FeatureServer");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.MethodNotAllowed);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -681,7 +688,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.DeleteAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.MethodNotAllowed);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -975,7 +983,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/query?layers={TestLayerId},&where=1%3D1&f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1254,7 +1263,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnCountOnly=true&f=geojson");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1265,7 +1275,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnIdsOnly=true&f=geojson");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1276,7 +1287,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=1%3D1&returnExtentOnly=true&f=geojson");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1371,8 +1383,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/generateRenderer?classificationDef={classificationDef}");
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest,
-            "only classBreaksDef and uniqueValueDef classification types are supported");
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("classificationDef");
@@ -1521,7 +1533,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/generateRenderer?classificationDef={malformedClassificationDef}");
 
-        response.HaveStatusCode(System.Net.HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("classificationDef must be valid JSON.");
@@ -1539,7 +1552,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=name='Test'; DROP TABLE users; --");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -1562,7 +1576,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?where=invalid syntax here");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -1584,7 +1599,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?unexpected=1");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -1643,7 +1659,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/nonexistent/FeatureServer/{TestLayerId}/query");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -1664,7 +1681,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/999/query");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -1961,7 +1979,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?objectIds=1,invalid,3");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -2357,7 +2376,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?geometry={Uri.EscapeDataString(invalidGeometry)}&f=json");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     /// <summary>
@@ -2377,7 +2397,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?geometry={Uri.EscapeDataString(pointGeometry)}&spatialRel={unsupportedSpatialRel}&f=json");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     /// <summary>
@@ -2665,7 +2686,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?f=invalid");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
         var content = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(content);
         var details = document.RootElement.GetProperty("error").GetProperty("details")
@@ -2879,7 +2901,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.PostAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query", content);
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     /// <summary>
@@ -2905,7 +2928,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.PostAsync($"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query", content);
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -3007,7 +3031,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/applyEdits",
             content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
         var responseContent = await response.Content.ReadAsStringAsync();
         responseContent.Should().Contain("Request body contains invalid JSON.");
         responseContent.Should().NotContain("BytePositionInLine");
@@ -3027,7 +3052,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/applyEdits",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var responseContent = await response.Content.ReadAsStringAsync();
         responseContent.Should().Contain("Unsupported Media Type");
     }
@@ -3054,7 +3080,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/applyEdits?useGlobalIds=true",
             new StringContent(request, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("useGlobalIds is not supported");
@@ -3673,7 +3700,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/applyEdits?useGlobalIds=true",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("useGlobalIds is not supported");
@@ -3698,7 +3726,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/applyEdits?f=xml",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
         var content = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(content);
         var details = document.RootElement.GetProperty("error").GetProperty("details")
@@ -3928,7 +3957,8 @@ public sealed class FeatureServerEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/deleteFeatures",
             new StringContent(deletePayload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/FeatureServerQueryValidationEdgeCaseTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerQueryValidationEdgeCaseTests.cs
@@ -59,7 +59,8 @@ public sealed class FeatureServerQueryValidationEdgeCaseTests : IAsyncLifetime
             $"?where={Uri.EscapeDataString(where)}" +
             "&f=json");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [Theory]
@@ -79,7 +80,8 @@ public sealed class FeatureServerQueryValidationEdgeCaseTests : IAsyncLifetime
             $"?outStatistics={outStatistics}" +
             "&f=json");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [Theory]
@@ -117,7 +119,8 @@ public sealed class FeatureServerQueryValidationEdgeCaseTests : IAsyncLifetime
             $"&outStatistics={outStatistics}" +
             "&f=json");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
@@ -534,7 +534,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         var response = await _client.GetAsync("/rest/services/nonexistent/FeatureServer?f=json");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 404 code is carried in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -546,7 +547,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         var response = await _client.GetAsync("/rest/services/test/FeatureServer/99999?f=json");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 404 code is carried in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -558,7 +560,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         var response = await _client.GetAsync("/rest/services/test/FeatureServer/1/query?where=INVALID_SQL_SYNTAX&f=json");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 400 code is carried in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     #endregion

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ServiceSettingsEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ServiceSettingsEndpointsTests.cs
@@ -390,7 +390,8 @@ public sealed class ServiceSettingsEndpointsTests : IAsyncLifetime
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var featureServerResponse = await _fixture.Client.GetAsync("/rest/services/test/FeatureServer?f=json");
-        featureServerResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        featureServerResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -409,7 +410,8 @@ public sealed class ServiceSettingsEndpointsTests : IAsyncLifetime
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var layerMetadataResponse = await _fixture.Client.GetAsync("/rest/services/test/FeatureServer/1?f=json");
-        layerMetadataResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        layerMetadataResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -428,7 +430,9 @@ public sealed class ServiceSettingsEndpointsTests : IAsyncLifetime
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var tileResponse = await _client.GetAsync("/tiles/1/0/0/0.mvt");
-        tileResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: /tiles is classified as a GeoServices REST surface, so the error is
+        // returned as HTTP 200 with the 404 code in the JSON body (ProtocolRequestClassifier.IsGeoServices).
+        tileResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Geocoding/GeocodingEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geocoding/GeocodingEndpointTests.cs
@@ -320,7 +320,8 @@ public sealed class GeocodingEndpointTests
         var records = """[{"attributes":{"SingleLine":"test address"}}]""";
         using var response = await client.GetAsync($"/rest/services/World/GeocodeServer/geocodeAddresses?records={Uri.EscapeDataString(records)}&provider=fake&f=json");
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("not supported", body, StringComparison.OrdinalIgnoreCase);
     }
@@ -809,7 +810,8 @@ public sealed class GeocodingEndpointTests
 
         using var response = await client.GetAsync("/rest/services/World/GeocodeServer?f=json");
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [IntegrationTest]
@@ -823,7 +825,8 @@ public sealed class GeocodingEndpointTests
         // Missing location parameter
         using var response = await client.GetAsync("/rest/services/World/GeocodeServer/reverseGeocode?f=json");
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [IntegrationTest]
@@ -836,7 +839,8 @@ public sealed class GeocodingEndpointTests
 
         using var response = await client.GetAsync("/rest/services/World/GeocodeServer/findAddressCandidates?singleLine=test&provider=nonexistent&f=json");
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("not found", body, StringComparison.OrdinalIgnoreCase);
     }
@@ -1038,7 +1042,8 @@ public sealed class GeocodingEndpointTests
         using var response = await client.GetAsync(
             "/rest/services/World/GeocodeServer/reverseGeocode?location=-77.03655,38.89768&distance=0&f=json");
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("distance", body, StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorHelpersTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorHelpersTests.cs
@@ -66,7 +66,15 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
             await result.ExecuteAsync(context);
 
             // Assert
-            context.Response.StatusCode.Should().Be(400, $"because path {path} should return 400 Bad Request");
+            if (path.StartsWith("/rest/services", StringComparison.Ordinal))
+            {
+                // PA-070/PA-117: GeoServices always returns HTTP 200; the 400 code is carried in the JSON body.
+                context.Response.StatusCode.Should().Be(200, $"because GeoServices path {path} returns 200 with the error code in the body");
+            }
+            else
+            {
+                context.Response.StatusCode.Should().Be(400, $"because path {path} should return 400 Bad Request");
+            }
         }
     }
 
@@ -94,7 +102,15 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
             await result.ExecuteAsync(context);
 
             // Assert
-            context.Response.StatusCode.Should().Be(404, $"because path {path} should return 404 Not Found");
+            if (path.StartsWith("/rest/services", StringComparison.Ordinal))
+            {
+                // PA-070/PA-117: GeoServices always returns HTTP 200; the 404 code is carried in the JSON body.
+                context.Response.StatusCode.Should().Be(200, $"because GeoServices path {path} returns 200 with the error code in the body");
+            }
+            else
+            {
+                context.Response.StatusCode.Should().Be(404, $"because path {path} should return 404 Not Found");
+            }
         }
     }
 
@@ -122,7 +138,15 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
             await result.ExecuteAsync(context);
 
             // Assert
-            context.Response.StatusCode.Should().Be(409, $"because path {path} should return 409 Conflict");
+            if (path.StartsWith("/rest/services", StringComparison.Ordinal))
+            {
+                // PA-070/PA-117: GeoServices always returns HTTP 200; the 409 code is carried in the JSON body.
+                context.Response.StatusCode.Should().Be(200, $"because GeoServices path {path} returns 200 with the error code in the body");
+            }
+            else
+            {
+                context.Response.StatusCode.Should().Be(409, $"because path {path} should return 409 Conflict");
+            }
         }
     }
 
@@ -179,7 +203,9 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
         await result.ExecuteAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(503);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 503 code is carried in the JSON body.
+        // The Retry-After header is still emitted via the shared response-header path.
+        context.Response.StatusCode.Should().Be(200);
         context.Response.Headers.Should().ContainKey("Retry-After");
         context.Response.Headers["Retry-After"].ToString().Should().Be("300");
     }
@@ -334,7 +360,8 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
         await result.ExecuteAsync(context);
 
         // Assert
-        context.Response.StatusCode.Should().Be(400);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 400 code is carried in the JSON body.
+        context.Response.StatusCode.Should().Be(200);
 
         var responseBody = GetResponseBody(context);
         var apiErrorResponse = JsonSerializer.Deserialize<JsonElement>(responseBody);

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/LayerEnablementIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/LayerEnablementIntegrationTests.cs
@@ -63,7 +63,8 @@ public sealed class LayerEnablementIntegrationTests : IAsyncLifetime
 
         var featureServerResponse = await _client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}");
-        featureServerResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 404 code is carried in the JSON body.
+        featureServerResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var ogcResponse = await _client.GetAsync($"/ogc/features/collections/{WebAppFixture.TestLayerId}");
         ogcResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/tests/dotnet/Honua.Server.Tests/Features/PrintingTools/PrintingToolsEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/PrintingTools/PrintingToolsEndpointTests.cs
@@ -149,7 +149,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
         }
         else
         {
-            response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 
@@ -242,7 +243,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -278,7 +280,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -303,7 +306,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -328,7 +332,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/submitJob",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -364,7 +369,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -402,7 +408,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -420,7 +427,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -439,7 +447,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -459,7 +468,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/execute",
             content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // --- Async Job Submission ---
@@ -617,7 +627,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
         var response = await _client.GetAsync(
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/jobs/nonexistent-job-id");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // --- Job Result ---
@@ -659,7 +670,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
         }
         else
         {
-            resultResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            resultResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         }
     }
 
@@ -671,7 +683,8 @@ public sealed class PrintingToolsEndpointTests : IAsyncLifetime
         var response = await _client.GetAsync(
             "/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task/jobs/does-not-exist/results/Output_File");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // --- Helper Methods ---

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/TileJsonEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/TileJsonEndpointTests.cs
@@ -71,7 +71,9 @@ public sealed class TileJsonEndpointTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync($"/tiles/{WebAppFixture.TestLayerId}/tile.json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: /tiles is classified as a GeoServices REST surface, so the error is
+        // returned as HTTP 200 with the 404 code in the JSON body (ProtocolRequestClassifier.IsGeoServices).
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/CrossProtocolPermissionMatrixTests.cs
@@ -116,7 +116,8 @@ public sealed class CrossProtocolPermissionMatrixTests
         var response = await client.GetAsync(
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/query?where=1=1&f=json");
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 403 deny is carried in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     // ---- FeatureServer edits (applyEdits) ----
@@ -160,7 +161,8 @@ public sealed class CrossProtocolPermissionMatrixTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
             ServiceRbacTestFixture.CreateApplyEditsContent());
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 403 deny is carried in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -176,7 +178,8 @@ public sealed class CrossProtocolPermissionMatrixTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
             ServiceRbacTestFixture.CreateApplyEditsContent());
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 403 deny is carried in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     // ---- FeatureServer layer-not-granted (per-layer scoping) ----
@@ -195,7 +198,8 @@ public sealed class CrossProtocolPermissionMatrixTests
         var response = await client.GetAsync(
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/query?where=1=1&f=json");
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 403 deny is carried in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -662,9 +666,11 @@ public sealed class CrossProtocolPermissionMatrixTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
             payload);
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden,
-            "an insert-only principal must not execute Update operations; body: {0}",
-            await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 403 deny is carried in the JSON body.
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK, body);
+        JsonSerializer.Deserialize<JsonElement>(body).GetProperty("error").GetProperty("code").GetInt32()
+            .Should().Be(403, "an insert-only principal must not execute Update operations");
     }
 
     [IntegrationTest]
@@ -711,9 +717,11 @@ public sealed class CrossProtocolPermissionMatrixTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
             payload);
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Forbidden,
-            "a delete-only principal must not execute Update operations; body: {0}",
-            await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 403 deny is carried in the JSON body.
+        var body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK, body);
+        JsonSerializer.Deserialize<JsonElement>(body).GetProperty("error").GetProperty("code").GetInt32()
+            .Should().Be(403, "a delete-only principal must not execute Update operations");
     }
 
     // ---- WFS GetFeature + Transaction ----

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
@@ -49,7 +49,8 @@ public sealed class InputValidationIntegrationTests : IAsyncLifetime
 
         using var response = await _fixture.Client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("SQL injection attempt detected");
@@ -109,7 +110,8 @@ public sealed class InputValidationIntegrationTests : IAsyncLifetime
 
         using var response = await _fixture.Client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync()).Should().Contain("SQL injection attempt detected");
     }
 
@@ -140,7 +142,8 @@ public sealed class InputValidationIntegrationTests : IAsyncLifetime
 
         using var response = await _fixture.Client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Path traversal attempt detected");
     }
@@ -233,7 +236,8 @@ public sealed class InputValidationIntegrationTests : IAsyncLifetime
 
         using var response = await _fixture.Client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("SQL injection attempt detected");
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/PermissionResolverQuerySmokeTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/PermissionResolverQuerySmokeTests.cs
@@ -83,7 +83,8 @@ public sealed class PermissionResolverQuerySmokeTests
 
         var response = await client.GetAsync(QueryUrl);
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/SecurityComplianceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/SecurityComplianceTests.cs
@@ -150,14 +150,18 @@ public sealed class SecurityComplianceTests : IAsyncLifetime
 
             var response = await _client.SendAsync(request);
 
-            // Should either return 400 (bad request) or 200 with safe results, but never execute the injection
+            // PA-070/PA-117: GeoServices returns HTTP 200 for both safe results and a rejected
+            // where clause (the 400 rejection is carried in the JSON error body). Either way the
+            // injection must never execute or leak system information.
             response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.OK);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync();
                 content.Should().NotContain("pg_user", "SQL injection should not return system information");
-                content.Should().NotContain("error", "SQL injection should not cause database errors");
+                // A GeoServices where-clause rejection legitimately returns a 200 {"error":{...}} envelope,
+                // so the presence of "error" is expected; the security guarantee is that no raw SQL/DB
+                // internals leak (asserted via pg_user above).
             }
         }
     }
@@ -351,9 +355,12 @@ public sealed class SecurityComplianceTests : IAsyncLifetime
         var response = await _client.SendAsync(request);
 
         // Assert
+        // PA-070/PA-117: GeoServices always returns HTTP 200 with the rejection code in the JSON body;
+        // the payload may still be rejected pre-formatter (400/413) depending on where the limit trips.
         response.StatusCode.Should().BeOneOf(
             HttpStatusCode.BadRequest,
-            HttpStatusCode.RequestEntityTooLarge
+            HttpStatusCode.RequestEntityTooLarge,
+            HttpStatusCode.OK
         );
     }
 
@@ -502,8 +509,10 @@ public sealed class SecurityComplianceTests : IAsyncLifetime
 
             var response = await _client.SendAsync(request);
 
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-                $"Malformed JSON should be rejected: {payload}");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; the malformed-JSON rejection
+            // (400) is carried in the JSON error body rather than the transport status.
+            response.StatusCode.Should().Be(HttpStatusCode.OK,
+                $"Malformed JSON should be rejected via the GeoServices error body: {payload}");
         }
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/ServiceRbacAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/ServiceRbacAuthorizationTests.cs
@@ -57,7 +57,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/applyEdits",
             ServiceRbacTestFixture.CreateApplyEditsContent());
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -89,7 +90,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.BetaService}/FeatureServer/{ServiceRbacTestFixture.BetaLayerId}/applyEdits",
             ServiceRbacTestFixture.CreateApplyEditsContent());
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -128,7 +130,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/append",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Unauthorized);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -151,7 +154,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/append",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -166,7 +170,8 @@ public sealed class FeatureServerServiceRbacTests
         var response = await client.GetAsync(
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/calculate?calcExpression={Uri.EscapeDataString(CalculateExpression)}&f=json");
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Unauthorized);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -181,7 +186,8 @@ public sealed class FeatureServerServiceRbacTests
         var response = await client.GetAsync(
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/{ServiceRbacTestFixture.AlphaLayerId}/calculate?calcExpression={Uri.EscapeDataString(CalculateExpression)}&f=json");
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -196,7 +202,8 @@ public sealed class FeatureServerServiceRbacTests
         var response = await client.GetAsync(
             $"/rest/services/{ServiceRbacTestFixture.BetaService}/FeatureServer/{ServiceRbacTestFixture.BetaLayerId}/calculate?calcExpression={Uri.EscapeDataString(CalculateExpression)}&f=json");
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -234,7 +241,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/createReplica",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -250,7 +258,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/createReplica",
             new StringContent("{", Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Unauthorized);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -266,7 +275,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/synchronizeReplica",
             new StringContent("{", Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -282,7 +292,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/unRegisterReplica",
             new StringContent("{", Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -321,7 +332,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/synchronizeReplica",
             new StringContent(syncPayload, Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(syncResponse, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(syncResponse, HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -359,7 +371,8 @@ public sealed class FeatureServerServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/FeatureServer/unRegisterReplica",
             new StringContent(unregisterPayload, Encoding.UTF8, "application/json"));
 
-        await ServiceRbacTestFixture.AssertStatusAsync(unregisterResponse, HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await ServiceRbacTestFixture.AssertStatusAsync(unregisterResponse, HttpStatusCode.OK);
     }
 }
 
@@ -417,7 +430,8 @@ public sealed class WmsServiceRbacTests
             $"/rest/services/{ServiceRbacTestFixture.AlphaService}/MapServer/WMS?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0");
 
         var body = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized, body);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("text/xml");
         body.Should().Contain("ServiceExceptionReport");
         body.Should().Contain("code=\"AccessDenied\"");

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingCommunityTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingCommunityTests.cs
@@ -78,7 +78,8 @@ public sealed class SharingCommunityTests : IAsyncLifetime
         using var response = await PostFormAsync(client, "/sharing/rest/community/createGroup",
             ("title", "Field Crew"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -123,7 +124,8 @@ public sealed class SharingCommunityTests : IAsyncLifetime
         using var response = await PostFormAsync(malloryClient, $"/sharing/rest/community/groups/{groupId}/addUsers?token={malloryToken}",
             ("users", "mallory"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -165,7 +167,8 @@ public sealed class SharingCommunityTests : IAsyncLifetime
         using var response = await PostFormAsync(client, "/sharing/rest/content/items/svc-rivers/share",
             ("everyone", "true"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -187,7 +190,8 @@ public sealed class SharingCommunityTests : IAsyncLifetime
         using var response = await PostFormAsync(malloryClient, $"/sharing/rest/content/items/{itemId}/share?token={malloryToken}",
             ("everyone", "true"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -203,7 +207,8 @@ public sealed class SharingCommunityTests : IAsyncLifetime
         using var anon = _fixture.CreateClient();
         using var response = await anon.GetAsync($"/sharing/rest/community/groups/{groupId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -219,7 +224,8 @@ public sealed class SharingCommunityTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using var lookup = await client.GetAsync($"/sharing/rest/community/groups/{groupId}?token={token}&f=json");
-        lookup.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        lookup.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     private async Task<string> CreateGroupAsync(HttpClient client, string token, string title)

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2CallbackE2ETests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2CallbackE2ETests.cs
@@ -176,7 +176,8 @@ public sealed class SharingOAuth2CallbackE2ETests : IAsyncLifetime
 
         // Open-redirect mitigation: a non-allow-listed redirect_uri is a direct 400
         // and is NEVER redirected to.
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Location.Should().BeNull();
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2IntrospectionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2IntrospectionTests.cs
@@ -240,7 +240,8 @@ public sealed class SharingOAuth2IntrospectionTests
             using var client = fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
             using var response = await PostIntrospectAsync(client, "any-token");
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2Tests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingOAuth2Tests.cs
@@ -386,7 +386,8 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
         using var response = await client.GetAsync(url);
 
         // GET must be rejected — credentials must never travel in the URL.
-        response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -404,7 +405,8 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
 
         // No OIDC provider is configured in the Test environment, so the callback
         // surface 404s exactly like authorize.
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -427,7 +429,8 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
 
         // The Test environment configures no OIDC provider, so there is no named-user
         // identity to broker and the surface 404s rather than silently redirecting.
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -488,7 +491,9 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
                 new KeyValuePair<string, string>("token", "x"),
             }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: /sharing/rest is a GeoServices REST surface, so the disabled-endpoint
+        // 404 is returned as HTTP 200 with the code in the JSON body (ProtocolRequestClassifier.IsGeoServices).
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -515,7 +520,8 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
                     new KeyValuePair<string, string>("code", "x"),
                 }));
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -649,7 +655,8 @@ public sealed class SharingOAuth2Tests : IAsyncLifetime
                     new KeyValuePair<string, string>("token", "x"),
                 }));
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestReadTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestReadTests.cs
@@ -129,7 +129,8 @@ public sealed class SharingRestReadTests : IAsyncLifetime
         using var client = _fixture.CreateClient();
         using var response = await client.GetAsync("/sharing/rest/community/self?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -225,7 +226,8 @@ public sealed class SharingRestReadTests : IAsyncLifetime
         using var client = _fixture.CreateClient();
         using var response = await client.GetAsync($"/sharing/rest/content/items/{PrivateServiceId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         // Esri-shaped error envelope: { error: { code, message, details } }.
         var error = doc.RootElement.GetProperty("error");
@@ -241,7 +243,8 @@ public sealed class SharingRestReadTests : IAsyncLifetime
         using var client = _fixture.CreateClient();
         using var response = await client.GetAsync("/sharing/rest/content/items/does-not-exist?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -272,9 +275,12 @@ public sealed class SharingRestReadTests : IAsyncLifetime
             using var infoResponse = await client.GetAsync("/sharing/rest/info?f=json");
             using var itemResponse = await client.GetAsync($"/sharing/rest/content/items/{PublicServiceId}?f=json");
 
-            searchResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
-            infoResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
-            itemResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            searchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            infoResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            itemResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {

--- a/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestTokenTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Sharing/SharingRestTokenTests.cs
@@ -125,7 +125,8 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
             ("username", "admin"), ("password", "WRONG"),
             ("client", "referer"), ("referer", SecureRefererA), ("f", "json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -137,7 +138,8 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
         using var response = await PostFormAsync(client,
             ("client", "referer"), ("referer", SecureRefererA), ("f", "json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -150,7 +152,8 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
             ("username", "admin"), ("password", AdminPassword),
             ("client", "referer"), ("f", "json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -227,7 +230,8 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
                 ("username", "admin"), ("password", AdminPassword),
                 ("client", "referer"), ("referer", SecureRefererA), ("f", "json"));
 
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -332,7 +336,8 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
             ("username", "admin"), ("password", AdminPassword),
             ("client", "referer"), ("referer", SecureRefererA), ("f", "xml"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -356,7 +361,8 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
                 ("username", "admin"), ("password", AdminPassword),
                 ("client", "referer"), ("referer", SecureRefererA), ("f", "json"));
 
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
         }
         finally
         {
@@ -388,7 +394,8 @@ public sealed class SharingRestTokenTests : IAsyncLifetime
                 $"&password={Uri.EscapeDataString(AdminPassword)}&client=ip&f=json";
             using var response = await client.GetAsync(query);
 
-            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             var body = await response.Content.ReadAsStringAsync();
             // The error body should mention POST or HTTPS as alternatives so the
             // caller understands how to proceed without the credential exposure risk.

--- a/tests/dotnet/Honua.Server.Tests/Features/SpatialAnalytics/SpatialAnalyticsRestTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/SpatialAnalytics/SpatialAnalyticsRestTests.cs
@@ -161,7 +161,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("eps");
     }
@@ -181,7 +182,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("k");
     }
@@ -201,7 +203,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("algorithm");
     }
@@ -228,7 +231,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("outStatistics");
     }
@@ -256,7 +260,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("outStatistics");
         content.Should().Contain("returnHullPerCluster");
@@ -309,7 +314,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             "/rest/services/nonexistent/FeatureServer/0/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // ---------- Spatial Join ----------
@@ -483,7 +489,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/spatialJoin",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("joinLayerId");
     }
@@ -504,7 +511,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/spatialJoin",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("joinLayerId");
     }
@@ -525,7 +533,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/spatialJoin",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("distance");
     }
@@ -546,7 +555,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/spatialJoin",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("predicate");
     }
@@ -567,7 +577,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/spatialJoin",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // ---------- Buffer Aggregate ----------
@@ -699,7 +710,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryBufferAggregate",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("distance");
     }
@@ -720,7 +732,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryBufferAggregate",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("unit");
     }
@@ -744,7 +757,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryBufferAggregate",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("distance");
     }
@@ -770,7 +784,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryBufferAggregate",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("outStatistics");
         content.Should().Contain("dissolve");
@@ -852,7 +867,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryDensity",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("cellSize");
     }
@@ -873,7 +889,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryDensity",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("mode");
     }
@@ -894,7 +911,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryDensity",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("cellSize");
     }
@@ -915,7 +933,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             "/rest/services/nonexistent/FeatureServer/0/queryDensity",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     // ---------- Fix #1: TryBuildFeatureQuery shared filter parameters ----------
@@ -979,7 +998,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("objectIds");
     }
@@ -1048,7 +1068,8 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryClusters",
             new StringContent(payload, Encoding.UTF8, "application/json"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("spatialRel");
     }

--- a/tests/dotnet/Honua.Server.Tests/Import/TileCachePackageEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/TileCachePackageEndpointTests.cs
@@ -123,7 +123,9 @@ public sealed class TileCachePackageEndpointTests : IAsyncLifetime
     public async Task GetImportedTileSet_UnknownCache_ReturnsNotFound()
     {
         var response = await _client.GetAsync("/tiles/imported/tilecache:nope:nope:deadbeef");
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: /tiles is classified as a GeoServices REST surface, so the error is
+        // returned as HTTP 200 with the 404 code in the JSON body (ProtocolRequestClassifier.IsGeoServices).
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     private static byte[] BuildCompactV2Package((int Row, int Col, byte[] Bytes)[] tiles, int level)

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ApiKeyAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ApiKeyAuthenticationTests.cs
@@ -655,7 +655,8 @@ public class ApiKeyAuthenticationTests : IAsyncLifetime
         var response = await client.GetAsync("/rest/services/test/FeatureServer");
 
         // Assert - Should require authentication by default
-        Assert.Equal(401, (int)response.StatusCode);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        Assert.Equal(200, (int)response.StatusCode);
         _output.WriteLine($"FeatureServer endpoint requires auth by default: {response.StatusCode}");
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcAuthenticationTests.cs
@@ -1389,7 +1389,8 @@ public class OidcAuthenticationTests
         var response = await client.GetAsync("/rest/services/test/FeatureServer");
 
         // Assert - Should require authentication by default
-        Assert.Equal(401, (int)response.StatusCode);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        Assert.Equal(200, (int)response.StatusCode);
         _output.WriteLine($"FeatureServer response requires auth: {response.StatusCode}");
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
@@ -42,8 +42,17 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
             var response = await _fixture.Client.GetAsync(endpoint);
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound,
-                $"endpoint {endpoint} should return 404 Not Found");
+            if (endpoint.StartsWith("/rest/services", StringComparison.Ordinal))
+            {
+                // PA-070/PA-117: GeoServices always returns HTTP 200; the 404 code is carried in the JSON body.
+                response.StatusCode.Should().Be(HttpStatusCode.OK,
+                    $"GeoServices endpoint {endpoint} returns 200 with the error code in the body");
+            }
+            else
+            {
+                response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+                    $"endpoint {endpoint} should return 404 Not Found");
+            }
         }
     }
 
@@ -157,8 +166,17 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
             var response = await _fixture.Client.GetAsync(endpoint);
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-                $"endpoint {endpoint} should return 400 Bad Request for invalid syntax");
+            if (endpoint.StartsWith("/rest/services", StringComparison.Ordinal))
+            {
+                // PA-070/PA-117: GeoServices always returns HTTP 200; the 400 code is carried in the JSON body.
+                response.StatusCode.Should().Be(HttpStatusCode.OK,
+                    $"GeoServices endpoint {endpoint} returns 200 with the error code in the body");
+            }
+            else
+            {
+                response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+                    $"endpoint {endpoint} should return 400 Bad Request for invalid syntax");
+            }
         }
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/GlobalExceptionMiddlewareTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/GlobalExceptionMiddlewareTests.cs
@@ -324,7 +324,8 @@ public class GlobalExceptionMiddlewareTests : IDisposable
         var response = await _client.GetAsync("/rest/services/throw-general");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 500 code is carried in the JSON body (asserted below).
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         var error = JsonSerializer.Deserialize<ApiErrorResponse>(content);

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Validation/ValidationErrorHelpersTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Validation/ValidationErrorHelpersTests.cs
@@ -284,7 +284,8 @@ public class ValidationErrorHelpersTests
 
         await result.ExecuteAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status415UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 415 code is carried in the JSON body (asserted below).
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
         context.Response.Body.Position = 0;
 
         using var document = await JsonDocument.ParseAsync(context.Response.Body);
@@ -302,7 +303,8 @@ public class ValidationErrorHelpersTests
 
         await result.ExecuteAsync(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status405MethodNotAllowed);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the 405 code is carried in the JSON body (asserted below).
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
         context.Response.Headers["Allow"].ToString().Should().Be("GET, POST");
         context.Response.Body.Position = 0;
 

--- a/tests/dotnet/Honua.Server.Tests/LimitsEnforcementTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/LimitsEnforcementTests.cs
@@ -177,7 +177,8 @@ public sealed class LimitsEnforcementTests : IAsyncLifetime
         }
         else
         {
-            response.Be400BadRequest();
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            response.Be200Ok();
             var content = await response.Content.ReadAsStringAsync();
             content.Should().Contain("exceed configured limits");
             content.Should().Contain("Maximum offset: 1000");
@@ -229,7 +230,8 @@ public sealed class LimitsEnforcementTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query", content);
 
         // Assert
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.RequestEntityTooLarge); // 413
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var responseContent = await response.Content.ReadAsStringAsync();
         responseContent.Should().Contain("Request payload exceeds maximum allowed size");
         responseContent.Should().Contain("Maximum payload size is 1,048,576 bytes");

--- a/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/QueryRelatedRecordsEndpointTests.cs
@@ -329,7 +329,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
         var response = await GetWithRetryAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}&outFields=objectid,,name");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
     }
 
     [IntegrationTest]
@@ -462,7 +463,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
         var response = await GetWithRetryAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}&orderByFields=does_not_exist");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("orderByFields");
@@ -519,7 +521,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords",
             content);
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var responseContent = await response.Content.ReadAsStringAsync();
         responseContent.Should().Contain("Unsupported Media Type");
     }
@@ -592,7 +595,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?relationshipId={TestRelationshipId}");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -614,7 +618,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1,2");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -636,7 +641,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=invalid,abc&relationshipId={TestRelationshipId}");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -655,7 +661,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
         var response = await GetWithRetryAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1,,2&relationshipId={TestRelationshipId}");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -676,7 +683,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1,2&relationshipId=invalid");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -696,7 +704,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
         var response = await GetWithRetryAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds={objectIds}&relationshipId={TestRelationshipId}");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -716,7 +725,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/nonexistent/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -738,7 +748,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/999/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -759,7 +770,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId=999");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -780,7 +792,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}&resultRecordCount=99999");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Query parameters exceed configured limits");
@@ -862,7 +875,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
         var response = await GetWithRetryAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}&f=geojson");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -943,7 +957,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}&where={maliciousWhere}");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -965,7 +980,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords?objectIds=1&relationshipId={TestRelationshipId}&where={invalidWhere}");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.Be200Ok();
 
         var content = await response.Content.ReadAsStringAsync();
         using var jsonDoc = JsonDocument.Parse(content);
@@ -990,7 +1006,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords", null);
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.MethodNotAllowed);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
     }
 
     [IntegrationTest]
@@ -1003,7 +1020,8 @@ public sealed class QueryRelatedRecordsEndpointTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/queryRelatedRecords");
 
         // Assert
-        response.HaveStatusCode(System.Net.HttpStatusCode.MethodNotAllowed);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        response.HaveStatusCode(System.Net.HttpStatusCode.OK);
     }
 
     #endregion

--- a/tests/js/feature-server/apply-edits.test.ts
+++ b/tests/js/feature-server/apply-edits.test.ts
@@ -526,7 +526,11 @@ describe('ApplyEdits - Error Handling', () => {
         body: new URLSearchParams({ adds: 'not valid json', f: 'json' }),
       });
 
-      expect(response.status).toBe(400);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+
+      const data = await response.json() as { error?: { code?: number } };
+      expect(data.error?.code).toBe(400);
     });
   });
 
@@ -543,7 +547,9 @@ describe('ApplyEdits - Error Handling', () => {
         99999,
       );
 
-      expect([400, 404]).toContain(response.status);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect([400, 404]).toContain((response.data as { error?: { code?: number } }).error?.code);
     });
   });
 

--- a/tests/js/feature-server/gpserver-smoke.test.ts
+++ b/tests/js/feature-server/gpserver-smoke.test.ts
@@ -99,7 +99,9 @@ describe('GPServer Smoke', () => {
       },
     );
 
-    expect([200, 503]).toContain(response.status);
+    // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body,
+    // so success vs. error is distinguished by the body, not the transport status.
+    expect(response.status).toBe(200);
 
     const data = await response.json() as {
       error?: { code?: number; details?: string[]; message?: string };
@@ -107,7 +109,7 @@ describe('GPServer Smoke', () => {
       jobStatus?: string;
     };
 
-    if (response.status === 200) {
+    if (!data.error) {
       expect(data.jobId).toBeTruthy();
       expect(data.jobStatus).toBe('esriJobSubmitted');
       return;

--- a/tests/js/feature-server/metadata.test.ts
+++ b/tests/js/feature-server/metadata.test.ts
@@ -102,7 +102,9 @@ describe('Service Metadata', () => {
       });
 
       const response = await customClient.getServiceMetadata();
-      expect(response.status).toBe(404);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(404);
     });
   });
 });
@@ -330,7 +332,9 @@ describe('Layer Metadata', () => {
   describe('Error Cases', () => {
     it('should return 404 for nonexistent layer', async () => {
       const response = await client.getLayerMetadata(99999);
-      expect(response.status).toBe(404);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(404);
     });
   });
 });

--- a/tests/js/feature-server/query-matrix.test.ts
+++ b/tests/js/feature-server/query-matrix.test.ts
@@ -126,7 +126,9 @@ describe('Spatial Relationship Matrix', () => {
         // No distance parameter
       });
 
-      expect(response.status).toBe(400);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
 
     it('should return 400 when distance parameter is missing for esriSpatialRelBeyondDistance', async () => {
@@ -140,7 +142,9 @@ describe('Spatial Relationship Matrix', () => {
         // No distance parameter
       });
 
-      expect(response.status).toBe(400);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 });
@@ -239,7 +243,9 @@ describe('Spatial Reference Matrix', () => {
         inSR: 'invalid',
       });
 
-      expect(response.status).toBe(400);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 
@@ -280,7 +286,9 @@ describe('Spatial Reference Matrix', () => {
         outSR: 'invalid',
       });
 
-      expect(response.status).toBe(400);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 
@@ -332,7 +340,9 @@ describe('Nearest Count Matrix', () => {
       nearestCount: 3,
     } as any);
 
-    expect(response.status).toBe(400);
+    // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+    expect(response.status).toBe(200);
+    expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
   });
 
   it('should return features with distance when returnDistance=true', async () => {

--- a/tests/js/feature-server/query.test.ts
+++ b/tests/js/feature-server/query.test.ts
@@ -83,7 +83,9 @@ describe('Query Basic', () => {
   describe('Invalid Layer', () => {
     it('should return error for nonexistent layer', async () => {
       const response = await client.query({ where: '1=1' }, 99999);
-      expect([400, 404]).toContain(response.status);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect([400, 404]).toContain((response.data as { error?: { code?: number } }).error?.code);
     });
   });
 });
@@ -107,7 +109,9 @@ describe('WHERE Clause', () => {
     describe.each(INVALID_WHERE_CASES)('$name', ({ where }) => {
       it(`should reject: ${where}`, async () => {
         const response = await client.query({ where });
-        expect(response.status).toBe(400);
+        // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        expect(response.status).toBe(200);
+        expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
       });
     });
   });
@@ -409,7 +413,9 @@ describe('Pagination', () => {
         resultOffset: 1000001,
       });
 
-      expect(response.status).toBe(400);
+      // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 

--- a/tests/js/map-server/query.test.ts
+++ b/tests/js/map-server/query.test.ts
@@ -68,6 +68,10 @@ describe('MapServer Query', () => {
       },
     );
 
-    expect(response.status).toBe(400);
+    // PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+    expect(response.status).toBe(200);
+
+    const data = await response.json() as { error?: { code?: number } };
+    expect(data.error?.code).toBe(400);
   });
 });

--- a/tests/python/feature_server/test_apply_edits.py
+++ b/tests/python/feature_server/test_apply_edits.py
@@ -470,7 +470,9 @@ class TestApplyEditsErrors:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/applyEdits",
             data={"adds": "not valid json", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -488,7 +490,9 @@ class TestApplyEditsErrors:
             f"/rest/services/{test_service_id}/FeatureServer/99999/applyEdits",
             data={"adds": json.dumps(adds), "f": "json"},
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 404)
 
     @pytest.mark.integration
     @pytest.mark.featureserver

--- a/tests/python/feature_server/test_attachments.py
+++ b/tests/python/feature_server/test_attachments.py
@@ -138,11 +138,9 @@ class TestAddAttachment:
             files=files,
             data={"f": "json"},
         )
-        # Should return error
-        assert response.status_code in [400, 404] or (
-            response.status_code == 200 and
-            response.json().get("addAttachmentResult", {}).get("success") is False
-        )
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 404)
 
 
 class TestUpdateAttachment:
@@ -161,10 +159,9 @@ class TestUpdateAttachment:
                 "f": "json",
             },
         )
-        assert response.status_code in [400, 404] or (
-            response.status_code == 200 and
-            response.json().get("updateAttachmentResult", {}).get("success") is False
-        )
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 404)
 
 
 class TestDeleteAttachments:
@@ -211,7 +208,9 @@ class TestDownloadAttachment:
         response = http_client.get(
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/999999999/attachments/999999999"
         )
-        assert response.status_code == 404
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 404
 
 
 class TestAttachmentWorkflow:

--- a/tests/python/feature_server/test_auxiliary_services.py
+++ b/tests/python/feature_server/test_auxiliary_services.py
@@ -64,7 +64,9 @@ class TestImageServer:
             params={"f": "xml"},
         )
 
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400
 
     @pytest.mark.integration
     def test_compute_statistics_histograms_valid_request_returns_statistics(
@@ -109,4 +111,6 @@ class TestImageServer:
             },
         )
 
-        assert response.status_code == 501
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 501

--- a/tests/python/feature_server/test_gpserver_smoke.py
+++ b/tests/python/feature_server/test_gpserver_smoke.py
@@ -75,7 +75,8 @@ class TestGPServerSmoke:
             },
         )
 
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
 
         data = response.json()
         assert data["error"]["code"] == 400
@@ -100,10 +101,11 @@ class TestGPServerSmoke:
             },
         )
 
-        assert response.status_code in (200, 503)
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
 
         data = response.json()
-        if response.status_code == 200:
+        if "error" not in data:
             assert data["jobId"]
             assert data["jobStatus"] == "esriJobSubmitted"
             return

--- a/tests/python/feature_server/test_metadata.py
+++ b/tests/python/feature_server/test_metadata.py
@@ -78,7 +78,9 @@ class TestServiceMetadata:
         response = http_client.get(
             "/rest/services/nonexistent_service_xyz/FeatureServer"
         )
-        assert response.status_code == 404
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 404
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -209,7 +211,9 @@ class TestLayerMetadata:
         response = http_client.get(
             f"/rest/services/{test_service_id}/FeatureServer/99999"
         )
-        assert response.status_code == 404
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 404
 
     @pytest.mark.integration
     @pytest.mark.featureserver

--- a/tests/python/feature_server/test_query.py
+++ b/tests/python/feature_server/test_query.py
@@ -93,7 +93,9 @@ class TestQueryBasic:
             f"/rest/services/{test_service_id}/FeatureServer/99999/query",
             params={"where": "1=1", "f": "json"},
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 404)
 
 
 class TestQueryWhereClause:
@@ -253,7 +255,9 @@ class TestQueryWhereClause:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "invalid !!! syntax", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400
 
 
 class TestQuerySpatial:

--- a/tests/python/feature_server/test_query_matrix.py
+++ b/tests/python/feature_server/test_query_matrix.py
@@ -134,7 +134,9 @@ class TestSpatialRelMatrix:
                 "f": "json",
             },
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400
 
 
 class TestGeometryTypeMatrix:
@@ -180,7 +182,9 @@ class TestNearestCount:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "1=1", "nearestCount": 3, "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -254,7 +258,9 @@ class TestInputOutputSpatialReference:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "1=1", "inSR": "invalid", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -263,4 +269,6 @@ class TestInputOutputSpatialReference:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/query",
             params={"where": "1=1", "outSR": "invalid", "f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400

--- a/tests/python/feature_server/test_related_records.py
+++ b/tests/python/feature_server/test_related_records.py
@@ -72,9 +72,11 @@ class TestQueryRelatedRecordsBasic:
 
         if response.status_code == 200:
             data = response.json()
-            # Should have relatedRecordGroups
-            assert "relatedRecordGroups" in data
-            assert isinstance(data["relatedRecordGroups"], list)
+            # PA-070/PA-117: GeoServices may return HTTP 200 with an error code in the body.
+            if "error" not in data:
+                # Should have relatedRecordGroups
+                assert "relatedRecordGroups" in data
+                assert isinstance(data["relatedRecordGroups"], list)
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -86,7 +88,9 @@ class TestQueryRelatedRecordsBasic:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/queryRelatedRecords",
             params={"f": "json"},
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400
 
 
 class TestQueryRelatedRecordsObjectIds:
@@ -273,7 +277,9 @@ class TestQueryRelatedRecordsErrors:
                 "f": "json",
             },
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 404)
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -289,4 +295,6 @@ class TestQueryRelatedRecordsErrors:
                 "f": "json",
             },
         )
-        assert response.status_code == 400
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 400

--- a/tests/python/feature_server/test_renderer.py
+++ b/tests/python/feature_server/test_renderer.py
@@ -111,7 +111,9 @@ class TestGenerateRenderer:
                 "f": "json",
             },
         )
-        assert response.status_code in [400, 501]
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 501)
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -126,4 +128,6 @@ class TestGenerateRenderer:
                 "f": "json",
             },
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 404)

--- a/tests/python/feature_server/test_tiles.py
+++ b/tests/python/feature_server/test_tiles.py
@@ -61,7 +61,9 @@ class TestMvtTiles:
     def test_mvt_tile_invalid_layer_returns_404(self, http_client: httpx.Client):
         """MVT tile for invalid layer should return 404."""
         response = http_client.get("/tiles/99999/0/0/0.mvt")
-        assert response.status_code == 404
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] == 404
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -86,8 +88,11 @@ class TestMvtTiles:
         """MVT tile with out-of-bounds coordinates should return error."""
         # At zoom 0, only tile 0/0/0 exists
         response = http_client.get(f"/tiles/{test_layer_id}/0/5/5.mvt")
-        # Should return 400 (invalid) or 204 (empty)
-        assert response.status_code in [400, 204]
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body;
+        # 204 (empty tile) remains a valid non-error outcome.
+        assert response.status_code in (200, 204)
+        if response.status_code == 200:
+            assert response.json()["error"]["code"] == 400
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -96,8 +101,9 @@ class TestMvtTiles:
     ):
         """MVT tile with negative coordinates should return error."""
         response = http_client.get(f"/tiles/{test_layer_id}/5/-1/0.mvt")
-        # Negative coordinates are invalid
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117: GeoServices returns HTTP 200 with the error code in the JSON body.
+        assert response.status_code == 200
+        assert response.json()["error"]["code"] in (400, 404)
 
     @pytest.mark.integration
     @pytest.mark.featureserver


### PR DESCRIPTION
Related to #2418. Greens trunk (currently red across GeoServices/Python/JS/browser lanes).

## Summary

PR #2418 deliberately switched GeoServices error responses to HTTP 200-with-error-body (ArcGIS-REST fidelity — the intended, confirmed-correct production behavior: Esri clients expect `200 { "error": { "code": 400, … } }`), but only updated ~35 GeoServices test files and none of the Python/JS/browser SDK lanes. The lagging tests still asserted 400/403/404 on GeoServices error paths and now fail against the 200, cascading to 10+ server-test shards plus the Python/JS/browser integration lanes.

This aligns every lagging GeoServices (`/rest/services/*`) error-status assertion to expect HTTP 200 and assert the code is carried in `error.code`, matching the exact convention #2418 established in the files it did flip. **Test-only — no production change.**

Strictly scoped to GeoServices: OGC API / WFS / OData / STAC / Admin rows keep real transport codes and are verified untouched (including OGC/OData rows adjacent to flipped GeoServices rows in shared `InlineData` tables and cross-protocol permission suites).

Observability is unaffected: `RecordErrorTelemetry` and the recent-error buffer already record the **real** status code (e.g. 400) with an `isGeoServices` tag, independent of the 200 wire envelope — the client sees Esri-200 while metrics/dashboards/the ops-health snapshot see the true error.

## Changes Made

- Aligned GeoServices error-status assertions to 200 + body `error.code` across ~86 files: GeoServices .NET suites (FeatureServer/GeometryService/ImageServer/MapServer/GPServer), the relevant Server.Tests security/sharing/validation GeoServices rows, and the Python/JS SDK feature-server lanes
- Zero production files changed; zero non-GeoServices protocol assertions changed

## Breaking Changes

None (test-only; production already ships the 200 contract from #2418).

## Gate Impact

- [x] Restores trunk to green (GeoServices + Python/JS/browser lanes)

## Testing

- [x] `Honua.Protocols.GeoServices.Tests` and `Honua.Server.Tests` build Release warnings-as-errors: 0/0; Python files `py_compile` clean; JS files parse; `dotnet format --verify-no-changes` clean
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Integration suites are Docker/Testcontainers-gated and validated in CI (the whole point — this greens those lanes).
