### PR TITLE
fix(geoservices): map 409/415 + complete residual error-status alignment to the 200 contract (#2505)

### DIFF
--- a/src/Honua.Hosting/Features/Models/GeoServicesErrorCodes.cs
+++ b/src/Honua.Hosting/Features/Models/GeoServicesErrorCodes.cs
@@ -82,6 +82,18 @@ internal static class GeoServicesErrorCodes
     public const int TokenRequired = 499;
 
     /// <summary>
+    /// Conflict - The request conflicts with the current state of the resource
+    /// Used for: optimistic-concurrency / version reconcile conflicts
+    /// </summary>
+    public const int Conflict = 409;
+
+    /// <summary>
+    /// Unsupported Media Type - The request payload content type is not supported
+    /// Used for: a GeoServices operation POSTed with an unsupported Content-Type
+    /// </summary>
+    public const int UnsupportedMediaType = 415;
+
+    /// <summary>
     /// Internal Server Error - Unexpected server error
     /// Used for: Database errors, unhandled exceptions
     /// </summary>
@@ -113,7 +125,9 @@ internal static class GeoServicesErrorCodes
         404 => NotFound,
         405 => MethodNotAllowed,
         408 => RequestTimeout,
+        409 => Conflict,
         413 => PayloadTooLarge,
+        415 => UnsupportedMediaType,
         429 => TooManyRequests,
         422 => UnprocessableEntity,
         498 => InvalidToken,

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/GeoservicesCatalogEndpointTests.cs
@@ -60,7 +60,8 @@ public sealed class GeoservicesCatalogEndpointTests : IClassFixture<WebAppFixtur
     {
         var response = await _fixture.Client.GetAsync("/rest/services?f=xml");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerExtrusionTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerExtrusionTests.cs
@@ -116,7 +116,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(422);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.HeightFieldMissing);
     }
@@ -136,7 +137,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(422);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.HeightFieldNotFound);
     }
@@ -156,7 +158,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(422);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.HeightFieldTypeInvalid);
     }
@@ -180,7 +183,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(422);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.UnitUnrecognized);
     }
@@ -201,7 +205,8 @@ public sealed class FeatureServerExtrusionTests : IAsyncLifetime
         var response = await client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}?f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(422);
         var payload = await response.Content.ReadAsStringAsync();
         payload.Should().Contain(MetadataV2ExtrusionErrorCodes.NegativeDefaultHeight);
     }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerNotImplementedOperationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerNotImplementedOperationTests.cs
@@ -103,24 +103,26 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
         // image: honest 404; this server stores no FeatureServer image resource.
         var image = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/image");
-        image.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await image.ShouldBeGeoServicesError(404);
 
         // Invalid-service branch (404) for each GET surface.
-        (await _fixture.Client.GetAsync(
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/queryContingentValues?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/query?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/htmlPopup?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/image"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            .ShouldBeGeoServicesError(404);
     }
 
     // ----- Service-level mutation operations (POST, honest rejection) -----
@@ -133,23 +135,24 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
     public async Task ServiceLevelSharedTemplateMutations_RejectHonestlyAnd404OnMissingService()
     {
         // Valid service: honest rejection (no shared-template store).
-        (await _fixture.Client.PostAsync(
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await (await _fixture.Client.PostAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/sharedTemplates/add",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await _fixture.Client.PostAsync(
+            EmptyJsonBody())).ShouldBeGeoServicesError(400);
+        await (await _fixture.Client.PostAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/sharedTemplates/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            EmptyJsonBody())).ShouldBeGeoServicesError(400);
 
         // Invalid service: 404 takes precedence over rejection.
-        (await _fixture.Client.PostAsync(
+        await (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/add",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.PostAsync(
+            EmptyJsonBody())).ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.PostAsync(
+            EmptyJsonBody())).ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/sharedTemplates/delete",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
+            EmptyJsonBody())).ShouldBeGeoServicesError(404);
     }
 
     // ----- Layer-level read operations (GET, spec-shaped 200) -----
@@ -194,15 +197,16 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
         }
 
         // Invalid-service branch (404) for each GET surface.
-        (await _fixture.Client.GetAsync(
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/hasAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/queryAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/cleanupAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+            .ShouldBeGeoServicesError(404);
     }
 
     // ----- Layer-level rejection operations (honest rejection) -----
@@ -216,31 +220,32 @@ public sealed class FeatureServerNotImplementedOperationTests : IClassFixture<We
     public async Task LayerLevelUnsupportedOperations_RejectHonestlyAnd404OnMissingService()
     {
         // Valid layer: honest rejection (no asset / 3D / metadata-write surface).
-        (await _fixture.Client.GetAsync(
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await (await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/uploadAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(400);
+        await (await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/convert3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(400);
+        await (await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        (await _fixture.Client.PostAsync(
+            .ShouldBeGeoServicesError(400);
+        await (await _fixture.Client.PostAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/metadata/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            EmptyJsonBody())).ShouldBeGeoServicesError(400);
 
         // Invalid service: 404 takes precedence over rejection.
-        (await _fixture.Client.GetAsync(
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/uploadAssets?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/convert3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.GetAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.GetAsync(
             "/rest/services/nonexistent/FeatureServer/0/query3D?f=json"))
-            .StatusCode.Should().Be(HttpStatusCode.NotFound);
-        (await _fixture.Client.PostAsync(
+            .ShouldBeGeoServicesError(404);
+        await (await _fixture.Client.PostAsync(
             "/rest/services/nonexistent/FeatureServer/0/metadata/update",
-            EmptyJsonBody())).StatusCode.Should().Be(HttpStatusCode.NotFound);
+            EmptyJsonBody())).ShouldBeGeoServicesError(404);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -557,7 +557,8 @@ public sealed class FeatureServerQueryParameterTests : IClassFixture<WebAppFixtu
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/query",
             new StringContent(payload, Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Unsupported Media Type");
     }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryParameterTests.cs
@@ -814,8 +814,8 @@ public sealed class FeatureServerQueryParameterTests : IClassFixture<WebAppFixtu
             "?where=1%3D1&outFields=category&returnDistinctValues=true&returnGeometry=false" +
             "&resultOffset=200000&f=json");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "returnDistinctValues with a very large resultOffset must be rejected to prevent OOM");
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("returnDistinctValues",

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerServiceQueryTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerServiceQueryTests.cs
@@ -163,8 +163,8 @@ public sealed class FeatureServerServiceQueryTests : IClassFixture<WebAppFixture
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/query?where=1=1&f=geojson");
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "f=geojson is not supported for service-level queries which always return ServiceQueryResponse JSON");
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
@@ -199,7 +199,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -215,7 +216,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -231,7 +233,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -244,7 +247,8 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync(requestUri);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeometryValidationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/GeometryValidationTests.cs
@@ -483,7 +483,8 @@ public sealed class GeometryValidationTests : IAsyncLifetime
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query?geometry={Uri.EscapeDataString(malformedGeometry)}&f=json");
 
         // Assert
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     #endregion

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MobileOfflineDemoFixtureReplicationTests.cs
@@ -483,8 +483,8 @@ public sealed class MobileOfflineDemoFixtureReplicationTests : IAsyncLifetime
 
         // An undeclared filter field must be a clean 400, not a 500.
         var undeclaredResponse = await _fixture.Client.GetAsync(runTaggedUri);
-        undeclaredResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "an undeclared filter field is a client error, not a server 'Query execution failed' 500");
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await undeclaredResponse.ShouldBeGeoServicesError(400);
         using (var undeclaredDocument = await ReadJsonDocumentAsync(undeclaredResponse))
         {
             undeclaredDocument.RootElement.GetProperty("error").GetProperty("code").GetInt32()

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileEndpointTests.cs
@@ -69,8 +69,8 @@ public class MvtTileEndpointTests : IClassFixture<WebAppFixture>
         foreach (var coordinate in invalidCoordinates)
         {
             var response = await _fixture.Client.GetAsync(coordinate);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-                $"coordinate {coordinate} should return BadRequest");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            await response.ShouldBeGeoServicesError(400);
         }
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
@@ -172,8 +172,9 @@ public class MvtTileErrorHandlingTests : IClassFixture<WebAppFixture>
         var queryResponse = await _fixture.Client.GetAsync("/rest/services/99999/FeatureServer/0/query");
 
         // Assert - Both should return the same error response format
-        mvtResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        queryResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await mvtResponse.ShouldBeGeoServicesError(404);
+        await queryResponse.ShouldBeGeoServicesError(404);
 
         var mvtContent = await mvtResponse.Content.ReadAsStringAsync();
         var queryContent = await queryResponse.Content.ReadAsStringAsync();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaConflictReviewEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicaConflictReviewEndpointTests.cs
@@ -340,7 +340,8 @@ public sealed class ReplicaConflictReviewEndpointTests : IAsyncLifetime
             ResolvePath(WebAppFixture.TestServiceId, replicaId, conflictId),
             JsonContent.Create(new ReplicaConflictResolutionRequest { Action = "keepServer" }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(409);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicationDurabilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/ReplicationDurabilityTests.cs
@@ -222,7 +222,8 @@ public sealed class ReplicationDurabilityTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/synchronizeReplica",
             new StringContent(failedUploadPayload, Encoding.UTF8, "application/json"));
 
-        failedUploadResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await failedUploadResponse.ShouldBeGeoServicesError(400);
 
         var afterFailure = await repo.GetAsync(replicaId);
         afterFailure.Should().NotBeNull();

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerClientCompatibilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerClientCompatibilityTests.cs
@@ -122,7 +122,8 @@ public sealed class GPServerClientCompatibilityTests : IClassFixture<WebAppFixtu
             25.5,
             new KeyValuePair<string, string>("env:transferDomains", "true"));
 
-        error.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; the failing code is in the JSON body.
+        error.StatusCode.Should().Be(HttpStatusCode.OK);
         error.Code.Should().Be(400);
         error.Message.Should().Be("Bad Request");
         error.Details.Should().Contain(detail => detail.Contains("GP environment controls are not yet supported", StringComparison.Ordinal));

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
@@ -129,7 +129,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             $"/rest/services/{ServiceId}/GPServer",
             new StringContent("""{"f":"json"}""", Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
     }
 
     [IntegrationTest]
@@ -521,7 +522,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
             $"/rest/services/{ServiceId}/GPServer/geometry.buffer/submitJob",
             new StringContent("""{"f":"json"}""", Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/GPServerEndpointTests.cs
@@ -854,7 +854,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var statusResponse = await _client.GetAsync(
             $"/rest/services/OtherService/GPServer/BufferAnalysis/jobs/{jobId}?f=json");
 
-        statusResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await statusResponse.ShouldBeGeoServicesError(404);
     }
 
     [IntegrationTest]
@@ -893,7 +894,8 @@ public sealed class GPServerEndpointTests : IAsyncLifetime
         var statusResponse = await _client.GetAsync(
             $"/rest/services/{ServiceId}/GPServer/DifferentTask/jobs/{jobId}?f=json");
 
-        statusResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await statusResponse.ShouldBeGeoServicesError(404);
     }
 
     // -----------------------------------------------------------------------

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
@@ -63,7 +63,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Intersect_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/intersect?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -101,7 +102,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Union_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/union");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -211,7 +213,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/clip",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -220,7 +223,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Clip_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/clip?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -260,7 +264,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Difference_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/difference?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // #1308: ArcGIS clients wrap the single operating geometry as
@@ -430,7 +435,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Area_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/areasAndLengths?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -524,7 +530,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     public async Task Length_GetMissingParameters_Returns400()
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/lengths?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- Intersect: additional coverage ---
@@ -571,7 +578,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/intersect",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -597,7 +605,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/intersect",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -624,7 +633,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/intersect",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- Union: additional coverage ---
@@ -694,7 +704,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/union",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -718,7 +729,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/union",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- Difference: additional coverage ---
@@ -795,7 +807,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/difference",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -822,7 +835,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/difference",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- Area/Length: missing SR coverage ---
@@ -845,7 +859,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/areasAndLengths",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -866,7 +881,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/lengths",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -888,7 +904,8 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/lengths",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
 
         var content = await response.Content.ReadAsStringAsync();
         var result = JsonSerializer.Deserialize<ApiErrorResponse>(content);

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceBufferTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceBufferTests.cs
@@ -259,7 +259,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -282,7 +283,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
 
         var responseContent = await response.Content.ReadAsStringAsync();
         var error = JsonSerializer.Deserialize<ApiErrorResponse>(responseContent);
@@ -314,7 +316,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -340,7 +343,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
             "/rest/services/Utilities/Geometry/GeometryServer/buffer",
             new StringContent(requestBody, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("maximum of 1000 geometries");
@@ -371,7 +375,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
             "/rest/services/Utilities/Geometry/GeometryServer/buffer",
             new StringContent(requestBody, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
 
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("maximum of 1000 values");
@@ -406,7 +411,8 @@ public sealed class GeometryServiceBufferTests : IClassFixture<WebAppFixture>
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/buffer?inSR=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
@@ -104,7 +104,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var target = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolygon","geometries":[{"rings":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/cut?target={target}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- trimExtend ---
@@ -194,7 +195,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var polylines = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolyline","geometries":[{"paths":[[[0,0],[2,0]]]}]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/trimExtend?polylines={polylines}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- offset ---
@@ -276,7 +278,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var geometries = Uri.EscapeDataString("""{"geometryType":"esriGeometryPolyline","geometries":[{"paths":[[[0,0],[5,0]]]}]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/offset?geometries={geometries}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- autoComplete ---
@@ -317,7 +320,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/autoComplete?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- reshape ---
@@ -359,7 +363,8 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
         var target = Uri.EscapeDataString("""{"rings":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]}""");
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/reshape?target={target}&sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- findTransformations ---
@@ -394,6 +399,7 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/findTransformations?inSR=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceGeoCoordinateStringTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceGeoCoordinateStringTests.cs
@@ -135,7 +135,8 @@ public sealed class GeometryServiceGeoCoordinateStringTests : IClassFixture<WebA
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/toGeoCoordinateString", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -148,7 +149,8 @@ public sealed class GeometryServiceGeoCoordinateStringTests : IClassFixture<WebA
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/toGeoCoordinateString", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -240,7 +242,8 @@ public sealed class GeometryServiceGeoCoordinateStringTests : IClassFixture<WebA
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/fromGeoCoordinateString", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     private static async Task<GeometryServiceToGeoCoordinateStringResponse?> DeserializeToAsync(HttpResponseMessage response)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
@@ -82,7 +82,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/distance?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // #1308: ArcGIS clients wrap geometry1/geometry2 as
@@ -199,7 +200,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/relation?geometries1={geometries1}&geometries2={geometries2}&sr=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- densify ---
@@ -247,7 +249,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/densify?geometries={geometries}&sr=3857");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -275,7 +278,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
             "/rest/services/Utilities/Geometry/GeometryServer/densify",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -355,7 +359,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/convexHull?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- generalize ---
@@ -403,7 +408,8 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/Utilities/Geometry/GeometryServer/generalize?geometries={geometries}&sr=3857");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     // --- labelPoints ---
@@ -442,6 +448,7 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
     {
         var response = await _fixture.Client.GetAsync(
             "/rest/services/Utilities/Geometry/GeometryServer/labelPoints?sr=4326");
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceProjectTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceProjectTests.cs
@@ -109,7 +109,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/project", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -174,7 +175,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/project?inSR=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -267,7 +269,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/project", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -290,7 +293,8 @@ public sealed class GeometryServiceProjectTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/project", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceSimplifyTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceSimplifyTests.cs
@@ -132,7 +132,8 @@ public sealed class GeometryServiceSimplifyTests : IClassFixture<WebAppFixture>
     {
         var response = await _fixture.Client.GetAsync("/rest/services/Utilities/Geometry/GeometryServer/simplify?sr=4326");
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -152,6 +153,7 @@ public sealed class GeometryServiceSimplifyTests : IClassFixture<WebAppFixture>
 
         var response = await _fixture.Client.PostAsync("/rest/services/Utilities/Geometry/GeometryServer/simplify", content);
 
-        response.Be400BadRequest();
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -1925,7 +1925,8 @@ public class ImageServerEndpointsTests
                 $"/rest/services/{TestLayerId}/ImageServer/exportTiles?{query}");
 
             var content = await response.Content.ReadAsStringAsync();
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            await response.ShouldBeGeoServicesError(400);
             content.Should().Contain("compact");
         }
         finally

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRasterMetadataTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerRasterMetadataTests.cs
@@ -233,11 +233,13 @@ public class ImageServerRasterMetadataTests
         {
             var invalidFormat = await fixture.Client.GetAsync(
                 $"/rest/services/{TestLayerId}/ImageServer/statistics?f=xml");
-            invalidFormat.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            await invalidFormat.ShouldBeGeoServicesError(400);
 
             var missingLayer = await fixture.Client.GetAsync(
                 "/rest/services/99999/ImageServer/histograms?f=json");
-            missingLayer.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            await missingLayer.ShouldBeGeoServicesError(404);
         }
         finally
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerDynamicJoinTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerDynamicJoinTests.cs
@@ -116,7 +116,8 @@ public sealed class MapServerDynamicJoinTests
             $"&dynamicLayers={dynamicLayers}&f=json");
 
         var content = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
         content.Should().Contain("inaccessible right layer");
     }
 
@@ -168,7 +169,8 @@ public sealed class MapServerDynamicJoinTests
             $"&dynamicLayers={dynamicLayers}&f=json");
 
         var content = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
         content.Should().Contain("not a valid field name");
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -527,7 +527,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/exportTiles?f=json&levels=0&exportExtent=-180,-85,180,85&maxTiles=1&storageFormat=tpkx");
 
         var content = await response.Content.ReadAsStringAsync();
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
         content.Should().Contain("compact");
     }
 
@@ -1335,7 +1336,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
 
         var invalidResponse = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/legend?f=json&size=invalid");
-        invalidResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await invalidResponse.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerEndpointTests.cs
@@ -1517,7 +1517,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/{WebAppFixture.TestLayerId}/query",
             new StringContent(payload, Encoding.UTF8, "text/plain"));
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
         var content = await response.Content.ReadAsStringAsync();
         content.Should().Contain("Unsupported Media Type");
     }
@@ -1529,7 +1530,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/find");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
     }
 
     [IntegrationTest]
@@ -1539,7 +1541,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/export");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
     }
 
     [IntegrationTest]
@@ -1549,7 +1552,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/identify");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
     }
 
     [IntegrationTest]
@@ -1559,7 +1563,8 @@ public sealed class MapServerEndpointTests : IAsyncLifetime
     {
         var response = await PostTextPlainJsonAsync("/generateKml");
 
-        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(415);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerTileEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/MapServer/MapServerTileEndpointTests.cs
@@ -138,7 +138,8 @@ public sealed class MapServerTileEndpointTests : IClassFixture<WebAppFixture>
         var invalidResponse = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/tile/2/10/10");
 
-        invalidResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await invalidResponse.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -155,7 +155,8 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
         foreach (var url in badCoordinates)
         {
             var response = await _fixture.Client.GetAsync(url);
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest, $"{url} is out of range");
+            // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+            await response.ShouldBeGeoServicesError(400);
         }
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
@@ -90,8 +90,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var second = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/create",
             ("versionName", "admin.dup_name_test"), ("accessPermission", "private"), ("f", "json"));
-        second.StatusCode.Should().Be(HttpStatusCode.Conflict,
-            "duplicate version name must return 409; body: {0}", await second.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await second.ShouldBeGeoServicesError(409);
 
         using var doc = JsonDocument.Parse(await second.Content.ReadAsStringAsync());
         doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(
@@ -252,9 +252,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var editResponse = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/startEditing",
             ("f", "json"));
-        editResponse.StatusCode.Should().Be(HttpStatusCode.Conflict,
-            "opening an edit session against a reconciling version must return 409; body: {0}",
-            await editResponse.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await editResponse.ShouldBeGeoServicesError(409);
 
         using (var doc = JsonDocument.Parse(await editResponse.Content.ReadAsStringAsync()))
         {
@@ -518,9 +517,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/delete",
             ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict,
-            "BH6-002: deleting a reconciling version must return 409; body: {0}",
-            await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(409);
 
         using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         doc.RootElement.TryGetProperty("error", out _).Should().BeTrue(

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VersionManagementServer/VersionManagementServerEndpointTests.cs
@@ -181,8 +181,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{Guid.NewGuid()}/startReading",
             ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
-            "an unknown version should not open a session; body: {0}", await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(404);
     }
 
     [IntegrationTest]
@@ -226,8 +226,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{Guid.NewGuid()}/startEditing",
             ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
-            "an unknown version should not open an edit session; body: {0}", await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(404);
     }
 
     [IntegrationTest]
@@ -359,8 +359,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
         var response = await PostFormAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}/reconcile",
             ("conflictDetection", "byPlanet"), ("f", "json"));
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "an unsupported conflictDetection mode should be rejected; body: {0}", await response.Content.ReadAsStringAsync());
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     [IntegrationTest]
@@ -543,7 +543,8 @@ public sealed class VersionManagementServerEndpointTests : IAsyncLifetime
 
         var info = await _fixture.Client.GetAsync(
             $"/rest/services/{WebAppFixture.TestServiceId}/VersionManagementServer/versions/{guid}?f=json");
-        info.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await info.ShouldBeGeoServicesError(404);
     }
 
     // ---- helpers --------------------------------------------------------------------------------

--- a/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Comprehensive/ApiSurfaceComplianceTests.cs
@@ -104,7 +104,8 @@ public class ApiSurfaceComplianceTests : IAsyncLifetime
 
         // Test invalid layer ID
         var invalidResponse = await client.GetAsync("/rest/services/test/FeatureServer/999?f=json");
-        invalidResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await invalidResponse.ShouldBeGeoServicesError(404);
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
@@ -534,7 +534,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         var response = await _client.GetAsync("/rest/services/nonexistent/FeatureServer?f=json");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(404);
     }
 
     [IntegrationTest]
@@ -546,7 +547,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         var response = await _client.GetAsync("/rest/services/test/FeatureServer/99999?f=json");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(404);
     }
 
     [IntegrationTest]
@@ -558,7 +560,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         var response = await _client.GetAsync("/rest/services/test/FeatureServer/1/query?where=INVALID_SQL_SYNTAX&f=json");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
+        await response.ShouldBeGeoServicesError(400);
     }
 
     #endregion

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
@@ -42,8 +42,17 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
             var response = await _fixture.Client.GetAsync(endpoint);
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound,
-                $"endpoint {endpoint} should return 404 Not Found");
+            if (endpoint.StartsWith("/rest/services", StringComparison.Ordinal) ||
+                endpoint.StartsWith("/tiles", StringComparison.Ordinal))
+            {
+                // PA-070/PA-117: GeoServices signals not-found through HTTP 200 with the code in the JSON body.
+                await response.ShouldBeGeoServicesError(404);
+            }
+            else
+            {
+                response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+                    $"endpoint {endpoint} should return 404 Not Found");
+            }
         }
     }
 
@@ -157,8 +166,17 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
             var response = await _fixture.Client.GetAsync(endpoint);
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-                $"endpoint {endpoint} should return 400 Bad Request for invalid syntax");
+            if (endpoint.StartsWith("/rest/services", StringComparison.Ordinal) ||
+                endpoint.StartsWith("/tiles", StringComparison.Ordinal))
+            {
+                // PA-070/PA-117: GeoServices signals bad-request through HTTP 200 with the code in the JSON body.
+                await response.ShouldBeGeoServicesError(400);
+            }
+            else
+            {
+                response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+                    $"endpoint {endpoint} should return 400 Bad Request for invalid syntax");
+            }
         }
     }
 

--- a/tests/dotnet/Honua.TestKit/Extensions/HttpResponseAssertions.cs
+++ b/tests/dotnet/Honua.TestKit/Extensions/HttpResponseAssertions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 
 namespace Honua.TestKit.Extensions;
@@ -63,6 +64,32 @@ public static class HttpResponseAssertions
     {
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.InternalServerError, "the server encountered an error");
+    }
+
+    /// <summary>
+    /// Asserts that a GeoServices response signals an error through the Esri error contract:
+    /// HTTP 200 OK with the failing code carried in the JSON body as
+    /// <c>{"error":{"code":N,...}}</c>.
+    /// </summary>
+    /// <remarks>
+    /// PA-070/PA-117: Esri GeoServices REST responses (including errors) always use HTTP 200 OK;
+    /// the error is signalled exclusively through the JSON body error code, never the HTTP status.
+    /// </remarks>
+    /// <param name="response">The HTTP response returned by a GeoServices endpoint.</param>
+    /// <param name="expectedCode">The error code expected in the JSON body (for example 400, 403, 404).</param>
+    public static async Task ShouldBeGeoServicesError(this HttpResponseMessage response, int expectedCode)
+    {
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            "GeoServices signals errors through the JSON body, not the HTTP status");
+
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        using var document = JsonDocument.Parse(content);
+        var code = document.RootElement.GetProperty("error").GetProperty("code").GetInt32();
+        code.Should().Be(
+            expectedCode,
+            "the GeoServices error body should carry the intended error code");
     }
 
     /// <summary>

--- a/tests/js/feature-server/apply-edits.test.ts
+++ b/tests/js/feature-server/apply-edits.test.ts
@@ -526,7 +526,9 @@ describe('ApplyEdits - Error Handling', () => {
         body: new URLSearchParams({ adds: 'not valid json', f: 'json' }),
       });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
+      const data = await response.json() as { error?: { code?: number } };
+      expect(data.error?.code).toBe(400);
     });
   });
 

--- a/tests/js/feature-server/metadata.test.ts
+++ b/tests/js/feature-server/metadata.test.ts
@@ -102,7 +102,8 @@ describe('Service Metadata', () => {
       });
 
       const response = await customClient.getServiceMetadata();
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(404);
     });
   });
 });
@@ -330,7 +331,8 @@ describe('Layer Metadata', () => {
   describe('Error Cases', () => {
     it('should return 404 for nonexistent layer', async () => {
       const response = await client.getLayerMetadata(99999);
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(404);
     });
   });
 });

--- a/tests/js/feature-server/query-matrix.test.ts
+++ b/tests/js/feature-server/query-matrix.test.ts
@@ -126,7 +126,8 @@ describe('Spatial Relationship Matrix', () => {
         // No distance parameter
       });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
 
     it('should return 400 when distance parameter is missing for esriSpatialRelBeyondDistance', async () => {
@@ -140,7 +141,8 @@ describe('Spatial Relationship Matrix', () => {
         // No distance parameter
       });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 });
@@ -239,7 +241,8 @@ describe('Spatial Reference Matrix', () => {
         inSR: 'invalid',
       });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 
@@ -280,7 +283,8 @@ describe('Spatial Reference Matrix', () => {
         outSR: 'invalid',
       });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 
@@ -332,7 +336,8 @@ describe('Nearest Count Matrix', () => {
       nearestCount: 3,
     } as any);
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(200);
+    expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
   });
 
   it('should return features with distance when returnDistance=true', async () => {

--- a/tests/js/feature-server/query.test.ts
+++ b/tests/js/feature-server/query.test.ts
@@ -107,7 +107,8 @@ describe('WHERE Clause', () => {
     describe.each(INVALID_WHERE_CASES)('$name', ({ where }) => {
       it(`should reject: ${where}`, async () => {
         const response = await client.query({ where });
-        expect(response.status).toBe(400);
+        expect(response.status).toBe(200);
+        expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
       });
     });
   });
@@ -409,7 +410,8 @@ describe('Pagination', () => {
         resultOffset: 1000001,
       });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
+      expect((response.data as { error?: { code?: number } }).error?.code).toBe(400);
     });
   });
 

--- a/tests/js/map-server/query.test.ts
+++ b/tests/js/map-server/query.test.ts
@@ -68,6 +68,8 @@ describe('MapServer Query', () => {
       },
     );
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(200);
+    const data = await response.json() as { error?: { code?: number } };
+    expect(data.error?.code).toBe(400);
   });
 });

--- a/tests/python/feature_server/test_attachments.py
+++ b/tests/python/feature_server/test_attachments.py
@@ -123,7 +123,15 @@ class TestAddAttachment:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/1/addAttachment",
             data={"f": "json"},
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117 (#2418): a missing file now yields HTTP 200 + {"error": {...}}
+        # per the Esri GeoServices convention; a legacy 4xx or an
+        # addAttachmentResult.success == False is also accepted.
+        assert response.status_code in [400, 404] or (
+            response.status_code == 200 and (
+                isinstance(response.json().get("error"), dict) or
+                response.json().get("addAttachmentResult", {}).get("success") is False
+            )
+        )
 
     @pytest.mark.integration
     @pytest.mark.featureserver
@@ -206,7 +214,15 @@ class TestDeleteAttachments:
             f"/rest/services/{test_service_id}/FeatureServer/{test_layer_id}/1/deleteAttachments",
             data={"f": "json"},
         )
-        assert response.status_code in [400, 404]
+        # PA-070/PA-117 (#2418): missing parameters now yield HTTP 200 + {"error": {...}}
+        # per the Esri GeoServices convention; a legacy 4xx or a
+        # deleteAttachmentsResult.success == False is also accepted.
+        assert response.status_code in [400, 404] or (
+            response.status_code == 200 and (
+                isinstance(response.json().get("error"), dict) or
+                response.json().get("deleteAttachmentsResult", {}).get("success") is False
+            )
+        )
 
 
 class TestDownloadAttachment:

--- a/tests/python/gp_server/test_gpserver_client_compat.py
+++ b/tests/python/gp_server/test_gpserver_client_compat.py
@@ -121,5 +121,7 @@ def test_gpserver_python_client_missing_job_uses_esri_error_shape(
 
     response = client.missing_job_status()
 
-    assert response.status_code in (404, 503)
-    _assert_esri_error(response, response.status_code)
+    # PA-070/PA-117 (#2418): a not-found job now yields HTTP 200 + {"error": {"code": 404}}
+    # per the Esri GeoServices convention; a durable-store outage still surfaces as 503.
+    assert response.status_code in (200, 503)
+    _assert_esri_error(response, 404 if response.status_code == 200 else 503)

--- a/tests/python/image_server/test_imageserver_client_compat.py
+++ b/tests/python/image_server/test_imageserver_client_compat.py
@@ -94,13 +94,15 @@ def test_imageserver_python_client_error_shapes(
     invalid_format = client.service_info(f="xml")
     invalid_identify_format = client.identify(geometry="0,0", f="xml")
 
-    assert invalid_format.status_code == 400
+    # PA-070/PA-117 (#2418): GeoServices REST signals errors with HTTP 200 and an
+    # {"error": {"code": N}} body; the failing code moved into the body, not the status.
+    assert invalid_format.status_code == 200
     invalid_format_error = _assert_esri_error(invalid_format, 400)
     assert "Only JSON format is supported" in " ".join(
         invalid_format_error["error"].get("details") or []
     )
 
-    assert invalid_identify_format.status_code == 400
+    assert invalid_identify_format.status_code == 200
     identify_error = _assert_esri_error(invalid_identify_format, 400)
     assert "Only JSON format is supported" in " ".join(
         identify_error["error"].get("details") or []


### PR DESCRIPTION
Related to #2505 (completes the GeoServices HTTP-200-error-body migration) and #2418. Greens trunk (currently red on the residual GeoServices error-status stragglers your #2509/#2510 didn't reach).

## Summary

#2505/#2510/#2509 migrated the integration suites to the GeoServices 200-with-error-body contract but left a residual of test assertions (helper-form and inline-form) still expecting real 4xx on GeoServices service-op error paths. This finishes that residual, plus fixes a production body-code bug the work surfaced.

**Production (2 lines):** `GeoServicesErrorCodes.FromHttpStatusCode` had no mapping for **409 (Conflict)** or **415 (Unsupported Media Type)** — both fell through to the `500` default, so a GeoServices conflict/unsupported-media-type error returned `{ "error": { "code": 500 } }` instead of the real code. Added `409 => Conflict`, `415 => UnsupportedMediaType` (Esri convention mirrors the HTTP status).

**Tests:** aligned the remaining GeoServices **service-op** error assertions to HTTP 200 + `error.code` via a shared `ShouldBeGeoServicesError(expectedCode)` helper:
- Helper-form (`Be400BadRequest()`): GeometryService suites, FeatureServerSpatialReference, GeometryValidation, GeoservicesCatalog (~51).
- Inline-form (`.StatusCode.Should().Be(…)`): MapServer, GPServer, ImageServer, VersionManagementServer, VectorTile/MVT, FeatureServer extrusion/query/replication, and the not-implemented-operation envelope — including the 12 now-correct 409/415 assertions.

**Strictly scoped to GeoServices service ops** (paths that flow through `FormatGeoServicesError`). Verified untouched: admin/import (`FormatAdminError`, real codes), OGC/WFS/OData/STAC, negative assertions, success 200s, and auth PA-167 (401→499). The `FeatureServerNotImplementedOperationTests` 404/400s were confirmed to route through `FormatGeoServicesError` (registered routes + StandardErrorHelpers), not framework routing, so they were correctly flipped.

Observability unaffected — error telemetry + the recent-error buffer record the real status code independent of the 200 wire envelope.

## Breaking Changes

None to production behavior beyond the 409/415 body-code correction (previously mis-reported as 500).

## Gate Impact

- [x] Restores trunk to green (residual GeoServices error-status lanes)

## Testing

- [x] `Honua.Server`, `Honua.Protocols.GeoServices.Tests`, `Honua.Server.Tests`, `Honua.TestKit` build Release warnings-as-errors 0/0; `dotnet format --verify-no-changes` clean
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Integration suites are Docker/Testcontainers-gated and validated in CI (the point — this greens those lanes).
