### PR TITLE
fix: start server without Redis by making OpsFindingsService gateway optional (#2511)

### DIFF
--- a/src/Honua.Core/Features/Observability/Domain/OpsFindingModels.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsFindingModels.cs
@@ -150,6 +150,14 @@ public enum OpsFindingProposalStatus
 
     /// <summary>The gateway does not support the action's operation class.</summary>
     NotSupported = 5,
+
+    /// <summary>
+    /// The durable control-plane operation gateway is unavailable, so the recommended action cannot
+    /// be routed. This is the degraded outcome when the server runs without its durable backend
+    /// (Redis): findings are still evaluated and returned, but proposing their fixes requires the
+    /// gateway, which is only wired when the durable control-plane graph is registered.
+    /// </summary>
+    GatewayUnavailable = 6,
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
@@ -86,6 +86,18 @@ internal static class OpsObservabilityEndpoints
                 detail);
         }
 
+        if (result.Status is OpsFindingProposalStatus.GatewayUnavailable)
+        {
+            // The server is running without its durable control-plane backend, so the approval
+            // gateway is not wired and the recommended fix cannot be routed (#2511). Surface a 503
+            // so callers can distinguish "temporarily degraded" from a not-found/no-action finding.
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                StatusCodes.Status503ServiceUnavailable,
+                ProblemDetailsHelpers.GetTitle(StatusCodes.Status503ServiceUnavailable),
+                result.Message
+                    ?? "The control-plane operation gateway is unavailable; the recommended action cannot be proposed.");
+        }
+
         var response = new OpsFindingProposeResponse
         {
             FindingId = result.FindingId,

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
@@ -33,7 +33,7 @@ internal sealed class OpsFindingsService : IOpsFindingsService
     private readonly IOptionsMonitor<ControlPlaneOptions> _controlPlaneOptions;
     private readonly IAlertDispatchHealth _alertHealth;
     private readonly IDeployPreflightProbe _deployProbe;
-    private readonly IOperationGateway _gateway;
+    private readonly IOperationGateway? _gateway;
     private readonly IWorkflowOperationStore? _workflowStore;
     private readonly IExecutionJobStore? _jobStore;
 
@@ -42,7 +42,7 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         IOptionsMonitor<ControlPlaneOptions> controlPlaneOptions,
         IAlertDispatchHealth alertHealth,
         IDeployPreflightProbe deployProbe,
-        IOperationGateway gateway,
+        IOperationGateway? gateway = null,
         IWorkflowOperationStore? workflowStore = null,
         IExecutionJobStore? jobStore = null)
     {
@@ -92,6 +92,21 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         if (finding.RecommendedAction is null)
         {
             return new OpsFindingProposalResult { Status = OpsFindingProposalStatus.NoRecommendedAction, FindingId = findingId };
+        }
+
+        // Degraded mode: the operation gateway is only wired when the durable control-plane graph is
+        // registered (which requires Redis — see Program.cs). Without it the server still evaluates
+        // and serves findings, but their recommended fixes cannot be routed for approval. Report a
+        // clear degraded outcome instead of failing to construct the service at startup (#2511).
+        if (_gateway is null)
+        {
+            return new OpsFindingProposalResult
+            {
+                Status = OpsFindingProposalStatus.GatewayUnavailable,
+                FindingId = findingId,
+                Message = "The durable control-plane operation gateway is unavailable "
+                    + "(it requires the durable backend / Redis); the recommended action cannot be proposed.",
+            };
         }
 
         var action = finding.RecommendedAction;

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
@@ -8,10 +8,12 @@ using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Guardrails.Domain;
 using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Observability.Abstractions;
 using Honua.Core.Features.Observability.Domain;
 using Honua.Infrastructure.Monitoring;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 
@@ -261,6 +263,70 @@ public sealed class OpsFindingsServiceTests
                 r.RequestedByAgent == OpsFindingsService.RequestedByAgent &&
                 r.IdempotencyKey == finding.Id),
             Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Propose_ActionableFinding_WithoutOperationGateway_ReturnsGatewayUnavailable()
+    {
+        // Redis-less composition (#2511): OpsFindingsService is constructed without an
+        // IOperationGateway (only wired with the durable control-plane graph). Findings still
+        // evaluate; proposing an otherwise-actionable fix degrades cleanly instead of throwing.
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        workflowStore.ListActiveAsync(Arg.Any<WorkflowOperationKind?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<WorkflowOperationRecord>
+            {
+                BuildDeployOperation("op-9", WorkflowOperationStatus.ManualInterventionRequired, currentRevision: "rev-1", desiredRevision: "rev-2"),
+            });
+
+        var service = new OpsFindingsService(
+            new StaticOptionsMonitor<OpsFindingsOptions>(new OpsFindingsOptions()),
+            new StaticOptionsMonitor<ControlPlaneOptions>(new ControlPlaneOptions()),
+            new FakeAlertDispatchHealth(),
+            new FakeDeployPreflightProbe(BuildDeploySnapshot()),
+            gateway: null,
+            workflowStore: workflowStore);
+
+        var finding = (await service.EvaluateAsync()).Single(f => f.Rule == OpsFindingsService.RuleDeployManualIntervention);
+        Assert.NotNull(finding.RecommendedAction);
+
+        var result = await service.ProposeAsync(finding.Id);
+
+        Assert.Equal(OpsFindingProposalStatus.GatewayUnavailable, result.Status);
+        Assert.Equal(finding.Id, result.FindingId);
+        Assert.False(string.IsNullOrWhiteSpace(result.Message));
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void ServiceComposition_WithoutRedisOperationGateway_ResolvesOpsFindingsService()
+    {
+        // Reproduces the #2511 startup failure at the composition level: the server registers
+        // IOpsFindingsService unconditionally, but IOperationGateway is only registered when the
+        // durable backend (Redis) is present. With ValidateOnBuild — exactly as Program.cs builds
+        // the host — resolving the service must NOT throw when the gateway is absent.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.Configure<OpsFindingsOptions>(_ => { });
+        services.Configure<ControlPlaneOptions>(_ => { });
+        services.AddSingleton<IAlertDispatchHealth>(new FakeAlertDispatchHealth());
+        services.AddSingleton<IDeployPreflightProbe>(new FakeDeployPreflightProbe(BuildDeploySnapshot()));
+
+        // Deliberately no IOperationGateway / IWorkflowOperationStore / IExecutionJobStore —
+        // these are the Redis-gated control-plane registrations.
+        services.AddScoped<IOpsFindingsService, OpsFindingsService>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+
+        using var scope = provider.CreateScope();
+        var resolved = scope.ServiceProvider.GetRequiredService<IOpsFindingsService>();
+
+        Assert.NotNull(resolved);
     }
 
     private static OpsFindingsService CreateService(


### PR DESCRIPTION
## Summary

Fixes #2511. The server failed DI validation at `WebApplicationBuilder.Build()` whenever it ran **without Redis**: `OpsFindingsService` is registered unconditionally, but its `IOperationGateway` dependency is only registered inside the Redis-gated control-plane block in `Program.cs`. With `ValidateOnBuild` on, any Postgres-only deployment/CI job never bound `:5000`. This killed the three browser/JS jobs (`MapLibre GL JS Browser Compatibility`, `Esri Leaflet Browser Tests`, `JavaScript Integration Tests`) at their "Setup Honua Server" step, plus `OpsObservabilityEndpointsTests.GetFindings`.

The gateway is only used by `ProposeAsync`; `EvaluateAsync` (GET findings) never touches it. The service already treats its other durable-backend seams (`IWorkflowOperationStore`, `IExecutionJobStore`) as optional-with-null-checks — this makes `IOperationGateway` optional the same way, matching the codebase's existing degraded-mode pattern.

## Changes Made

- Made `OpsFindingsService`'s `IOperationGateway` constructor parameter optional (`IOperationGateway? gateway = null`), mirroring the already-optional `IWorkflowOperationStore`/`IExecutionJobStore`.
- Added `OpsFindingProposalStatus.GatewayUnavailable`; `ProposeAsync` returns it (with a clear message) when a fix is proposed while the gateway is absent.
- `OpsObservabilityEndpoints` maps `GatewayUnavailable` to a `503 Service Unavailable` problem so callers can distinguish "degraded backend" from not-found/no-action.
- Added a unit test for the degraded propose path and a `ServiceCollection` composition test that builds the services **without** the Redis-gated gateway and asserts `IOpsFindingsService` resolves under `ValidateOnBuild` (reproduces the exact #2511 startup failure).

## Breaking Changes

None. Behavior with Redis is unchanged; only the Redis-less path is fixed.

## Gate Impact

- [x] This change affects CI gate behavior (unblocks the three Redis-less browser/JS jobs + OpsObservability GetFindings)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Release warnings-as-errors build green (0/0); `dotnet format --verify-no-changes` clean; the 14 `OpsFindingsServiceTests` (including the 2 new no-Redis tests) pass locally. Docker/Testcontainers unavailable locally; CI proves the browser/JS setup + integration path.
