### PR TITLE
fix(test): add missing asset_storage_prefix column to scene_datasets CI seed

### DIFF
--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -581,6 +581,7 @@ sql:
           name                  VARCHAR(128) NOT NULL,
           description           TEXT,
           asset_root            TEXT NOT NULL,
+          asset_storage_prefix  TEXT,
           tileset_file_name     VARCHAR(64) NOT NULL DEFAULT 'tileset.json',
           dataset_type          VARCHAR(32) NOT NULL DEFAULT 'hosted_tiles',
           extent_xmin           DOUBLE PRECISION,


### PR DESCRIPTION
## Summary

Fixes the `scene_datasets` schema regression: `Npgsql 42703 column "asset_storage_prefix" of relation "scene_datasets" does not exist`, which failed the Operator Eval Harness, SceneServer catalog tests, and scene-serving endpoints (e.g. `/scenes/{id}/tiles/...`).

Migration `074_AddSceneAssetStoragePrefix.sql` (#2459, ADR-0060) added `honua.scene_datasets.asset_storage_prefix` and `PostgresSceneDatasetRegistry.FindAsync` now `SELECT`s it — but the hand-maintained `tests/seed/server.yaml` scene_datasets DDL was never updated to match. The integration servers run with `HONUA_SKIP_MIGRATIONS=true` and provision the literal `honua` schema from this seed (as do the `setup-honua-server` action and the Operator Eval Harness), so the DbUp migration never ran there and the column was absent.

The DbUp migration itself is correct and complete; this is purely the parallel CI seed that drifted.

## Changes Made

- Added the nullable `asset_storage_prefix TEXT` column to the `honua.scene_datasets` table definition in `tests/seed/server.yaml`, matching migration 074 and the `PostgresSceneDatasetRegistry` projection.

## Breaking Changes

None. Test-seed-only change; the column is nullable and mirrors the shipped migration.

## Gate Impact

- [x] This change affects CI gate behavior (unblocks Operator Eval Harness, SceneServer catalog + scene-serving tests)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Seed-only change (no compile). The scene-serving integration tests exercise the `PostgresSceneDatasetRegistry` SELECT path that was throwing 42703 and provide the runtime coverage; Docker/Testcontainers unavailable locally, CI proves the seeded-schema shards.
