### PR TITLE
test: migrate stale OGC NumberMatched/GML assertions to the #2418 contract

### DIFF
--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesEnhancementsTests.cs
@@ -293,7 +293,9 @@ public sealed class OgcFeaturesEnhancementsTests : IAsyncLifetime
 
         itemLinkTypes.Should().Contain("application/geo+json");
         itemLinkTypes.Should().Contain("application/json");
-        itemLinkTypes.Should().Contain("application/gml+xml;version=3.2");
+        // GML 3.2 media type carries the IANA-canonical spaced form ("...; version=3.2")
+        // since #2418 (PA-169); the link type mirrors MediaTypes.Gml.
+        itemLinkTypes.Should().Contain("application/gml+xml; version=3.2");
         itemLinkTypes.Should().Contain("text/html");
 
         links.Any(link =>

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStreamingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Features/OgcFeaturesStreamingTests.cs
@@ -75,11 +75,15 @@ public sealed class OgcFeaturesStreamingTests : IClassFixture<OgcFeaturesStreami
 
     /// <summary>
     /// Regression for BH4-008: streaming responses must expose an advisory
-    /// <c>numberMatched</c> snapshot count (in the JSON body and
-    /// <c>OGC-NumberMatched</c> header). The value is a pre-flight snapshot
-    /// estimate — it is advisory per OGC API Features Part 1 §7.7, not an
-    /// authoritative exact count — but it must always be a non-negative integer,
-    /// never absent or negative.
+    /// <c>numberMatched</c> snapshot count in the JSON <c>FeatureCollection</c>
+    /// body — the spec-compliant location (OGC 17-069r4 §7.14.4). The value is a
+    /// pre-flight snapshot estimate — advisory per OGC API Features Part 1 §7.7,
+    /// not an authoritative exact count — but it must always be a non-negative
+    /// integer, never absent or negative.
+    ///
+    /// The non-standard <c>OGC-NumberMatched</c> response header was removed in
+    /// #2418 (PA-122/PA-168); this test now guards that it stays absent so the
+    /// count is carried only in its spec-compliant body location.
     /// </summary>
     [IntegrationTest]
     [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
@@ -100,13 +104,10 @@ public sealed class OgcFeaturesStreamingTests : IClassFixture<OgcFeaturesStreami
         nmProp.GetInt64().Should().BeGreaterThanOrEqualTo(0,
             "numberMatched snapshot estimate must be a non-negative integer");
 
-        // HTTP header form: OGC-NumberMatched must also be set for protocol-level consumers.
-        response.Headers.TryGetValues("OGC-NumberMatched", out var headerValues)
-            .Should().BeTrue("streaming path must set OGC-NumberMatched response header (BH4-008)");
-        var headerValue = headerValues!.First();
-        long.TryParse(headerValue, out var parsedHeader).Should().BeTrue(
-            "OGC-NumberMatched header must be parseable as a long integer");
-        parsedHeader.Should().BeGreaterThanOrEqualTo(0,
-            "OGC-NumberMatched header value must be non-negative");
+        // The non-standard OGC-NumberMatched header was removed in #2418 (PA-122/PA-168):
+        // the count lives only in the spec-compliant JSON body location above. Guard that the
+        // header is not reintroduced.
+        response.Headers.TryGetValues("OGC-NumberMatched", out _)
+            .Should().BeFalse("the non-standard OGC-NumberMatched header was removed in #2418 (PA-122/PA-168)");
     }
 }


### PR DESCRIPTION
## Summary

Related to #2418. Migrates two stale OGC API Features test assertions that still encoded pre-#2418 behavior (the tranche of #2418 protocol changes beyond the GeoServices error contract handled by #2510/#2513). Evidence-based, assertion-only; no runtime behavior changes.

- **PA-122 / PA-168** removed the non-standard `OGC-NumberMatched` streaming response header. `numberMatched` is now carried only in the `FeatureCollection` JSON body — the spec-compliant location (OGC 17-069r4 §7.14.4). `OgcFeaturesStreamingTests.GetItems_LargeLimit_Streaming_ProvidesAdvisorySnapshotNumberMatched` still required the header (`must set OGC-NumberMatched response header`).
- **PA-169** moved the GML 3.2 media type to the IANA-canonical spaced form `application/gml+xml; version=3.2` (`MediaTypes.Gml`). `OgcFeaturesEnhancementsTests` item-links assertion still expected the unspaced `application/gml+xml;version=3.2`.

## Changes Made

- Rewrote the streaming-numberMatched test to assert the advisory count in the JSON body and to guard that the removed `OGC-NumberMatched` header stays absent (regression guard against reintroducing the non-standard header).
- Updated the GML 3.2 item-link media-type expectation to the canonical spaced form, matching `MediaTypes.Gml`.

## Breaking Changes

None. Test-only; runtime behavior is unchanged (both surfaces already emit the #2418 contract on trunk).

## Gate Impact

- [x] This change affects CI gate behavior (fixes two stale OGC API Features shard assertions)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Release warnings-as-errors build of `Honua.Protocols.OgcApi.Tests` green (0/0); format clean. These are `[IntegrationTest]`s (WebAppFixture/Postgres) that cannot run locally without Docker; CI's OGC API Features shard proves them.
