### PR TITLE
test: migrate FeatureServer auth-required assertions to the GeoServices 200+error contract

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ApiKeyAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ApiKeyAuthenticationTests.cs
@@ -13,6 +13,7 @@ using Honua.Core.Features.Security.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
 using Honua.TestKit.Infrastructure;
 using Honua.Server.Tests;
 using Microsoft.AspNetCore.Hosting;
@@ -654,8 +655,11 @@ public class ApiKeyAuthenticationTests : IAsyncLifetime
         // Act - Access public FeatureServer endpoint without API key
         var response = await client.GetAsync("/rest/services/test/FeatureServer");
 
-        // Assert - Should require authentication by default
-        Assert.Equal(401, (int)response.StatusCode);
+        // Assert - Should require authentication by default. FeatureServer is a GeoServices
+        // REST path, so an auth failure is emitted as the Esri contract: HTTP 200 +
+        // {"error":{"code":401|499}} (#2418, PA-167). The helper still fails on a
+        // success-shaped body, so it keeps catching a real "unauthenticated read allowed" leak.
+        await response.AssertGeoServicesErrorAsync(new[] { 401, 499 });
         _output.WriteLine($"FeatureServer endpoint requires auth by default: {response.StatusCode}");
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcAuthenticationTests.cs
@@ -15,6 +15,7 @@ using Honua.Server.Tests;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Extensions;
 using Honua.TestKit.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -1388,8 +1389,11 @@ public class OidcAuthenticationTests
         // Act - Access FeatureServer endpoint without auth
         var response = await client.GetAsync("/rest/services/test/FeatureServer");
 
-        // Assert - Should require authentication by default
-        Assert.Equal(401, (int)response.StatusCode);
+        // Assert - Should require authentication by default. FeatureServer is a GeoServices
+        // REST path, so an auth failure is emitted as the Esri contract: HTTP 200 +
+        // {"error":{"code":401|499}} (#2418, PA-167). The helper still fails on a
+        // success-shaped body, so it keeps catching a real "unauthenticated read allowed" leak.
+        await response.AssertGeoServicesErrorAsync(new[] { 401, 499 });
         _output.WriteLine($"FeatureServer response requires auth: {response.StatusCode}");
     }
 


### PR DESCRIPTION
## Summary

Related to #2418. Migrates two stale GeoServices auth-contract assertions in the Authentication test suites that the #2505/#2510/#2513 migration missed (the `Infrastructure/Authentication` files were not in that tranche).

#2418 (PA-167 / PA-070) made GeoServices REST auth failures return **HTTP 200** with an `{"error":{"code":401|499}}` body instead of a bare `401`. Two tests that hit the GeoServices path `/rest/services/test/FeatureServer` unauthenticated still asserted a raw `401` and now fail (got `200`):

- `OidcAuthenticationTests.FeatureServerEndpoint_OidcEnabled_RequiresAuthByDefault`
- `ApiKeyAuthenticationTests.FeatureServerEndpoint_NoAuth_RequiresAuthByDefault`

## Changes Made

- Routed both through `response.AssertGeoServicesErrorAsync(new[] { 401, 499 })` — the same helper the migrated `Security`/`Sharing` suites use. It accepts the `200 + {"error":{"code":401|499}}` form (or a legacy `>= 400`) and **fails on a success-shaped body**, so it still catches a real "unauthenticated read allowed" regression.
- Left every other `401` assertion in these files unchanged — they target admin/token `/api/...` paths that keep real HTTP status.

## Breaking Changes

None. Test-only; runtime behavior is unchanged (the 200+error-body contract already ships on trunk from #2418).

## Gate Impact

- [x] This change affects CI gate behavior (fixes two stale GeoServices auth-contract assertions in the Admin & Infrastructure shard)

## Testing

- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed

Release warnings-as-errors build of `Honua.Server.Tests` green (0/0); `dotnet format --verify-no-changes` clean. These are `[IntegrationTest]`s (WebAppFixture/Postgres) that cannot run locally without Docker; CI's Admin & Infrastructure shard proves them.
