### PR TITLE
test: scope outStatistics groupBy cap regression to seeded rows

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/FeatureServerQueryValidationEdgeCaseTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/FeatureServerQueryValidationEdgeCaseTests.cs
@@ -139,9 +139,17 @@ public sealed class FeatureServerQueryValidationEdgeCaseTests : IAsyncLifetime
     }
 
     // BH7-003 regression: outStatistics with groupByFieldsForStatistics must apply
-    // the configured MaxRecordCount cap (not null) so a high-cardinality groupBy
-    // cannot exhaust server memory. With few test rows the cap is never hit; the
-    // test guards the code path and verifies no regression in the normal case.
+    // the configured MaxRecordCount cap (default 10 000, not null) so a
+    // high-cardinality groupBy cannot exhaust server memory. With few groups the
+    // cap is never hit; the test guards the code path and verifies no regression
+    // in the normal (sub-threshold) case.
+    //
+    // Layer 0 is not empty at the start of the test: the shared server.yaml seed
+    // pre-populates it with five features (objectid 1-5, each a distinct name), on
+    // top of which InitializeAsync inserts "edge_one" and "edge_two". The where
+    // clause therefore scopes the groupBy to just this class's two inserted rows —
+    // mirroring FeatureServerStatisticsHavingTests — so the expected group count is
+    // stable regardless of what the shared seed contains.
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
@@ -150,11 +158,11 @@ public sealed class FeatureServerQueryValidationEdgeCaseTests : IAsyncLifetime
         var outStatistics = Uri.EscapeDataString(
             "[{\"statisticType\":\"count\",\"onStatisticField\":\"objectid\",\"outStatisticFieldName\":\"feature_count\"}]");
 
-        // Each of the two seeded features has a distinct name, so the groupBy produces
-        // one statistics row per name — well within the MaxRecordCount cap.
+        // Scope to the two features this test inserted so the groupBy produces exactly
+        // two statistics rows (one per distinct name) — well within the MaxRecordCount cap.
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{TestServiceId}/FeatureServer/{TestLayerId}/query" +
-            "?where=1%3D1" +
+            "?where=name+LIKE+'edge_%'" +
             "&groupByFieldsForStatistics=name" +
             $"&outStatistics={outStatistics}" +
             "&f=json");
@@ -165,7 +173,11 @@ public sealed class FeatureServerQueryValidationEdgeCaseTests : IAsyncLifetime
         var body = await response.Content.ReadAsStringAsync();
         var doc = System.Text.Json.JsonDocument.Parse(body);
         doc.RootElement.TryGetProperty("features", out var features).Should().BeTrue();
+
         // Two distinct names -> two groups; both within the default MaxRecordCount cap.
-        features.GetArrayLength().Should().Be(2);
+        var groups = features.EnumerateArray()
+            .Select(f => f.GetProperty("attributes").GetProperty("name").GetString())
+            .ToArray();
+        groups.Should().BeEquivalentTo(["edge_one", "edge_two"]);
     }
 }


### PR DESCRIPTION
## Issue Link
Fixes #2520

## Summary
`Query_OutStatisticsGroupByWithCap_ReturnsGroupedResultsWithinLimit` (Honua.Server.Tests, core shard) failed in the full CI matrix — it asserted two groupBy result groups but the query returned seven. Root cause is test scoping, not the production code: the test queried `where=1=1` over FeatureServer layer `0`, which the shared `tests/seed/server.yaml` seed pre-populates with five distinct-name features (objectid 1–5) on top of the two rows (`edge_one`, `edge_two`) the test's `InitializeAsync` inserts. The groupBy therefore produced seven groups, and `Should().Be(2)` failed (`Expected 2, found 7`).

The BH7-003 cap added in #2488 (statistics query `Limit = queryLimits.MaxRecordCount`, default 10 000) is correct and never truncated anything here (7 ≪ 10 000). The fix mirrors the existing `FeatureServerStatisticsHavingTests` pattern: scope the query to this class's inserted rows and assert the exact group set.

## Changes Made
- Scope the query with `where=name LIKE 'edge_%'` so the groupBy sees only the two rows this test inserts, making the expected group count independent of shared-seed contents.
- Strengthen the assertion from a bare count (`Be(2)`) to the exact group names (`edge_one`, `edge_two`) so a genuine cap-truncation regression would fail loudly.
- Update the test comment to document the pre-seeded layer-0 rows and the scoping rationale.

## Testing
- [x] Integration tests added/updated

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
