### PR TITLE
fix(geoservices): map 409/415 in the error envelope (#2505)

### DIFF
--- a/src/Honua.Hosting/Features/Models/GeoServicesErrorCodes.cs
+++ b/src/Honua.Hosting/Features/Models/GeoServicesErrorCodes.cs
@@ -82,6 +82,18 @@ internal static class GeoServicesErrorCodes
     public const int TokenRequired = 499;
 
     /// <summary>
+    /// Conflict - The request conflicts with the current state of the resource
+    /// Used for: optimistic-concurrency / version reconcile conflicts
+    /// </summary>
+    public const int Conflict = 409;
+
+    /// <summary>
+    /// Unsupported Media Type - The request payload content type is not supported
+    /// Used for: a GeoServices operation POSTed with an unsupported Content-Type
+    /// </summary>
+    public const int UnsupportedMediaType = 415;
+
+    /// <summary>
     /// Internal Server Error - Unexpected server error
     /// Used for: Database errors, unhandled exceptions
     /// </summary>
@@ -113,7 +125,9 @@ internal static class GeoServicesErrorCodes
         404 => NotFound,
         405 => MethodNotAllowed,
         408 => RequestTimeout,
+        409 => Conflict,
         413 => PayloadTooLarge,
+        415 => UnsupportedMediaType,
         429 => TooManyRequests,
         422 => UnprocessableEntity,
         498 => InvalidToken,


### PR DESCRIPTION
Related to #2505 (companion to the merged test migration #2513). Fixes a real production body-code bug that leaves trunk red.

## Summary

`GeoServicesErrorCodes.FromHttpStatusCode` had no mapping for **409 (Conflict)** or **415 (Unsupported Media Type)** — both fell through to the `_ => InternalServerError` default, so a GeoServices version-conflict or unsupported-content-type error returned `{ "error": { "code": 500 } }` instead of the real status.

The #2505 test migration (#2513) now asserts `AssertGeoServicesErrorAsync(409)` for the version-management conflict ops (`Create_DuplicateVersionName_Returns409Conflict`, `StartEditing_VersionMidReconcile_Returns409Locked`) and `(415)` for the MapServer/GPServer unsupported-content-type POSTs — so trunk is **red** on those until this mapping exists.

Adds `409 => Conflict`, `415 => UnsupportedMediaType` (Esri convention mirrors the HTTP status). 2-line switch + 2 constants; no other change.

## Breaking Changes

None — corrects a wrong body code (was 500 for these; now the real 409/415).

## Gate Impact

- [x] Greens the 409/415 GeoServices error tests introduced by #2513

## Testing

- [x] Release build (warnings-as-errors) 0/0; format clean
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed