### PR TITLE
test: migrate JS/Python/Scene/residual GeoServices error assertions to the 200+error-body contract (#2505)

### DIFF
--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixtureTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sConformanceFixtureTests.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.Licensing.Abstractions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
+using Honua.TestKit.Extensions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -128,7 +129,7 @@ public sealed class I3sConformanceFixtureTests : IAsyncLifetime
     {
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/nodepages/99");
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -157,7 +158,7 @@ public sealed class I3sConformanceFixtureTests : IAsyncLifetime
     {
         var response = await _fixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/statistics/f_99/0");
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     private sealed class EnterpriseLicenseStatusProvider : ILicenseStatusProvider

--- a/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.Scene.Tests/Source/I3sSceneServerEndpointTests.cs
@@ -12,6 +12,7 @@ using Honua.Core.Features.Scene.Conversion;
 using Honua.Core.Features.Scene.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
+using Honua.TestKit.Extensions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -367,7 +368,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
     {
         var response = await _communityFixture.Client.GetAsync($"/rest/services/{SceneId}/SceneServer");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        await response.AssertGeoServicesErrorAsync(403);
     }
 
     [IntegrationTest]
@@ -535,7 +536,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _communityFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/geometries/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        await response.AssertGeoServicesErrorAsync(403);
     }
 
     [IntegrationTest]
@@ -546,7 +547,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/geometries/7");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -557,7 +558,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/7/nodes/0/geometries/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -570,7 +571,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{NoGeometrySceneId}/SceneServer/layers/0/nodes/0/geometries/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -581,7 +582,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{ProtectedSceneId}/SceneServer/layers/0/nodes/0/geometries/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await response.AssertGeoServicesErrorAsync(401, 499);
     }
 
     [IntegrationTest]
@@ -625,7 +626,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _communityFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        await response.AssertGeoServicesErrorAsync(403);
     }
 
     [IntegrationTest]
@@ -636,7 +637,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_99/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -647,7 +648,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/7");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -658,7 +659,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{SceneId}/SceneServer/layers/7/nodes/0/attributes/f_0/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -669,7 +670,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{NoGeometrySceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -680,7 +681,7 @@ public sealed class I3sSceneServerEndpointTests : IAsyncLifetime
         var response = await _enterpriseFixture.Client.GetAsync(
             $"/rest/services/{ProtectedSceneId}/SceneServer/layers/0/nodes/0/attributes/f_0/0");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await response.AssertGeoServicesErrorAsync(401, 499);
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/API/EndpointCoverageTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Honua.Protocols.OData.Models;
 using Honua.TestKit;
+using Honua.TestKit.Extensions;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.Core.Features.Licensing.Domain;
@@ -533,8 +534,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         // Act
         var response = await _client.GetAsync("/rest/services/nonexistent/FeatureServer?f=json");
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert (PA-070/PA-117 #2418: GeoServices errors are HTTP 200 + {"error":{"code":404}})
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -545,8 +546,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         // Act
         var response = await _client.GetAsync("/rest/services/test/FeatureServer/99999?f=json");
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert (PA-070/PA-117 #2418: GeoServices errors are HTTP 200 + {"error":{"code":404}})
+        await response.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -557,8 +558,8 @@ public sealed class EndpointCoverageTests : IAsyncLifetime
         // Act
         var response = await _client.GetAsync("/rest/services/test/FeatureServer/1/query?where=INVALID_SQL_SYNTAX&f=json");
 
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert (PA-070/PA-117 #2418: GeoServices errors are HTTP 200 + {"error":{"code":400}})
+        await response.AssertGeoServicesErrorAsync(400);
     }
 
     #endregion

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ServiceSettingsEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ServiceSettingsEndpointsTests.cs
@@ -410,7 +410,8 @@ public sealed class ServiceSettingsEndpointsTests : IAsyncLifetime
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var layerMetadataResponse = await _fixture.Client.GetAsync("/rest/services/test/FeatureServer/1?f=json");
-        layerMetadataResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // PA-070/PA-117 (#2418): a blocked GeoServices surface reports HTTP 200 + {"error":{"code":404}}
+        await layerMetadataResponse.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]
@@ -429,7 +430,8 @@ public sealed class ServiceSettingsEndpointsTests : IAsyncLifetime
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var tileResponse = await _client.GetAsync("/tiles/1/0/0/0.mvt");
-        tileResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // /tiles is GeoServices-classified: blocked tiles report HTTP 200 + {"error":{"code":404}}
+        await tileResponse.AssertGeoServicesErrorAsync(404);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorHelpersTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorHelpersTests.cs
@@ -65,8 +65,10 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
             var result = StandardErrorHelpers.CreateBadRequest(context, "Invalid request parameters", additionalDetails);
             await result.ExecuteAsync(context);
 
-            // Assert
-            context.Response.StatusCode.Should().Be(400, $"because path {path} should return 400 Bad Request");
+            // Assert — PA-070/PA-117 (#2418): GeoServices paths transport errors as
+            // HTTP 200 + {"error":{"code":400}}; other protocols keep the real status.
+            var expectedStatus = path.StartsWith("/rest/services", StringComparison.Ordinal) ? 200 : 400;
+            context.Response.StatusCode.Should().Be(expectedStatus, $"because path {path} should return {expectedStatus}");
         }
     }
 
@@ -93,8 +95,10 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
             var result = StandardErrorHelpers.CreateNotFound(context, "Resource not found");
             await result.ExecuteAsync(context);
 
-            // Assert
-            context.Response.StatusCode.Should().Be(404, $"because path {path} should return 404 Not Found");
+            // Assert — PA-070/PA-117 (#2418): GeoServices paths transport errors as
+            // HTTP 200 + {"error":{"code":404}}; other protocols keep the real status.
+            var expectedStatus = path.StartsWith("/rest/services", StringComparison.Ordinal) ? 200 : 404;
+            context.Response.StatusCode.Should().Be(expectedStatus, $"because path {path} should return {expectedStatus}");
         }
     }
 
@@ -121,8 +125,10 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
             var result = StandardErrorHelpers.CreateConflict(context, "Resource already exists");
             await result.ExecuteAsync(context);
 
-            // Assert
-            context.Response.StatusCode.Should().Be(409, $"because path {path} should return 409 Conflict");
+            // Assert — PA-070/PA-117 (#2418): GeoServices paths transport errors as
+            // HTTP 200 + {"error":{"code":409}}; other protocols keep the real status.
+            var expectedStatus = path.StartsWith("/rest/services", StringComparison.Ordinal) ? 200 : 409;
+            context.Response.StatusCode.Should().Be(expectedStatus, $"because path {path} should return {expectedStatus}");
         }
     }
 
@@ -178,8 +184,9 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
         var result = StandardErrorHelpers.CreateFromException(context, serviceException);
         await result.ExecuteAsync(context);
 
-        // Assert
-        context.Response.StatusCode.Should().Be(503);
+        // Assert — PA-070/PA-117 (#2418): the GeoServices path transports the 503 as
+        // HTTP 200 + {"error":{"code":503}}; the Retry-After header is still emitted.
+        context.Response.StatusCode.Should().Be(200);
         context.Response.Headers.Should().ContainKey("Retry-After");
         context.Response.Headers["Retry-After"].ToString().Should().Be("300");
     }
@@ -333,8 +340,9 @@ public sealed class StandardErrorHelpersTests : IAsyncLifetime
         var result = StandardErrorHelpers.CreateGeometryError(context, "Polygon is self-intersecting");
         await result.ExecuteAsync(context);
 
-        // Assert
-        context.Response.StatusCode.Should().Be(400);
+        // Assert — PA-070/PA-117 (#2418): the GeoServices path transports the error as
+        // HTTP 200; the 400 is carried in the body envelope asserted below.
+        context.Response.StatusCode.Should().Be(200);
 
         var responseBody = GetResponseBody(context);
         var apiErrorResponse = JsonSerializer.Deserialize<JsonElement>(responseBody);

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorResponseFormatterTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Errors/StandardErrorResponseFormatterTests.cs
@@ -280,7 +280,9 @@ public sealed class StandardErrorResponseFormatterTests : IAsyncLifetime
         var responseBody = GetResponseBody(context);
         responseBody.Should().Contain("<ServiceExceptionReport");
         responseBody.Should().Contain("LayerNotDefined");
-        responseBody.Should().Contain("Layer 'test-service' not found.");
+        // The exception text is XML-escaped by the formatter (SecurityElement.Escape),
+        // so apostrophes appear as &apos; in the serialized report.
+        responseBody.Should().Contain("Layer &apos;test-service&apos; not found.");
         responseBody.Should().NotContain("\"error\"");
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/PermissionResolverQuerySmokeTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/PermissionResolverQuerySmokeTests.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.Authorization.Domain;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Security.Domain;
 using Honua.TestKit.Attributes;
+using Honua.TestKit.Extensions;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Helpers;
 using Honua.TestKit.Infrastructure;
@@ -83,7 +84,9 @@ public sealed class PermissionResolverQuerySmokeTests
 
         var response = await client.GetAsync(QueryUrl);
 
-        await ServiceRbacTestFixture.AssertStatusAsync(response, HttpStatusCode.Forbidden);
+        // PA-070/PA-117 (#2418): the GeoServices query surface reports the coarse-policy
+        // deny as HTTP 200 + {"error":{"code":403}} (or a legacy 403).
+        await response.AssertGeoServicesErrorAsync(403);
     }
 
     /// <summary>

--- a/tests/js/feature-server/apply-edits.test.ts
+++ b/tests/js/feature-server/apply-edits.test.ts
@@ -16,6 +16,7 @@ import {
   FeatureServerClient,
   assertEsriFeatureSet,
   assertEditSuccess,
+  assertGeoServicesError,
 } from '../shared/client';
 import { GeometryGenerator } from '../shared/geometry';
 import { GEOMETRY_TYPE_CASES } from '../shared/constants';
@@ -526,7 +527,8 @@ describe('ApplyEdits - Error Handling', () => {
         body: new URLSearchParams({ adds: 'not valid json', f: 'json' }),
       });
 
-      expect(response.status).toBe(400);
+      const body = (await response.json()) as unknown;
+      assertGeoServicesError({ status: response.status, data: body }, { bodyCodes: [400] });
     });
   });
 
@@ -543,7 +545,7 @@ describe('ApplyEdits - Error Handling', () => {
         99999,
       );
 
-      expect([400, 404]).toContain(response.status);
+      assertGeoServicesError(response, { bodyCodes: [400, 404] });
     });
   });
 

--- a/tests/js/feature-server/gpserver-smoke.test.ts
+++ b/tests/js/feature-server/gpserver-smoke.test.ts
@@ -107,7 +107,10 @@ describe('GPServer Smoke', () => {
       jobStatus?: string;
     };
 
-    if (response.status === 200) {
+    // PA-070/PA-117 (#2418): the job-store-unavailable error is now signalled as
+    // HTTP 200 + {"error":{"code":503}} rather than a 503 status, so branch on the
+    // body error member instead of the HTTP status.
+    if (response.status === 200 && !data.error) {
       expect(data.jobId).toBeTruthy();
       expect(data.jobStatus).toBe('esriJobSubmitted');
       return;

--- a/tests/js/feature-server/metadata.test.ts
+++ b/tests/js/feature-server/metadata.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { FeatureServerClient } from '../shared/client';
+import { FeatureServerClient, assertGeoServicesError } from '../shared/client';
 import { VALID_ESRI_GEOMETRY_TYPES } from '../shared/constants';
 
 // =============================================================================
@@ -102,7 +102,7 @@ describe('Service Metadata', () => {
       });
 
       const response = await customClient.getServiceMetadata();
-      expect(response.status).toBe(404);
+      assertGeoServicesError(response, { bodyCodes: [404] });
     });
   });
 });
@@ -330,7 +330,7 @@ describe('Layer Metadata', () => {
   describe('Error Cases', () => {
     it('should return 404 for nonexistent layer', async () => {
       const response = await client.getLayerMetadata(99999);
-      expect(response.status).toBe(404);
+      assertGeoServicesError(response, { bodyCodes: [404] });
     });
   });
 });

--- a/tests/js/feature-server/query-matrix.test.ts
+++ b/tests/js/feature-server/query-matrix.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { FeatureServerClient, assertEsriFeatureSet } from '../shared/client';
+import { FeatureServerClient, assertEsriFeatureSet, assertGeoServicesError } from '../shared/client';
 import { GeometryGenerator } from '../shared/geometry';
 import {
   NON_DISTANCE_SPATIAL_RELS,
@@ -126,7 +126,7 @@ describe('Spatial Relationship Matrix', () => {
         // No distance parameter
       });
 
-      expect(response.status).toBe(400);
+      assertGeoServicesError(response, { bodyCodes: [400] });
     });
 
     it('should return 400 when distance parameter is missing for esriSpatialRelBeyondDistance', async () => {
@@ -140,7 +140,7 @@ describe('Spatial Relationship Matrix', () => {
         // No distance parameter
       });
 
-      expect(response.status).toBe(400);
+      assertGeoServicesError(response, { bodyCodes: [400] });
     });
   });
 });
@@ -239,7 +239,7 @@ describe('Spatial Reference Matrix', () => {
         inSR: 'invalid',
       });
 
-      expect(response.status).toBe(400);
+      assertGeoServicesError(response, { bodyCodes: [400] });
     });
   });
 
@@ -280,7 +280,7 @@ describe('Spatial Reference Matrix', () => {
         outSR: 'invalid',
       });
 
-      expect(response.status).toBe(400);
+      assertGeoServicesError(response, { bodyCodes: [400] });
     });
   });
 
@@ -332,7 +332,7 @@ describe('Nearest Count Matrix', () => {
       nearestCount: 3,
     } as any);
 
-    expect(response.status).toBe(400);
+    assertGeoServicesError(response, { bodyCodes: [400] });
   });
 
   it('should return features with distance when returnDistance=true', async () => {

--- a/tests/js/feature-server/query.test.ts
+++ b/tests/js/feature-server/query.test.ts
@@ -18,6 +18,7 @@ import {
   FeatureServerClient,
   assertEsriFeatureSet,
   assertGeoJsonFeatureCollection,
+  assertGeoServicesError,
 } from '../shared/client';
 import { GeometryGenerator } from '../shared/geometry';
 import {
@@ -83,7 +84,7 @@ describe('Query Basic', () => {
   describe('Invalid Layer', () => {
     it('should return error for nonexistent layer', async () => {
       const response = await client.query({ where: '1=1' }, 99999);
-      expect([400, 404]).toContain(response.status);
+      assertGeoServicesError(response, { bodyCodes: [400, 404] });
     });
   });
 });
@@ -107,7 +108,7 @@ describe('WHERE Clause', () => {
     describe.each(INVALID_WHERE_CASES)('$name', ({ where }) => {
       it(`should reject: ${where}`, async () => {
         const response = await client.query({ where });
-        expect(response.status).toBe(400);
+        assertGeoServicesError(response, { bodyCodes: [400] });
       });
     });
   });
@@ -409,7 +410,7 @@ describe('Pagination', () => {
         resultOffset: 1000001,
       });
 
-      expect(response.status).toBe(400);
+      assertGeoServicesError(response, { bodyCodes: [400] });
     });
   });
 

--- a/tests/js/map-server/query.test.ts
+++ b/tests/js/map-server/query.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { config } from '../shared/client';
+import { assertGeoServicesError, config } from '../shared/client';
 
 interface MapServerQueryResponse {
   features?: Array<{
@@ -68,6 +68,7 @@ describe('MapServer Query', () => {
       },
     );
 
-    expect(response.status).toBe(400);
+    const body = (await response.json()) as unknown;
+    assertGeoServicesError({ status: response.status, data: body }, { bodyCodes: [400] });
   });
 });

--- a/tests/js/shared/client.ts
+++ b/tests/js/shared/client.ts
@@ -428,3 +428,59 @@ export function assertError(response: { status: number; data: unknown }, expecte
     expect(response.status).toBeGreaterThanOrEqual(400);
   }
 }
+
+/**
+ * Assert a GeoServices REST/tiles error response.
+ *
+ * PA-070 / PA-117 (honua-server #2418) aligned the GeoServices REST surface
+ * (paths under `/rest/services` and `/tiles`) with the Esri ArcGIS REST
+ * convention: operation errors are signalled with **HTTP 200** and an
+ * `{"error": {"code": N, ...}}` JSON body rather than a non-2xx HTTP status.
+ * Modern OGC API (RFC 7807) error paths were intentionally left untouched.
+ *
+ * This helper accepts either the Esri 200 + `{"error": {...}}` body contract
+ * or a legacy `>= 400` status, and FAILS on a success-shaped body — mirroring
+ * `tests/python/shared/geoservices.py::assert_geoservices_error` and the .NET
+ * `Honua.TestKit.Extensions.GeoServicesErrorAssertions`.
+ *
+ * @param response - the `{ status, data }` pair to inspect.
+ * @param options.bodyCodes - if provided, the `error.code` of a 200 body (or
+ *   the HTTP status of a legacy `>= 400` response) must be one of these.
+ * @param options.allowEmpty - also accept an empty `204 No Content` (used by
+ *   tile endpoints that emit an empty tile rather than an error body).
+ */
+export function assertGeoServicesError(
+  response: { status: number; data: unknown },
+  options: { bodyCodes?: number[]; allowEmpty?: boolean } = {},
+): void {
+  const { bodyCodes, allowEmpty = false } = options;
+  const { status, data } = response;
+
+  if (allowEmpty && status === 204) {
+    return;
+  }
+
+  if (status >= 400) {
+    // Legacy transition tolerance: a non-2xx status still counts as an error.
+    if (bodyCodes) {
+      expect(bodyCodes, `unexpected legacy error status ${status}`).toContain(status);
+    }
+    return;
+  }
+
+  expect(status, `expected 200 + {"error"} body or a legacy >= 400 status, got ${status}`).toBe(200);
+
+  const body = data as { error?: { code?: number } } | null | undefined;
+  const error = body && typeof body === 'object' ? body.error : undefined;
+  expect(
+    error && typeof error === 'object',
+    `expected a GeoServices error object {"error": {...}}, got: ${JSON.stringify(data)?.slice(0, 300)}`,
+  ).toBeTruthy();
+
+  if (bodyCodes) {
+    expect(
+      bodyCodes,
+      `unexpected GeoServices error code ${error?.code}: ${JSON.stringify(error)?.slice(0, 300)}`,
+    ).toContain(error?.code);
+  }
+}

--- a/tests/python/feature_server/test_auxiliary_services.py
+++ b/tests/python/feature_server/test_auxiliary_services.py
@@ -113,5 +113,7 @@ class TestImageServer:
         )
 
         # PA-070/PA-117 (#2418): the not-implemented signal is now HTTP 200 +
-        # {"error": {"code": 501}} rather than a bare 501 status.
-        assert_geoservices_error(response, body_codes={501})
+        # an {"error"} envelope rather than a bare 501 status. The envelope maps
+        # 501 to body code 500 (GeoServicesErrorCodes.FromHttpStatusCode has no
+        # 501 entry), so accept both.
+        assert_geoservices_error(response, body_codes={501, 500})

--- a/tests/python/gp_server/test_gpserver_client_compat.py
+++ b/tests/python/gp_server/test_gpserver_client_compat.py
@@ -11,6 +11,8 @@ from typing import Any
 import httpx
 import pytest
 
+from shared.geoservices import assert_geoservices_error
+
 POINT_WKB_BASE64 = "AQEAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 
@@ -96,7 +98,10 @@ def test_gpserver_python_client_submit_and_poll_workflow(
     assert submit.status_code in (200, 503)
     submit_data = submit.json()
 
-    if submit.status_code == 503:
+    # PA-070/PA-117 (#2418): job-store unavailability is now signalled as
+    # HTTP 200 + {"error":{"code":503}} rather than a 503 status, so branch on
+    # the body error member instead of the HTTP status.
+    if submit.status_code == 503 or "error" in submit_data:
         error = _assert_esri_error(submit, 503)
         details = " ".join(error["error"].get("details") or [])
         assert "Redis-backed durable storage" in details
@@ -121,5 +126,9 @@ def test_gpserver_python_client_missing_job_uses_esri_error_shape(
 
     response = client.missing_job_status()
 
-    assert response.status_code in (404, 503)
-    _assert_esri_error(response, response.status_code)
+    # PA-070/PA-117 (#2418): the missing-job error is now HTTP 200 +
+    # {"error":{"code":404|503}} (or a legacy 404/503 status).
+    assert_geoservices_error(response, body_codes={404, 503})
+    data = response.json()
+    assert data["error"]["message"]
+    assert isinstance(data["error"].get("details"), list)

--- a/tests/python/image_server/test_imageserver_client_compat.py
+++ b/tests/python/image_server/test_imageserver_client_compat.py
@@ -11,6 +11,8 @@ from typing import Any
 import httpx
 import pytest
 
+from shared.geoservices import assert_geoservices_error
+
 
 @dataclass(frozen=True)
 class ImageServerClient:
@@ -94,13 +96,15 @@ def test_imageserver_python_client_error_shapes(
     invalid_format = client.service_info(f="xml")
     invalid_identify_format = client.identify(geometry="0,0", f="xml")
 
-    assert invalid_format.status_code == 400
+    # PA-070/PA-117 (#2418): GeoServices errors are HTTP 200 + {"error":{"code":400}}
+    # (or a legacy 400 status).
+    assert_geoservices_error(invalid_format, body_codes={400})
     invalid_format_error = _assert_esri_error(invalid_format, 400)
     assert "Only JSON format is supported" in " ".join(
         invalid_format_error["error"].get("details") or []
     )
 
-    assert invalid_identify_format.status_code == 400
+    assert_geoservices_error(invalid_identify_format, body_codes={400})
     identify_error = _assert_esri_error(invalid_identify_format, 400)
     assert "Only JSON format is supported" in " ".join(
         identify_error["error"].get("details") or []


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2505

## Summary
Third tranche of the #2418 GeoServices `200 + {"error":{"code":N}}` contract migration, driven by batch run `28778454088` (the first run after the nine health PRs merged). Now that #2515 fixed no-Redis startup, the **JavaScript Integration suite booted and surfaced its own stale GeoServices assertions for the first time**; the run also exposed residual stale assertions in Scene.Tests, Server.Tests, and two Python client-compat directories the #2507 sweep missed. Test-only; no product code changes.

## Changes Made
- **JS (`tests/js`)**: port the shared contract helper to vitest — `shared/client.ts::assertGeoServicesError({status,data}, {bodyCodes, allowEmpty})`, mirroring `tests/python/shared/geoservices.py::assert_geoservices_error` and `Honua.TestKit.Extensions.GeoServicesErrorAssertions` (accepts `200+{"error":{"code"}}` or legacy `>=400`; fails on success-shaped bodies). Migrate the 16 failing tests across `query`, `query-matrix`, `metadata`, `apply-edits`, `map-server/query` (incl. two raw-`fetch` sites) — only `/rest/services` paths; `gpserver-smoke` branches on the body `error` member for the 200-transported 503 envelope.
- **Python (`tests/python`)**: migrate `gp_server/` + `image_server/` client-compat tests (directories missed by #2507): status asserts → `assert_geoservices_error`; submit-and-poll branches on the body `error` member (fixes `KeyError: 'jobId'`); `computeClassStatistics` accepts body code `{501, 500}` (the envelope maps 501→500 via `FromHttpStatusCode`'s default).
- **Scene.Tests**: 14 stale 4xx assertions on I3S SceneServer `/rest/services/.../SceneServer` paths migrated (`401 → {401,499}`); `/scenes`-path tests deliberately untouched (real HTTP status).
- **Server.Tests**: `EndpointCoverageTests` ErrorHandling (3); `ServiceSettingsEndpointsTests.UpdateProtocols` Blocks LayerTiles/LayerMetadata (2, incl. a `/tiles` path); `StandardErrorHelpersTests` AllProtocols loops branch `/rest/services` rows to 200-transport while OData/OGC/admin rows keep real status (3 loops) + `CreateGeometryError` + `ServiceUnavailable` Retry-After (header still asserted); `StandardErrorResponseFormatterTests` WMS-alias test expects the XML-escaped `&apos;` exception text; `PermissionResolverQuerySmokeTests` NoGrant coarse-deny → 403 envelope.

## Testing
- [x] Integration tests added/updated

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None (test-only).

---

## Verified locally vs. what CI must prove
- Local: `Honua.Server.Tests` + `Honua.Protocols.Scene.Tests` Release `/p:TreatWarningsAsErrors=true` — **green (0 errors each)**; `dotnet format --verify-no-changes` on changed .cs — clean; `tsc --noEmit` on `tests/js` — clean; `py_compile` on changed Python — clean. Docker/live server unavailable locally.
- CI proves: `JavaScript Integration Tests`, `Python Integration Tests`, `Server Tests (Scene / STAC and API Governance / Infra and Security / Server Features Admin Operations partial)` go green on the migrated assertions.

## Autopsied but deliberately NOT fixed here (different root causes — routed to the coordinator)
1. **`Server Tests (FeatureServer Replication)`** — `SynchronizeReplica_UploadFailure_DoesNotAdvanceGeneration`: the SRID-3857 "invalid" upload now returns `{"success":true,...,"serverGen":N}` — the failure injection no longer fails (likely #2418's `SpatialReferenceExtensions`/`ExtentExtensions` reprojection fixes make 3857 input legal). Behavior change: the test needs a new failure injection or a product decision; the tolerant helper correctly rejects the success body.
2. **`Server Tests (Server Features Admin Operations)`** — `SeedOperateObservabilityFixture_*`: `/api/v1/admin/dev/fixtures/operate-observability/...` returns a real **500** admin problem. Server-side error, not a stale assertion.
3. **`Server Tests (Server Features Data and Sharing)`** — `GetManifest_RegistryDerived_MatchesHandCuratedComposition`: registry-derived manifest drift at index 5167 vs the hand-curated composition — needs manifest re-curation after the recent endpoint changes.
4. **`Postgres Compatibility (16/17/18)`** — all three fail on exactly one identical test: `PostgresAuditLogTests.RecordAsync_TruncatesOverlongActor_AndStillPersists` — expected the truncated actor to end with `…` but it ends with `â€¦` (UTF-8 ellipsis read back mis-decoded). Encoding bug in the audit-log truncation path (or its test fixture), introduced by a recent sibling change; not a contract issue.

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
