### PR TITLE
ci: gate merge-train batches selectively vs trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ on:
   # gate on `event_name != 'merge_group'`, so the train's workflow_dispatch (and
   # the nightly schedule) still run them; only the per-PR fan-out is dropped.
   # A genuinely-broken PR is caught when the train batches it (attribute+drop).
+  #
+  # SELECTIVE BATCHES: a train/batch/* dispatch is gated like a PR diffed against
+  # trunk — the `changes` + `targeted-shards` jobs run only the shards/lanes the
+  # batch's cumulative diff touches (the smart-ci subset the train computes),
+  # not the whole fanout every batch. The targeted-tests selector self-escalates
+  # to run_all on infra/shared/unmapped changes, and the nightly `schedule` still
+  # runs the FULL matrix as the backstop, so coverage is preserved while the
+  # per-batch rerun of already-green shards is eliminated. `-f full_ci=true`
+  # (or a schedule/non-train dispatch) forces the full lane.
   # Merge queue (LEAN gate): GitHub batches approved PRs and runs CI once on
   # the combined commit before fast-forwarding trunk. The full ~45-job matrix
   # (AOT, docker, the 30+-shard Server Tests fanout, browser/MCP lanes) already
@@ -36,6 +45,11 @@ on:
         description: 'honua-sdk-js git ref for MCP tests (overrides MCP_SDK_REF env)'
         required: false
         default: ''
+      full_ci:
+        description: 'Force the FULL matrix even on a train/batch/* dispatch (overrides the selective-vs-trunk batch gate). No effect off a train/batch ref.'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   # PR runs key on the PR number (re-push cancels the prior run). merge_group
@@ -344,7 +358,15 @@ jobs:
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          # A merge-train batch CI is dispatched via workflow_dispatch on a
+          # `train/batch/*` branch. Treat it like a PR diffed against trunk: gate
+          # only the shards/lanes its cumulative diff touches (the smart-ci subset
+          # the train already computes) instead of re-running the full matrix on
+          # every batch. The targeted-tests script self-escalates to run_all on
+          # infra/shared/unmapped changes, and the nightly `schedule` still runs
+          # the full lane, so coverage is preserved. `-f full_ci=true` forces full.
+          SELECTIVE_BATCH="${{ github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/train/batch/') && inputs.full_ci != true }}"
+          if [ "${{ github.event_name }}" != "pull_request" ] && [ "${SELECTIVE_BATCH}" != "true" ]; then
             echo "build_changes=true" >> "$GITHUB_OUTPUT"
             echo "non_test_changes=true" >> $GITHUB_OUTPUT
             echo "integration_changes=true" >> "$GITHUB_OUTPUT"
@@ -450,10 +472,27 @@ jobs:
         run: |
           set -euo pipefail
           all_shards_json=$(jq -c '[.shards[].name]' .github/ci-shards.json)
+          # Selective base: a PR diffs against its base branch; a merge-train
+          # batch (workflow_dispatch on train/batch/*, no full_ci override) diffs
+          # against trunk so it runs ONLY the shards its cumulative diff touches
+          # — the smart-ci subset — instead of the full fanout every batch.
+          selective_base=""
           if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ needs.changes.outputs.full_ci }}" != "true" ]; then
+            selective_base="origin/${{ github.base_ref }}"
+          elif [ "${{ github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/train/batch/') && inputs.full_ci != true }}" = "true" ]; then
+            selective_base="origin/trunk"
+          fi
+
+          if [ -n "${selective_base}" ]; then
             # Full base history (not --depth=1) so the targeted-tests diff has a merge-base.
-            git fetch --no-tags origin "${{ github.base_ref }}"
-            descriptor=$(scripts/ci/honua-server-targeted-tests.sh --base "origin/${{ github.base_ref }}")
+            git fetch --no-tags origin "${selective_base#origin/}"
+            # Fail SAFE to run_all if the diff/script cannot be computed, so a
+            # batch is never under-tested by a silent selection failure.
+            if ! descriptor=$(scripts/ci/honua-server-targeted-tests.sh --base "${selective_base}"); then
+              echo "::warning::targeted-tests selection failed for base ${selective_base}; falling back to run_all."
+              descriptor=$(jq -nc --argjson shards "${all_shards_json}" \
+                '{run_all: true, shards: $shards, reason: "targeted_selection_failed"}')
+            fi
           else
             reason="scheduled_or_manual_full_ci"
             if [ "${{ github.event_name }}" = "pull_request" ]; then


### PR DESCRIPTION
## Issue Link
Fixes #2524
Related to #2475

## Summary
The merge-train dispatches one batch CI per batch via `workflow_dispatch` on a `train/batch/*` branch, and `ci.yml` forced the FULL matrix on every non-PR event — so each batch re-ran the entire ~30-shard Server Tests fanout plus every integration lane from scratch, re-running already-green shards batch after batch (the dominant CI cost). `smart-ci.sh` already computed the affected-shard subset for the batch's diff but logged and discarded it; ci.yml never honored it.

This treats a `train/batch/*` dispatch like a PR diffed against trunk: the `changes` and `targeted-shards` jobs run only the shards/lanes the batch's cumulative diff touches, reusing the existing selective PR path and the `honua-server-targeted-tests.sh` selector. This also unblocks a stuck train — a batch that doesn't touch a pre-existing-red shard's paths no longer re-runs (and fails on) that shard, so innocent batches can land.

## Changes Made
- `ci.yml` `changes` job: a `train/batch/*` workflow_dispatch (no `full_ci` override) now takes the selective PR filter path (diff vs trunk) instead of forcing full CI.
- `ci.yml` `targeted-shards` job: computes the server-tests subset via `honua-server-targeted-tests.sh --base origin/trunk` for train batches; fails safe to run_all if selection can't be computed.
- Added a `full_ci` workflow_dispatch input (default false) as an escape hatch to force the full lane on a risky batch.
- The nightly `schedule` still runs the FULL matrix as the backstop (unchanged).
- Updated the header comment documenting the selective-batch behavior.

## Testing
- [x] Architecture tests pass
- [x] Manual testing performed
<!-- validate-ci-router.sh PASS (653 test classes claimed); YAML lint PASS; honua-server-targeted-tests.sh dry-runs across feature/infra/core/doc diffs route as expected (targeted subset for feature changes, run_all for Core/geometry/hosting-infra). -->

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. Selection is additive: PRs, nightly, merge_group, and non-train dispatches behave exactly as before; only `train/batch/*` dispatches become selective (with run_all self-escalation + nightly full backstop preserving coverage).

## Notes for reviewer
- Coverage tradeoff: python/js-integration/docker lanes gate on `full_ci`, so on a selective batch they follow the same posture as a non-`ci/full` PR (covered by the nightly full run). Force with `-f full_ci=true` if a batch needs them.
- Observation (not changed here): the selector routes root shared-build files (`Directory.Build.props`, `Directory.Packages.props`) to Core-only, not run_all — the `build` job still validates them via `build_changes`. `Honua.sln` exclusion is intentional (#1897). Consider whether `Directory.*.props` warrant `infrastructure_paths` in a follow-up.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above