### PR TITLE
test: align alert_events integration-fixture schema with migration 075

### DIFF
--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -1113,7 +1113,11 @@ sql:
       CREATE TABLE IF NOT EXISTS honua.alert_events (
           event_id BIGSERIAL PRIMARY KEY,
           dedupe_key TEXT NOT NULL,
-          rule_id BIGINT NOT NULL REFERENCES honua.alert_rules(rule_id) ON DELETE CASCADE,
+          -- rule_id is nullable and `source` discriminates rule-driven (gis) vs
+          -- operations-notification (ops) events, mirroring 075_AddAlertOpsSource.sql
+          -- (#2427 alerts GA) so this migration-skipping integration fixture matches
+          -- the canonical alert_events shape the alert stores write to.
+          rule_id BIGINT REFERENCES honua.alert_rules(rule_id) ON DELETE CASCADE,
           zone_id BIGINT NULL REFERENCES honua.alert_zones(zone_id) ON DELETE SET NULL,
           service_id TEXT NOT NULL,
           layer_id INT NOT NULL,
@@ -1125,6 +1129,7 @@ sql:
           payload JSONB NOT NULL DEFAULT '{}'::jsonb,
           incident_status SMALLINT NOT NULL DEFAULT 1,
           incident_duration_ms BIGINT NOT NULL DEFAULT 0,
+          source TEXT,
           created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
           CONSTRAINT alert_events_valid_dedupe_key CHECK (length(dedupe_key) > 0),
           CONSTRAINT alert_events_valid_trigger CHECK (trigger_type IN (1, 2, 3, 4)),
@@ -1133,6 +1138,8 @@ sql:
           CONSTRAINT alert_events_valid_incident_status CHECK (incident_status IN (1, 2, 3))
       );
   - "CREATE UNIQUE INDEX IF NOT EXISTS uq_alert_events_dedupe_key ON honua.alert_events(dedupe_key);"
+  # Partial index for ops-notification queries (mirrors 075_AddAlertOpsSource.sql).
+  - "CREATE INDEX IF NOT EXISTS ix_alert_events_source_ops ON honua.alert_events(occurred_at DESC) WHERE source = 'ops';"
   - |
       CREATE TABLE IF NOT EXISTS honua.alert_event_lifecycle (
           event_id           BIGINT      PRIMARY KEY REFERENCES honua.alert_events(event_id) ON DELETE CASCADE,


### PR DESCRIPTION
## Issue Link
Fixes #2527

## Summary
Integration tests skip startup migrations (`NullDatabaseMigrationRunner`) and provision the `honua` schema from the hand-maintained `tests/seed/server.yaml`. Its `honua.alert_events` DDL drifted from `075_AddAlertOpsSource.sql` (#2427, alerts GA) — missing the `source` column and still `rule_id NOT NULL`. `PostgresAlertEventStore.TryAppendAsync` INSERTs `source` (and a NULL `rule_id` for ops events), so the Operate observability seed endpoint threw `42703: column "source" does not exist` → 500, reddening two tests on the Admin Operations shard.

## Changes Made
- `tests/seed/server.yaml`: add `source TEXT` to `honua.alert_events`.
- `tests/seed/server.yaml`: drop `NOT NULL` on `rule_id` (ops-notification events carry NULL rule_id), matching 075.
- `tests/seed/server.yaml`: add the `ix_alert_events_source_ops` partial index for parity.

## Testing
- [x] Integration tests added/updated
- [x] Manual testing performed
<!-- Ran locally with Testcontainers + PostGIS: OperateObservabilityFixture* 11/11 pass (both previously-failing tests now green). Also SQL-validated the store's exact INSERT against the fixed schema for both rule-driven and ops (NULL rule_id, source='ops') events. -->

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. Test-fixture-only change; strictly additive (adds a column, relaxes a constraint) so existing seeded data stays compatible.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above