### PR TITLE
fix(capabilities): re-curate versioning.branch into the hand-curated manifest roster (#2526)

### DIFF
--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -404,7 +404,12 @@ internal sealed class CapabilityManifestService(
                 policyCapability: "features.query"),
             Capability("publication.metadata-release", "publication", context, policyCapability: "catalog.publish", requiresEnvironment: true),
             Capability("upload.file", "upload", context, entitlementKey: "import.file", policyCapability: "metadata.write"),
-            Capability("edit.features", "edit", context, entitlementKey: FeatureCatalog.FeatureServerEditsKey, policyCapability: "features.edit")
+            Capability("edit.features", "edit", context, entitlementKey: FeatureCatalog.FeatureServerEditsKey, policyCapability: "features.edit"),
+            // Branch versioning (VMS) — built-experimental, gated OFF the GA surface by
+            // default (#2480 / ADR-0058). Kept last to mirror the registry descriptor order
+            // (CapabilityRegistry.BuildManifestCapabilityDescriptors) so the hand-curated and
+            // registry-derived Capabilities[] stay byte-identical.
+            Capability("versioning.branch", "versioning", context, entitlementKey: FeatureCatalog.BranchVersioningKey)
         ];
     }
 
@@ -513,6 +518,7 @@ internal sealed class CapabilityManifestService(
             ["publication.metadata-release"] = new() { PolicyCapability = "catalog.publish", RequiresEnvironment = true },
             ["upload.file"] = new() { EntitlementKey = "import.file", PolicyCapability = "metadata.write" },
             ["edit.features"] = new() { EntitlementKey = FeatureCatalog.FeatureServerEditsKey, PolicyCapability = "features.edit" },
+            ["versioning.branch"] = new() { EntitlementKey = FeatureCatalog.BranchVersioningKey },
         };
     }
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2526 (item 3)

## Summary
`Server Tests (Server Features Data and Sharing)` fails on `GetManifest_RegistryDerived_MatchesHandCuratedComposition`: the registry-derived `Capabilities[]` diverges from the hand-curated composition at index 5167 — the derived array carries one extra trailing entry (`{"id":"ve…"`).

Root cause: #2480 (BH6-001/BH6-002 VMS gating) added the `versioning.branch` descriptor to `CapabilityRegistry.BuildManifestCapabilityDescriptors()` but did not re-curate the hand-curated roster in `CapabilityManifestService.BuildCapabilities()` / `BuildManifestCapabilitySpecs()`, so only the registry-derived path emits it. The #2335 (B3) golden test exists precisely to catch this drift.

## Changes Made
- Add `versioning.branch` (category `versioning`, entitlement `FeatureCatalog.BranchVersioningKey`) as the final entry of the hand-curated `BuildCapabilities()` roster, mirroring the registry descriptor order so the two composition paths serialize byte-identically.
- Add the matching `["versioning.branch"]` spec entry to `BuildManifestCapabilitySpecs()` (the map that keeps the derived path's per-capability knobs identical to the hand-curated arguments).

Note the entry only appears on the wire when the experimental gate is opted in — with default config both paths omit it identically (it is Experimental + flag-off), and the parity test compares the two paths under the same fixture config, so they now agree in both states.

## Testing
- [x] Integration tests added/updated (existing golden parity test now passes; no new test needed — this is the re-curation the test demanded)

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Verified locally vs. what CI must prove
- Local: full Release build `-p:TreatWarningsAsErrors=true` green; `dotnet format` clean on the changed file. The parity test needs a live Postgres-backed WebAppFixture (Docker), unavailable locally.
- CI proves: `Server Tests (Server Features Data and Sharing)` — `GetManifest_RegistryDerived_MatchesHandCuratedComposition` goes green.

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh equivalents (Release warnings-as-errors build, format) — Docker-gated shards deferred to CI
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
