### PR TITLE
fix: S3 empty-listing NRE breaking rendered-image exports + AOT image writable-dir gap

### DIFF
--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -152,10 +152,21 @@ RUN addgroup -g 1001 -S honua && \
 WORKDIR /app
 COPY --from=build --chown=1001:1001 /app .
 
-# Security: Create runtime directories with proper permissions
-RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics && \
-    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics && \
-    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics
+# Security: Create runtime directories with proper permissions.
+# This set MUST include every writable directory the default configuration writes
+# to at runtime. Under the read-only root filesystem this image is built for
+# (security.read-only-root="true"), any path not provisioned here — and not backed
+# by a writable volume mount by the deployment — is read-only, so a write attempt
+# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /tmp/honua-storage
+# (FileStorage:LocalStorage:BasePath) back the map-image export href/f=json responses
+# (MapServer export, ImageServer exportImage); omitting them makes every rendered
+# image export fail with a 500 while inline f=image responses (which never touch
+# temp storage) still succeed. Keep this list in sync with the default storage
+# directories in appsettings.json — DockerfileWritableStorageDirectoryTests enforces
+# it for every Dockerfile that declares security.read-only-root="true".
+RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
+    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
+    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage
 
 # Security: Remove unnecessary setuid/setgid binaries
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true

--- a/src/Honua.Aws/Features/FileStorage/AwsS3FileStorage.cs
+++ b/src/Honua.Aws/Features/FileStorage/AwsS3FileStorage.cs
@@ -348,17 +348,25 @@ internal sealed class AwsS3FileStorage : CloudFileStorageBase
 
             var response = await _client.ListObjectsV2Async(request, cancellationToken);
 
+            // AWS SDK v4 leaves response collections null when S3 returns no items (an empty
+            // prefix produces a ListBucketResult with no <Contents>, unmarshalled as
+            // S3Objects == null rather than an empty list). Normalize before dereferencing —
+            // an unguarded .Count here NRE'd the temporary-file quota listing against the
+            // empty temporary-files/ prefix and 500'd every rendered map-image href/f=json
+            // export on S3-backed deployments (honua-server#2311).
+            var s3Objects = response.S3Objects ?? [];
+
             // ListObjectsV2 already carries the key, size, and last-modified for every object, so a
             // size/last-modified-only listing needs no per-object HEAD. Only fetch per-object
             // metadata (HeadObject) when the caller explicitly asks for the custom user metadata
             // (original file name, expiry, custom keys) that the flat listing cannot return — and
             // even then bound the parallelism so a page is N concurrent HEADs rather than N
             // sequential round trips.
-            var pageBatch = new CloudFile?[response.S3Objects.Count];
+            var pageBatch = new CloudFile?[s3Objects.Count];
             if (includeMetadata)
             {
                 await Parallel.ForEachAsync(
-                    response.S3Objects.Select((item, index) => (item, index)),
+                    s3Objects.Select((item, index) => (item, index)),
                     new ParallelOptions { MaxDegreeOfParallelism = 8, CancellationToken = cancellationToken },
                     async (entry, ct) =>
                     {
@@ -371,9 +379,9 @@ internal sealed class AwsS3FileStorage : CloudFileStorageBase
             }
             else
             {
-                for (var index = 0; index < response.S3Objects.Count; index++)
+                for (var index = 0; index < s3Objects.Count; index++)
                 {
-                    pageBatch[index] = ToCloudFile(response.S3Objects[index]);
+                    pageBatch[index] = ToCloudFile(s3Objects[index]);
                 }
             }
 
@@ -497,7 +505,8 @@ internal sealed class AwsS3FileStorage : CloudFileStorageBase
             request.ContinuationToken = continuationToken;
             var response = await _client.ListObjectsV2Async(request, cancellationToken);
 
-            foreach (var item in response.S3Objects)
+            // SDK v4: S3Objects is null (not empty) when the listing has no results.
+            foreach (var item in response.S3Objects ?? [])
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 var metadata = await GetMetadataDictionaryAsync(item.Key, cancellationToken);
@@ -650,7 +659,9 @@ internal sealed class AwsS3FileStorage : CloudFileStorageBase
         {
             request.ContinuationToken = continuationToken;
             var response = await _client.ListObjectsV2Async(request, cancellationToken);
-            foreach (var item in response.S3Objects)
+
+            // SDK v4: S3Objects is null (not empty) when the listing has no results.
+            foreach (var item in response.S3Objects ?? [])
             {
                 if (await DeleteObjectAsync(item.Key, cancellationToken))
                 {

--- a/tests/dotnet/Honua.Architecture.Tests/DockerfileWritableStorageDirectoryTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/DockerfileWritableStorageDirectoryTests.cs
@@ -8,38 +8,95 @@ using Xunit;
 namespace Honua.Architecture.Tests;
 
 /// <summary>
-/// Guards the demo-render contract (honua-server#2311): the runtime image is built for a
-/// read-only root filesystem (<c>security.read-only-root="true"</c>), so every directory the
-/// default configuration writes to at runtime MUST be provisioned as a writable runtime
-/// directory in the Dockerfile. When the two file-storage directories were omitted, inline
-/// map-image responses (<c>f=image</c>, which stream bytes directly) still worked while every
-/// <c>href</c>/<c>f=json</c> export response — MapServer <c>export</c>, ImageServer
-/// <c>exportImage</c>, OGC API Maps — failed with a 500, because persisting the rendered image
-/// to <c>TemporaryFiles:StorageDirectory</c> threw on the read-only path. This test keeps the
-/// Dockerfile's provisioned writable directories in sync with the default storage directories
-/// declared in appsettings.json so that regression cannot recur silently.
+/// Guards the demo-render contract (honua-server#2311): a runtime image built for a
+/// read-only root filesystem (<c>security.read-only-root="true"</c>) makes every path that
+/// is not explicitly provisioned (or volume-mounted by the deployment) read-only, so every
+/// directory the default configuration writes to at runtime MUST be provisioned as a
+/// writable runtime directory in that image's Dockerfile. When the two file-storage
+/// directories were omitted, inline map-image responses (<c>f=image</c>, which stream bytes
+/// directly) still worked while every <c>href</c>/<c>f=json</c> export response — MapServer
+/// <c>export</c>, ImageServer <c>exportImage</c> — failed with a 500, because persisting the
+/// rendered image to <c>TemporaryFiles:StorageDirectory</c> threw on the read-only path.
+/// This test discovers every Dockerfile in the repository that declares the read-only-root
+/// label and keeps its provisioned writable directories in sync with the default storage
+/// directories declared in appsettings.json, so the regression cannot recur silently in any
+/// read-only-root image (the container Dockerfile and docker/Dockerfile.aot today).
 /// </summary>
 [Trait("Category", "Architecture")]
 public sealed class DockerfileWritableStorageDirectoryTests
 {
-    private const string DockerfileRelativePath = "Dockerfile";
+    private const string ReadOnlyRootLabel = "security.read-only-root=\"true\"";
     private const string AppSettingsRelativePath = "src/Honua.Server/appsettings.json";
 
     [ArchitectureTest]
-    public void Dockerfile_ProvisionsEveryDefaultLocalStorageDirectory()
+    public void ReadOnlyRootDockerfiles_ProvisionEveryDefaultLocalStorageDirectory()
     {
         var repositoryRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
-        var dockerfilePath = Path.Combine(repositoryRoot, DockerfileRelativePath);
         var appSettingsPath = Path.Combine(
             repositoryRoot,
             AppSettingsRelativePath.Replace('/', Path.DirectorySeparatorChar));
 
-        File.Exists(dockerfilePath).Should().BeTrue(
-            "the runtime Dockerfile must exist at the canonical path: {0}", dockerfilePath);
         File.Exists(appSettingsPath).Should().BeTrue(
             "the server appsettings.json must exist at the canonical path: {0}", appSettingsPath);
 
-        var dockerfile = File.ReadAllText(dockerfilePath);
+        var requiredDirectories = ReadRequiredStorageDirectories(appSettingsPath);
+        requiredDirectories.Should().NotBeEmpty(
+            "appsettings.json must declare the default local storage directories this test protects.");
+
+        var readOnlyRootDockerfiles = DiscoverReadOnlyRootDockerfiles(repositoryRoot);
+        readOnlyRootDockerfiles.Should().NotBeEmpty(
+            "at least the root container Dockerfile declares {0}; if the label moved, update this test.",
+            ReadOnlyRootLabel);
+
+        foreach (var dockerfilePath in readOnlyRootDockerfiles)
+        {
+            var dockerfile = File.ReadAllText(dockerfilePath);
+            var relativePath = Path.GetRelativePath(repositoryRoot, dockerfilePath);
+
+            foreach (var (configPath, directory) in requiredDirectories)
+            {
+                IsProvisionedInDockerfile(dockerfile, directory).Should().BeTrue(
+                    "the default storage directory '{0}' ({1}) must be provisioned as a writable runtime " +
+                    "directory in '{2}' (mkdir -p + chown to the runtime user). That image declares a " +
+                    "read-only root filesystem, so any unprovisioned path is read-only and every rendered " +
+                    "map-image export (href/f=json) that persists to it fails with a 500 (honua-server#2311).",
+                    directory,
+                    configPath,
+                    relativePath);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Finds every Dockerfile in the repository that declares the read-only-root security
+    /// label. Scans the repo root and the docker/ directory (where all runtime image
+    /// definitions live) rather than hardcoding file names, so a new read-only-root image
+    /// is covered automatically.
+    /// </summary>
+    private static List<string> DiscoverReadOnlyRootDockerfiles(string repositoryRoot)
+    {
+        var candidates = new List<string>();
+
+        var rootDockerfile = Path.Combine(repositoryRoot, "Dockerfile");
+        if (File.Exists(rootDockerfile))
+        {
+            candidates.Add(rootDockerfile);
+        }
+
+        var dockerDirectory = Path.Combine(repositoryRoot, "docker");
+        if (Directory.Exists(dockerDirectory))
+        {
+            candidates.AddRange(Directory.EnumerateFiles(dockerDirectory, "Dockerfile*", SearchOption.TopDirectoryOnly));
+        }
+
+        return candidates
+            .Where(path => File.ReadAllText(path).Contains(ReadOnlyRootLabel, StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static List<(string ConfigPath, string Directory)> ReadRequiredStorageDirectories(string appSettingsPath)
+    {
         using var appSettings = JsonDocument.Parse(File.ReadAllText(appSettingsPath));
         var root = appSettings.RootElement;
 
@@ -57,19 +114,7 @@ public sealed class DockerfileWritableStorageDirectoryTests
             requiredDirectories.Add(("FileStorage:LocalStorage:BasePath", storageBasePath));
         }
 
-        requiredDirectories.Should().NotBeEmpty(
-            "appsettings.json must declare the default local storage directories this test protects.");
-
-        foreach (var (configPath, directory) in requiredDirectories)
-        {
-            IsProvisionedInDockerfile(dockerfile, directory).Should().BeTrue(
-                "the default storage directory '{0}' ({1}) must be provisioned as a writable runtime " +
-                "directory in the Dockerfile (mkdir -p + chown to the runtime user). The image runs with " +
-                "a read-only root filesystem, so any unprovisioned path is read-only and every rendered " +
-                "map-image export (href/f=json) that persists to it fails with a 500 (honua-server#2311).",
-                directory,
-                configPath);
-        }
+        return requiredDirectories;
     }
 
     // A path is provisioned when it appears both in a `mkdir -p` invocation and a `chown`

--- a/tests/dotnet/Honua.Server.Tests/Features/FileStorage/AwsS3FileStorageEmptyListingTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/FileStorage/AwsS3FileStorageEmptyListingTests.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Honua.FileStorage;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Tests.Features.FileStorage;
+
+/// <summary>
+/// Regression tests for the AWS SDK v4 null-collection behavior (honua-server#2311): when a
+/// ListObjectsV2 call matches zero objects, S3 returns a ListBucketResult with no
+/// &lt;Contents&gt; elements and the SDK v4 unmarshaller leaves <c>response.S3Objects</c>
+/// <c>null</c> instead of an empty list. Unguarded dereferences of that collection threw
+/// <c>NullReferenceException</c> from every listing over an empty prefix — most visibly
+/// <c>CloudBackedTemporaryFileService.EnsureCloudStorageCapacityAsync</c>'s quota listing of the
+/// empty <c>temporary-files/</c> prefix, which turned every rendered map-image
+/// <c>href</c>/<c>f=json</c> export (MapServer <c>export</c>, ImageServer <c>exportImage</c>)
+/// into a 500 on S3-backed deployments such as demo.honua.io.
+///
+/// The tests drive the real <see cref="AwsS3FileStorage"/> and the real SDK serialization
+/// pipeline against a local HTTP stub that answers ListObjectsV2 with the exact empty
+/// ListBucketResult payload live S3 returns for an empty prefix, so the S3Objects-null shape is
+/// produced by the SDK itself rather than hand-constructed.
+/// </summary>
+[Collection("Unit")]
+public sealed class AwsS3FileStorageEmptyListingTests
+{
+    private const string EmptyListBucketResultXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+            <Name>unit-test-bucket</Name>
+            <Prefix>temporary-files/</Prefix>
+            <KeyCount>0</KeyCount>
+            <MaxKeys>1000</MaxKeys>
+            <IsTruncated>false</IsTruncated>
+        </ListBucketResult>
+        """;
+
+    [UnitTest]
+    public async Task ListFilesAsync_EmptyPrefix_ReturnsEmptyListInsteadOfThrowing()
+    {
+        using var stub = EmptyListObjectsStub.Start();
+        var storage = CreateStorage(stub.ServiceUrl);
+
+        var files = await storage.ListFilesAsync(
+            "temporary-files",
+            maxResults: int.MaxValue,
+            includeMetadata: true);
+
+        files.Should().BeEmpty(
+            "an empty S3 prefix (SDK v4 unmarshals it as S3Objects == null) must produce an empty " +
+            "listing, not a NullReferenceException — the NRE 500'd every rendered map-image " +
+            "href/f=json export on S3-backed deployments (honua-server#2311)");
+        stub.ListRequestCount.Should().BeGreaterThan(0, "the storage provider must have issued a ListObjectsV2 request");
+    }
+
+    [UnitTest]
+    public async Task CleanupExpiredFilesAsync_EmptyBucket_ReturnsZeroInsteadOfThrowing()
+    {
+        using var stub = EmptyListObjectsStub.Start();
+        var storage = CreateStorage(stub.ServiceUrl);
+
+        var cleaned = await storage.CleanupExpiredFilesAsync();
+
+        cleaned.Should().Be(0);
+    }
+
+    [UnitTest]
+    public async Task DeleteBatchAsync_EmptyPrefix_ReturnsZeroInsteadOfThrowing()
+    {
+        using var stub = EmptyListObjectsStub.Start();
+        var storage = CreateStorage(stub.ServiceUrl);
+
+        var deleted = await storage.DeleteBatchAsync("no-such-batch");
+
+        deleted.Should().Be(0);
+    }
+
+    private static AwsS3FileStorage CreateStorage(string serviceUrl)
+    {
+        var options = Options.Create(new CloudStorageOptions
+        {
+            Provider = CloudStorageProvider.AwsS3,
+            AwsS3 = new AwsS3Options
+            {
+                BucketName = "unit-test-bucket",
+                Region = "us-east-1",
+                AccessKeyId = "test-access-key",
+                SecretAccessKey = "test-secret-key",
+                ServiceUrl = serviceUrl,
+                ForcePathStyle = true
+            }
+        });
+
+        return new AwsS3FileStorage(
+            options,
+            NullLogger<AwsS3FileStorage>.Instance,
+            new InMemoryUploadProgressStore());
+    }
+
+    /// <summary>
+    /// Minimal local S3 endpoint that answers every GET (ListObjectsV2) with the canonical
+    /// empty ListBucketResult document. Requests other than listings are answered 404 so any
+    /// unexpected follow-up call (e.g. a per-object HEAD) surfaces as a test failure rather
+    /// than hanging.
+    /// </summary>
+    private sealed class EmptyListObjectsStub : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly Task _serveLoop;
+        private int _listRequestCount;
+
+        public string ServiceUrl { get; }
+
+        public int ListRequestCount => Volatile.Read(ref _listRequestCount);
+
+        private EmptyListObjectsStub(HttpListener listener, string serviceUrl)
+        {
+            _listener = listener;
+            ServiceUrl = serviceUrl;
+            _serveLoop = Task.Run(ServeAsync);
+        }
+
+        public static EmptyListObjectsStub Start()
+        {
+            // HttpListener cannot bind port 0, so probe for a free port. Retry a few times to
+            // absorb the small race between picking the port and binding the listener.
+            for (var attempt = 0; ; attempt++)
+            {
+                var port = GetFreeTcpPort();
+                var listener = new HttpListener();
+                listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+                try
+                {
+                    listener.Start();
+                    return new EmptyListObjectsStub(listener, $"http://127.0.0.1:{port}");
+                }
+                catch (HttpListenerException) when (attempt < 5)
+                {
+                    listener.Close();
+                }
+            }
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var probe = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        private async Task ServeAsync()
+        {
+            while (!_shutdown.IsCancellationRequested)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await _listener.GetContextAsync().ConfigureAwait(false);
+                }
+                catch (Exception) when (_shutdown.IsCancellationRequested || !_listener.IsListening)
+                {
+                    return;
+                }
+
+                try
+                {
+                    if (string.Equals(context.Request.HttpMethod, "GET", StringComparison.Ordinal) &&
+                        context.Request.QueryString["list-type"] == "2")
+                    {
+                        Interlocked.Increment(ref _listRequestCount);
+                        var payload = Encoding.UTF8.GetBytes(EmptyListBucketResultXml);
+                        context.Response.StatusCode = 200;
+                        context.Response.ContentType = "application/xml";
+                        context.Response.ContentLength64 = payload.Length;
+                        await context.Response.OutputStream.WriteAsync(payload).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 404;
+                    }
+                }
+                catch (Exception)
+                {
+                    // The client may abort mid-response during shutdown; ignore.
+                }
+                finally
+                {
+                    try
+                    {
+                        context.Response.Close();
+                    }
+                    catch (Exception)
+                    {
+                        // Already closed/aborted.
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _shutdown.Cancel();
+            try
+            {
+                _listener.Stop();
+                _listener.Close();
+            }
+            catch (Exception)
+            {
+                // Listener may already be stopped.
+            }
+
+            try
+            {
+                _serveLoop.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception)
+            {
+                // Best-effort shutdown; the loop exits on listener stop.
+            }
+
+            _shutdown.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2311

## Summary
Rework of the P0.3 demo-render delivery after gate review. Two independent fixes:

**1. The live demo's actual 500 (AWS SDK v4 null collections).** demo.honua.io runs on Lambda with `FileStorage__Provider=AwsS3`, so rendered-image `href`/`f=json` exports persist via the cloud branch of `CloudBackedTemporaryFileService`. The CloudWatch stack trace for a live failing `MapServer/export?f=json` shows the render completing (10,000 features in 1.2 s) and then `NullReferenceException` in `AwsS3FileStorage.ListFilesAsync`, called from `EnsureCloudStorageCapacityAsync` during `StoreTemporaryFileAsync`; the identical stack reproduces for ImageServer `exportImage?f=json`. Cause: the capacity check lists the `temporary-files/` prefix, which is empty on the demo bucket (`list-objects-v2` → `KeyCount: 0`, no `Contents` element), and AWS SDK v4 (`AWSSDK.S3 4.0.21.2`) leaves `ListObjectsV2Response.S3Objects` **null** — not empty — when a listing has no results. The code already handled SDK v4 nullability for `IsTruncated` but dereferenced `S3Objects` unguarded in three methods. This also explains the failure asymmetry precisely: `f=image` streams bytes without listing S3 (200 live), `f=json` must persist (500 live) — and the bug is self-sustaining because the failing store keeps the prefix empty.

**2. Read-only-root gap in the AOT image.** `docker/Dockerfile.aot` declares `security.read-only-root="true"` but provisions only logs/cache/diagnostics as writable — the same defect #2486 fixed in the root `Dockerfile` — and the #2486 guard test hardcoded the root `Dockerfile` path so it did not protect the AOT image. The guard test now discovers every Dockerfile that declares the read-only-root label and enforces provisioning in each. (`docker/Dockerfile.functions.aot` and the lambda Dockerfiles declare no read-only-root posture and rely on platform-writable filesystems — no change needed there.)

Demo remediation after merge is an image bump only (rebuild/push `*-lambda-aot`, update the demo Lambda image): Redis and S3 IAM are already correctly configured on the demo, and with the S3 provider the `/temp/{token}` href resolves via S3 + the Redis token cache, so it is safe across Lambda instances.

**Proposed follow-ups (kept out of this PR to keep it minimal and fast to merge):** (1) `CloudBackedTemporaryFileService.EnsureCloudStorageCapacityAsync` lets any capacity-listing failure fail the user's render even though the rendered image is already in hand; degrading gracefully — log the capacity-check failure and proceed with the upload (quota enforcement is advisory, and S3 TTL metadata still bounds growth) — would have kept exports alive through this bug. (2) The pre-store `CleanupExpiredFilesAsync` lists the whole bucket with a per-object HEAD on every temp write (~6.5 s of the observed request); scoping it to the `temporary-files/` prefix would cut most of that.

## Changes Made
- `AwsS3FileStorage`: normalize `ListObjectsV2Response.S3Objects` (null under AWS SDK v4 when a listing has no results) before dereferencing in `ListFilesAsync`, `CleanupExpiredFilesAsync`, and `DeleteByPrefixAsync` (same-pattern sweep found no other unguarded sites).
- Add `AwsS3FileStorageEmptyListingTests`: drives the real `AwsS3FileStorage` and the real SDK unmarshaller against a local HTTP stub returning the exact empty `ListBucketResult` payload live S3 returns, covering all three affected methods. All three fail with `NullReferenceException` before the fix, pass after.
- `docker/Dockerfile.aot`: provision `/tmp/honua-temp` and `/tmp/honua-storage` as writable runtime directories (mkdir + chown uid 1001 + chmod 750), matching the root `Dockerfile` fix from #2486.
- `DockerfileWritableStorageDirectoryTests`: generalized from the hardcoded root `Dockerfile` to discover every Dockerfile declaring `security.read-only-root="true"` (repo root + `docker/`), so new read-only-root images are covered automatically. Fails against the unfixed `docker/Dockerfile.aot`, passes after.

## Testing
- [x] Unit tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires infrastructure changes

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
