### PR TITLE
perf(metadata): cache Metadata v2 graph snapshot on the hot read path

### DIFF
--- a/src/Honua.Core.Abstractions/Features/Metadata/Abstractions/IMetadataV2GraphCacheInvalidator.cs
+++ b/src/Honua.Core.Abstractions/Features/Metadata/Abstractions/IMetadataV2GraphCacheInvalidator.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Metadata.Abstractions;
+
+/// <summary>
+/// Drops any in-process cached Metadata v2 graph snapshot for an environment so the next
+/// read reloads it from the backing store.
+/// </summary>
+/// <remarks>
+/// The canonical read path resolves services/layers through <see cref="IMetadataV2GraphProvider"/>,
+/// which the shared caching decorator wraps with a short-TTL, per-instance snapshot cache. The
+/// single canonical catalog write (<c>IMetadataV2GraphStore.SaveAsync</c>) invalidates that cache
+/// on the writing node so read surfaces observe the mutation immediately instead of waiting out
+/// the TTL. Multi-node deployments still bound cross-node staleness with the TTL because a save on
+/// one node does not reach the others' in-process caches; the TTL is the correctness backstop and
+/// this hook is the same-node fast path. Read-modify-write callers do not depend on this: they read
+/// the persisted snapshot directly through the uncached store, never the cached provider.
+/// </remarks>
+public interface IMetadataV2GraphCacheInvalidator
+{
+    /// <summary>
+    /// Invalidates the cached snapshot for the supplied environment.
+    /// </summary>
+    /// <param name="environment">The metadata environment whose cached snapshot should be dropped.</param>
+    void Invalidate(string environment);
+
+    /// <summary>
+    /// Invalidates every cached snapshot across all environments.
+    /// </summary>
+    void InvalidateAll();
+}

--- a/src/Honua.Core/Features/Caching/CacheOptions.cs
+++ b/src/Honua.Core/Features/Caching/CacheOptions.cs
@@ -79,6 +79,23 @@ public sealed class CacheOptions
     public double JitterPercentage { get; set; } = 0.2;
 
     /// <summary>
+    /// Whether the in-process Metadata v2 graph snapshot cache is enabled. When enabled, the
+    /// caching provider decorator reuses one materialized catalog snapshot across request scopes
+    /// instead of re-reading the full catalog document (whole-JSONB SELECT + deserialize + index
+    /// rebuild) on every catalog resolution. Default is true.
+    /// </summary>
+    public bool MetadataGraphCacheEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Time-to-live for the in-process Metadata v2 graph snapshot cache in seconds. Kept short to
+    /// bound cross-node staleness in multi-node deployments (a catalog write on one node does not
+    /// reach another node's in-process cache); same-node writes invalidate immediately. Set to 0 to
+    /// disable the snapshot cache. Default is 10 seconds.
+    /// </summary>
+    [Range(0, 3600, ErrorMessage = "MetadataGraphTtlSeconds must be between 0 and 3600 seconds.")]
+    public int MetadataGraphTtlSeconds { get; set; } = 10;
+
+    /// <summary>
     /// Whether to use in-memory fallback when Redis is unavailable.
     /// Default is true for high availability.
     /// </summary>
@@ -169,6 +186,11 @@ public sealed class CacheOptions
     /// Gets the query response TTL as a TimeSpan.
     /// </summary>
     public TimeSpan QueryTtl => TimeSpan.FromSeconds(QueryTtlSeconds);
+
+    /// <summary>
+    /// Gets the Metadata v2 graph snapshot cache TTL as a TimeSpan.
+    /// </summary>
+    public TimeSpan MetadataGraphTtl => TimeSpan.FromSeconds(MetadataGraphTtlSeconds);
 
     /// <summary>
     /// Gets the retry interval as a TimeSpan.

--- a/src/Honua.Core/Features/Metadata/Caching/CachingMetadataV2GraphProvider.cs
+++ b/src/Honua.Core/Features/Metadata/Caching/CachingMetadataV2GraphProvider.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Core.Features.Metadata.Caching;
+
+/// <summary>
+/// Read-through caching decorator over <see cref="IMetadataV2GraphProvider"/>. Serves the current
+/// graph snapshot from a shared, per-instance <see cref="MetadataV2GraphSnapshotCache"/> so repeated
+/// catalog resolutions (every MCP tool call, every REST/OGC metadata read) reuse one materialized
+/// snapshot instead of re-reading the full catalog document from the backing store on each call.
+/// </summary>
+/// <remarks>
+/// Only the read surface (<see cref="IMetadataV2GraphProvider"/>) is decorated. Admin/write paths
+/// resolve the concrete store's persisted-snapshot reader directly and are never routed through this
+/// cache, so read-modify-write always sees a fresh snapshot. Historical revision lookups
+/// (<see cref="GetByRevisionAsync"/>) are rare and revision-specific, so they pass straight through.
+/// </remarks>
+public sealed class CachingMetadataV2GraphProvider : IMetadataV2GraphProvider
+{
+    private readonly IMetadataV2GraphProvider _inner;
+    private readonly MetadataV2GraphSnapshotCache _cache;
+    private readonly string _environment;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingMetadataV2GraphProvider"/> class.
+    /// </summary>
+    /// <param name="inner">The provider that reads the snapshot from the backing store.</param>
+    /// <param name="cache">The shared per-instance snapshot cache.</param>
+    /// <param name="environment">The metadata environment this provider resolves (the cache key).</param>
+    public CachingMetadataV2GraphProvider(
+        IMetadataV2GraphProvider inner,
+        MetadataV2GraphSnapshotCache cache,
+        string environment)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _environment = string.IsNullOrWhiteSpace(environment)
+            ? throw new ArgumentException("Environment must be set.", nameof(environment))
+            : environment;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<MetadataV2GraphSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
+        => _cache.GetOrLoadAsync(_environment, _inner.GetCurrentAsync, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(long revision, CancellationToken cancellationToken = default)
+        => _inner.GetByRevisionAsync(revision, cancellationToken);
+}

--- a/src/Honua.Core/Features/Metadata/Caching/MetadataV2GraphSnapshotCache.cs
+++ b/src/Honua.Core/Features/Metadata/Caching/MetadataV2GraphSnapshotCache.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Features.Metadata.Caching;
+
+/// <summary>
+/// Process-wide, per-environment cache of the current Metadata v2 graph snapshot. Registered as a
+/// singleton so a resolved snapshot survives across request scopes; the backing store is scoped and
+/// otherwise re-reads the full catalog document (a whole-JSONB <c>SELECT</c> plus a full deserialize
+/// and index rebuild) on every call. The snapshot is immutable for its revision, so sharing the
+/// object reference across threads and requests is safe.
+/// </summary>
+/// <remarks>
+/// Staleness is bounded by a short, configurable TTL (<see cref="CacheOptions.MetadataGraphTtl"/>);
+/// this is what keeps multi-node deployments correct because a catalog write on one node does not
+/// reach another node's in-process cache. Same-node writes call <see cref="Invalidate(string)"/> for
+/// immediate freshness. Concurrent misses are coalesced (single-flight) so a TTL expiry under load
+/// triggers a single reload rather than a stampede.
+/// </remarks>
+public sealed class MetadataV2GraphSnapshotCache : IMetadataV2GraphCacheInvalidator
+{
+    private readonly ConcurrentDictionary<string, CacheSlot> _slots = new(StringComparer.Ordinal);
+    private readonly IOptions<CacheOptions> _options;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataV2GraphSnapshotCache"/> class.
+    /// </summary>
+    /// <param name="options">Cache options supplying the enablement flag and TTL.</param>
+    /// <param name="timeProvider">Time source used for TTL expiry (injected for testability).</param>
+    public MetadataV2GraphSnapshotCache(IOptions<CacheOptions> options, TimeProvider? timeProvider = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Returns the cached snapshot for the environment when fresh, otherwise loads it through
+    /// <paramref name="load"/>, caches it for the configured TTL, and returns it. When caching is
+    /// disabled or the TTL is non-positive the loader is invoked directly with no caching.
+    /// </summary>
+    /// <param name="environment">The metadata environment key.</param>
+    /// <param name="load">Loader that reads the current snapshot from the backing store.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async ValueTask<MetadataV2GraphSnapshot> GetOrLoadAsync(
+        string environment,
+        Func<CancellationToken, ValueTask<MetadataV2GraphSnapshot>> load,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(load);
+
+        var options = _options.Value;
+        var ttl = options.MetadataGraphTtl;
+        if (!options.MetadataGraphCacheEnabled || ttl <= TimeSpan.Zero)
+        {
+            return await load(cancellationToken).ConfigureAwait(false);
+        }
+
+        // Fast path: a single volatile read of the slot state — no lock, torn-read-free.
+        if (_slots.TryGetValue(environment, out var existing)
+            && existing.State is { } fresh
+            && !IsExpired(fresh, _timeProvider.GetTimestamp()))
+        {
+            return await fresh.Snapshot.ConfigureAwait(false);
+        }
+
+        // Slow path: coalesce concurrent reloads for this environment under a per-slot lock so a
+        // TTL expiry under load triggers a single store read instead of a stampede.
+        Task<MetadataV2GraphSnapshot> snapshotTask;
+        var slot = _slots.GetOrAdd(environment, static _ => new CacheSlot());
+        lock (slot.Gate)
+        {
+            var now = _timeProvider.GetTimestamp();
+            if (slot.State is { } current && !IsExpired(current, now))
+            {
+                snapshotTask = current.Snapshot;
+            }
+            else
+            {
+                var expiresAt = now + (long)(ttl.TotalSeconds * _timeProvider.TimestampFrequency);
+                snapshotTask = LoadAndCacheAsync(environment, slot, load, cancellationToken);
+                slot.State = new SlotState(snapshotTask, expiresAt);
+            }
+        }
+
+        return await snapshotTask.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Invalidate(string environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        _slots.TryRemove(environment, out _);
+    }
+
+    /// <inheritdoc />
+    public void InvalidateAll() => _slots.Clear();
+
+    private static bool IsExpired(SlotState state, long nowTicks)
+    {
+        if (nowTicks >= state.ExpiresAtTicks)
+        {
+            return true;
+        }
+
+        // A faulted or cancelled load must never be served; treat it as expired so the next
+        // access rebuilds it.
+        var snapshot = state.Snapshot;
+        return snapshot.IsFaulted || snapshot.IsCanceled;
+    }
+
+    private async Task<MetadataV2GraphSnapshot> LoadAndCacheAsync(
+        string environment,
+        CacheSlot slot,
+        Func<CancellationToken, ValueTask<MetadataV2GraphSnapshot>> load,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await load(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Never cache a failed load: drop the slot so the next caller retries the store
+            // rather than replaying the exception for the whole TTL window.
+            lock (slot.Gate)
+            {
+                slot.State = null;
+            }
+
+            _slots.TryRemove(new KeyValuePair<string, CacheSlot>(environment, slot));
+            throw;
+        }
+    }
+
+    private sealed class CacheSlot
+    {
+        public object Gate { get; } = new();
+
+        // Immutable state swapped atomically; reads on the fast path see either the old or new
+        // reference, never a torn value.
+        public volatile SlotState? State;
+    }
+
+    private sealed record SlotState(Task<MetadataV2GraphSnapshot> Snapshot, long ExpiresAtTicks);
+}

--- a/src/Honua.Core/Features/Metadata/MetadataServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Metadata/MetadataServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Caching;
 using Honua.Core.Features.Metadata.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -26,6 +27,25 @@ public static class MetadataServiceCollectionExtensions
         services.TryAddSingleton<IMetadataReleasePackageStore, InMemoryMetadataReleasePackageStore>();
         services.TryAddScoped<IMetadataReleaseService, MetadataReleaseService>();
         services.TryAddScoped<IMetadataCompatibilityPrevalidationService, MetadataCompatibilityPrevalidationService>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the shared, per-instance Metadata v2 graph snapshot cache and its invalidation
+    /// hook. Idempotent — safe to call from every provider registration path. The cache lets the
+    /// caching provider decorator reuse one materialized snapshot across request scopes instead of
+    /// re-reading the full catalog document on every catalog resolution. Staleness is bounded by
+    /// <c>Cache:MetadataGraphTtlSeconds</c>; catalog writes invalidate the writing node immediately.
+    /// </summary>
+    /// <param name="services">The service collection to add services to.</param>
+    public static IServiceCollection AddMetadataV2GraphSnapshotCache(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<MetadataV2GraphSnapshotCache>();
+        services.TryAddSingleton<IMetadataV2GraphCacheInvalidator>(
+            static sp => sp.GetRequiredService<MetadataV2GraphSnapshotCache>());
         return services;
     }
 

--- a/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2GraphStore.cs
+++ b/src/Honua.Postgres/Features/Metadata/PostgresMetadataV2GraphStore.cs
@@ -22,6 +22,7 @@ namespace Honua.Postgres.Features.Metadata;
 internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMetadataV2GraphWriteBaseReader
 {
     private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly IMetadataV2GraphCacheInvalidator? _cacheInvalidator;
     private readonly string _environment;
     private readonly string _schemaName;
     private readonly string _snapshotsTable;
@@ -36,7 +37,8 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
     public PostgresMetadataV2GraphStore(
         IAdoNetDatabaseConnectionProvider connectionProvider,
         string environment,
-        string? schemaName = null)
+        string? schemaName = null,
+        IMetadataV2GraphCacheInvalidator? cacheInvalidator = null)
     {
         ArgumentNullException.ThrowIfNull(connectionProvider);
         if (string.IsNullOrWhiteSpace(environment))
@@ -45,6 +47,7 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
         }
 
         _connectionProvider = connectionProvider;
+        _cacheInvalidator = cacheInvalidator;
         _environment = environment;
         _schemaName = string.IsNullOrWhiteSpace(schemaName) ? "honua" : schemaName.Trim();
         _snapshotsTable = Infrastructure.SchemaSearchPath.QualifyTable("metadata_v2_snapshots", schemaName);
@@ -233,6 +236,14 @@ internal sealed class PostgresMetadataV2GraphStore : IMetadataV2GraphStore, IMet
 
         var snapshot = new MetadataV2GraphSnapshot(graph, etag, DateTimeOffset.UtcNow);
         _cachedCurrent = snapshot;
+
+        // Drop the shared read-through snapshot cache for this environment so read surfaces
+        // (MCP tools, REST/OGC metadata) observe the committed mutation immediately on this node
+        // instead of waiting out the TTL. Other nodes remain TTL-bounded. This is the canonical
+        // catalog write, so every mutation path (admin publish, migration/import, release
+        // reconcilers) invalidates through here. (mcp A2 hot-path caching.)
+        _cacheInvalidator?.Invalidate(_environment);
+
         return snapshot;
     }
 

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -28,7 +28,9 @@ using Honua.Core.Features.Infrastructure.Caching;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Infrastructure.Monitoring;
 using Honua.Core.Features.Infrastructure.Resilience;
+using Honua.Core.Features.Metadata;
 using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Caching;
 using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Share.Abstractions;
@@ -216,12 +218,27 @@ internal static class ServiceCollectionExtensions
             Features.FieldWorkflows.PostgresFieldExportStore>();
 
         // Register Metadata v2 graph store (Postgres-backed JSONB + sidecar indexes)
+        var metadataEnvironment = configuration["Metadata:Environment"] ?? configuration["Environment"] ?? "default";
+
+        // Shared, per-instance snapshot cache (idempotent registration) so repeated catalog reads
+        // reuse one materialized snapshot instead of re-reading the full catalog document on every
+        // MCP tool call / REST/OGC metadata resolution. (mcp A2 hot-path caching.)
+        services.AddMetadataV2GraphSnapshotCache();
+
         services.AddScoped<IMetadataV2GraphStore>(serviceProvider =>
             new Features.Metadata.PostgresMetadataV2GraphStore(
                 serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
-                configuration["Metadata:Environment"] ?? configuration["Environment"] ?? "default",
-                configuration["Database:Schema"]));
-        services.AddScoped<IMetadataV2GraphProvider>(sp => sp.GetRequiredService<IMetadataV2GraphStore>());
+                metadataEnvironment,
+                configuration["Database:Schema"],
+                serviceProvider.GetRequiredService<IMetadataV2GraphCacheInvalidator>()));
+
+        // The read surface is the cached path; the write surface (IMetadataV2GraphStore) stays the
+        // raw store so read-modify-write publish paths always load a fresh persisted snapshot.
+        services.AddScoped<IMetadataV2GraphProvider>(serviceProvider =>
+            new CachingMetadataV2GraphProvider(
+                serviceProvider.GetRequiredService<IMetadataV2GraphStore>(),
+                serviceProvider.GetRequiredService<MetadataV2GraphSnapshotCache>(),
+                metadataEnvironment));
         // Legacy V1 catalog -> Metadata v2 graph projector (honua-server#2081). Lets compat
         // seeding paths (cloud-demo reset/startup) project freshly-seeded legacy services
         // into the active graph store so the v2 read paths resolve them.

--- a/src/Honua.Server/appsettings.json
+++ b/src/Honua.Server/appsettings.json
@@ -133,7 +133,9 @@
     "EnableFallback": true,
     "FallbackMaxEntries": 1000,
     "RetryIntervalSeconds": 30,
-    "KeyPrefix": "honua:"
+    "KeyPrefix": "honua:",
+    "MetadataGraphCacheEnabled": true,
+    "MetadataGraphTtlSeconds": 10
   },
   "Deployment": {
     "Mode": "SingleInstance"

--- a/tests/dotnet/Honua.Core.Tests/Features/Metadata/Caching/MetadataV2GraphSnapshotCacheTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Metadata/Caching/MetadataV2GraphSnapshotCacheTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Metadata.Caching;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Core.Tests.Features.Metadata.Caching;
+
+/// <summary>
+/// Unit tests for the shared per-instance Metadata v2 graph snapshot cache and its caching
+/// provider decorator (MCP A2 hot-path caching). Proves repeated reads reuse one materialized
+/// snapshot, staleness is TTL-bounded, catalog writes invalidate immediately, disabling the cache
+/// is a transparent pass-through, and failed loads are never cached.
+/// </summary>
+public sealed class MetadataV2GraphSnapshotCacheTests
+{
+    private const string Environment = "test-env";
+
+    [Fact]
+    public async Task GetCurrentAsync_RepeatedCalls_LoadsBackingStoreOnce()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1));
+        var cache = NewCache(ttlSeconds: 60, out _);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var snapshot = await sut.GetCurrentAsync();
+            snapshot.Revision.Should().Be(1);
+        }
+
+        provider.GetCurrentCalls.Should().Be(1, "the snapshot should be materialized once and reused within the TTL window");
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_AfterTtlExpires_ReloadsBackingStore()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1));
+        var cache = NewCache(ttlSeconds: 30, out var clock);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        await sut.GetCurrentAsync();
+        await sut.GetCurrentAsync();
+        provider.GetCurrentCalls.Should().Be(1);
+
+        // Advance past the TTL so the next read must reload — this is the multi-node staleness bound.
+        clock.Advance(TimeSpan.FromSeconds(31));
+        provider.Next = SnapshotWithRevision(2);
+
+        var reloaded = await sut.GetCurrentAsync();
+        reloaded.Revision.Should().Be(2);
+        provider.GetCurrentCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Invalidate_DropsCachedSnapshot_SoNextReadReloads()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1));
+        var cache = NewCache(ttlSeconds: 3600, out _);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        (await sut.GetCurrentAsync()).Revision.Should().Be(1);
+        provider.GetCurrentCalls.Should().Be(1);
+
+        // Simulate a catalog write on this node: SaveAsync invalidates the shared cache.
+        provider.Next = SnapshotWithRevision(2);
+        cache.Invalidate(Environment);
+
+        (await sut.GetCurrentAsync()).Revision.Should().Be(2, "invalidation must force a fresh read even inside the TTL window");
+        provider.GetCurrentCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task InvalidateAll_DropsEveryEnvironment()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1));
+        var cache = NewCache(ttlSeconds: 3600, out _);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        await sut.GetCurrentAsync();
+        provider.Next = SnapshotWithRevision(2);
+        cache.InvalidateAll();
+
+        (await sut.GetCurrentAsync()).Revision.Should().Be(2);
+        provider.GetCurrentCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenCacheDisabled_AlwaysReadsBackingStore()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1));
+        var cache = NewCache(ttlSeconds: 60, out _, enabled: false);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        await sut.GetCurrentAsync();
+        await sut.GetCurrentAsync();
+        await sut.GetCurrentAsync();
+
+        provider.GetCurrentCalls.Should().Be(3, "a disabled cache must be a transparent pass-through");
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenTtlIsZero_AlwaysReadsBackingStore()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1));
+        var cache = NewCache(ttlSeconds: 0, out _);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        await sut.GetCurrentAsync();
+        await sut.GetCurrentAsync();
+
+        provider.GetCurrentCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_ConcurrentMisses_CoalesceIntoSingleLoad()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1)) { LoadDelay = TimeSpan.FromMilliseconds(50) };
+        var cache = NewCache(ttlSeconds: 60, out _);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        var tasks = Enumerable.Range(0, 32).Select(_ => sut.GetCurrentAsync().AsTask()).ToArray();
+        await Task.WhenAll(tasks);
+
+        tasks.Should().OnlyContain(t => t.Result.Revision == 1);
+        provider.GetCurrentCalls.Should().Be(1, "a stampede of concurrent misses must trigger a single backing-store read");
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_WhenLoadThrows_DoesNotCacheFailure()
+    {
+        var provider = new CountingProvider(SnapshotWithRevision(1)) { ThrowOnce = true };
+        var cache = NewCache(ttlSeconds: 60, out _);
+        var sut = new CachingMetadataV2GraphProvider(provider, cache, Environment);
+
+        var act = async () => await sut.GetCurrentAsync();
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // The failed load must not have been cached — the retry succeeds and loads afresh.
+        var snapshot = await sut.GetCurrentAsync();
+        snapshot.Revision.Should().Be(1);
+        provider.GetCurrentCalls.Should().Be(2);
+    }
+
+    private static MetadataV2GraphSnapshotCache NewCache(int ttlSeconds, out TestClock clock, bool enabled = true)
+    {
+        clock = new TestClock();
+        var options = Options.Create(new CacheOptions
+        {
+            MetadataGraphCacheEnabled = enabled,
+            MetadataGraphTtlSeconds = ttlSeconds,
+        });
+        return new MetadataV2GraphSnapshotCache(options, clock);
+    }
+
+    private static MetadataV2GraphSnapshot SnapshotWithRevision(long revision)
+    {
+        var graph = new MetadataV2Graph
+        {
+            Environment = Environment,
+            Revision = revision,
+            GeneratedAt = DateTimeOffset.UtcNow,
+        };
+        return new MetadataV2GraphSnapshot(graph, $"\"rev-{revision}\"", DateTimeOffset.UtcNow);
+    }
+
+    private sealed class CountingProvider(MetadataV2GraphSnapshot initial)
+        : Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider
+    {
+        private int _calls;
+
+        public int GetCurrentCalls => Volatile.Read(ref _calls);
+
+        public MetadataV2GraphSnapshot Next { get; set; } = initial;
+
+        public TimeSpan LoadDelay { get; set; }
+
+        public bool ThrowOnce { get; set; }
+
+        public async ValueTask<MetadataV2GraphSnapshot> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _calls);
+            if (LoadDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(LoadDelay, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (ThrowOnce)
+            {
+                ThrowOnce = false;
+                throw new InvalidOperationException("transient load failure");
+            }
+
+            return Next;
+        }
+
+        public ValueTask<MetadataV2GraphSnapshot?> GetByRevisionAsync(long revision, CancellationToken cancellationToken = default)
+            => new((MetadataV2GraphSnapshot?)null);
+    }
+
+    /// <summary>Manually advanced monotonic clock for deterministic TTL tests.</summary>
+    private sealed class TestClock : TimeProvider
+    {
+        private long _ticks = 1_000_000;
+
+        public override long GetTimestamp() => Interlocked.Read(ref _ticks);
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public void Advance(TimeSpan delta) => Interlocked.Add(ref _ticks, (long)(delta.TotalSeconds * TimestampFrequency));
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphCacheTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphCacheTests.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using FluentAssertions;
+using Honua.Core.Features.Caching;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Metadata.Caching;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Postgres.Features.Metadata;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Infrastructure;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using Xunit.Abstractions;
+
+namespace Honua.Postgres.Tests.Features.Metadata;
+
+/// <summary>
+/// Integration tests for the Metadata v2 hot-path snapshot cache (MCP A2). Proves, against the real
+/// Postgres store, that the caching provider decorator serves repeated catalog reads from one
+/// materialized snapshot, that a catalog write through the store invalidates that cache so read
+/// surfaces observe the mutation immediately, and measures the per-call wall-clock delta the cache
+/// removes from the hot path.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresMetadataV2GraphCacheTests(PostgresFixture fixture, ITestOutputHelper output)
+{
+    private const string Environment = "Test";
+
+    [IntegrationTest]
+    public async Task CachedProvider_RepeatedReads_ServeOneSnapshot_AndSaveInvalidates()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataV2GraphCacheTests));
+        try
+        {
+            var connectionProvider = new TestConnectionProvider(fixture.DataSource, schema);
+            var cache = new MetadataV2GraphSnapshotCache(
+                Options.Create(new CacheOptions { MetadataGraphCacheEnabled = true, MetadataGraphTtlSeconds = 3600 }));
+
+            // Read surface: the store wired to invalidate the shared cache on write.
+            var store = new PostgresMetadataV2GraphStore(connectionProvider, Environment, schema, cache);
+            var provider = new CachingMetadataV2GraphProvider(store, cache, Environment);
+
+            // A second store WITHOUT the invalidator simulates a mutation from another node — it
+            // updates the database but does not touch this node's in-process cache.
+            var otherNodeStore = new PostgresMetadataV2GraphStore(connectionProvider, Environment, schema);
+
+            var snap1 = await store.SaveAsync(BuildGraph(revision: 1, serviceCount: 3), expectedEtag: null);
+
+            // First read materializes and caches the snapshot.
+            (await provider.GetCurrentAsync()).Graph.Revision.Should().Be(1);
+
+            // Out-of-band mutation (another node) advances the database to revision 2 but leaves this
+            // node's cache untouched — the cached read must still return revision 1 within the TTL.
+            var snap2 = await otherNodeStore.SaveAsync(BuildGraph(revision: 2, serviceCount: 3), expectedEtag: snap1.Etag);
+            (await provider.GetCurrentAsync()).Graph.Revision.Should()
+                .Be(1, "reads are served from the per-instance cache until the TTL expires or a local write invalidates");
+
+            // A write through the invalidator-wired store (the canonical SaveAsync seam) drops the
+            // cache so the very next read observes the fresh catalog immediately.
+            await store.SaveAsync(BuildGraph(revision: 3, serviceCount: 3), expectedEtag: snap2.Etag);
+            (await provider.GetCurrentAsync()).Graph.Revision.Should()
+                .Be(3, "SaveAsync must invalidate the snapshot cache so read surfaces never serve a stale catalog after a local write");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task CachedProvider_IsFasterThanPerCallStoreReads()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresMetadataV2GraphCacheTests));
+        try
+        {
+            var connectionProvider = new TestConnectionProvider(fixture.DataSource, schema);
+            var seedStore = new PostgresMetadataV2GraphStore(connectionProvider, Environment, schema);
+            await seedStore.SaveAsync(BuildGraph(revision: 1, serviceCount: 60), expectedEtag: null);
+
+            const int iterations = 200;
+
+            // Baseline: a fresh scoped store per call (what happens today — every request/tool call
+            // resolves a new scoped store that re-reads the full catalog document + deserializes).
+            var uncached = Stopwatch.StartNew();
+            for (var i = 0; i < iterations; i++)
+            {
+                var perCallStore = new PostgresMetadataV2GraphStore(connectionProvider, Environment, schema);
+                _ = await perCallStore.GetCurrentAsync();
+            }
+
+            uncached.Stop();
+
+            // Cached: one materialization, then in-process object-reference hits.
+            var cache = new MetadataV2GraphSnapshotCache(
+                Options.Create(new CacheOptions { MetadataGraphCacheEnabled = true, MetadataGraphTtlSeconds = 3600 }));
+            var provider = new CachingMetadataV2GraphProvider(
+                new PostgresMetadataV2GraphStore(connectionProvider, Environment, schema, cache), cache, Environment);
+
+            var cached = Stopwatch.StartNew();
+            for (var i = 0; i < iterations; i++)
+            {
+                _ = await provider.GetCurrentAsync();
+            }
+
+            cached.Stop();
+
+            var uncachedPerCall = uncached.Elapsed.TotalMilliseconds / iterations;
+            var cachedPerCall = cached.Elapsed.TotalMilliseconds / iterations;
+            output.WriteLine($"Metadata v2 GetCurrentAsync x{iterations} (60-service catalog):");
+            output.WriteLine($"  uncached (per-call store read): {uncached.Elapsed.TotalMilliseconds:F1} ms total, {uncachedPerCall:F3} ms/call");
+            output.WriteLine($"  cached   (decorator):           {cached.Elapsed.TotalMilliseconds:F1} ms total, {cachedPerCall:F3} ms/call");
+            output.WriteLine($"  speedup: {uncached.Elapsed.TotalMilliseconds / Math.Max(cached.Elapsed.TotalMilliseconds, 0.001):F1}x");
+
+            cached.Elapsed.Should().BeLessThan(uncached.Elapsed,
+                "the in-process snapshot cache must remove the per-call catalog read+deserialize from the hot path");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    private static MetadataV2Graph BuildGraph(long revision, int serviceCount)
+    {
+        var builder = new TestMetadataV2GraphBuilder()
+            .WithEnvironment(Environment)
+            .WithRevision(revision)
+            .AddConnection("conn-1", "Primary");
+
+        for (var i = 0; i < serviceCount; i++)
+        {
+            var resourceId = $"res-{i}";
+            var bindingId = $"sb-{i}";
+            var serviceId = $"svc-{i}";
+            builder
+                .AddResource(resourceId, $"Resource {i}")
+                .AddStorageBinding(bindingId, resourceId, locator: $"public.layer_{i}", connectionId: "conn-1", storageLayerId: i)
+                .AddService(serviceId, $"Service {i}", route: $"service-{i}", protocols: ["ogc-api-features"])
+                .AddPublication($"pub-{i}", serviceId, resourceId, storageBindingId: bindingId, layerIndex: 0);
+        }
+
+        return builder.Build();
+    }
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IAdoNetDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var conn = await dataSource.OpenConnectionAsync(cancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SET search_path TO \"{schemaName}\", public;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return conn;
+        }
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var conn = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var tx = await conn.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (conn, tx);
+            }
+            catch
+            {
+                await conn.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation,
+            CancellationToken cancellationToken = default)
+            => operation();
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #2538

## Summary

The Metadata v2 graph provider resolves services/layers for every MCP tool call and every REST/OGC metadata read, but the Postgres store is registered **Scoped** and its `GetCurrentAsync` re-reads the full catalog JSONB `document`, deserializes the entire `MetadataV2Graph`, and rebuilds lookup indexes on **every** call — the single worst hot-path cost (MCP A-grade Efficiency C+), compounding per request and per Lambda invocation.

This adds a shared, opt-in-by-callsite read-through cache in front of the provider so repeated catalog resolutions reuse one materialized snapshot, with correctness preserved for multi-node and admin/write paths.

**Root cause (verified):** `src/Honua.Postgres/ServiceCollectionExtensions.cs:224` aliased `IMetadataV2GraphProvider` to the Scoped `PostgresMetadataV2GraphStore`; `GetCurrentAsync` (`PostgresMetadataV2GraphStore.cs:59`) calls `TryLoadCurrentAsync` (whole-document `SELECT`) + `MaterializeSnapshot` (full deserialize + `MetadataV2GraphIndex.Build`) unconditionally — the instance `_cachedCurrent` field only avoids returning a different object, not the DB read/deserialize, and a fresh Scoped instance per request starts empty anyway.

**Design:** A `CachingMetadataV2GraphProvider` decorator (Honua.Core) serves the snapshot from a process-wide, per-environment `MetadataV2GraphSnapshotCache` (singleton; single-flight; short configurable TTL). Only the **read** interface (`IMetadataV2GraphProvider`) is decorated — admin/write paths inject the concrete `IMetadataV2GraphStore` and read the persisted snapshot directly (`TryGetPersistedCurrentAsync`), so read-modify-write is always fresh and stale-RMW is structurally impossible. Snapshots are immutable per revision, so a cache hit is a pure memory read (no DB round-trip, no deserialize, no index rebuild) — ideal for per-instance Lambda memory. Reuses the existing `Cache` options section/posture rather than adding a parallel cache stack.

**Staleness bounds:** `Cache:MetadataGraphTtlSeconds` (default **10s**, `0` disables) bounds cross-node staleness — a write on one node reaches other nodes' in-process caches within the TTL. The canonical catalog write, `PostgresMetadataV2GraphStore.SaveAsync`, invalidates the **writing** node immediately (covers admin publish, migration/import, release reconcilers — every mutation funnels through `SaveAsync`), so same-node reads observe mutations with zero staleness.

**Measured latency delta** (local Testcontainers PostGIS, 60-service catalog, 200 repeated `GetCurrentAsync` calls):

| Path | per-call | total |
|---|---:|---:|
| Uncached (per-call Scoped store read) | **5.199 ms** | 1039.8 ms |
| Cached (decorator) | **0.023 ms** | 4.6 ms |
| **Speedup** | **~225x** | |

New MCP tools (incl. incoming PRs #2494/#2495/#2497/#2499) inherit the cached path automatically because they resolve `IMetadataV2GraphProvider` from request services — no per-tool wiring.

## Changes Made
- Add `IMetadataV2GraphCacheInvalidator` (Honua.Core.Abstractions) — invalidation hook for the shared snapshot cache.
- Add `MetadataV2GraphSnapshotCache` (Honua.Core) — singleton, per-environment, single-flight, TTL-bounded snapshot cache; caches the object reference (no re-serialize on hit); never caches a failed load.
- Add `CachingMetadataV2GraphProvider` (Honua.Core) — read-through decorator over `IMetadataV2GraphProvider`; passes historical revision lookups straight through.
- Register the cache + decorate the provider in `Honua.Postgres/ServiceCollectionExtensions` (read surface only); pass the invalidator to `PostgresMetadataV2GraphStore` and call it after commit in `SaveAsync`.
- Add `Cache:MetadataGraphCacheEnabled` (default true) and `Cache:MetadataGraphTtlSeconds` (default 10) to `CacheOptions` + `appsettings.json`.
- Tests: unit coverage (caching, TTL expiry, invalidation, single-flight, disabled pass-through, failed-load non-caching) and integration coverage (end-to-end caching + `SaveAsync` invalidation against the real store, plus the latency benchmark).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
