### PR TITLE
perf(mcp): shape tool responses for token efficiency (A1)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolModels.cs
@@ -140,6 +140,16 @@ internal sealed class McpQueryFeaturesArgument
 
     [JsonPropertyName("outSrid")]
     public int? OutSrid { get; set; }
+
+    /// <summary>
+    /// Number of decimal places to round returned geometry coordinates to
+    /// (x-honua extension over the geospatial-mcp query_features shape). Defaults
+    /// to 6 (~0.1&#160;m at the equator) to keep GeoJSON compact; pass a higher
+    /// value for finer precision or a negative value for full, unrounded
+    /// coordinates. Ignored when <see cref="ReturnGeometry"/> is false.
+    /// </summary>
+    [JsonPropertyName("geometryPrecision")]
+    public int? GeometryPrecision { get; set; }
 }
 
 /// <summary>
@@ -235,6 +245,17 @@ internal sealed class McpRenderMapArgument
 
     [JsonPropertyName("transparent")]
     public bool? Transparent { get; set; }
+
+    /// <summary>
+    /// Opt-in ceiling (bytes) for inlining the rendered PNG as a base64
+    /// <c>image</c> content block (x-honua extension). When the encoded image is
+    /// at or below this size it is returned inline; otherwise — and by default
+    /// (null / 0) — the tool returns a fetchable artifact href
+    /// (<c>resource_link</c>) plus dimensions and byte size in text, so a
+    /// ~2&#160;MB render never floods the model context.
+    /// </summary>
+    [JsonPropertyName("maxInlineBytes")]
+    public int? MaxInlineBytes { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/MapToolSchemas.cs
@@ -26,6 +26,21 @@ internal static class MapToolSchemas
     /// <summary>Maximum render width/height per side (caps cost and payload).</summary>
     public const int MaxRenderSize = 1024;
 
+    /// <summary>
+    /// Default number of decimal places returned <c>honua_query_features</c>
+    /// geometry coordinates are rounded to (~0.1&#160;m at the equator). Trims
+    /// full-precision coordinate noise that otherwise dominates the response
+    /// token budget.
+    /// </summary>
+    public const int DefaultGeometryPrecision = 6;
+
+    /// <summary>
+    /// Maximum decimal places <c>geometryPrecision</c> can request. Values above
+    /// this (or below zero) skip quantization and return full-precision
+    /// coordinates; <see cref="System.Math.Round(double, int)"/> caps at 15.
+    /// </summary>
+    public const int MaxGeometryPrecision = 15;
+
     private const string ListLayersArgumentSchemaJson = """
         {
           "type": "object",
@@ -101,6 +116,11 @@ internal static class MapToolSchemas
               "type": "integer",
               "default": 4326,
               "description": "Output spatial reference (SRID/WKID) for returned geometries."
+            },
+            "geometryPrecision": {
+              "type": "integer",
+              "default": 6,
+              "description": "x-honua extension: decimal places to round returned geometry coordinates to. Defaults to 6 (~0.1 m at the equator) so coordinates stay compact instead of emitting 15-digit full-precision noise that inflates the response token budget. Pass a higher value for finer precision, or a negative value for full unrounded coordinates. Ignored when returnGeometry=false."
             }
           }
         }
@@ -162,6 +182,12 @@ internal static class MapToolSchemas
               "type": "boolean",
               "default": false,
               "description": "Render a transparent background instead of an opaque one."
+            },
+            "maxInlineBytes": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "x-honua extension: opt-in ceiling (bytes) for inlining the rendered PNG as a base64 image content block. When the encoded image is at or below this size it is returned inline; otherwise, and by default (0), the tool returns a fetchable artifact href (resource_link) with the image dimensions and byte size in text so a multi-megabyte render never floods the model context."
             }
           }
         }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/QueryFeaturesTool.cs
@@ -50,7 +50,9 @@ internal sealed class QueryFeaturesTool : IMcpTool
         Title = "Query features",
         Description = "Query features from a published layer (by serviceId/layerId) with an optional attribute WHERE clause, bbox, outFields, and result limit. Returns a GeoJSON FeatureCollection. "
             + "Paging: results are capped at 'limit' (default 100, max 1000). When the response reports exceededTransferLimit=true there are more matching features; page through them mechanically by re-issuing the SAME query with resultOffset set to the returned nextOffset, repeating until exceededTransferLimit=false. "
-            + "Set returnCountOnly=true to get just the matching {count} (no features) for a cheap cardinality check, and returnGeometry=false to return attribute-only rows (geometry omitted) when scanning attributes.",
+            + "Set returnCountOnly=true to get just the matching {count} (no features) for a cheap cardinality check, and returnGeometry=false to return attribute-only rows (geometry omitted) when scanning attributes. "
+            + "Geometry coordinates are rounded to geometryPrecision decimal places (default 6, ~0.1 m) to keep responses compact; pass a higher value for finer precision or a negative value for full precision. "
+            + "The full FeatureCollection is always in structuredContent; for large pages the text block is a one-line summary (counts, ids, paging hint), not a duplicate of the data.",
         InputSchema = MapToolSchemas.QueryFeaturesArgumentSchema,
         OutputSchema = McpToolOutputSchemas.QueryFeaturesOutputSchema,
         Annotations = McpToolAnnotationSets.ReadOnly("Query features")
@@ -79,6 +81,7 @@ internal sealed class QueryFeaturesTool : IMcpTool
         var offset = ResolveOffset(argument.ResultOffset);
         var returnGeometry = argument.ReturnGeometry ?? true;
         var returnCountOnly = argument.ReturnCountOnly ?? false;
+        var geometryPrecision = argument.GeometryPrecision ?? MapToolSchemas.DefaultGeometryPrecision;
         var outSrid = argument.OutSrid ?? 4326;
         if (outSrid <= 0)
         {
@@ -116,7 +119,10 @@ internal sealed class QueryFeaturesTool : IMcpTool
                 Count = count
             };
 
-            return McpToolHelpers.SuccessResult(countOutput, MapToolJsonContext.Default.McpQueryFeaturesOutput);
+            return McpToolHelpers.SuccessResult(
+                countOutput,
+                MapToolJsonContext.Default.McpQueryFeaturesOutput,
+                SummarizeQueryResult);
         }
 
         var result = await reader.QueryAsync(layer.StorageLayerId, query, cancellationToken).ConfigureAwait(false);
@@ -124,7 +130,7 @@ internal sealed class QueryFeaturesTool : IMcpTool
         var features = new List<JsonNode>(result.Items.Length);
         foreach (var feature in result.Items)
         {
-            features.Add(ToGeoJsonFeature(feature, geometryService, returnGeometry));
+            features.Add(ToGeoJsonFeature(feature, geometryService, returnGeometry, geometryPrecision));
         }
 
         var output = new McpQueryFeaturesOutput
@@ -141,7 +147,50 @@ internal sealed class QueryFeaturesTool : IMcpTool
             GeoJson = new McpGeoJsonFeatureCollection { Features = features }
         };
 
-        return McpToolHelpers.SuccessResult(output, MapToolJsonContext.Default.McpQueryFeaturesOutput);
+        return McpToolHelpers.SuccessResult(
+            output,
+            MapToolJsonContext.Default.McpQueryFeaturesOutput,
+            SummarizeQueryResult);
+    }
+
+    /// <summary>
+    /// One-line, information-bearing summary of a query result for the <c>text</c>
+    /// content block: feature count, layer address, offset, the paging next-step
+    /// hint, and whether geometry was included — never a duplicate of the GeoJSON
+    /// payload (which always rides in <c>structuredContent</c>).
+    /// </summary>
+    private static string SummarizeQueryResult(McpQueryFeaturesOutput output)
+    {
+        if (output.Count is { } count)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "Matched {0} feature(s) in {1}/{2} (count only, no geometry). Count in structuredContent.count.",
+                count,
+                output.ServiceId,
+                output.LayerId);
+        }
+
+        var geometryNote = output.GeoJson is { Features.Count: > 0 } collection
+            && collection.Features[0] is JsonObject first
+            && first.TryGetPropertyValue("geometry", out var geometryNode)
+            && geometryNode is null
+                ? "geometry omitted"
+                : "geometry included";
+
+        var pagingNote = output.ExceededTransferLimit && output.NextOffset is { } next
+            ? string.Format(CultureInfo.InvariantCulture, "more available: re-query with resultOffset={0}", next)
+            : "last page";
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "Returned {0} feature(s) from {1}/{2} at offset {3} ({4}, {5}). GeoJSON FeatureCollection in structuredContent.geojson.",
+            output.ReturnedCount,
+            output.ServiceId,
+            output.LayerId,
+            output.ResultOffset,
+            pagingNote,
+            geometryNote);
     }
 
     private static int ResolveLimit(int? requested)
@@ -260,13 +309,21 @@ internal sealed class QueryFeaturesTool : IMcpTool
             envelopeMaxY: maxY);
     }
 
-    private static JsonObject ToGeoJsonFeature(Feature feature, IGeometryService geometryService, bool returnGeometry)
+    private static JsonObject ToGeoJsonFeature(
+        Feature feature,
+        IGeometryService geometryService,
+        bool returnGeometry,
+        int geometryPrecision)
     {
         JsonNode? geometryNode = null;
         if (returnGeometry)
         {
             var geometryJson = geometryService.ConvertWkbToGeoJson(feature.Geometry);
             geometryNode = geometryJson is null ? null : JsonNode.Parse(geometryJson);
+            if (geometryNode is not null)
+            {
+                QuantizeCoordinates(geometryNode, geometryPrecision);
+            }
         }
 
         var properties = new JsonObject();
@@ -282,6 +339,50 @@ internal sealed class QueryFeaturesTool : IMcpTool
             ["geometry"] = geometryNode,
             ["properties"] = properties
         };
+    }
+
+    /// <summary>
+    /// Rounds every coordinate in a GeoJSON geometry node to
+    /// <paramref name="precision"/> decimal places in place. Walks the geometry
+    /// tree uniformly so Point/LineString/Polygon/Multi*/GeometryCollection
+    /// coordinates (and any <c>bbox</c>) are all quantized. A negative or
+    /// out-of-range precision leaves coordinates untouched (full precision).
+    /// </summary>
+    private static void QuantizeCoordinates(JsonNode node, int precision)
+    {
+        if (precision < 0 || precision > MapToolSchemas.MaxGeometryPrecision)
+        {
+            return;
+        }
+
+        switch (node)
+        {
+            case JsonArray array:
+                for (var i = 0; i < array.Count; i++)
+                {
+                    var element = array[i];
+                    if (element is JsonValue value && value.TryGetValue<double>(out var coordinate))
+                    {
+                        array[i] = JsonValue.Create(Math.Round(coordinate, precision, MidpointRounding.AwayFromZero));
+                    }
+                    else if (element is not null)
+                    {
+                        QuantizeCoordinates(element, precision);
+                    }
+                }
+
+                break;
+            case JsonObject obj:
+                foreach (var property in obj)
+                {
+                    if (property.Value is not null)
+                    {
+                        QuantizeCoordinates(property.Value, precision);
+                    }
+                }
+
+                break;
+        }
     }
 
     private static JsonValue? ToJsonValue(object? value) => value switch

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/RenderMapTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/MapTools/RenderMapTool.cs
@@ -8,6 +8,7 @@ using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Geoprocessing;
+using Honua.Infrastructure.Services;
 using Honua.Ai.Protocols.Mcp.Models;
 using Honua.Ai.Protocols.Mcp.Tools;
 
@@ -43,11 +44,13 @@ internal sealed class RenderMapTool : IMcpTool
     {
         Name = ToolName,
         Title = "Render map",
-        Description = "Render a map image (PNG) for one or more published layers over a bbox and return it as an inline image. Layers draw bottom-to-top. Width/height are capped at 1024 px.",
+        Description = "Render a map image (PNG) for one or more published layers over a bbox. Layers draw bottom-to-top. Width/height are capped at 1024 px. "
+            + "By default the result is a fetchable artifact reference (resource_link href) with the image dimensions and byte size in text — NOT an inline base64 image — so a multi-megabyte render never floods the model context. "
+            + "Set maxInlineBytes to opt into inlining the base64 PNG when the encoded image is at or below that size.",
         InputSchema = MapToolSchemas.RenderMapArgumentSchema,
-        // Read-only render. No OutputSchema: this tool returns an image content
-        // block, not a structuredContent payload, so there is no structured
-        // result shape to describe.
+        // Read-only render. No OutputSchema: this tool returns an image or
+        // resource_link content block, not a structuredContent payload, so there
+        // is no structured result shape to describe.
         Annotations = McpToolAnnotationSets.ReadOnly("Render map")
     };
 
@@ -113,19 +116,72 @@ internal sealed class RenderMapTool : IMcpTool
             throw new GeoprocessingStoreUnavailableException("Map rendering produced an empty image.");
         }
 
-        var base64 = Convert.ToBase64String(result.Data);
-        var caption = string.Format(
+        var extentDescription = string.Format(
             CultureInfo.InvariantCulture,
-            "Rendered {0} layer{1} at {2}x{3} px over bbox [{4}, {5}, {6}, {7}] (SRID {8}).",
-            storageLayerIds.Length,
-            storageLayerIds.Length == 1 ? string.Empty : "s",
-            result.Width,
-            result.Height,
+            "over bbox [{0}, {1}, {2}, {3}] (SRID {4})",
             bbox[0],
             bbox[1],
             bbox[2],
             bbox[3],
             bboxSrid);
+        var layerCountDescription = string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} layer{1}",
+            storageLayerIds.Length,
+            storageLayerIds.Length == 1 ? string.Empty : "s");
+
+        // Default: hand back a fetchable artifact href instead of inlining a
+        // multi-megabyte base64 PNG into the model context. Inline only when the
+        // caller opts in via maxInlineBytes AND the encoded image fits under it.
+        var maxInlineBytes = argument.MaxInlineBytes ?? 0;
+        if (maxInlineBytes > 0 && result.Data.Length <= maxInlineBytes)
+        {
+            var inlineCaption = string.Format(
+                CultureInfo.InvariantCulture,
+                "Rendered {0} at {1}x{2} px {3} ({4}, {5:N0} bytes, inlined).",
+                layerCountDescription,
+                result.Width,
+                result.Height,
+                extentDescription,
+                result.ContentType,
+                result.Data.Length);
+
+            return new McpToolsCallResult
+            {
+                IsError = false,
+                Content =
+                [
+                    new McpContentBlock { Type = "text", Text = inlineCaption },
+                    new McpContentBlock
+                    {
+                        Type = "image",
+                        Data = Convert.ToBase64String(result.Data),
+                        MimeType = result.ContentType
+                    }
+                ]
+            };
+        }
+
+        var temporaryFileService = httpContext.RequestServices.GetRequiredService<ITemporaryFileService>();
+        var href = await temporaryFileService
+            .StoreTemporaryFileAsync(
+                result.Data,
+                result.ContentType,
+                TimeSpan.FromHours(1),
+                principal: httpContext.User,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        var caption = string.Format(
+            CultureInfo.InvariantCulture,
+            "Rendered {0} at {1}x{2} px {3} ({4}, {5:N0} bytes). Fetch the image at {6} (expires in 1h); returned as an artifact reference to conserve context. Pass maxInlineBytes >= {5} to inline it instead.",
+            layerCountDescription,
+            result.Width,
+            result.Height,
+            extentDescription,
+            result.ContentType,
+            result.Data.Length,
+            href);
 
         return new McpToolsCallResult
         {
@@ -135,8 +191,9 @@ internal sealed class RenderMapTool : IMcpTool
                 new McpContentBlock { Type = "text", Text = caption },
                 new McpContentBlock
                 {
-                    Type = "image",
-                    Data = base64,
+                    Type = "resource_link",
+                    Uri = href,
+                    Name = "rendered-map",
                     MimeType = result.ContentType
                 }
             ]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
@@ -397,11 +397,27 @@ internal sealed class McpContentBlock
     public string? Data { get; set; }
 
     /// <summary>
-    /// MIME type for an <c>image</c> content block (e.g. <c>image/png</c>). Null
-    /// for text blocks.
+    /// MIME type for an <c>image</c> or <c>resource_link</c> content block (e.g.
+    /// <c>image/png</c>). Null for text blocks.
     /// </summary>
     [JsonPropertyName("mimeType")]
     public string? MimeType { get; set; }
+
+    /// <summary>
+    /// Target URI for a <c>resource_link</c> content block (MCP 2025-06-18). Used
+    /// by <c>honua_render_map</c> to hand back a fetchable artifact href instead
+    /// of inlining a multi-megabyte base64 image into the model context. Null for
+    /// text/image blocks (omitted from the wire by <c>WhenWritingNull</c>).
+    /// </summary>
+    [JsonPropertyName("uri")]
+    public string? Uri { get; set; }
+
+    /// <summary>
+    /// Human-readable name for a <c>resource_link</c> content block. Null for
+    /// text/image blocks.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolHelpers.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolHelpers.cs
@@ -172,22 +172,64 @@ internal static class McpToolHelpers
     }
 
     /// <summary>
-    /// Builds the <see cref="McpToolsCallResult"/> for a successful tool call
-    /// with structured JSON output plus a text block containing the same data.
+    /// Serialized-text size (characters) at or above which the <c>text</c>
+    /// content block stops duplicating the full structured payload and instead
+    /// carries a one-line, information-bearing summary. The MCP spec says a
+    /// result that carries <c>structuredContent</c> SHOULD also include
+    /// functionally-equivalent <c>text</c> for backwards compatibility; small
+    /// payloads honor that literally (the compact JSON is cheap), while larger
+    /// payloads honor it with an informative summary so the same data is not
+    /// billed twice per tool call (honua-server MCP A1 token efficiency).
+    /// ~1&#160;KB keeps validate/dry-run/execute/cancel/count-only results inline
+    /// verbatim and only summarizes the genuinely large ones (feature
+    /// collections, catalogs, generated packages).
     /// </summary>
-    public static McpToolsCallResult SuccessResult<T>(T value, JsonTypeInfo<T> typeInfo)
+    public const int InlineTextThresholdChars = 1024;
+
+    /// <summary>
+    /// Builds the <see cref="McpToolsCallResult"/> for a successful tool call.
+    /// The full payload always travels in <see cref="McpToolsCallResult.StructuredContent"/>
+    /// (validated against the tool's <c>outputSchema</c>); the <c>text</c> block
+    /// carries the compact JSON verbatim when it is small
+    /// (&lt; <see cref="InlineTextThresholdChars"/>) and otherwise a one-line
+    /// information-bearing summary from <paramref name="summarize"/> (counts,
+    /// ids, next-step hints — never a bare "Success"), avoiding the ~2x token
+    /// cost of double-encoding large results. Callers with large payloads SHOULD
+    /// pass <paramref name="summarize"/>; when omitted, a generic size-bearing
+    /// summary is emitted that still points the reader at
+    /// <c>structuredContent</c>.
+    /// </summary>
+    public static McpToolsCallResult SuccessResult<T>(
+        T value,
+        JsonTypeInfo<T> typeInfo,
+        Func<T, string>? summarize = null)
     {
         var (element, text) = SerializeStructured(value, typeInfo);
+        var contentText = text.Length < InlineTextThresholdChars
+            ? text
+            : (summarize?.Invoke(value) ?? DefaultLargePayloadSummary(text));
+
         return new McpToolsCallResult
         {
             IsError = false,
             StructuredContent = element,
             Content =
             [
-                new McpContentBlock { Type = "text", Text = text }
+                new McpContentBlock { Type = "text", Text = contentText }
             ]
         };
     }
+
+    /// <summary>
+    /// Fallback summary for a large structured payload whose caller supplied no
+    /// bespoke summarizer. Information-bearing (serialized size + where the data
+    /// lives) rather than an empty acknowledgement so a reader still learns the
+    /// shape/cost of the elided text.
+    /// </summary>
+    private static string DefaultLargePayloadSummary(string serializedJson) =>
+        string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"Structured result ({serializedJson.Length:N0} chars) returned in structuredContent; text summary elided to conserve context.");
 
     /// <summary>
     /// Builds the <see cref="McpToolsCallResult"/> for a tool execution failure

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
@@ -14,6 +14,7 @@ using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Core.Queries.Filters;
 using Honua.Geoprocessing;
+using Honua.Infrastructure.Services;
 using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.Protocols.Mcp.MapTools;
 using Honua.Ai.Protocols.Mcp.Models;
@@ -335,9 +336,68 @@ public sealed class McpMapToolTests
 
     [UnitTest]
     [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_query_features")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_QueryFeatures_QuantizesGeometryToDefaultPrecision()
+    {
+        var reader = Substitute.For<IFeatureReader>();
+        reader.QueryAsync(StorageLayerId, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new QueryResult<Feature>
+            {
+                TotalCount = 1,
+                HasMoreResults = false,
+                Items =
+                [
+                    new Feature
+                    {
+                        Id = 7,
+                        Geometry = [0x01],
+                        Attributes = ImmutableDictionary<string, object?>.Empty
+                    }
+                ]
+            });
+
+        var geometryService = Substitute.For<IGeometryService>();
+        geometryService.ConvertWkbToGeoJson(Arg.Any<byte[]?>())
+            .Returns("""{"type":"Point","coordinates":[1.123456789,2.987654321]}""");
+
+        var surface = BuildSurface();
+
+        // Default precision (6 dp) rounds full-precision coordinate noise away.
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices(reader: reader, geometryService: geometryService)),
+            ToolCall("quant-1", QueryFeaturesTool.ToolName, $$"""
+                {"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}}}
+                """),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var coords = response.Result!.Value
+            .GetProperty("structuredContent").GetProperty("geojson").GetProperty("features")[0]
+            .GetProperty("geometry").GetProperty("coordinates");
+        coords[0].GetDouble().Should().Be(1.123457);
+        coords[1].GetDouble().Should().Be(2.987654);
+
+        // A negative precision opts back into full, unrounded coordinates.
+        var fullResponse = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices(reader: reader, geometryService: geometryService)),
+            ToolCall("quant-2", QueryFeaturesTool.ToolName, $$"""
+                {"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}},"geometryPrecision":-1}
+                """),
+            CancellationToken.None);
+
+        var fullCoords = fullResponse!.Result!.Value
+            .GetProperty("structuredContent").GetProperty("geojson").GetProperty("features")[0]
+            .GetProperty("geometry").GetProperty("coordinates");
+        fullCoords[0].GetDouble().Should().Be(1.123456789);
+        fullCoords[1].GetDouble().Should().Be(2.987654321);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
     [Endpoint("POST /mcp tools/call honua_render_map")]
     [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
-    public async Task ToolsCall_RenderMap_ReturnsImageContentBlock()
+    public async Task ToolsCall_RenderMap_ByDefault_ReturnsArtifactReferenceNotInlineImage()
     {
         var pngBytes = Encoding.ASCII.GetBytes("PNGDATA");
         var renderer = Substitute.For<IRasterMapRenderer>();
@@ -353,15 +413,80 @@ public sealed class McpMapToolTests
                 Height = 256
             });
 
+        const string href = "/temp/abc123.png";
+        var temporaryFileService = BuildTemporaryFileService(href);
+
         var surface = BuildSurface();
         var response = await surface.DispatchAsync(
-            AuthenticatedContext(BuildServices(renderer: renderer)),
+            AuthenticatedContext(BuildServices(renderer: renderer, temporaryFileService: temporaryFileService)),
             ToolCall("render-1", RenderMapTool.ToolName, $$"""
                 {
                   "layers":[{"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}}}],
                   "bbox":[-10,-10,10,10],
                   "width":256,
                   "height":256
+                }
+                """),
+            CancellationToken.None);
+
+        response!.Error.Should().BeNull();
+        var result = response.Result!.Value;
+        result.GetProperty("isError").GetBoolean().Should().BeFalse();
+
+        var content = result.GetProperty("content").EnumerateArray().ToArray();
+
+        // No base64 image block is inlined by default — the context stays clean.
+        content.Should().NotContain(block => block.GetProperty("type").GetString() == "image",
+            "the default render must not inline a base64 image into the model context");
+
+        var textBlock = content.Single(block => block.GetProperty("type").GetString() == "text");
+        textBlock.GetProperty("text").GetString().Should().Contain(href,
+            "the text block must carry the fetchable artifact href");
+
+        var linkBlock = content.Single(block => block.GetProperty("type").GetString() == "resource_link");
+        linkBlock.GetProperty("uri").GetString().Should().Be(href);
+        linkBlock.GetProperty("mimeType").GetString().Should().Be("image/png");
+
+        await temporaryFileService.Received(1).StoreTemporaryFileAsync(
+            Arg.Is<byte[]>(b => b.SequenceEqual(pngBytes)),
+            "image/png",
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_render_map")]
+    [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
+    public async Task ToolsCall_RenderMap_WithMaxInlineBytes_InlinesBase64Image()
+    {
+        var pngBytes = Encoding.ASCII.GetBytes("PNGDATA");
+        var renderer = Substitute.For<IRasterMapRenderer>();
+        renderer.RenderDatasetMapAsync(
+                Arg.Is<int[]>(ids => ids.Length == 1 && ids[0] == StorageLayerId),
+                Arg.Any<MapRenderRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new RasterResult
+            {
+                Data = pngBytes,
+                ContentType = "image/png",
+                Width = 256,
+                Height = 256
+            });
+
+        var temporaryFileService = BuildTemporaryFileService();
+
+        var surface = BuildSurface();
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(BuildServices(renderer: renderer, temporaryFileService: temporaryFileService)),
+            ToolCall("render-inline-1", RenderMapTool.ToolName, $$"""
+                {
+                  "layers":[{"serviceId":"{{ServiceId}}","layerId":{{LayerIndex}}}],
+                  "bbox":[-10,-10,10,10],
+                  "width":256,
+                  "height":256,
+                  "maxInlineBytes":1048576
                 }
                 """),
             CancellationToken.None);
@@ -378,6 +503,14 @@ public sealed class McpMapToolTests
         var data = imageBlock.GetProperty("data").GetString();
         data.Should().NotBeNullOrEmpty();
         Convert.FromBase64String(data!).Should().Equal(pngBytes);
+
+        // The small image fit under maxInlineBytes, so no temp artifact was created.
+        await temporaryFileService.DidNotReceive().StoreTemporaryFileAsync(
+            Arg.Any<byte[]>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
+            Arg.Any<CancellationToken>());
 
         await renderer.Received(1).RenderDatasetMapAsync(
             Arg.Any<int[]>(), Arg.Any<MapRenderRequest>(), Arg.Any<CancellationToken>());
@@ -412,7 +545,8 @@ public sealed class McpMapToolTests
     private static ServiceProvider BuildServices(
         IFeatureReader? reader = null,
         IGeometryService? geometryService = null,
-        IRasterMapRenderer? renderer = null)
+        IRasterMapRenderer? renderer = null,
+        ITemporaryFileService? temporaryFileService = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IMetadataV2GraphProvider>(BuildGraphProvider());
@@ -420,7 +554,22 @@ public sealed class McpMapToolTests
         services.AddSingleton(geometryService ?? Substitute.For<IGeometryService>());
         services.AddSingleton(renderer ?? Substitute.For<IRasterMapRenderer>());
         services.AddSingleton(Substitute.For<IFilterExpressionService>());
+        services.AddSingleton(temporaryFileService ?? BuildTemporaryFileService());
         return services.BuildServiceProvider();
+    }
+
+    private static ITemporaryFileService BuildTemporaryFileService(string href = "/temp/rendered-map.png")
+    {
+        var service = Substitute.For<ITemporaryFileService>();
+        service
+            .StoreTemporaryFileAsync(
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<System.Security.Claims.ClaimsPrincipal?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(href);
+        return service;
     }
 
     private static DefaultHttpContext AuthenticatedContext(IServiceProvider services)

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTokenEfficiencyTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTokenEfficiencyTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp.MapTools;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Xunit.Abstractions;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Measures the token cost of the MCP surface so the A1 token-efficiency work is
+/// evidenced by numbers, not assertions alone. Two axes are measured with the
+/// principal-engineer estimator (serialized chars / 4 ≈ tokens):
+/// <list type="number">
+/// <item><description><c>tools/list</c> serialized token estimate — guards against
+/// response-shaping regressions bloating the catalog, without forcing the
+/// teaching descriptions (#2499) to be gutted to win tokens.</description></item>
+/// <item><description>A representative <c>honua_query_features</c> result — proves
+/// the double-encoding fix: the full FeatureCollection rides only in
+/// <c>structuredContent</c>, and the <c>text</c> block is a compact summary
+/// rather than a byte-for-byte duplicate.</description></item>
+/// </list>
+/// </summary>
+public sealed partial class McpTaxonomyAlignmentTests
+{
+    private readonly ITestOutputHelper? _output;
+
+    /// <summary>
+    /// xUnit injects <see cref="ITestOutputHelper"/> so the measurement tests can
+    /// report exact token numbers. The parameterless-friendly nullable keeps the
+    /// other (static-helper-driven) conformance tests in this partial class
+    /// unaffected.
+    /// </summary>
+    public McpTaxonomyAlignmentTests(ITestOutputHelper output) => _output = output;
+
+    /// <summary>Principal-engineer token estimate: serialized characters / 4.</summary>
+    private static int EstimateTokens(string serialized) => serialized.Length / 4;
+
+    /// <summary>Token estimate from a raw character count.</summary>
+    private static int EstimateTokens(int chars) => chars / 4;
+
+    [UnitTest]
+    public void ToolsList_SerializedTokenEstimate_StaysWithinBudget()
+    {
+        var descriptors = BuildTools().Select(t => t.Describe()).ToArray();
+        var listResult = new McpToolsListResult { Tools = descriptors };
+
+        var serialized = JsonSerializer.Serialize(listResult, McpJsonContext.Default.McpToolsListResult);
+        var tokens = EstimateTokens(serialized);
+
+        _output?.WriteLine($"tools/list: {descriptors.Length} tools, {serialized.Length:N0} chars, ~{tokens:N0} tokens");
+
+        // The teaching descriptions (#2499) are worth their tokens; response
+        // shaping — not description trimming — is the A1 lever. Guard only against
+        // gross bloat so a future doubling of the catalog cost is caught.
+        tokens.Should().BeLessThan(15000,
+            "tools/list token cost must not balloon; the A1 win comes from response shaping, not from gutting teaching descriptions");
+    }
+
+    [UnitTest]
+    public void QueryFeatures_TextBlock_IsCompactSummaryNotDuplicatedPayload()
+    {
+        // A representative page: 100 features, each with quantized geometry and a
+        // handful of attributes — the shape query_features actually returns.
+        const int featureCount = 100;
+        var features = new List<JsonNode>(featureCount);
+        for (var i = 0; i < featureCount; i++)
+        {
+            features.Add(new JsonObject
+            {
+                ["type"] = "Feature",
+                ["id"] = i,
+                ["geometry"] = new JsonObject
+                {
+                    ["type"] = "Point",
+                    ["coordinates"] = new JsonArray(-97.743061 + (i * 0.0001), 30.267153 + (i * 0.0001)),
+                },
+                ["properties"] = new JsonObject
+                {
+                    ["parcel_id"] = $"R{100000 + i}",
+                    ["zoning"] = "R1",
+                    ["acreage"] = 0.25 + (i * 0.01),
+                },
+            });
+        }
+
+        var output = new McpQueryFeaturesOutput
+        {
+            ServiceId = "county_parcels",
+            LayerId = 0,
+            ReturnedCount = featureCount,
+            Limit = 100,
+            ResultOffset = 0,
+            ExceededTransferLimit = true,
+            NextOffset = 100,
+            GeoJson = new McpGeoJsonFeatureCollection { Features = features },
+        };
+
+        var payloadJson = JsonSerializer.Serialize(output, MapToolJsonContext.Default.McpQueryFeaturesOutput);
+
+        // "Before" (original double-encoding): SuccessResult copied the full JSON
+        // verbatim into the text block, so the wire result carried the payload
+        // twice — text == structuredContent.
+        var beforeText = payloadJson;
+        var beforeTotal = payloadJson.Length + beforeText.Length;
+
+        // "After": the live tool passes an information-bearing summarizer, so the
+        // text block is a one-line summary and the payload rides once, in
+        // structuredContent.
+        var afterResult = McpToolHelpers.SuccessResult(
+            output,
+            MapToolJsonContext.Default.McpQueryFeaturesOutput,
+            SummarizeForMeasurement);
+        var afterText = afterResult.Content[0].Text ?? string.Empty;
+        var afterTotal = payloadJson.Length + afterText.Length;
+
+        _output?.WriteLine($"query_features payload (structuredContent): {payloadJson.Length:N0} chars (~{EstimateTokens(payloadJson):N0} tokens)");
+        _output?.WriteLine($"BEFORE (double-encoded) result total {beforeTotal:N0} chars (~{EstimateTokens(beforeTotal):N0} tokens)");
+        _output?.WriteLine($"AFTER  text block: {afterText.Length:N0} chars ('{afterText}'); result total {afterTotal:N0} chars (~{EstimateTokens(afterTotal):N0} tokens)");
+        _output?.WriteLine($"result total reduction: {beforeTotal - afterTotal:N0} chars (~{EstimateTokens(beforeTotal - afterTotal):N0} tokens, {(beforeTotal - afterTotal) * 100.0 / beforeTotal:F0}%)");
+
+        // The structuredContent still carries the full payload.
+        (afterResult.StructuredContent?.GetRawText().Length ?? 0).Should().Be(payloadJson.Length);
+
+        // After, the text block is a short, information-bearing summary — not a
+        // duplicate — so the result is far smaller than the double-encoded form.
+        afterText.Length.Should().BeLessThan(payloadJson.Length / 4,
+            "the summarized text block must be a fraction of the payload, not a duplicate");
+        afterText.Should().Contain("county_parcels").And.Contain("resultOffset=100",
+            "the summary must carry the layer address and the mechanical paging next-step");
+        afterTotal.Should().BeLessThan(beforeTotal / 2 + 512,
+            "eliminating the duplicated text roughly halves the result size");
+    }
+
+    [UnitTest]
+    public void QueryFeatures_GeometryQuantization_ShrinksCoordinatePayload()
+    {
+        // Full-precision (double round-trip) coordinates vs the default 6-dp
+        // quantization the tool now applies, over a representative 100-point page.
+        const int featureCount = 100;
+        static string SerializePage(Func<int, JsonArray> coordinates)
+        {
+            var features = new List<JsonNode>(featureCount);
+            for (var i = 0; i < featureCount; i++)
+            {
+                features.Add(new JsonObject
+                {
+                    ["type"] = "Feature",
+                    ["id"] = i,
+                    ["geometry"] = new JsonObject { ["type"] = "Point", ["coordinates"] = coordinates(i) },
+                    ["properties"] = new JsonObject { ["parcel_id"] = $"R{100000 + i}" },
+                });
+            }
+
+            var output = new McpQueryFeaturesOutput
+            {
+                ServiceId = "county_parcels",
+                LayerId = 0,
+                ReturnedCount = featureCount,
+                Limit = 100,
+                GeoJson = new McpGeoJsonFeatureCollection { Features = features },
+            };
+            return JsonSerializer.Serialize(output, MapToolJsonContext.Default.McpQueryFeaturesOutput);
+        }
+
+        var fullPrecision = SerializePage(i => new JsonArray(
+            -97.743061928374651 + (i * 0.000012345678),
+            30.267153827364512 + (i * 0.000012345678)));
+        var quantized = SerializePage(i => new JsonArray(
+            Math.Round(-97.743061928374651 + (i * 0.000012345678), 6, MidpointRounding.AwayFromZero),
+            Math.Round(30.267153827364512 + (i * 0.000012345678), 6, MidpointRounding.AwayFromZero)));
+
+        _output?.WriteLine($"geometry full precision: {fullPrecision.Length:N0} chars (~{EstimateTokens(fullPrecision):N0} tokens)");
+        _output?.WriteLine($"geometry 6-dp quantized: {quantized.Length:N0} chars (~{EstimateTokens(quantized):N0} tokens)");
+        _output?.WriteLine($"quantization reduction: {fullPrecision.Length - quantized.Length:N0} chars (~{EstimateTokens(fullPrecision.Length - quantized.Length):N0} tokens, {(fullPrecision.Length - quantized.Length) * 100.0 / fullPrecision.Length:F0}%)");
+
+        quantized.Length.Should().BeLessThan(fullPrecision.Length,
+            "6-dp quantization must trim full-precision coordinate noise from the payload");
+    }
+
+    /// <summary>
+    /// Mirrors the live <c>QueryFeaturesTool</c> summary shape closely enough to
+    /// measure the token delta without reaching into the tool's private helper.
+    /// </summary>
+    private static string SummarizeForMeasurement(McpQueryFeaturesOutput output)
+    {
+        var pagingNote = output.ExceededTransferLimit && output.NextOffset is { } next
+            ? $"more available: re-query with resultOffset={next}"
+            : "last page";
+        return $"Returned {output.ReturnedCount} feature(s) from {output.ServiceId}/{output.LayerId} at offset {output.ResultOffset} ({pagingNote}, geometry included). GeoJSON FeatureCollection in structuredContent.geojson.";
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2540

## Summary
Delivers the A1 "token efficiency" workstream of the MCP A-grade program. The assessment graded MCP response efficiency C+; this PR removes the three response-shape costs it flagged — **without** trimming the #2499 teaching descriptions (the win is response shaping, not description quality). The full payload always rides in `structuredContent`; only the human-readable `text` block and the returned geometry/render bytes change.

## Changes Made
- **Double-encoding fix (`McpToolHelpers.SuccessResult`):** small payloads (< ~1KB) keep the compact JSON verbatim in the `text` block (MCP "functionally-equivalent text" nicety); larger payloads get a one-line, information-bearing summary (counts, ids, next-step hints — never "Success") while `structuredContent` carries the data. Optional per-tool summarizer; a generic size-bearing fallback otherwise. **Output schemas unchanged.**
- **Geometry quantization (`honua_query_features`):** new `geometryPrecision` param (x-honua extension over the geospatial-mcp `query_features` shape; default 6dp ≈ 0.1 m; negative = full precision) rounds returned coordinates. Added an information-bearing text summary (returned count, layer, offset, mechanical-paging next-step, geometry included/omitted).
- **Render payload (`honua_render_map`):** default now returns a fetchable artifact reference (`resource_link` href via the same `ITemporaryFileService` temp-file pipeline MapServer export uses) with dimensions + byte size in text, instead of inlining a multi-MB base64 PNG into context. Inline base64 only when the caller opts in via `maxInlineBytes` and the encoded image fits under it.
- Added `McpContentBlock.uri`/`name` (additive, nullable) so `resource_link` blocks serialize.
- Added measurement tests: `tools/list` token estimate, `query_features` double-encoding before/after, and geometry-quantization before/after.

## Measured token deltas (chars/4 estimate)
- **query_features**, representative 100-feature page: **8,245 → 4,168 tokens (−49%)** (double-encoded 32,980 chars → 16,672 chars; the 16,490-char payload is no longer duplicated into text).
- **geometry quantization** (6dp vs full precision), same page coordinates: **−12%** of the coordinate payload (~430 tokens), stacking on top of the double-encoding win.
- **tools/list**: 19 tools, 40,388 chars, **~10,097 tokens — unchanged** (teaching descriptions preserved; guard test caps at 15k so shaping can't regress into bloat).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact
<!-- Additive x-honua input params only (geometryPrecision, maxInlineBytes); outputSchemas and the geospatial-mcp required sets are unchanged. Upstreaming the two params into the geospatial-mcp standard is tracked as follow-up in #2540. -->

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. New params are optional with backward-compatible defaults; `structuredContent` and output schemas are unchanged. Clients that read the `text` block as full JSON for large results should read `structuredContent` instead (the documented, schema-backed source). The honua-sdk-js certification suite only validates `structuredContent` against `outputSchema` and asserts no text-content shape, so no cert change is required.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
