### PR TITLE
test: pin versioning.branch in the Honua.Ai.Tests manifest-capability roster

### DIFF
--- a/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
@@ -72,6 +72,7 @@ public sealed class CapabilityRegistryConformanceTests
         "publication.metadata-release",
         "upload.file",
         "edit.features",
+        "versioning.branch",
     ];
 
     // Format descriptors that intentionally exist beyond the SupportedFileFormat


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2526

## Summary
`ManifestCapabilities_AllHaveRegistryDescriptor` is red on trunk: #2532 re-curated `versioning.branch` into `CapabilityManifestService.BuildCapabilities` and the `Honua.Core.Tests` roster, but the #1186 capability roster is pinned in a third place — `CapabilityRegistryConformanceTests.ManifestCapabilityIds` in `Honua.Ai.Tests` — which was missed, so the freeze-discipline assertion fails against the updated registry. One-line roster sync.

## Changes Made
- Add `versioning.branch` to `ManifestCapabilityIds` in `tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs`.

## Testing
- [x] Unit tests added/updated

All 11 tests in `CapabilityRegistryConformanceTests` pass locally (previously 1 failing on trunk).

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
