### PR TITLE
fix: apply bound vector styles at pixel level in raster map renderer (#2498)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5988,6 +5988,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Infrastructure.Rendering.StyledVectorMapRenderTests.RenderStyledMap_VectorLayer_NoLongerThrowsNotSupported_Issue2498Regression",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetStyledMap_VectorCollectionTiff_ReturnsCleanErrorNeverPngLabeledTiff",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetStyledMap_VectorCollection_RendersPngInsteadOf501",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetStyledMap_WithValidStyle_ReachesStyledMapEndpoint",
@@ -6033,6 +6034,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Infrastructure.Rendering.StyledVectorMapRenderTests.RenderDatasetMap_BoundVectorStyle_IsAppliedAtPixelLevelAndVariesByStyle",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetDatasetMap_WithCollections_ReturnsMap",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetDatasetMap_WithoutCollections_ReturnsMap",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsErrorHandlingTests.GetDatasetMap_AllUnknownCollectionIds_ReturnsNotFound",

--- a/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
+++ b/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
@@ -513,6 +513,107 @@ internal static class RasterMapRenderingPipeline
         return VectorCollectionRenderResult.Success(imageBytes, totalFeatureCount);
     }
 
+    /// <summary>
+    /// Describes one vector layer to composite through
+    /// <see cref="RenderBoundStyleVectorLayersAsync"/>. When
+    /// <see cref="ExplicitMapLibreStyleJson"/> is <c>null</c> the layer's bound style is
+    /// resolved from the shared <see cref="ILayerStyleCatalog"/>; otherwise the supplied
+    /// MapLibre document overrides it (the styleId-resolved path).
+    /// </summary>
+    internal readonly record struct BoundStyleVectorLayer(
+        int LayerId,
+        MetadataV2GeometryType GeometryType,
+        int StorageSrid,
+        string? ExplicitMapLibreStyleJson);
+
+    /// <summary>
+    /// Composites one or more vector layers onto a single raster image, applying each
+    /// layer's bound MapLibre/drawingInfo style (fill/stroke/width/opacity for
+    /// polygon/line/point) through the shared Skia draw path — the same
+    /// <see cref="StyleTranslator"/> / <see cref="RenderLayerToCanvas"/> primitives WMS
+    /// GetMap, MapServer export, and OGC API Maps use. This is the canonical styled
+    /// vector→raster helper the vector-aware <see cref="Honua.Core.Features.Raster.Abstractions.IRasterMapRenderer"/>
+    /// composite drives so the MCP <c>honua_render_map</c> tool and the OGC/MapServer
+    /// surfaces reflect a bound style identically, with no protocol-local rasterization.
+    /// Layers draw bottom-to-top in the supplied order.
+    /// </summary>
+    internal static async Task<byte[]> RenderBoundStyleVectorLayersAsync(
+        IFeatureReader featureReader,
+        ILayerStyleCatalog styleCatalog,
+        IReadOnlyList<BoundStyleVectorLayer> layers,
+        SkiaMapRenderer.RenderExtent requestExtent,
+        int requestSrid,
+        int imageWidth,
+        int imageHeight,
+        int maxFeatures,
+        string format,
+        bool transparent,
+        SKColor? backgroundColor,
+        CancellationToken cancellationToken)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight, SKColorType.Rgba8888, SKAlphaType.Premul));
+        if (surface is null)
+        {
+            throw new InvalidOperationException($"Skia failed to allocate a render surface at {imageWidth}x{imageHeight}.");
+        }
+
+        var canvas = surface.Canvas;
+        var effectiveTransparent = transparent && string.Equals(format, "png", StringComparison.OrdinalIgnoreCase);
+        canvas.Clear(effectiveTransparent ? SKColors.Transparent : backgroundColor ?? SKColors.White);
+
+        var transform = SkiaMapRenderer.BuildTransform(requestExtent, imageWidth, imageHeight);
+
+        foreach (var layer in layers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (layer.GeometryType == MetadataV2GeometryType.None)
+            {
+                continue;
+            }
+
+            var stylePlan = layer.ExplicitMapLibreStyleJson is { } explicitJson
+                ? BuildRasterStylePlanFromJson(explicitJson)
+                : await GetRasterStylePlanAsync(styleCatalog, layer.LayerId, cancellationToken).ConfigureAwait(false);
+
+            var spatialFilter = CreateBboxSpatialFilter(requestExtent, requestSrid);
+            var featureQuery = CreateRasterFeatureQuery(
+                stylePlan,
+                spatialFilter,
+                layer.StorageSrid,
+                requestSrid,
+                maxFeatures);
+
+            var renderedPointCount = await TryRenderRasterPointFastPathAsync(
+                canvas,
+                featureReader,
+                layer.LayerId,
+                layer.GeometryType,
+                stylePlan,
+                featureQuery,
+                requestExtent,
+                imageWidth,
+                imageHeight,
+                transform,
+                cancellationToken).ConfigureAwait(false);
+            if (renderedPointCount >= 0)
+            {
+                continue;
+            }
+
+            var features = await QueryRasterFeaturesAsync(featureReader, layer.LayerId, featureQuery, cancellationToken)
+                .ConfigureAwait(false);
+            if (features.Length == 0)
+            {
+                continue;
+            }
+
+            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, layer.GeometryType);
+        }
+
+        return SkiaMapRenderer.EncodeSurface(surface, format);
+    }
+
     internal static void RenderLayerToCanvas(
         SKCanvas canvas,
         ImmutableArray<Feature> features,

--- a/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipelineLog.cs
+++ b/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipelineLog.cs
@@ -16,4 +16,13 @@ internal static partial class RasterMapRenderingPipelineLog
         int fromSrid,
         int toSrid,
         Exception exception);
+
+    [LoggerMessage(
+        EventId = 3471,
+        Level = LogLevel.Warning,
+        Message = "Failed to resolve style '{StyleId}' for styled vector render; falling back to the layer's bound style")]
+    public static partial void StyleResolutionFailed(
+        ILogger logger,
+        string styleId,
+        Exception exception);
 }

--- a/src/Honua.Hosting/Features/Rendering/VectorAwareRasterMapRenderer.cs
+++ b/src/Honua.Hosting/Features/Rendering/VectorAwareRasterMapRenderer.cs
@@ -1,0 +1,381 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Styling.Abstractions;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SkiaSharp;
+
+namespace Honua.Infrastructure.Rendering;
+
+/// <summary>
+/// Decorates the provider's raster-coverage <see cref="IRasterMapRenderer"/> (e.g. the
+/// PostGIS raster renderer) with server-side vector styling. The provider renderer only
+/// rasterizes stored raster coverages (the <c>raster_data</c> table); a bound vector style
+/// applied to a feature layer was therefore never reflected in a static render, and styled
+/// requests threw <see cref="NotSupportedException"/> (honua-server#2498).
+/// </summary>
+/// <remarks>
+/// <para>Behavior is <b>raster-first, vector-fallback</b>: whenever the wrapped renderer
+/// produces raster bytes (a layer backed by a raster coverage), those native bytes are
+/// returned unchanged, so raster rendering — including format, GDAL encoding, temporal
+/// mosaics, and multi-layer <c>ST_Union</c> merges — is untouched. Only when the raster
+/// path yields no data <b>and</b> the requested layer(s) carry geometry does this decorator
+/// render the features through the shared Skia pipeline
+/// (<see cref="RasterMapRenderingPipeline.RenderBoundStyleVectorLayersAsync"/>), applying
+/// each layer's bound MapLibre/drawingInfo style — the same styled draw path WMS GetMap,
+/// MapServer export, and OGC API Maps use. This is the render path the MCP
+/// <c>honua_render_map</c> tool drives, so an <c>honua_apply_style_preset</c> binding is now
+/// visibly reflected in the rendered pixels on the default (Postgres) profile.</para>
+/// <para>Styled vector output is encoded by Skia and therefore limited to PNG/JPEG; a TIFF
+/// (or otherwise non-Skia) request that would fall back to the vector path returns an empty
+/// result rather than mislabeled bytes, preserving the raster path's honest content typing.</para>
+/// </remarks>
+internal sealed class VectorAwareRasterMapRenderer : IRasterMapRenderer
+{
+    private readonly IRasterMapRenderer _inner;
+    private readonly IServiceProvider _services;
+    private readonly ILogger<VectorAwareRasterMapRenderer> _logger;
+
+    public VectorAwareRasterMapRenderer(
+        IRasterMapRenderer inner,
+        IServiceProvider services,
+        ILogger<VectorAwareRasterMapRenderer> logger)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<RasterResult> RenderCollectionMapAsync(
+        int layerId,
+        MapRenderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var rasterResult = await _inner.RenderCollectionMapAsync(layerId, request, cancellationToken).ConfigureAwait(false);
+        if (rasterResult.Data.Length > 0)
+        {
+            return rasterResult;
+        }
+
+        return await TryRenderStyledVectorAsync(
+            new[] { layerId },
+            request,
+            explicitStyleId: null,
+            fallback: rasterResult,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<RasterResult> RenderDatasetMapAsync(
+        int[] layerIds,
+        MapRenderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var rasterResult = await _inner.RenderDatasetMapAsync(layerIds, request, cancellationToken).ConfigureAwait(false);
+        if (rasterResult.Data.Length > 0)
+        {
+            return rasterResult;
+        }
+
+        return await TryRenderStyledVectorAsync(
+            layerIds,
+            request,
+            explicitStyleId: null,
+            fallback: rasterResult,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<RasterResult> RenderStyledMapAsync(
+        int layerId,
+        string styleId,
+        MapRenderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var snapshot = await GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        if (snapshot is not null &&
+            snapshot.Index.ResourcesByStorageLayerId.TryGetValue(layerId, out var resource) &&
+            HasGeometry(resource))
+        {
+            var styleJson = await ResolveExplicitStyleJsonAsync(styleId, cancellationToken).ConfigureAwait(false);
+            var rendered = await RenderStyledVectorLayersAsync(
+                new[] { (layerId, resource) },
+                request,
+                styleJson,
+                cancellationToken).ConfigureAwait(false);
+            if (rendered.HasValue)
+            {
+                return rendered.Value;
+            }
+        }
+
+        // Raster coverage (or a format the Skia path cannot encode): defer to the raster
+        // renderer, which reports an honest NotSupported for styled raster output.
+        return await _inner.RenderStyledMapAsync(layerId, styleId, request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<RasterResult> TryRenderStyledVectorAsync(
+        int[] layerIds,
+        MapRenderRequest request,
+        string? explicitStyleId,
+        RasterResult fallback,
+        CancellationToken cancellationToken)
+    {
+        var snapshot = await GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        if (snapshot is null)
+        {
+            return fallback;
+        }
+
+        var geometryLayers = new List<(int LayerId, MetadataV2Resource Resource)>(layerIds.Length);
+        foreach (var layerId in layerIds)
+        {
+            if (snapshot.Index.ResourcesByStorageLayerId.TryGetValue(layerId, out var resource) &&
+                HasGeometry(resource))
+            {
+                geometryLayers.Add((layerId, resource));
+            }
+        }
+
+        if (geometryLayers.Count == 0)
+        {
+            return fallback;
+        }
+
+        var styleJson = explicitStyleId is null
+            ? null
+            : await ResolveExplicitStyleJsonAsync(explicitStyleId, cancellationToken).ConfigureAwait(false);
+
+        var rendered = await RenderStyledVectorLayersAsync(geometryLayers, request, styleJson, cancellationToken)
+            .ConfigureAwait(false);
+        return rendered ?? fallback;
+    }
+
+    private async Task<RasterResult?> RenderStyledVectorLayersAsync(
+        IReadOnlyList<(int LayerId, MetadataV2Resource Resource)> geometryLayers,
+        MapRenderRequest request,
+        string? explicitStyleJson,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveSkiaFormat(request.Format, out var format))
+        {
+            // TIFF / non-Skia formats stay on the raster path so returned bytes always
+            // match the requested content type (#2365). Signal no vector render.
+            return null;
+        }
+
+        if (request.BoundingBox is not { Length: 4 })
+        {
+            return null;
+        }
+
+        var featureReader = _services.GetService<IFeatureReader>();
+        var styleCatalog = _services.GetService<ILayerStyleCatalog>();
+        if (featureReader is null || styleCatalog is null)
+        {
+            return null;
+        }
+
+        var requestSrid = request.Crs ?? request.BoundingBoxCrs ?? DefaultSrid;
+        var extent = new SkiaMapRenderer.RenderExtent(
+            request.BoundingBox[0],
+            request.BoundingBox[1],
+            request.BoundingBox[2],
+            request.BoundingBox[3]);
+
+        var layers = new List<RasterMapRenderingPipeline.BoundStyleVectorLayer>(geometryLayers.Count);
+        foreach (var (layerId, resource) in geometryLayers)
+        {
+            var geometryType = ResolveGeometryType(resource);
+            var storageSrid = resource.ReadSrid() ?? requestSrid;
+            layers.Add(new RasterMapRenderingPipeline.BoundStyleVectorLayer(
+                layerId,
+                geometryType,
+                storageSrid,
+                explicitStyleJson));
+        }
+
+        var imageBytes = await RasterMapRenderingPipeline.RenderBoundStyleVectorLayersAsync(
+            featureReader,
+            styleCatalog,
+            layers,
+            extent,
+            requestSrid,
+            request.Width,
+            request.Height,
+            RasterMapRenderingPipeline.MaxFeaturesPerLayer,
+            format,
+            request.Transparent,
+            ResolveBackgroundColor(request.BackgroundColor),
+            cancellationToken).ConfigureAwait(false);
+
+        return new RasterResult
+        {
+            Data = imageBytes,
+            ContentType = request.Format.ToContentType(),
+            Width = request.Width,
+            Height = request.Height,
+            Srid = requestSrid
+        };
+    }
+
+    private async Task<string?> ResolveExplicitStyleJsonAsync(string styleId, CancellationToken cancellationToken)
+    {
+        var styleProjection = _services.GetService<IOgcStyleProjection>();
+        if (styleProjection is null || string.IsNullOrWhiteSpace(styleId))
+        {
+            // No projection registered (or no style requested): render with the layer's
+            // bound style resolved from the catalog.
+            return null;
+        }
+
+        try
+        {
+            var stylesheet = await styleProjection
+                .GetStylesheetAsync(styleId, OgcStyleEncoding.MapboxStyle, cancellationToken)
+                .ConfigureAwait(false);
+            return stylesheet?.Content;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            RasterMapRenderingPipelineLog.StyleResolutionFailed(_logger, styleId, ex);
+            return null;
+        }
+    }
+
+    private async Task<MetadataV2GraphSnapshot?> GetSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var graphProvider = _services.GetService<IMetadataV2GraphProvider>();
+        if (graphProvider is null)
+        {
+            return null;
+        }
+
+        return await graphProvider.GetCurrentAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private const int DefaultSrid = 4326;
+
+    private static bool HasGeometry(MetadataV2Resource resource)
+        => resource.ReadGeometryType() != MetadataV2GeometryType.None ||
+           resource.FindPrimaryGeometryField() is not null;
+
+    private static MetadataV2GeometryType ResolveGeometryType(MetadataV2Resource resource)
+    {
+        var geometryType = resource.ReadGeometryType();
+        // A layer that surfaces geometry only through its schema (no typed Spatial slot)
+        // still renders; default to Polygon so the shared default-paint path draws a
+        // filled+stroked footprint rather than the point fast-path.
+        return geometryType == MetadataV2GeometryType.None
+            ? MetadataV2GeometryType.Polygon
+            : geometryType;
+    }
+
+    private static bool TryResolveSkiaFormat(RasterFormat format, out string skiaFormat)
+    {
+        switch (format)
+        {
+            case RasterFormat.PNG:
+                skiaFormat = "png";
+                return true;
+            case RasterFormat.JPEG:
+                skiaFormat = "jpeg";
+                return true;
+            default:
+                skiaFormat = string.Empty;
+                return false;
+        }
+    }
+
+    private static SKColor? ResolveBackgroundColor(string? backgroundColor)
+    {
+        if (string.IsNullOrWhiteSpace(backgroundColor))
+        {
+            return null;
+        }
+
+        // OGC background colors arrive as 0xRRGGBB; ignore anything else and fall back to
+        // the default white background used by the shared pipeline.
+        var value = backgroundColor.Trim();
+        if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase) &&
+            value.Length == 8 &&
+            uint.TryParse(value.AsSpan(2), System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture, out var rgb))
+        {
+            return new SKColor(
+                (byte)((rgb >> 16) & 0xFF),
+                (byte)((rgb >> 8) & 0xFF),
+                (byte)(rgb & 0xFF));
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Registration for the vector-aware raster map renderer decorator.
+/// </summary>
+public static class VectorAwareRasterMapRendererServiceCollectionExtensions
+{
+    /// <summary>
+    /// Wraps the currently registered <see cref="IRasterMapRenderer"/> (the provider's
+    /// raster-coverage renderer) with <see cref="VectorAwareRasterMapRenderer"/> so a
+    /// layer's bound vector style is applied at pixel level on the shared render path
+    /// (honua-server#2498). No-op when no inner renderer is registered.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddVectorAwareRasterMapRendering(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var innerDescriptor = services.LastOrDefault(d => d.ServiceType == typeof(IRasterMapRenderer));
+        if (innerDescriptor is null)
+        {
+            return services;
+        }
+
+        services.Remove(innerDescriptor);
+
+        services.Add(ServiceDescriptor.Describe(
+            typeof(IRasterMapRenderer),
+            sp =>
+            {
+                var inner = (IRasterMapRenderer)InstantiateInner(innerDescriptor, sp);
+                return new VectorAwareRasterMapRenderer(
+                    inner,
+                    sp,
+                    sp.GetRequiredService<ILogger<VectorAwareRasterMapRenderer>>());
+            },
+            innerDescriptor.Lifetime));
+
+        return services;
+    }
+
+    private static object InstantiateInner(ServiceDescriptor descriptor, IServiceProvider sp)
+    {
+        if (descriptor.ImplementationInstance is not null)
+        {
+            return descriptor.ImplementationInstance;
+        }
+
+        if (descriptor.ImplementationFactory is not null)
+        {
+            return descriptor.ImplementationFactory(sp);
+        }
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return ActivatorUtilities.CreateInstance(sp, descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException("Unable to resolve the inner IRasterMapRenderer implementation.");
+    }
+}

--- a/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
+++ b/src/Honua.Server/Startup/InfrastructureCompositionRoot.cs
@@ -212,6 +212,13 @@ internal static class InfrastructureCompositionRoot
                 return new CachingLayerStyleCatalog(innerStyleCatalog, cacheService, options, schemaContext);
             });
         }
+
+        // Wrap the provider's raster-coverage IRasterMapRenderer so a layer's bound vector
+        // style is applied at pixel level on the shared render path (honua-server#2498).
+        // Raster-backed renders keep the provider's native bytes; only feature layers with
+        // no raster coverage fall back to the shared Skia styled-vector pipeline.
+        Honua.Infrastructure.Rendering.VectorAwareRasterMapRendererServiceCollectionExtensions
+            .AddVectorAwareRasterMapRendering(services);
     }
 
     /// <summary>Bind + validate <see cref="LimitsOptions"/> from configuration.</summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyledVectorMapRenderTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyledVectorMapRenderTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Raster.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Helpers;
+using Honua.TestKit.Constants;
+using SkiaSharp;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Rendering;
+
+/// <summary>
+/// Integration coverage for honua-server#2498: the canonical <see cref="IRasterMapRenderer"/>
+/// render path (the same path the MCP <c>honua_render_map</c> tool drives) must apply a
+/// layer's bound vector style at pixel level on the default (Postgres) profile, and styled
+/// rendering must no longer throw <see cref="NotSupportedException"/> for feature layers.
+/// Layer 1 is a seeded vector (Point) collection with no raster coverage, so it exercises the
+/// styled Skia fallback rather than the raster-coverage renderer.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.OgcApiMaps)]
+public sealed class StyledVectorMapRenderTests : IAsyncLifetime
+{
+    // Layer 1 is a pure-vector Point layer (seeded features 101-104 around -122.x, 37.x)
+    // with no rows in raster_data, so the raster-coverage renderer yields no data and the
+    // decorator falls back to the shared styled-vector pipeline.
+    private const int VectorLayerId = 1;
+
+    private readonly WebAppFixture _fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    private static MapRenderRequest BuildRequest() => new()
+    {
+        // Tight bbox around the layer-1 point features so the styled markers cover
+        // several pixels and are trivially detectable.
+        BoundingBox = [-123.0, 37.0, -122.0, 38.0],
+        BoundingBoxCrs = 4326,
+        Crs = 4326,
+        Width = 256,
+        Height = 256,
+        Format = RasterFormat.PNG,
+        Transparent = false
+    };
+
+    private static string CircleStyle(string hexColor) =>
+        $$"""
+        {
+          "version": 8,
+          "sources": {},
+          "layers": [
+            {
+              "id": "points",
+              "type": "circle",
+              "source": "features",
+              "paint": { "circle-color": "{{hexColor}}", "circle-radius": 10 }
+            }
+          ]
+        }
+        """;
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    public async Task RenderDatasetMap_BoundVectorStyle_IsAppliedAtPixelLevelAndVariesByStyle()
+    {
+        var catalog = _fixture.GetService<ILayerStyleCatalog>();
+        var renderer = _fixture.GetService<IRasterMapRenderer>();
+        var request = BuildRequest();
+
+        // Bind a red circle style and render through the canonical renderer.
+        await catalog.SetMapLibreStyleAsync(VectorLayerId, CircleStyle("#ff0000"));
+        var red = await renderer.RenderDatasetMapAsync([VectorLayerId], request);
+
+        red.Data.Should().NotBeEmpty("a styled vector layer must render on the Postgres path (#2498)");
+        HasPixel(red.Data, isRed: true).Should().BeTrue("the bound red circle style must be applied at pixel level");
+
+        // Re-binding a different style must visibly change the rendered pixels, proving the
+        // render reflects the bound style rather than a default symbology.
+        await catalog.SetMapLibreStyleAsync(VectorLayerId, CircleStyle("#0000ff"));
+        var blue = await renderer.RenderDatasetMapAsync([VectorLayerId], request);
+
+        blue.Data.Should().NotBeEmpty();
+        HasPixel(blue.Data, isRed: false).Should().BeTrue("the re-bound blue style must be applied at pixel level");
+        HasPixel(blue.Data, isRed: true).Should().BeFalse("the previous red style must no longer be rendered");
+        blue.Data.Should().NotEqual(red.Data, "styled output must differ when the bound style changes");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    public async Task RenderStyledMap_VectorLayer_NoLongerThrowsNotSupported_Issue2498Regression()
+    {
+        var catalog = _fixture.GetService<ILayerStyleCatalog>();
+        var renderer = _fixture.GetService<IRasterMapRenderer>();
+        var request = BuildRequest();
+
+        await catalog.SetMapLibreStyleAsync(VectorLayerId, CircleStyle("#ff0000"));
+
+        // Before the fix this threw NotSupportedException on the Postgres path; it must now
+        // render the feature layer with its bound/style-resolved symbology.
+        var styleId = "default";
+        RasterResult result = default;
+        var act = async () => result = await renderer.RenderStyledMapAsync(VectorLayerId, styleId, request);
+
+        await act.Should().NotThrowAsync<NotSupportedException>(
+            "styled rendering of a vector layer must be supported (#2498)");
+        result.Data.Should().NotBeEmpty();
+        HasPngSignature(result.Data).Should().BeTrue();
+    }
+
+    private static bool HasPngSignature(byte[] data) =>
+        data.Length > 8 &&
+        data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47;
+
+    private static bool HasPixel(byte[] pngBytes, bool isRed)
+    {
+        using var bitmap = SKBitmap.Decode(pngBytes);
+        bitmap.Should().NotBeNull("the render output must be a decodable image");
+
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                if (isRed)
+                {
+                    if (pixel.Red > 150 && pixel.Green < 80 && pixel.Blue < 80)
+                    {
+                        return true;
+                    }
+                }
+                else if (pixel.Blue > 150 && pixel.Red < 80 && pixel.Green < 80)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyledVectorMapRenderTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyledVectorMapRenderTests.cs
@@ -68,6 +68,7 @@ public sealed class StyledVectorMapRenderTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Render)]
+    [Endpoint("GET /ogc/maps/map")]
     public async Task RenderDatasetMap_BoundVectorStyle_IsAppliedAtPixelLevelAndVariesByStyle()
     {
         var catalog = _fixture.GetService<ILayerStyleCatalog>();
@@ -94,6 +95,7 @@ public sealed class StyledVectorMapRenderTests : IAsyncLifetime
 
     [IntegrationTest]
     [Operation(Operations.Render)]
+    [Endpoint("GET /ogc/maps/collections/{collectionId}/styles/{styleId}/map")]
     public async Task RenderStyledMap_VectorLayer_NoLongerThrowsNotSupported_Issue2498Regression()
     {
         var catalog = _fixture.GetService<ILayerStyleCatalog>();

--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
@@ -266,6 +266,12 @@ internal static class WebAppFixturePostgresWiringMixin
 
         OverrideNonMultiplexingDataSource(services, connectionString);
 
+        // Mirror the production composition root: wrap the provider raster-coverage
+        // renderer with the vector-aware styled-render decorator (honua-server#2498) so
+        // integration tests exercise the same IRasterMapRenderer the running server uses.
+        Honua.Infrastructure.Rendering.VectorAwareRasterMapRendererServiceCollectionExtensions
+            .AddVectorAwareRasterMapRendering(services);
+
         // Replace the Postgres-backed Metadata v2 provider with an in-memory fixture so
         // endpoints read the seeded snapshot without a migrated snapshot row being
         // present in the test database.
@@ -297,6 +303,12 @@ internal static class WebAppFixturePostgresWiringMixin
         Honua.Postgres.ServiceCollectionExtensions.AddPostgreSqlServices(services, testConfiguration);
 
         OverrideNonMultiplexingDataSource(services, connectionString);
+
+        // Mirror the production composition root: wrap the provider raster-coverage
+        // renderer with the vector-aware styled-render decorator (honua-server#2498) so
+        // integration tests exercise the same IRasterMapRenderer the running server uses.
+        Honua.Infrastructure.Rendering.VectorAwareRasterMapRendererServiceCollectionExtensions
+            .AddVectorAwareRasterMapRendering(services);
 
         // Replace the Postgres-backed Metadata v2 provider with an in-memory fixture so
         // endpoints read the seeded snapshot without a migrated snapshot row being


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2498

## Summary
The canonical `IRasterMapRenderer` (Postgres profile: `PostgresRasterMapRenderer`) only rasterizes stored raster coverages (`raster_data`) and threw `NotSupportedException` from `RenderStyledMapAsync`, so a vector layer's bound MapLibre/drawingInfo style was never applied at pixel level on the render path the MCP `honua_render_map` tool drives. This PR wraps the provider renderer with a raster-first, vector-fallback decorator (`VectorAwareRasterMapRenderer`) that renders feature layers through the shared Skia pipeline with their bound (or styleId-resolved) style, closing the styled-map gap in the north-star "analysis → styled map" arc (#1948).

## Changes Made
- New `RasterMapRenderingPipeline.RenderBoundStyleVectorLayersAsync` shared helper: composites vector layers bottom-to-top onto one raster, resolving each layer's bound style from `ILayerStyleCatalog` (or an explicit MapLibre document) and drawing through the same `StyleTranslator`/`RenderLayerToCanvas`/point-fast-path primitives WMS GetMap, MapServer export, and OGC API Maps already use — no protocol-local rasterization added.
- New `VectorAwareRasterMapRenderer` decorator over the provider `IRasterMapRenderer`:
  - `RenderCollectionMapAsync`/`RenderDatasetMapAsync`: raster bytes returned by the wrapped renderer are passed through unchanged (format, GDAL encoding, temporal mosaics, `ST_Union` merges all untouched); only when the raster path yields no data and the layer(s) carry geometry does it render styled vectors.
  - `RenderStyledMapAsync`: resolves the styleId via `IOgcStyleProjection` (MapboxStyle encoding) and renders vector layers instead of throwing; raster coverages keep the honest `NotSupported` → 501.
  - Styled vector output is Skia-encoded (PNG/JPEG); TIFF stays on the raster path so bytes always match the Content-Type (preserves the #2365 contract).
- Registered the decorator in `InfrastructureCompositionRoot` (all providers) and mirrored it in the TestKit Postgres wiring so integration tests exercise the production renderer stack.
- Tests (Testcontainers + PostGIS, `StyledVectorMapRenderTests`):
  - Bound red circle style renders with red pixels; re-binding blue changes the output pixels and the red is gone (proves pixel-level application and style-change sensitivity via decoded-bitmap assertions).
  - Exact #2498 repro: `RenderStyledMapAsync` on a vector layer no longer throws `NotSupportedException` and returns a valid PNG.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Ran locally (Release):
- `StyledVectorMapRenderTests` — 2/2 pass (new)
- `Honua.Protocols.OgcApi.Tests` Maps suite — 119/119 pass
- `Honua.Protocols.OgcClassic.Tests` WMS suite — 60/60 pass
- `Honua.Ai.Tests` `McpMapToolTests` — 10/10 pass
- `Honua.Postgres.Tests` `RasterMapRenderer` suite — 7/7 pass
- `Honua.Protocols.GeoServices.Tests` MapServer/Export filter — 215 pass; the 17 failures (`ImageServerExportHandlerTests.ExportImageAsync*`) fail identically on pristine `origin/trunk` (verified in a clean baseline worktree) — pre-existing, unrelated to this change
- `Honua.Architecture.Tests` — 122/122 pass (includes regenerated `docs/gis/data/feature-catalog.json` for the new test evidence)
- `dotnet format --verify-no-changes` on changed files — clean
- Release build with `TreatWarningsAsErrors=true` — clean

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

Behavior notes (intentional, scoped to previously-failing cases):
- A pure-vector layer rendered through `IRasterMapRenderer` previously produced an empty result (MCP render errored "empty image"; OGC collection map 404'd). It now renders the features with bound/default symbology. Raster-backed layers are byte-identical to before.
- `RenderStyledMapAsync` on a vector layer previously threw `NotSupported` (501); it now renders. Raster coverages keep the 501.

Scope note: this delivers the #2498 acceptance slice (fill/stroke/circle color, width, opacity for polygon/line/point via the existing shared `StyleTranslator`). Data-driven expressions, filters, and zoom gates already supported by the shared pipeline apply unchanged; no style-engine surface was forked.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
