### PR TITLE
feat: server-authoritative aggregated operate status + read-only ops scope (#2559)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -2672,7 +2672,8 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetFindings_WithAdminAuth_ReturnsFindingsEnvelope",
-        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetFindings_WithoutAdminAuth_IsUnauthorized"
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetFindings_WithoutAdminAuth_IsUnauthorized",
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.OpsReadKey_CanReadStatusAndFindings"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -4523,6 +4524,23 @@
         "Honua.Server.Tests.Features.Console.ConsoleOpenDataEndpointsTests.AnonymousStac_AfterPublish_ExposesCatalogCollectionAndItem_AndDropsThemAfterUnpublish"
       ],
       "proof_ledger_surface": "console-open-data-dcat-stac",
+      "maturity": "implemented"
+    },
+    {
+      "id": "get-api-v1-operate-status",
+      "route": "/api/v1/operate/status",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.Operate.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.GetStatus_WithAdminAuth_ReturnsSelfDescribingVerdictAndDomains",
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.GetStatus_WithOpsReadKey_IsAuthorized",
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.GetStatus_WithoutAuth_IsUnauthorized",
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.OpsReadKey_CanReadStatusAndFindings",
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.OpsReadKey_IsNarrowerThanAdminRead_DeniedNonOpsAdminSurface"
+      ],
+      "proof_ledger_surface": "operate-status",
       "maturity": "implemented"
     },
     {
@@ -11884,7 +11902,8 @@
         "Honua.Server.Tests.Features.Admin.MetadataReleaseOperationEndpointsTests.RollbackDeployOperation_MetadataOnlyWithExplicitApproval_RequiresApproval",
         "Honua.Server.Tests.Features.Admin.MetadataReleaseOperationEndpointsTests.RollbackDeployOperation_MetadataOnly_UsesNonDestructiveApprovalPath",
         "Honua.Server.Tests.Features.Admin.MetadataReleaseOperationEndpointsTests.RollbackDeployOperation_WhenRollbackPlanApprovalRequirementChangesAfterApproval_ReturnsConflictWithoutMutation",
-        "Honua.Server.Tests.Features.Admin.MetadataReleaseOperationEndpointsTests.RollbackDeployOperation_WhenRollbackPlanChangesAfterApproval_ReturnsConflictWithoutMutation"
+        "Honua.Server.Tests.Features.Admin.MetadataReleaseOperationEndpointsTests.RollbackDeployOperation_WhenRollbackPlanChangesAfterApproval_ReturnsConflictWithoutMutation",
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.OpsReadKey_CannotInvokeMutatingOpsEndpoints"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"
@@ -13063,7 +13082,8 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.ProposeFinding_UnknownId_Returns404",
-        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.ProposeFinding_WithoutAdminAuth_IsUnauthorized"
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.ProposeFinding_WithoutAdminAuth_IsUnauthorized",
+        "Honua.Server.Tests.Features.OperateStatus.OperateStatusEndpointsTests.OpsReadKey_CannotInvokeMutatingOpsEndpoints"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented"

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -700,6 +700,50 @@
       ]
     },
     {
+      "surfaceId": "operate-status",
+      "displayName": "Aggregated Operational Status API",
+      "surfaceKind": "http-route-family",
+      "protocol": "Admin API",
+      "canonicalIdentifier": "/api/v1/operate/status",
+      "parentSurfaceId": "control-plane-admin",
+      "endpointPrefixes": [
+        "/api/v1/operate"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [],
+      "proofs": [
+        {
+          "proofClass": "route-coverage",
+          "proofMechanism": "EndpointRegistry coverage plus OperateStatusEndpointsTests integration tests assert the aggregated status endpoint returns a server-computed verdict, self-describing per-domain rollups, and the availability SLO block, and that the read-only ops:read scope can read status/findings but is denied mutating ops endpoints",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Server/EndpointRegistry.Operate.cs",
+            "tests/dotnet/Honua.Architecture.Tests/ApiSurfaceCoverageTests.cs",
+            "tests/dotnet/Honua.Server.Tests/Features/Operations/OperateStatusEndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": null,
+          "versionCaptureRule": null
+        },
+        {
+          "proofClass": "contract-governance",
+          "proofMechanism": "The overall verdict is computed server-side by OperateStatusVerdictEvaluator with documented rules and the availability SLO/error-budget by OperateSloEvaluator; both are unit-pinned, and OperateStatusJsonContext keeps the response DTOs AOT-safe",
+          "executionLane": "ci:test-all",
+          "evidenceLocations": [
+            "src/Honua.Server/Features/Operations/Status/OperateStatusVerdictEvaluator.cs",
+            "src/Honua.Server/Features/Operations/Status/OperateSloEvaluator.cs",
+            "src/Honua.Server/Features/Operations/Status/OperateStatusJsonContext.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": null,
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "audit-trail-siem",
       "displayName": "Audit trail SIEM export and tamper-evidence API",
       "surfaceKind": "http-route-family",

--- a/docs/guides/deploy/monitoring.md
+++ b/docs/guides/deploy/monitoring.md
@@ -18,6 +18,41 @@ You'll wire up health probes, Prometheus metrics, OpenTelemetry export, and the 
 | `GET /monitoring/metrics/{connection-pool,cache,resources,upload-queue,database-resilience}` | admin | Focused operational diagnostics |
 | `GET /monitoring/alerts` | admin | Current alert conditions from production thresholds |
 | `GET /api/v1/admin/observability/{errors,telemetry,events,migrations}` | admin | Error history, tracing status, Operate events, migration state |
+| `GET /api/v1/operate/status` | ops-reader or admin | **Server-authoritative aggregated status** — one server-computed verdict plus per-domain rollups and the availability SLO |
+
+## Aggregated operational status
+
+Instead of stitching the endpoints above and inventing your own "is the system healthy" verdict, call the one aggregated surface:
+
+```bash
+curl -s -H "X-API-Key: $HONUA_ADMIN_PASSWORD" http://localhost:8080/api/v1/operate/status
+```
+
+It returns a server-computed `status` (`healthy` / `degraded` / `unhealthy`) with the machine-readable `reasons` that drove it, per-domain rollups (`deploys`, `jobs`, `alerts`, `migrations`, `findings`, `telemetryBackends`) each carrying a `source` hint you can drill down to, and a `schemaVersion` + `generatedAt` so a consumer can version its parsing. The verdict rules are fixed and documented server-side: the health-check roll-up being `Unhealthy` ⇒ `unhealthy`; a `Critical` finding, a deploy parked in manual intervention, dead-lettered alerts, an impaired dispatcher, or an exhausted SLO error budget ⇒ `degraded`; otherwise `healthy`.
+
+### Availability SLO / error budget
+
+Configure an availability target and the `slo` block evaluates a burn rate and remaining error budget from the in-process, GIS-protocol-partitioned serving-latency window (no metrics database required):
+
+```bash
+Slo__Availability__Target=0.995          # fraction in (0,1); omit to leave the SLO "not configured"
+Slo__Availability__RollingWindowSeconds=300
+```
+
+When no target is set, `slo.configured` is `false` with an explicit reason rather than an invented number. v1 evaluates HTTP-5xx serving availability over the aggregator window; the in-band GeoServices error-envelope signal (2xx error envelopes) is not yet folded into the window.
+
+### Read-only ops credential
+
+Provision an ops-reader credential so a status dashboard or copilot can read the ops posture without holding a key that could `POST /rollback`. Mint an admin API key scoped to the `ops:read` grant (distinct from `admin:read`, which can also read the broader admin surfaces):
+
+```bash
+# With a full-admin key, mint an ops-reader key:
+curl -s -X POST http://localhost:8080/api/v1/admin/api-keys \
+  -H "X-API-Key: $HONUA_ADMIN_PASSWORD" -H 'Content-Type: application/json' \
+  -d '{"name":"ops-dashboard","permissions":["ops:read"]}'
+```
+
+The returned key authorizes the read-only ops surfaces — `GET /api/v1/operate/status`, `GET /api/v1/admin/observability/{ops-health,findings}`, and `GET /api/v1/admin/observability/alerts` — but is rejected with a `403` on every mutating ops operation (deploy rollback/promote/submit, `findings/{id}/propose`, alert `acknowledge`/`suppress`/`resolve`) and on non-ops admin surfaces such as key management. Full-admin keys and client-certificate admins are unaffected.
 
 ## Steps
 

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -248,6 +248,10 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
             // The VMS endpoints are gated OFF the GA surface by default (versioning.branch descriptor).
             // Opt in via Capabilities:Experimental:versioning.branch:Enabled=true.
             ("versioning.branch", "versioning", FeatureCatalog.BranchVersioningKey, CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
+
+            // Aggregated operational status (A12): the server-authoritative operate/status surface —
+            // one server-computed verdict + per-domain rollups + SLO/error-budget contract. Ungated GA.
+            ("operate.status", "operate", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
         ];
 
         foreach (var (id, category, entitlementKey, kind, packageSchemaVersion, maturity) in capabilities)

--- a/src/Honua.Hosting/Features/Authentication/AdminApiKeyPermission.cs
+++ b/src/Honua.Hosting/Features/Authentication/AdminApiKeyPermission.cs
@@ -42,6 +42,15 @@ internal static class AdminApiKeyPermission
     public const string PermissionClaimType = "permission";
 
     private const string AdminGrantPrefix = "admin:";
+    private const string OpsGrantPrefix = "ops:";
+
+    /// <summary>
+    /// Ops-reader grants that confer read-only access to the operational observability surfaces
+    /// (aggregated operate status, ops-health, findings, alerts) but no mutating authority — a
+    /// credential distinct from the admin family so a status/monitoring copilot can read the ops
+    /// posture without holding a key that could <c>POST</c> a rollback, promotion, or suppression.
+    /// </summary>
+    private static readonly string[] OpsReadGrants = ["ops:read", "ops:reader", "ops:*"];
 
     /// <summary>
     /// Grants that confer full administration (read and write).
@@ -139,6 +148,79 @@ internal static class AdminApiKeyPermission
         => string.Equals(httpMethod, "GET", StringComparison.OrdinalIgnoreCase)
            || string.Equals(httpMethod, "HEAD", StringComparison.OrdinalIgnoreCase)
            || string.Equals(httpMethod, "OPTIONS", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines whether a principal carries a read-only <c>ops:</c> grant (<c>ops:read</c>,
+    /// <c>ops:reader</c>, or <c>ops:*</c>). This is a strictly weaker, ops-scoped credential than the
+    /// admin family: it authorizes the read-only operational surfaces but never a mutating operation,
+    /// and it confers no access to the broader admin surfaces (users, keys, configuration) that
+    /// <c>admin:read</c> can observe.
+    /// </summary>
+    /// <param name="principal">The authenticated principal.</param>
+    /// <returns><see langword="true"/> when a read-only ops grant is present.</returns>
+    public static bool HasOpsReadGrant(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        foreach (var claim in principal.FindAll(PermissionClaimType))
+        {
+            var trimmed = claim.Value?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                continue;
+            }
+
+            foreach (var grant in OpsReadGrants)
+            {
+                if (string.Equals(trimmed, grant, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            // An unrecognized ops sub-grant (e.g. a future ops:deploy) still proves ops-read intent:
+            // it can observe the ops surfaces but, being non-admin, can never satisfy a mutating
+            // requirement (which requires full admin write).
+            if (trimmed.StartsWith(OpsGrantPrefix, StringComparison.OrdinalIgnoreCase)
+                && trimmed.Length > OpsGrantPrefix.Length)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a principal is authorized for an ops-observability request whose HTTP method
+    /// is <paramref name="httpMethod"/>. Safe (read) methods are authorized by an admin key of any
+    /// level (full or <c>admin:read</c>) or by a read-only <c>ops:</c> grant; mutating methods require
+    /// full admin write. This is the enforcement primitive behind the ops-reader authorization policy.
+    /// </summary>
+    /// <param name="principal">The authenticated principal.</param>
+    /// <param name="httpMethod">The request HTTP method.</param>
+    /// <returns><see langword="true"/> when the grants authorize the request.</returns>
+    public static bool IsOpsReadAuthorized(ClaimsPrincipal principal, string? httpMethod)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var level = ResolveAccessLevel(principal);
+
+        // Full admin authorizes everything, including mutating ops operations.
+        if (level == AdminAccessLevel.Write)
+        {
+            return true;
+        }
+
+        // Mutating ops operations require full admin write; a read-only admin or ops grant cannot pass.
+        if (!IsSafeMethod(httpMethod))
+        {
+            return false;
+        }
+
+        // Safe method: a read-only admin grant or a read-only ops grant is sufficient.
+        return level == AdminAccessLevel.Read || HasOpsReadGrant(principal);
+    }
 
     private static AdminAccessLevel ClassifyGrant(string? grant)
     {

--- a/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
@@ -28,6 +28,15 @@ public static class AuthenticationExtensions
     public const string AdminPolicyAlias = "AdminPolicy";
 
     /// <summary>
+    /// Authorization policy name for the read-only operational-observability surfaces (A12).
+    /// Admits the admin family (full admin or <c>admin:read</c>) or a dedicated read-only
+    /// <c>ops:read</c> credential for safe reads, while still requiring full admin write for any
+    /// mutating request routed through it. Distinct from <see cref="AdminPolicy"/> so an ops-reader
+    /// key can observe the ops posture without holding a credential that could mutate.
+    /// </summary>
+    public const string OpsReadPolicy = "OpsRead";
+
+    /// <summary>
     /// Authorization policy name for temporal-history read access (honua-server#1166).
     /// Distinct from the current-read and admin surfaces so it can be tightened to a
     /// dedicated permission grant in a later slice without touching endpoint code. In
@@ -65,6 +74,10 @@ public static class AuthenticationExtensions
         // in every policy that adds AdminPermissionRequirement below.
         services.AddSingleton<IAuthorizationHandler, AdminPermissionAuthorizationHandler>();
 
+        // Enforces the read-only ops-reader split (A12): admits admin or ops:read grants for safe
+        // reads while requiring full admin write for mutating requests routed through OpsReadPolicy.
+        services.AddSingleton<IAuthorizationHandler, OpsReadAuthorizationHandler>();
+
         // Add authentication with API key scheme
         _ = services.AddAuthentication(defaultScheme: ApiKeyScheme)
             .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
@@ -76,6 +89,7 @@ public static class AuthenticationExtensions
         {
             options.AddPolicy(AdminPolicy, ConfigureAdminPolicy);
             options.AddPolicy(AdminPolicyAlias, ConfigureAdminPolicy);
+            options.AddPolicy(OpsReadPolicy, ConfigureOpsReadPolicy);
             options.AddPolicy(TemporalHistoryReadPolicy, ConfigureAdminPolicy);
             options.AddPolicy(TemporalDiffReadPolicy, ConfigureAdminPolicy);
             options.AddPolicy(TemporalRollbackExecutePolicy, ConfigureAdminPolicy);
@@ -100,6 +114,21 @@ public static class AuthenticationExtensions
     }
 
     /// <summary>
+    /// Configures the read-only ops-reader authorization policy (A12). Unlike the admin family it
+    /// does NOT require the <c>admin</c> role — a key minted with only an <c>ops:read</c> grant
+    /// authenticates as a non-admin scoped principal — so authorization is decided by
+    /// <see cref="OpsReadRequirement"/> (via <see cref="AdminApiKeyPermission.IsOpsReadAuthorized"/>):
+    /// admin (any level) or ops:read for safe methods; full admin write for mutating methods.
+    /// </summary>
+    private static void ConfigureOpsReadPolicy(AuthorizationPolicyBuilder policy)
+    {
+        _ = policy.RequireAuthenticatedUser();
+        _ = policy.AddRequirements(new OpsReadRequirement());
+        policy.AuthenticationSchemes.Add(ApiKeyScheme);
+        policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
+    }
+
+    /// <summary>
     /// Adds authentication middleware to the request pipeline
     /// </summary>
     public static IApplicationBuilder UseApiKeyAuthentication(this IApplicationBuilder app)
@@ -113,6 +142,16 @@ public static class AuthenticationExtensions
     /// </summary>
     public static TBuilder RequireAdminAuthorization<TBuilder>(this TBuilder builder)
         where TBuilder : IEndpointConventionBuilder => builder.RequireAuthorization(AdminPolicy);
+
+    /// <summary>
+    /// Requires read-only ops-reader authorization for an endpoint or group (A12). Safe reads are
+    /// authorized by an admin key (any level) or a read-only <c>ops:read</c> grant; a mutating
+    /// request routed through this policy still requires full admin write, so applying it to a mixed
+    /// read/write group keeps every mutation admin-only while additionally admitting ops-reader keys
+    /// to the reads.
+    /// </summary>
+    public static TBuilder RequireOpsReadAuthorization<TBuilder>(this TBuilder builder)
+        where TBuilder : IEndpointConventionBuilder => builder.RequireAuthorization(OpsReadPolicy);
 
     /// <summary>
     /// Requires the distinct temporal-history read authorization for an endpoint or group

--- a/src/Honua.Hosting/Features/Authentication/AuthenticationLog.cs
+++ b/src/Honua.Hosting/Features/Authentication/AuthenticationLog.cs
@@ -171,4 +171,14 @@ internal static partial class AuthenticationLog
         Level = LogLevel.Warning,
         Message = "Scoped admin API key denied {Method} admin request: key permissions do not authorize this operation")]
     public static partial void ScopedAdminKeyDenied(ILogger logger, string method);
+
+    /// <summary>
+    /// Logs when a principal is denied a read-only ops-observability request because it carries
+    /// neither an admin grant nor a read-only <c>ops:</c> grant sufficient for the request method.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 4115,
+        Level = LogLevel.Warning,
+        Message = "Ops-reader authorization denied {Method} ops request: principal lacks an admin or ops:read grant authorizing this operation")]
+    public static partial void OpsReaderKeyDenied(ILogger logger, string method);
 }

--- a/src/Honua.Hosting/Features/Authentication/OpsReadAuthorization.cs
+++ b/src/Honua.Hosting/Features/Authentication/OpsReadAuthorization.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace Honua.Infrastructure.Authentication;
+
+/// <summary>
+/// Authorization requirement for the read-only operational-observability surfaces (aggregated
+/// operate status, ops-health, findings, and alert reads). It admits either the admin family (full
+/// admin or <c>admin:read</c>) or a dedicated read-only <c>ops:</c> credential for safe
+/// (GET/HEAD/OPTIONS) requests, while a mutating request (rollback, promote, submit, suppress, …)
+/// still requires full admin write.
+/// </summary>
+/// <remarks>
+/// This is the ops-reader half of the split the ops review called for: "no read-only ops role — all
+/// ops endpoints share one admin scope, so any credential that can read status can also POST
+/// /rollback." A key minted with only an <c>ops:read</c> grant satisfies this requirement on the read
+/// surfaces but is denied every mutating ops endpoint — those keep the admin policy, which an
+/// ops-reader key (authenticated as a non-admin scoped principal) can never satisfy. The evaluation
+/// is delegated to <see cref="AdminApiKeyPermission.IsOpsReadAuthorized"/> so the ops-reader grammar
+/// stays a single source of truth alongside the admin grant grammar (no parallel auth mechanism).
+/// </remarks>
+internal sealed class OpsReadRequirement : IAuthorizationRequirement;
+
+/// <summary>
+/// Evaluates <see cref="OpsReadRequirement"/> against the principal's admin/ops permission grants and
+/// the current request's HTTP method.
+/// </summary>
+internal sealed class OpsReadAuthorizationHandler(
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<OpsReadAuthorizationHandler> logger)
+    : AuthorizationHandler<OpsReadRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+    private readonly ILogger<OpsReadAuthorizationHandler> _logger = logger;
+
+    /// <inheritdoc />
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        OpsReadRequirement requirement)
+    {
+        // Mirror AdminPermissionAuthorizationHandler: the HTTP method is the behavior-changing input;
+        // prefer the resource the middleware supplies and fall back to the ambient accessor.
+        var httpContext = context.Resource as HttpContext ?? _httpContextAccessor.HttpContext;
+        var method = httpContext?.Request.Method;
+
+        if (AdminApiKeyPermission.IsOpsReadAuthorized(context.User, method))
+        {
+            context.Succeed(requirement);
+        }
+        else
+        {
+            AuthenticationLog.OpsReaderKeyDenied(_logger, method ?? "(unknown)");
+            // Leave the requirement unmet (do not Fail): yields a 403 and lets other
+            // handlers/requirements report their own outcome, matching the admin handler.
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Honua.Server/EndpointRegistry.Operate.cs
+++ b/src/Honua.Server/EndpointRegistry.Operate.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server;
+
+public static partial class EndpointRegistry
+{
+    // Server-authoritative aggregated operational status (A12). One endpoint returns a server-computed
+    // verdict plus per-domain rollups; guarded by the read-only ops-reader authorization policy.
+    private static IReadOnlyList<EndpointDefinition> OperateStatusEndpoints =>
+    [
+        new("GET", "/api/v1/operate/status"),
+    ];
+}

--- a/src/Honua.Server/EndpointRegistry.cs
+++ b/src/Honua.Server/EndpointRegistry.cs
@@ -32,6 +32,7 @@ public static partial class EndpointRegistry
         .. PlatformEndpoints,
         .. AdminEndpoints,
         .. AdminObservabilityEndpoints,
+        .. OperateStatusEndpoints,
         .. IdentityProvisioningEndpoints,
         .. ConsoleEndpoints,
         .. StudioEndpoints,

--- a/src/Honua.Server/Features/Admin/ObservabilityAlertEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ObservabilityAlertEndpoints.cs
@@ -21,11 +21,14 @@ internal static class ObservabilityAlertEndpoints
 
     public static void MapObservabilityAlertEndpoints(this IEndpointRouteBuilder endpoints)
     {
+        // Read-only ops-reader authorization (A12): the GET alert reads additionally admit an ops:read
+        // credential, while the mutating POSTs (acknowledge/suppress/resolve) still require full admin
+        // write — the ops-read policy is method-aware.
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/observability/alerts")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Observability", "Alerts")
-            .RequireAdminAuthorization();
+            .RequireOpsReadAuthorization();
 
         group.MapGet("", HandleList)
             .WithDisplayName("List Observability Alerts")

--- a/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
@@ -23,11 +23,15 @@ internal static class OpsObservabilityEndpoints
     /// <param name="endpoints">The endpoint route builder.</param>
     public static void MapOpsObservabilityEndpoints(this IEndpointRouteBuilder endpoints)
     {
+        // Read-only ops-reader authorization (A12): the GET reads (ops-health, findings) additionally
+        // admit an ops:read credential, while the mutating POST (findings/propose) still requires full
+        // admin write — the ops-read policy is method-aware, so applying it at the group keeps every
+        // mutation admin-only.
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/observability")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)
             .WithTags("Admin", "Observability")
-            .RequireAdminAuthorization();
+            .RequireOpsReadAuthorization();
 
         group.MapGet("/ops-health", HandleGetOpsHealth)
             .WithDisplayName("Get Ops Health Snapshot")

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -406,10 +406,13 @@ internal sealed class CapabilityManifestService(
             Capability("upload.file", "upload", context, entitlementKey: "import.file", policyCapability: "metadata.write"),
             Capability("edit.features", "edit", context, entitlementKey: FeatureCatalog.FeatureServerEditsKey, policyCapability: "features.edit"),
             // Branch versioning (VMS) — built-experimental, gated OFF the GA surface by
-            // default (#2480 / ADR-0058). Kept last to mirror the registry descriptor order
+            // default (#2480 / ADR-0058). Mirrors the registry descriptor order
             // (CapabilityRegistry.BuildManifestCapabilityDescriptors) so the hand-curated and
             // registry-derived Capabilities[] stay byte-identical.
-            Capability("versioning.branch", "versioning", context, entitlementKey: FeatureCatalog.BranchVersioningKey)
+            Capability("versioning.branch", "versioning", context, entitlementKey: FeatureCatalog.BranchVersioningKey),
+            // Aggregated operate status (A12) — the server-authoritative operate/status surface. Ungated
+            // GA; read-authorized (ops:read) at the HTTP layer. Kept last to mirror the registry order.
+            Capability("operate.status", "operate", context, requiresAuthentication: true)
         ];
     }
 
@@ -519,6 +522,7 @@ internal sealed class CapabilityManifestService(
             ["upload.file"] = new() { EntitlementKey = "import.file", PolicyCapability = "metadata.write" },
             ["edit.features"] = new() { EntitlementKey = FeatureCatalog.FeatureServerEditsKey, PolicyCapability = "features.edit" },
             ["versioning.branch"] = new() { EntitlementKey = FeatureCatalog.BranchVersioningKey },
+            ["operate.status"] = new() { RequiresAuthentication = true },
         };
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Caching;
 using Honua.Infrastructure.Compression;
 using Honua.Infrastructure.Models;
+using Honua.Server.Features.Operations.Status;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -56,6 +57,10 @@ internal static class ObservabilityServiceCollectionExtensions
             .ValidateOnStart();
         services.AddScoped<IOpsHealthSnapshotService, OpsHealthSnapshotService>();
         services.AddScoped<IOpsFindingsService, OpsFindingsService>();
+
+        // Aggregated operate-status surface (A12): composes the ops-health snapshot + findings into
+        // one server-authoritative verdict, and binds the SLO/error-budget contract.
+        services.AddOperateStatus(configuration);
 
         return services;
     }

--- a/src/Honua.Server/Features/Operations/Status/OperateSloEvaluator.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateSloEvaluator.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.ServiceDefaults;
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>
+/// Pure evaluation of the minimal v1 availability SLO from the telemetry the server already
+/// aggregates in-process. No metrics database is involved: availability is computed from the
+/// GIS-protocol-partitioned serving-latency rolling window (request and server-error counts).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What v1 actually evaluates:</b> observed availability = 1 - (server errors / requests) over the
+/// aggregator's window, where a "server error" is an HTTP response with status &gt;= 500
+/// (<c>ServingLatencyAggregator.ServerErrorFloor</c>). The error budget is <c>1 - target</c>; the burn
+/// rate is the observed error fraction divided by that budget; remaining budget is
+/// <c>1 - burnRate</c> clamped to [0, 1].
+/// </para>
+/// <para>
+/// <b>Honest limitation / where a richer signal would plug in:</b> the in-process rolling window
+/// counts 5xx serving errors only. The GIS-aware <em>in-band</em> GeoServices error signal (error
+/// envelopes delivered with a 2xx status, emitted as the cumulative <c>honua_geoservices_error_total</c>
+/// / <c>honua_request_error_total{in_band}</c> counters) is not yet windowed, so it does not currently
+/// contribute to this availability figure. Adding a windowed aggregator for those counters and folding
+/// its error count into <see cref="Evaluate"/> is the single, well-scoped extension point; the
+/// contract shape here does not change when that lands.
+/// </para>
+/// </remarks>
+internal static class OperateSloEvaluator
+{
+    internal const string EvaluationSource = "serving-latency-window(http-5xx)";
+
+    /// <summary>
+    /// Evaluates the availability SLO against a serving-latency snapshot.
+    /// </summary>
+    /// <param name="options">The SLO configuration.</param>
+    /// <param name="snapshot">The in-process serving-latency snapshot.</param>
+    /// <returns>The SLO view: configured with an evaluation, or the explicit not-configured state.</returns>
+    public static OperateSloView Evaluate(OperateSloOptions options, ServingLatencySnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        if (!options.HasAvailabilityTarget)
+        {
+            return new OperateSloView
+            {
+                Configured = false,
+                Reason = "No availability SLO target is configured. Set Slo:Availability:Target to a "
+                    + "fraction in (0, 1) (for example 0.995) to evaluate an error budget from the "
+                    + "in-process serving-latency window.",
+                Availability = null,
+            };
+        }
+
+        var target = options.Availability.Target!.Value;
+
+        long requestCount = 0;
+        long errorCount = 0;
+        foreach (var protocol in snapshot.Protocols)
+        {
+            requestCount += protocol.RequestCount;
+            errorCount += protocol.ErrorCount;
+        }
+
+        double? observed = null;
+        double? burnRate = null;
+        double? budgetRemaining = null;
+
+        if (requestCount > 0)
+        {
+            var errorFraction = (double)errorCount / requestCount;
+            observed = 1.0 - errorFraction;
+
+            var errorBudget = 1.0 - target; // allowed error fraction
+            if (errorBudget <= 0)
+            {
+                // A target of 1.0 admits no error budget; any error is an infinite burn. Guarded here
+                // even though HasAvailabilityTarget excludes target >= 1.
+                burnRate = errorFraction > 0 ? double.PositiveInfinity : 0.0;
+                budgetRemaining = errorFraction > 0 ? 0.0 : 1.0;
+            }
+            else
+            {
+                burnRate = errorFraction / errorBudget;
+                budgetRemaining = Math.Clamp(1.0 - burnRate.Value, 0.0, 1.0);
+            }
+        }
+
+        return new OperateSloView
+        {
+            Configured = true,
+            Reason = null,
+            Availability = new OperateSloAvailabilityView
+            {
+                Target = target,
+                WindowSeconds = snapshot.WindowSeconds,
+                RequestCount = requestCount,
+                ErrorCount = errorCount,
+                Observed = observed,
+                BurnRate = burnRate,
+                ErrorBudgetRemaining = budgetRemaining,
+                EvaluationSource = EvaluationSource,
+            },
+        };
+    }
+
+    /// <summary>
+    /// Determines whether a configured SLO has exhausted its error budget over the window (a verdict
+    /// degradation signal). Only true when there is traffic to evaluate and the remaining budget is
+    /// at or below zero.
+    /// </summary>
+    /// <param name="slo">The evaluated SLO view.</param>
+    /// <returns><see langword="true"/> when the error budget is exhausted.</returns>
+    public static bool IsErrorBudgetExhausted(OperateSloView slo)
+        => slo.Configured
+           && slo.Availability is { ErrorBudgetRemaining: <= 0.0 };
+}

--- a/src/Honua.Server/Features/Operations/Status/OperateSloOptions.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateSloOptions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>
+/// Configuration for the minimal, honest v1 SLO / error-budget contract surfaced in the aggregated
+/// operate status payload. Bound from the <c>Slo</c> configuration section. When no availability
+/// target is configured the status payload reports the SLO block as explicitly <c>not configured</c>
+/// rather than inventing a number.
+/// </summary>
+/// <remarks>
+/// v1 deliberately does NOT stand up a metrics database. The availability SLO is evaluated from the
+/// telemetry the server already aggregates in-process: the GIS-protocol-partitioned serving-latency
+/// rolling window (<c>HonuaTelemetry.GetServingLatencySnapshot()</c>), which counts requests and
+/// server errors (HTTP status &gt;= 500) over its window. The window used for evaluation is therefore
+/// that aggregator's window; <see cref="AvailabilityOptions.RollingWindowSeconds"/> is advisory
+/// metadata echoed on the payload so operators can see the intended horizon.
+/// </remarks>
+internal sealed class OperateSloOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Slo";
+
+    /// <summary>
+    /// The availability SLO block. Present-but-untargeted (a null <see cref="AvailabilityOptions.Target"/>)
+    /// is treated as "not configured".
+    /// </summary>
+    public AvailabilityOptions Availability { get; set; } = new();
+
+    /// <summary>
+    /// Whether a usable availability target is configured (a value in the open interval (0, 1)).
+    /// </summary>
+    public bool HasAvailabilityTarget
+        => Availability.Target is > 0 and < 1;
+}
+
+/// <summary>
+/// Availability SLO target and rolling-window metadata.
+/// </summary>
+internal sealed class AvailabilityOptions
+{
+    /// <summary>
+    /// The target availability as a fraction in the open interval (0, 1) — for example <c>0.995</c>
+    /// for "99.5% of requests succeed". Null (the default) means the availability SLO is not
+    /// configured and the status payload reports it as such.
+    /// </summary>
+    [Range(0d, 1d)]
+    public double? Target { get; set; }
+
+    /// <summary>
+    /// Advisory rolling-window horizon in seconds echoed onto the payload. The actual evaluation
+    /// window is the in-process serving-latency aggregator's window (default 300s); this value
+    /// documents operator intent and does not resize that aggregator.
+    /// </summary>
+    [Range(1, 30 * 24 * 60 * 60)]
+    public int RollingWindowSeconds { get; set; } = 300;
+}

--- a/src/Honua.Server/Features/Operations/Status/OperateStatusEndpoints.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateStatusEndpoints.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Infrastructure.Authentication;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>
+/// HTTP surface for the server-authoritative aggregated operational status (A12). One endpoint
+/// returns a server-computed verdict plus per-domain rollups and an availability SLO snapshot, so a
+/// copilot no longer stitches ~8 endpoints and invents its own health verdict. Guarded by the
+/// read-only ops-reader policy: an <c>ops:read</c> key (or any admin key) can read it, but a mutating
+/// ops operation still requires full admin write.
+/// </summary>
+internal static class OperateStatusEndpoints
+{
+    /// <summary>Maps the aggregated operate-status endpoint.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    public static void MapOperateStatusEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("/api/v{version:apiVersion}/operate")
+            .WithApiVersionSet()
+            .HasApiVersion(1, 0)
+            .WithTags("Operate")
+            .RequireOpsReadAuthorization();
+
+        group.MapGet("/status", HandleGetStatus)
+            .WithName("GetOperateStatus")
+            .WithSummary("Get the server-authoritative aggregated operational status")
+            .WithDescription(
+                "Returns a server-computed overall verdict (healthy/degraded/unhealthy), per-domain "
+                + "rollups (deploys, jobs, alerts, migrations, findings, telemetry backends), and — when "
+                + "configured — an availability SLO / error-budget snapshot. Accepts a read-only ops:read "
+                + "credential as well as admin keys.")
+            .Produces<OperateStatusResponse>();
+    }
+
+    private static async Task<IResult> HandleGetStatus(
+        [FromServices] IOperateStatusService service,
+        HttpContext context)
+    {
+        var status = await service.GetAsync(context.RequestAborted).ConfigureAwait(false);
+        return Results.Json(status, OperateStatusJsonContext.Default.OperateStatusResponse);
+    }
+}

--- a/src/Honua.Server/Features/Operations/Status/OperateStatusJsonContext.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateStatusJsonContext.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>
+/// Source-generated JSON context for the aggregated operate-status response. AOT-safe: no
+/// reflection-based serialization.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = false)]
+[JsonSerializable(typeof(OperateStatusResponse))]
+internal sealed partial class OperateStatusJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/Operations/Status/OperateStatusModels.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateStatusModels.cs
@@ -1,0 +1,392 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>
+/// Server-authoritative aggregated operational status returned by
+/// <c>GET /api/v{version}/operate/status</c>. One request yields a server-computed overall verdict
+/// plus per-domain rollups (deploys, jobs, alerts, migrations, findings, telemetry backends) and,
+/// when configured, an availability SLO / error-budget snapshot — so a copilot no longer has to
+/// stitch ~8 endpoints and invent its own "is the system healthy" verdict. The verdict logic lives
+/// server-side (see <see cref="OperateStatusVerdictEvaluator"/>); each domain carries a
+/// <c>source</c> hint so a caller can drill down to the authoritative endpoint.
+/// </summary>
+public sealed class OperateStatusResponse
+{
+    /// <summary>Gets the payload schema version (semantic; additive changes bump the minor).</summary>
+    [JsonPropertyName("schemaVersion")]
+    public required string SchemaVersion { get; init; }
+
+    /// <summary>Gets the UTC time the status was computed.</summary>
+    [JsonPropertyName("generatedAt")]
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Gets the server-computed overall verdict: <c>healthy</c>, <c>degraded</c>, or <c>unhealthy</c>.</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Gets the documented, machine-readable reasons that drove the verdict (for example
+    /// <c>health-rollup:Degraded</c>, <c>critical-finding:deploy-manual-intervention</c>,
+    /// <c>deploy-parked</c>). Empty when the verdict is <c>healthy</c>.
+    /// </summary>
+    [JsonPropertyName("reasons")]
+    public required IReadOnlyList<string> Reasons { get; init; }
+
+    /// <summary>Gets the per-domain operational rollups.</summary>
+    [JsonPropertyName("domains")]
+    public required OperateStatusDomains Domains { get; init; }
+
+    /// <summary>Gets the availability SLO / error-budget snapshot (or its explicit not-configured state).</summary>
+    [JsonPropertyName("slo")]
+    public required OperateSloView Slo { get; init; }
+}
+
+/// <summary>Per-domain operational rollups composing the aggregated status.</summary>
+public sealed class OperateStatusDomains
+{
+    /// <summary>Gets the deploy control-plane rollup.</summary>
+    [JsonPropertyName("deploys")]
+    public required OperateDeploysView Deploys { get; init; }
+
+    /// <summary>Gets the durable jobs / batch-compute rollup.</summary>
+    [JsonPropertyName("jobs")]
+    public required OperateJobsView Jobs { get; init; }
+
+    /// <summary>Gets the alert dispatch / outbox rollup.</summary>
+    [JsonPropertyName("alerts")]
+    public required OperateAlertsView Alerts { get; init; }
+
+    /// <summary>Gets the schema-migration rollup.</summary>
+    [JsonPropertyName("migrations")]
+    public required OperateMigrationsView Migrations { get; init; }
+
+    /// <summary>Gets the deterministic ops-findings rollup.</summary>
+    [JsonPropertyName("findings")]
+    public required OperateFindingsView Findings { get; init; }
+
+    /// <summary>Gets the telemetry-backend posture rollup.</summary>
+    [JsonPropertyName("telemetryBackends")]
+    public required OperateTelemetryBackendsView TelemetryBackends { get; init; }
+}
+
+/// <summary>Deploy control-plane rollup: active/parked/awaiting-approval counts and last outcome.</summary>
+public sealed class OperateDeploysView
+{
+    /// <summary>Gets the drill-down source endpoint hint.</summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    /// <summary>Gets a value indicating whether the durable workflow-operation store is wired (Redis control plane).</summary>
+    [JsonPropertyName("available")]
+    public required bool Available { get; init; }
+
+    /// <summary>Gets the count of in-flight deploy operations (Submitted/Reconciling/RollbackRequested).</summary>
+    [JsonPropertyName("active")]
+    public required int Active { get; init; }
+
+    /// <summary>Gets the count of deploy operations parked in ManualInterventionRequired.</summary>
+    [JsonPropertyName("parked")]
+    public required int Parked { get; init; }
+
+    /// <summary>Gets the count of deploy operations blocked awaiting an approval step.</summary>
+    [JsonPropertyName("awaitingApproval")]
+    public required int AwaitingApproval { get; init; }
+
+    /// <summary>Gets the active deploy-operation counts by workflow status.</summary>
+    [JsonPropertyName("byStatus")]
+    public required IReadOnlyDictionary<string, int> ByStatus { get; init; }
+
+    /// <summary>Gets the status of the most-recently-updated active operation, or <c>null</c> when none are active.</summary>
+    [JsonPropertyName("lastOutcome")]
+    public string? LastOutcome { get; init; }
+}
+
+/// <summary>Durable jobs / batch-compute rollup: queued/running counts, backend kinds, substrate posture.</summary>
+public sealed class OperateJobsView
+{
+    /// <summary>Gets the drill-down source endpoint hint.</summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    /// <summary>Gets a value indicating whether the durable execution-job store is wired.</summary>
+    [JsonPropertyName("available")]
+    public required bool Available { get; init; }
+
+    /// <summary>Gets the total active jobs (queued + provisioning + running).</summary>
+    [JsonPropertyName("totalActive")]
+    public required int TotalActive { get; init; }
+
+    /// <summary>Gets the count of queued jobs.</summary>
+    [JsonPropertyName("queued")]
+    public required int Queued { get; init; }
+
+    /// <summary>Gets the count of provisioning/running jobs.</summary>
+    [JsonPropertyName("running")]
+    public required int Running { get; init; }
+
+    /// <summary>Gets the distinct batch-compute backend kinds observed in the active queue (e.g. <c>local</c>, <c>honua-aws-batch</c>).</summary>
+    [JsonPropertyName("backends")]
+    public required IReadOnlyList<string> Backends { get; init; }
+
+    /// <summary>Gets the active-job counts bucketed by status and backend.</summary>
+    [JsonPropertyName("byStatusBackend")]
+    public required IReadOnlyList<OperateJobBucketView> ByStatusBackend { get; init; }
+
+    /// <summary>Gets the local-backend substrate-compatibility posture.</summary>
+    [JsonPropertyName("substrate")]
+    public required OperateSubstrateView Substrate { get; init; }
+}
+
+/// <summary>A single active-job status/backend bucket.</summary>
+public sealed class OperateJobBucketView
+{
+    /// <summary>Gets the non-terminal job status (Queued/Provisioning/Running).</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>Gets the batch-compute backend identifier.</summary>
+    [JsonPropertyName("backend")]
+    public required string Backend { get; init; }
+
+    /// <summary>Gets the active-job count in this bucket.</summary>
+    [JsonPropertyName("count")]
+    public required int Count { get; init; }
+}
+
+/// <summary>Local batch-compute substrate-compatibility posture.</summary>
+public sealed class OperateSubstrateView
+{
+    /// <summary>
+    /// Gets a value indicating whether the substrate compatibility of the local backends has been
+    /// evaluated. v1 reports <c>false</c> (not evaluated) until the substrate-profile resolver lands
+    /// on this branch; the field is present so the payload shape is stable across that follow-up.
+    /// </summary>
+    [JsonPropertyName("evaluated")]
+    public required bool Evaluated { get; init; }
+
+    /// <summary>Gets the resolved substrate profile when evaluated (<c>SingleHost</c>/<c>MultiNode</c>/<c>Serverless</c>), otherwise <c>null</c>.</summary>
+    [JsonPropertyName("profile")]
+    public string? Profile { get; init; }
+
+    /// <summary>Gets a value indicating whether the local batch-compute backends are compatible with the substrate, when evaluated.</summary>
+    [JsonPropertyName("compatible")]
+    public bool? Compatible { get; init; }
+
+    /// <summary>Gets an operator-facing note about the substrate posture.</summary>
+    [JsonPropertyName("note")]
+    public string? Note { get; init; }
+}
+
+/// <summary>Alert dispatch / outbox rollup: open/dead-lettered counts, dispatcher state, channel circuits.</summary>
+public sealed class OperateAlertsView
+{
+    /// <summary>Gets the drill-down source endpoint hint.</summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    /// <summary>Gets a value indicating whether the alert pipeline is enabled by configuration.</summary>
+    [JsonPropertyName("enabled")]
+    public required bool Enabled { get; init; }
+
+    /// <summary>Gets a value indicating whether the dispatcher loop is running.</summary>
+    [JsonPropertyName("dispatcherRunning")]
+    public required bool DispatcherRunning { get; init; }
+
+    /// <summary>Gets a value indicating whether the most recent dispatch pass failed to reach the backlog store.</summary>
+    [JsonPropertyName("storagePollFailing")]
+    public required bool StoragePollFailing { get; init; }
+
+    /// <summary>Gets the pending (open, undelivered) dispatch backlog count, when a snapshot is available.</summary>
+    [JsonPropertyName("open")]
+    public long? Open { get; init; }
+
+    /// <summary>Gets the dead-lettered dispatch count (exhausted retries), when a snapshot is available.</summary>
+    [JsonPropertyName("deadLettered")]
+    public long? DeadLettered { get; init; }
+
+    /// <summary>Gets the timestamp of the most recent successful dispatch pass, when known.</summary>
+    [JsonPropertyName("lastPollAt")]
+    public DateTimeOffset? LastPollAt { get; init; }
+
+    /// <summary>
+    /// Gets the per-channel delivery circuit-breaker states. Empty on this branch — the per-channel
+    /// circuit breaker lands separately; the field is present so the shape is stable when it wires in.
+    /// </summary>
+    [JsonPropertyName("channelCircuits")]
+    public required IReadOnlyList<OperateChannelCircuitView> ChannelCircuits { get; init; }
+}
+
+/// <summary>Per-channel delivery circuit-breaker state.</summary>
+public sealed class OperateChannelCircuitView
+{
+    /// <summary>Gets the notification channel identifier.</summary>
+    [JsonPropertyName("channel")]
+    public required string Channel { get; init; }
+
+    /// <summary>Gets the circuit state (<c>open</c>/<c>half-open</c>/<c>closed</c>).</summary>
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+}
+
+/// <summary>Schema-migration rollup: pending counts and classification.</summary>
+public sealed class OperateMigrationsView
+{
+    /// <summary>Gets the drill-down source endpoint hint.</summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    /// <summary>Gets the count of pending (non-contract) migration scripts.</summary>
+    [JsonPropertyName("pending")]
+    public required int Pending { get; init; }
+
+    /// <summary>Gets the count of pending contract migration scripts (which hold coordinated-deploy readiness).</summary>
+    [JsonPropertyName("pendingContract")]
+    public required int PendingContract { get; init; }
+
+    /// <summary>Gets a value indicating whether a schema upgrade is required to reach the target version.</summary>
+    [JsonPropertyName("upgradeRequired")]
+    public required bool UpgradeRequired { get; init; }
+
+    /// <summary>Gets the coarse classification of the pending set: <c>none</c>, <c>expand-only</c>, or <c>contract-pending</c>.</summary>
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+}
+
+/// <summary>Deterministic ops-findings rollup: count by severity and the top items.</summary>
+public sealed class OperateFindingsView
+{
+    /// <summary>Gets the drill-down source endpoint hint.</summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    /// <summary>Gets the total number of active findings.</summary>
+    [JsonPropertyName("total")]
+    public required int Total { get; init; }
+
+    /// <summary>Gets the finding counts keyed by severity (<c>critical</c>/<c>warning</c>/<c>info</c>).</summary>
+    [JsonPropertyName("bySeverity")]
+    public required IReadOnlyDictionary<string, int> BySeverity { get; init; }
+
+    /// <summary>Gets the highest-severity findings (capped), each with its drill-down id.</summary>
+    [JsonPropertyName("top")]
+    public required IReadOnlyList<OperateFindingSummaryView> Top { get; init; }
+}
+
+/// <summary>A compact summary of a single ops finding for the aggregated status.</summary>
+public sealed class OperateFindingSummaryView
+{
+    /// <summary>Gets the deterministic finding identifier (used to drill down / propose its action).</summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>Gets the kebab-case rule identifier.</summary>
+    [JsonPropertyName("rule")]
+    public required string Rule { get; init; }
+
+    /// <summary>Gets the severity (<c>Info</c>/<c>Warning</c>/<c>Critical</c>).</summary>
+    [JsonPropertyName("severity")]
+    public required string Severity { get; init; }
+
+    /// <summary>Gets the short title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+}
+
+/// <summary>Telemetry-backend posture rollup: configured backends, kind, reachability posture.</summary>
+public sealed class OperateTelemetryBackendsView
+{
+    /// <summary>Gets the drill-down source hint (the configuration section).</summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    /// <summary>Gets the count of configured telemetry connections.</summary>
+    [JsonPropertyName("configured")]
+    public required int Configured { get; init; }
+
+    /// <summary>Gets the configured telemetry backends.</summary>
+    [JsonPropertyName("backends")]
+    public required IReadOnlyList<OperateTelemetryBackendView> Backends { get; init; }
+}
+
+/// <summary>A single configured telemetry backend.</summary>
+public sealed class OperateTelemetryBackendView
+{
+    /// <summary>Gets the connection identifier.</summary>
+    [JsonPropertyName("connectionId")]
+    public required string ConnectionId { get; init; }
+
+    /// <summary>Gets the provider kind (<c>prometheus</c>/<c>cloudwatch</c>/<c>azure-monitor</c>).</summary>
+    [JsonPropertyName("provider")]
+    public required string Provider { get; init; }
+
+    /// <summary>
+    /// Gets the reachability posture. v1 reports <c>configured-not-probed</c> — the backend is a
+    /// deploy-gating query provider, not liveness-probed on the status path; the field documents that
+    /// honestly rather than asserting reachability the server has not verified.
+    /// </summary>
+    [JsonPropertyName("reachabilityPosture")]
+    public required string ReachabilityPosture { get; init; }
+}
+
+/// <summary>Availability SLO / error-budget snapshot, or its explicit not-configured state.</summary>
+public sealed class OperateSloView
+{
+    /// <summary>Gets a value indicating whether an availability SLO target is configured.</summary>
+    [JsonPropertyName("configured")]
+    public required bool Configured { get; init; }
+
+    /// <summary>Gets an operator-facing reason when the SLO is not configured, otherwise <c>null</c>.</summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    /// <summary>Gets the availability SLO evaluation when configured, otherwise <c>null</c>.</summary>
+    [JsonPropertyName("availability")]
+    public OperateSloAvailabilityView? Availability { get; init; }
+}
+
+/// <summary>Evaluated availability SLO: target, observed availability, burn rate, remaining budget.</summary>
+public sealed class OperateSloAvailabilityView
+{
+    /// <summary>Gets the configured target availability (fraction in (0, 1)).</summary>
+    [JsonPropertyName("target")]
+    public required double Target { get; init; }
+
+    /// <summary>Gets the evaluation window in seconds (the in-process serving-latency aggregator's window).</summary>
+    [JsonPropertyName("windowSeconds")]
+    public required double WindowSeconds { get; init; }
+
+    /// <summary>Gets the request count observed over the window.</summary>
+    [JsonPropertyName("requestCount")]
+    public required long RequestCount { get; init; }
+
+    /// <summary>Gets the server-error count (HTTP status &gt;= 500) observed over the window.</summary>
+    [JsonPropertyName("errorCount")]
+    public required long ErrorCount { get; init; }
+
+    /// <summary>Gets the observed availability over the window (1 - errorRate), or <c>null</c> when there is no traffic to evaluate.</summary>
+    [JsonPropertyName("observed")]
+    public double? Observed { get; init; }
+
+    /// <summary>
+    /// Gets the error-budget burn rate: observed error fraction divided by the allowed error budget
+    /// (1 - target). <c>1.0</c> means the budget is being consumed exactly at the sustainable rate;
+    /// &gt; <c>1.0</c> means it is burning too fast. <c>null</c> when there is no traffic to evaluate.
+    /// </summary>
+    [JsonPropertyName("burnRate")]
+    public double? BurnRate { get; init; }
+
+    /// <summary>
+    /// Gets the fraction of the error budget still remaining over the window (0.0 = exhausted,
+    /// 1.0 = untouched), or <c>null</c> when there is no traffic to evaluate.
+    /// </summary>
+    [JsonPropertyName("errorBudgetRemaining")]
+    public double? ErrorBudgetRemaining { get; init; }
+
+    /// <summary>Gets a short label naming what the SLO actually evaluated against.</summary>
+    [JsonPropertyName("evaluationSource")]
+    public required string EvaluationSource { get; init; }
+}

--- a/src/Honua.Server/Features/Operations/Status/OperateStatusService.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateStatusService.cs
@@ -1,0 +1,285 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
+using Honua.Infrastructure.Monitoring;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>
+/// Composes the server-authoritative aggregated operational status: one server-computed verdict plus
+/// per-domain rollups and, when configured, an availability SLO snapshot. Built on the existing
+/// deterministic ops spine — it reuses <see cref="IOpsHealthSnapshotService"/> (which already stitches
+/// health, serving latency, GP queue, alert dispatch, deploy readiness, and database utilization) and
+/// <see cref="IOpsFindingsService"/> rather than re-wiring the low-level seams, and adds the
+/// deploy-operation state counts and telemetry-backend posture on top.
+/// </summary>
+internal interface IOperateStatusService
+{
+    /// <summary>Builds the aggregated operate status.</summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The composed status response.</returns>
+    Task<OperateStatusResponse> GetAsync(CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+internal sealed class OperateStatusService : IOperateStatusService
+{
+    /// <summary>The payload schema version. Additive changes bump the minor component.</summary>
+    internal const string SchemaVersion = "1.0";
+
+    private const int MaxTopFindings = 5;
+
+    private readonly IOpsHealthSnapshotService _healthSnapshot;
+    private readonly IOpsFindingsService _findings;
+    private readonly IOptionsMonitor<OperateSloOptions> _sloOptions;
+    private readonly IOptionsMonitor<ControlPlaneOptions> _controlPlaneOptions;
+    private readonly IWorkflowOperationStore? _workflowStore;
+
+    public OperateStatusService(
+        IOpsHealthSnapshotService healthSnapshot,
+        IOpsFindingsService findings,
+        IOptionsMonitor<OperateSloOptions> sloOptions,
+        IOptionsMonitor<ControlPlaneOptions> controlPlaneOptions,
+        IWorkflowOperationStore? workflowStore = null)
+    {
+        _healthSnapshot = healthSnapshot;
+        _findings = findings;
+        _sloOptions = sloOptions;
+        _controlPlaneOptions = controlPlaneOptions;
+        _workflowStore = workflowStore;
+    }
+
+    public async Task<OperateStatusResponse> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _healthSnapshot.GetAsync(cancellationToken).ConfigureAwait(false);
+        var findings = await _findings.EvaluateAsync(cancellationToken).ConfigureAwait(false);
+        var deploys = await BuildDeploysViewAsync(cancellationToken).ConfigureAwait(false);
+
+        var jobs = BuildJobsView(snapshot);
+        var alerts = BuildAlertsView(snapshot);
+        var migrations = BuildMigrationsView(snapshot);
+        var findingsView = BuildFindingsView(findings);
+        var telemetryBackends = BuildTelemetryBackendsView();
+        var slo = OperateSloEvaluator.Evaluate(_sloOptions.CurrentValue, HonuaTelemetry.GetServingLatencySnapshot());
+
+        var signals = new OperateStatusSignals(
+            HealthRollupStatus: snapshot.OverallStatus,
+            CriticalFindingRules: findings
+                .Where(f => f.Severity == OpsFindingSeverity.Critical)
+                .Select(f => f.Rule)
+                .Distinct(StringComparer.Ordinal)
+                .ToList(),
+            ParkedDeploys: deploys.Parked,
+            AlertDeadLettered: alerts.DeadLettered ?? 0,
+            AlertDispatchImpaired: (alerts.Enabled && !alerts.DispatcherRunning) || alerts.StoragePollFailing,
+            SloErrorBudgetExhausted: OperateSloEvaluator.IsErrorBudgetExhausted(slo));
+
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(signals);
+
+        return new OperateStatusResponse
+        {
+            SchemaVersion = SchemaVersion,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Status = OperateStatusVerdictEvaluator.ToWire(status),
+            Reasons = reasons,
+            Domains = new OperateStatusDomains
+            {
+                Deploys = deploys,
+                Jobs = jobs,
+                Alerts = alerts,
+                Migrations = migrations,
+                Findings = findingsView,
+                TelemetryBackends = telemetryBackends,
+            },
+            Slo = slo,
+        };
+    }
+
+    private async Task<OperateDeploysView> BuildDeploysViewAsync(CancellationToken cancellationToken)
+    {
+        const string source = "GET /api/v1/admin/deploy/operations/{operationId}";
+
+        if (_workflowStore is null)
+        {
+            return new OperateDeploysView
+            {
+                Source = source,
+                Available = false,
+                Active = 0,
+                Parked = 0,
+                AwaitingApproval = 0,
+                ByStatus = new Dictionary<string, int>(StringComparer.Ordinal),
+                LastOutcome = null,
+            };
+        }
+
+        var operations = await _workflowStore.ListActiveAsync(WorkflowOperationKind.Deploy, cancellationToken).ConfigureAwait(false);
+
+        var byStatus = operations
+            .GroupBy(o => o.Status)
+            .ToDictionary(g => g.Key.ToString(), g => g.Count(), StringComparer.Ordinal);
+
+        var active = Count(byStatus, WorkflowOperationStatus.Submitted)
+            + Count(byStatus, WorkflowOperationStatus.Reconciling)
+            + Count(byStatus, WorkflowOperationStatus.RollbackRequested);
+
+        var lastOutcome = operations
+            .OrderByDescending(o => o.UpdatedAt)
+            .Select(o => o.Status.ToString())
+            .FirstOrDefault();
+
+        return new OperateDeploysView
+        {
+            Source = source,
+            Available = true,
+            Active = active,
+            Parked = Count(byStatus, WorkflowOperationStatus.ManualInterventionRequired),
+            AwaitingApproval = Count(byStatus, WorkflowOperationStatus.AwaitingApproval),
+            ByStatus = byStatus,
+            LastOutcome = lastOutcome,
+        };
+
+        static int Count(IReadOnlyDictionary<string, int> byStatus, WorkflowOperationStatus status)
+            => byStatus.TryGetValue(status.ToString(), out var count) ? count : 0;
+    }
+
+    private static OperateJobsView BuildJobsView(OpsHealthSnapshotResponse snapshot)
+    {
+        var gp = snapshot.Geoprocessing;
+        var buckets = gp.Buckets
+            .Select(b => new OperateJobBucketView { Status = b.Status, Backend = b.Backend, Count = b.Count })
+            .ToList();
+
+        var queued = buckets
+            .Where(b => string.Equals(b.Status, nameof(ExecutionJobStatus.Queued), StringComparison.OrdinalIgnoreCase))
+            .Sum(b => b.Count);
+        var running = buckets
+            .Where(b => !string.Equals(b.Status, nameof(ExecutionJobStatus.Queued), StringComparison.OrdinalIgnoreCase))
+            .Sum(b => b.Count);
+
+        var backends = buckets
+            .Select(b => b.Backend)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(b => b, StringComparer.Ordinal)
+            .ToList();
+
+        return new OperateJobsView
+        {
+            Source = "GET /api/v1/admin/observability/ops-health",
+            Available = gp.Available,
+            TotalActive = gp.TotalActive,
+            Queued = queued,
+            Running = running,
+            Backends = backends,
+            ByStatusBackend = buckets,
+            // The substrate-profile resolver / local-backend compatibility evaluator are not on this
+            // branch yet; the shape is present and reports "not evaluated" until that lands (see PR
+            // fix/substrate-fail-closed).
+            Substrate = new OperateSubstrateView
+            {
+                Evaluated = false,
+                Profile = null,
+                Compatible = null,
+                Note = "Substrate compatibility is not evaluated on this build; local-backend "
+                    + "substrate posture is surfaced by the substrate-fail-closed work.",
+            },
+        };
+    }
+
+    private static OperateAlertsView BuildAlertsView(OpsHealthSnapshotResponse snapshot)
+    {
+        var dispatch = snapshot.AlertDispatch;
+        return new OperateAlertsView
+        {
+            Source = "GET /api/v1/admin/observability/alerts",
+            Enabled = dispatch.DispatcherEnabled,
+            DispatcherRunning = dispatch.DispatcherRunning,
+            StoragePollFailing = dispatch.StoragePollFailing,
+            Open = dispatch.PendingCount,
+            DeadLettered = dispatch.DeadLetteredCount,
+            LastPollAt = dispatch.LastPollAt,
+            // Per-channel delivery circuit-breaker enumeration is not on this branch; empty until the
+            // alert circuit-breaker work exposes a state snapshot.
+            ChannelCircuits = [],
+        };
+    }
+
+    private static OperateMigrationsView BuildMigrationsView(OpsHealthSnapshotResponse snapshot)
+    {
+        var deploy = snapshot.Deploy;
+        var pending = deploy.PendingMigrationsCount;
+        var pendingContract = deploy.PendingContractScriptsCount;
+
+        var classification = pendingContract > 0
+            ? "contract-pending"
+            : pending > 0 ? "expand-only" : "none";
+
+        return new OperateMigrationsView
+        {
+            Source = "GET /api/v1/admin/observability/migrations",
+            Pending = pending,
+            PendingContract = pendingContract,
+            UpgradeRequired = pending > 0 || pendingContract > 0,
+            Classification = classification,
+        };
+    }
+
+    private static OperateFindingsView BuildFindingsView(IReadOnlyList<OpsFinding> findings)
+    {
+        var bySeverity = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["critical"] = findings.Count(f => f.Severity == OpsFindingSeverity.Critical),
+            ["warning"] = findings.Count(f => f.Severity == OpsFindingSeverity.Warning),
+            ["info"] = findings.Count(f => f.Severity == OpsFindingSeverity.Info),
+        };
+
+        // findings arrive ordered by descending severity from the engine; take the top N verbatim.
+        var top = findings
+            .Take(MaxTopFindings)
+            .Select(f => new OperateFindingSummaryView
+            {
+                Id = f.Id,
+                Rule = f.Rule,
+                Severity = f.Severity.ToString(),
+                Title = f.Title,
+            })
+            .ToList();
+
+        return new OperateFindingsView
+        {
+            Source = "GET /api/v1/admin/observability/findings",
+            Total = findings.Count,
+            BySeverity = bySeverity,
+            Top = top,
+        };
+    }
+
+    private OperateTelemetryBackendsView BuildTelemetryBackendsView()
+    {
+        var connections = _controlPlaneOptions.CurrentValue.TelemetryConnections;
+        var backends = connections
+            .Select(c => new OperateTelemetryBackendView
+            {
+                ConnectionId = c.ConnectionId,
+                Provider = string.IsNullOrWhiteSpace(c.Provider) ? "prometheus" : c.Provider,
+                // These are deploy-gating query providers, not liveness-probed on the status path.
+                ReachabilityPosture = "configured-not-probed",
+            })
+            .OrderBy(b => b.ConnectionId, StringComparer.Ordinal)
+            .ToList();
+
+        return new OperateTelemetryBackendsView
+        {
+            Source = "ControlPlane:TelemetryConnections",
+            Configured = backends.Count,
+            Backends = backends,
+        };
+    }
+}

--- a/src/Honua.Server/Features/Operations/Status/OperateStatusServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateStatusServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>
+/// DI registration for the aggregated operate-status feature (A12): the SLO options and the
+/// composing service.
+/// </summary>
+internal static class OperateStatusServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the aggregated operate-status service and binds the SLO configuration. Scoped
+    /// because it composes the scoped ops-health snapshot and ops-findings services.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddOperateStatus(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<OperateSloOptions>()
+            .Bind(configuration.GetSection(OperateSloOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddScoped<IOperateStatusService, OperateStatusService>();
+
+        return services;
+    }
+}

--- a/src/Honua.Server/Features/Operations/Status/OperateStatusVerdictEvaluator.cs
+++ b/src/Honua.Server/Features/Operations/Status/OperateStatusVerdictEvaluator.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Server.Features.Operations.Status;
+
+/// <summary>The server-computed overall operational verdict.</summary>
+public enum OperateOverallStatus
+{
+    /// <summary>All observed domains are clear.</summary>
+    Healthy = 0,
+
+    /// <summary>Serving continues but at least one domain needs attention.</summary>
+    Degraded = 1,
+
+    /// <summary>A critical dependency is down; the system is not fully serving.</summary>
+    Unhealthy = 2,
+}
+
+/// <summary>
+/// The signals the verdict is computed from. Kept as a plain input record so the verdict rules are
+/// side-effect-free and unit-testable without any DI, HTTP, or store access.
+/// </summary>
+/// <param name="HealthRollupStatus">
+/// The ASP.NET Core health-check roll-up status string (<c>Healthy</c>/<c>Degraded</c>/<c>Unhealthy</c>).
+/// </param>
+/// <param name="CriticalFindingRules">The kebab-case rule ids of active Critical findings (drives reasons).</param>
+/// <param name="ParkedDeploys">Count of deploy operations parked in ManualInterventionRequired.</param>
+/// <param name="AlertDeadLettered">Dead-lettered alert dispatch count (0 when unknown/none).</param>
+/// <param name="AlertDispatchImpaired">Whether the alert dispatcher is enabled but not running, or its storage poll is failing.</param>
+/// <param name="SloErrorBudgetExhausted">Whether a configured availability SLO has exhausted its error budget over the window.</param>
+public readonly record struct OperateStatusSignals(
+    string HealthRollupStatus,
+    IReadOnlyList<string> CriticalFindingRules,
+    int ParkedDeploys,
+    long AlertDeadLettered,
+    bool AlertDispatchImpaired,
+    bool SloErrorBudgetExhausted);
+
+/// <summary>
+/// Pure, documented verdict rules for the aggregated operate status. The verdict lives server-side so
+/// every caller sees the same authoritative "is the system healthy" answer instead of inventing one.
+/// </summary>
+/// <remarks>
+/// Rules (evaluated in order):
+/// <list type="number">
+///   <item><b>unhealthy</b> — the health-check roll-up is <c>Unhealthy</c> (a critical dependency such
+///   as the database or Redis is down; the system is not fully serving).</item>
+///   <item><b>degraded</b> — not unhealthy, but any of: the health roll-up is <c>Degraded</c>; at least
+///   one <c>Critical</c> finding is active; a deploy is parked in ManualInterventionRequired; alert
+///   deliveries have dead-lettered; the alert dispatcher is impaired; or a configured availability SLO
+///   has exhausted its error budget.</item>
+///   <item><b>healthy</b> — none of the above.</item>
+/// </list>
+/// Warning/Info findings and pending (non-parking) work do not by themselves downgrade the verdict —
+/// they are surfaced in the domain rollups for an operator to weigh, keeping the verdict honest about
+/// what actually threatens serving.
+/// </remarks>
+public static class OperateStatusVerdictEvaluator
+{
+    /// <summary>
+    /// Computes the overall verdict and the machine-readable reasons that drove it.
+    /// </summary>
+    /// <param name="signals">The aggregated verdict signals.</param>
+    /// <returns>The overall status and an ordered, deduplicated list of reason tokens.</returns>
+    public static (OperateOverallStatus Status, IReadOnlyList<string> Reasons) Evaluate(OperateStatusSignals signals)
+    {
+        var reasons = new List<string>();
+        var rollup = signals.HealthRollupStatus;
+
+        // Rule 1: a critical dependency is down.
+        if (string.Equals(rollup, "Unhealthy", StringComparison.OrdinalIgnoreCase))
+        {
+            reasons.Add("health-rollup:Unhealthy");
+            return (OperateOverallStatus.Unhealthy, reasons);
+        }
+
+        // Rule 2: degradation signals.
+        if (string.Equals(rollup, "Degraded", StringComparison.OrdinalIgnoreCase))
+        {
+            reasons.Add("health-rollup:Degraded");
+        }
+
+        foreach (var rule in signals.CriticalFindingRules ?? [])
+        {
+            reasons.Add($"critical-finding:{rule}");
+        }
+
+        if (signals.ParkedDeploys > 0)
+        {
+            reasons.Add("deploy-parked");
+        }
+
+        if (signals.AlertDeadLettered > 0)
+        {
+            reasons.Add("alert-dead-lettered");
+        }
+
+        if (signals.AlertDispatchImpaired)
+        {
+            reasons.Add("alert-dispatch-impaired");
+        }
+
+        if (signals.SloErrorBudgetExhausted)
+        {
+            reasons.Add("slo-error-budget-exhausted");
+        }
+
+        var status = reasons.Count > 0 ? OperateOverallStatus.Degraded : OperateOverallStatus.Healthy;
+        return (status, reasons);
+    }
+
+    /// <summary>Maps the verdict enum to its lowercase wire token.</summary>
+    /// <param name="status">The verdict.</param>
+    /// <returns>The wire string (<c>healthy</c>/<c>degraded</c>/<c>unhealthy</c>).</returns>
+    public static string ToWire(OperateOverallStatus status) => status switch
+    {
+        OperateOverallStatus.Healthy => "healthy",
+        OperateOverallStatus.Degraded => "degraded",
+        OperateOverallStatus.Unhealthy => "unhealthy",
+        _ => "unhealthy",
+    };
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -71,6 +71,7 @@ using Honua.Server.Features.Orchestration;
 using Honua.Server.Features.Studio;
 using Honua.PackageReview;
 using Honua.Server.Features.Operations;
+using Honua.Server.Features.Operations.Status;
 using Honua.Server.Features.Streaming;
 using Honua.Server.Features.WorkflowPackages;
 using Honua.Server.Startup;
@@ -1311,6 +1312,9 @@ app.MapProposalEndpoints();
 
 // Consolidated ops-health snapshot + deterministic ops-findings engine (ADR-0060 WS4 / #2457).
 app.MapOpsObservabilityEndpoints();
+
+// Server-authoritative aggregated operational status + read-only ops scope (A12).
+app.MapOperateStatusEndpoints();
 
 // Configure admin layer style endpoints
 app.MapAdminLayerStyleEndpoints();

--- a/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
@@ -73,6 +73,7 @@ public sealed class CapabilityRegistryConformanceTests
         "upload.file",
         "edit.features",
         "versioning.branch",
+        "operate.status",
     ];
 
     // Format descriptors that intentionally exist beyond the SupportedFileFormat

--- a/tests/dotnet/Honua.Architecture.Tests/EndpointAuthorizationGuardTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/EndpointAuthorizationGuardTests.cs
@@ -38,6 +38,9 @@ public sealed class EndpointAuthorizationGuardTests
         "RequireTemporalHistoryRead",
         "RequireTemporalDiffRead",
         "RequireTemporalRollbackExecute",
+        // Read-only ops-reader policy (A12): a method-aware Require*Authorization helper that admits
+        // ops:read/admin for safe reads while still requiring full admin write for mutating routes.
+        "RequireOpsReadAuthorization",
     };
 
     private static readonly Regex MapMutationRegex = new(

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
@@ -57,6 +57,7 @@ public sealed class CapabilityManifestRegistryProjectionTests
         "upload.file",
         "edit.features",
         "versioning.branch",
+        "operate.status",
     ];
 
     private static bool IsManifestCapability(CapabilityDescriptor descriptor)

--- a/tests/dotnet/Honua.Server.Tests/Features/Operations/OperateSloEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Operations/OperateSloEvaluatorTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Features.Operations.Status;
+using Honua.ServiceDefaults;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.OperateStatus;
+
+/// <summary>
+/// Unit tests for the minimal v1 availability SLO / error-budget evaluation (A12). Deterministic —
+/// exercises what the contract actually computes from the in-process serving-latency window, and the
+/// explicit not-configured state.
+/// </summary>
+public sealed class OperateSloEvaluatorTests
+{
+    private static ServingLatencySnapshot Snapshot(long requestCount, long errorCount, double windowSeconds = 300)
+        => new()
+        {
+            WindowSeconds = windowSeconds,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Protocols =
+            [
+                new ServingLatencyProtocolSnapshot
+                {
+                    Protocol = "featureserver",
+                    RequestCount = requestCount,
+                    ErrorCount = errorCount,
+                    ErrorRate = requestCount == 0 ? 0 : (double)errorCount / requestCount,
+                    P50Ms = 1,
+                    P95Ms = 2,
+                    P99Ms = 3,
+                    MaxMs = 4,
+                },
+            ],
+        };
+
+    [Fact]
+    public void Evaluate_NoTarget_ReportsNotConfigured()
+    {
+        var options = new OperateSloOptions { Availability = new AvailabilityOptions { Target = null } };
+
+        var view = OperateSloEvaluator.Evaluate(options, Snapshot(100, 0));
+
+        view.Configured.Should().BeFalse();
+        view.Reason.Should().NotBeNullOrWhiteSpace();
+        view.Availability.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_ConfiguredWithHealthyTraffic_ComputesBudgetRemaining()
+    {
+        var options = new OperateSloOptions { Availability = new AvailabilityOptions { Target = 0.99 } };
+
+        // 1000 requests, 1 error => error fraction 0.001; budget 0.01; burn 0.1; remaining 0.9.
+        var view = OperateSloEvaluator.Evaluate(options, Snapshot(1000, 1));
+
+        view.Configured.Should().BeTrue();
+        view.Availability.Should().NotBeNull();
+        view.Availability!.Target.Should().Be(0.99);
+        view.Availability.RequestCount.Should().Be(1000);
+        view.Availability.ErrorCount.Should().Be(1);
+        view.Availability.Observed.Should().BeApproximately(0.999, 1e-9);
+        view.Availability.BurnRate.Should().BeApproximately(0.1, 1e-9);
+        view.Availability.ErrorBudgetRemaining.Should().BeApproximately(0.9, 1e-9);
+        OperateSloEvaluator.IsErrorBudgetExhausted(view).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_ConfiguredWithNoTraffic_LeavesEvaluationNull()
+    {
+        var options = new OperateSloOptions { Availability = new AvailabilityOptions { Target = 0.995 } };
+
+        var view = OperateSloEvaluator.Evaluate(options, Snapshot(0, 0));
+
+        view.Configured.Should().BeTrue();
+        view.Availability.Should().NotBeNull();
+        view.Availability!.Observed.Should().BeNull();
+        view.Availability.BurnRate.Should().BeNull();
+        view.Availability.ErrorBudgetRemaining.Should().BeNull();
+        OperateSloEvaluator.IsErrorBudgetExhausted(view).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Evaluate_BudgetExhausted_IsDetected()
+    {
+        var options = new OperateSloOptions { Availability = new AvailabilityOptions { Target = 0.99 } };
+
+        // 100 requests, 5 errors => error fraction 0.05; budget 0.01; burn 5.0; remaining clamped to 0.
+        var view = OperateSloEvaluator.Evaluate(options, Snapshot(100, 5));
+
+        view.Availability!.ErrorBudgetRemaining.Should().Be(0.0);
+        view.Availability.BurnRate.Should().BeApproximately(5.0, 1e-9);
+        OperateSloEvaluator.IsErrorBudgetExhausted(view).Should().BeTrue();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Operations/OperateStatusEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Operations/OperateStatusEndpointsTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Server.Features.Admin.Models;
+using Honua.Infrastructure.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.OperateStatus;
+
+/// <summary>
+/// Integration tests for the server-authoritative aggregated operate-status endpoint and the
+/// read-only ops-reader authorization split (A12). Compile locally; the full assertions run in CI
+/// (Testcontainers).
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.HealthCheck)]
+public sealed class OperateStatusEndpointsTests : IAsyncLifetime
+{
+    private const string AdminPassword = "operate-status-admin-key";
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public OperateStatusEndpointsTests()
+    {
+        _fixture = new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                // Configure the availability SLO so the payload evaluates (rather than reporting
+                // not-configured) on this fixture.
+                builder.UseSetting("Slo:Availability:Target", "0.995");
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", AdminPassword));
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/operate/status")]
+    public async Task GetStatus_WithAdminAuth_ReturnsSelfDescribingVerdictAndDomains()
+    {
+        var response = await _client.GetAsync("/api/v1/operate/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("schemaVersion").GetString().Should().Be("1.0");
+        root.TryGetProperty("generatedAt", out _).Should().BeTrue();
+        root.GetProperty("status").GetString().Should().BeOneOf("healthy", "degraded", "unhealthy");
+        root.GetProperty("reasons").ValueKind.Should().Be(JsonValueKind.Array);
+
+        var domains = root.GetProperty("domains");
+        foreach (var domain in new[] { "deploys", "jobs", "alerts", "migrations", "findings", "telemetryBackends" })
+        {
+            domains.TryGetProperty(domain, out var view).Should().BeTrue($"domain '{domain}' must be present");
+            view.GetProperty("source").GetString().Should().NotBeNullOrWhiteSpace(
+                $"domain '{domain}' must carry a drill-down source hint");
+        }
+
+        // findings rollup carries a severity breakdown so a copilot need not recount.
+        var findings = domains.GetProperty("findings");
+        findings.TryGetProperty("total", out _).Should().BeTrue();
+        findings.GetProperty("bySeverity").TryGetProperty("critical", out _).Should().BeTrue();
+
+        // SLO configured on this fixture => it evaluates an availability block.
+        var slo = root.GetProperty("slo");
+        slo.GetProperty("configured").GetBoolean().Should().BeTrue();
+        slo.GetProperty("availability").GetProperty("target").GetDouble().Should().Be(0.995);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/operate/status")]
+    public async Task GetStatus_WithoutAuth_IsUnauthorized()
+    {
+        using var anonymous = _fixture.CreateClient();
+
+        var response = await anonymous.GetAsync("/api/v1/operate/status");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/operate/status")]
+    public async Task GetStatus_WithOpsReadKey_IsAuthorized()
+    {
+        using var opsReader = await CreateOpsReaderClientAsync();
+
+        var response = await opsReader.GetAsync("/api/v1/operate/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/operate/status")]
+    [Endpoint("GET /api/v1/admin/observability/findings")]
+    public async Task OpsReadKey_CanReadStatusAndFindings()
+    {
+        using var opsReader = await CreateOpsReaderClientAsync();
+
+        (await opsReader.GetAsync("/api/v1/operate/status")).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await opsReader.GetAsync("/api/v1/admin/observability/findings")).StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/admin/deploy/operations/{operationId}/rollback")]
+    [Endpoint("POST /api/v1/admin/observability/findings/{findingId}/propose")]
+    public async Task OpsReadKey_CannotInvokeMutatingOpsEndpoints()
+    {
+        using var opsReader = await CreateOpsReaderClientAsync();
+
+        // Mutating deploy endpoint keeps the admin policy: an ops-reader (non-admin scoped) key is 403.
+        var rollback = await opsReader.PostAsync(
+            "/api/v1/admin/deploy/operations/does-not-exist/rollback", content: null);
+        rollback.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        // Mutating propose endpoint shares the method-aware ops-read group but still requires admin write.
+        var propose = await opsReader.PostAsync(
+            "/api/v1/admin/observability/findings/does-not-exist/propose", content: null);
+        propose.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/operate/status")]
+    public async Task OpsReadKey_IsNarrowerThanAdminRead_DeniedNonOpsAdminSurface()
+    {
+        using var opsReader = await CreateOpsReaderClientAsync();
+
+        // ops:read is scoped to the ops-observability surfaces; it does NOT grant admin key-management.
+        var adminSurface = await opsReader.GetAsync("/api/v1/admin/api-keys");
+        adminSurface.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private async Task<HttpClient> CreateOpsReaderClientAsync()
+    {
+        var request = new CreateAdminApiKeyRequest
+        {
+            Name = $"ops-reader-{Guid.NewGuid():N}",
+            Permissions = ["ops:read"],
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/admin/api-keys", request, _jsonOptions);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var created = JsonSerializer.Deserialize<ApiResponse<AdminApiKeySecretResponse>>(
+            await response.Content.ReadAsStringAsync(), _jsonOptions);
+        created!.Data.Should().NotBeNull();
+
+        return _fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", created.Data.Key));
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Operations/OperateStatusVerdictEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Operations/OperateStatusVerdictEvaluatorTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Features.Operations.Status;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.OperateStatus;
+
+/// <summary>
+/// Unit tests for the server-side aggregated-status verdict rules (A12). Pure and deterministic —
+/// they pin the documented "is the system healthy" logic under composed conditions so the verdict is
+/// never client-invented.
+/// </summary>
+public sealed class OperateStatusVerdictEvaluatorTests
+{
+    private static OperateStatusSignals Clear(string rollup = "Healthy")
+        => new(
+            HealthRollupStatus: rollup,
+            CriticalFindingRules: [],
+            ParkedDeploys: 0,
+            AlertDeadLettered: 0,
+            AlertDispatchImpaired: false,
+            SloErrorBudgetExhausted: false);
+
+    [Fact]
+    public void Evaluate_AllClear_IsHealthy()
+    {
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(Clear());
+
+        status.Should().Be(OperateOverallStatus.Healthy);
+        reasons.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Evaluate_HealthRollupUnhealthy_IsUnhealthy()
+    {
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(Clear("Unhealthy"));
+
+        status.Should().Be(OperateOverallStatus.Unhealthy);
+        reasons.Should().Contain("health-rollup:Unhealthy");
+    }
+
+    [Fact]
+    public void Evaluate_CriticalFinding_IsDegraded()
+    {
+        var signals = Clear() with { CriticalFindingRules = ["deploy-manual-intervention"] };
+
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(signals);
+
+        status.Should().Be(OperateOverallStatus.Degraded);
+        reasons.Should().Contain("critical-finding:deploy-manual-intervention");
+    }
+
+    [Fact]
+    public void Evaluate_ParkedDeploy_IsDegraded()
+    {
+        var signals = Clear() with { ParkedDeploys = 1 };
+
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(signals);
+
+        status.Should().Be(OperateOverallStatus.Degraded);
+        reasons.Should().Contain("deploy-parked");
+    }
+
+    [Fact]
+    public void Evaluate_HealthRollupDegraded_IsDegraded()
+    {
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(Clear("Degraded"));
+
+        status.Should().Be(OperateOverallStatus.Degraded);
+        reasons.Should().Contain("health-rollup:Degraded");
+    }
+
+    [Fact]
+    public void Evaluate_AlertDeadLettered_IsDegraded()
+    {
+        var signals = Clear() with { AlertDeadLettered = 3 };
+
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(signals);
+
+        status.Should().Be(OperateOverallStatus.Degraded);
+        reasons.Should().Contain("alert-dead-lettered");
+    }
+
+    [Fact]
+    public void Evaluate_SloErrorBudgetExhausted_IsDegraded()
+    {
+        var signals = Clear() with { SloErrorBudgetExhausted = true };
+
+        var (status, reasons) = OperateStatusVerdictEvaluator.Evaluate(signals);
+
+        status.Should().Be(OperateOverallStatus.Degraded);
+        reasons.Should().Contain("slo-error-budget-exhausted");
+    }
+
+    [Fact]
+    public void Evaluate_UnhealthyDominatesOtherDegradations()
+    {
+        var signals = Clear("Unhealthy") with
+        {
+            CriticalFindingRules = ["deploy-manual-intervention"],
+            ParkedDeploys = 2,
+        };
+
+        var (status, _) = OperateStatusVerdictEvaluator.Evaluate(signals);
+
+        status.Should().Be(OperateOverallStatus.Unhealthy);
+    }
+
+    [Theory]
+    [InlineData(OperateOverallStatus.Healthy, "healthy")]
+    [InlineData(OperateOverallStatus.Degraded, "degraded")]
+    [InlineData(OperateOverallStatus.Unhealthy, "unhealthy")]
+    public void ToWire_MapsToLowercaseToken(OperateOverallStatus status, string expected)
+        => OperateStatusVerdictEvaluator.ToWire(status).Should().Be(expected);
+}

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OpsReadAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OpsReadAuthorizationTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Xunit;
+
+namespace Honua.Server.Tests.Infrastructure.Authentication;
+
+/// <summary>
+/// Unit tests for the read-only ops-reader permission grammar (A12). Pure, deterministic tests of
+/// <see cref="AdminApiKeyPermission.HasOpsReadGrant"/> and
+/// <see cref="AdminApiKeyPermission.IsOpsReadAuthorized"/> — no database or Docker.
+/// </summary>
+public sealed class OpsReadAuthorizationTests
+{
+    private static ClaimsPrincipal Principal(string? role, params string[] permissions)
+    {
+        var claims = new List<Claim>();
+        if (role is not null)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        foreach (var permission in permissions)
+        {
+            claims.Add(new Claim(AdminApiKeyPermission.PermissionClaimType, permission));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+    }
+
+    [Theory]
+    [InlineData("ops:read")]
+    [InlineData("ops:reader")]
+    [InlineData("ops:*")]
+    [InlineData("OPS:READ")]
+    public void HasOpsReadGrant_OpsGrant_IsTrue(string grant)
+        => AdminApiKeyPermission.HasOpsReadGrant(Principal("scoped-api-key", grant)).Should().BeTrue();
+
+    [Theory]
+    [InlineData("admin:read")]
+    [InlineData("write:svc/layer")]
+    [InlineData("read:layers")]
+    public void HasOpsReadGrant_NonOpsGrant_IsFalse(string grant)
+        => AdminApiKeyPermission.HasOpsReadGrant(Principal("scoped-api-key", grant)).Should().BeFalse();
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public void IsOpsReadAuthorized_OpsReadKey_SafeMethod_IsAuthorized(string method)
+        => AdminApiKeyPermission.IsOpsReadAuthorized(Principal("scoped-api-key", "ops:read"), method)
+            .Should().BeTrue();
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("PATCH")]
+    [InlineData("DELETE")]
+    public void IsOpsReadAuthorized_OpsReadKey_MutatingMethod_IsDenied(string method)
+        => AdminApiKeyPermission.IsOpsReadAuthorized(Principal("scoped-api-key", "ops:read"), method)
+            .Should().BeFalse();
+
+    [Fact]
+    public void IsOpsReadAuthorized_AdminReadKey_SafeMethod_IsAuthorized()
+        => AdminApiKeyPermission.IsOpsReadAuthorized(Principal("admin", "admin:read"), "GET")
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsOpsReadAuthorized_AdminReadKey_MutatingMethod_IsDenied()
+        => AdminApiKeyPermission.IsOpsReadAuthorized(Principal("admin", "admin:read"), "POST")
+            .Should().BeFalse();
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    [InlineData("DELETE")]
+    public void IsOpsReadAuthorized_FullAdmin_AnyMethod_IsAuthorized(string method)
+        => AdminApiKeyPermission.IsOpsReadAuthorized(Principal("admin", "admin:*"), method)
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsOpsReadAuthorized_BootstrapAdmin_NoClaims_AnyMethod_IsAuthorized()
+    {
+        // Bootstrap password / client cert: admin role, no permission claims => full admin write.
+        AdminApiKeyPermission.IsOpsReadAuthorized(Principal("admin"), "POST").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsOpsReadAuthorized_NonOpsNonAdminKey_IsDenied()
+    {
+        // A layer-scoped write key carries no admin or ops grant: denied even on safe reads.
+        AdminApiKeyPermission.IsOpsReadAuthorized(Principal("layer-write-key", "write:svc/layer"), "GET")
+            .Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Issue Link
Closes #2559

## Summary
Adds one server-authoritative aggregated operational status surface and a read-only ops authorization scope, closing the two gaps the ops review named: (1) copilots had to stitch ~8 endpoints and invent their own "is the system healthy" verdict, with no error-budget contract; (2) all ops endpoints shared one admin scope, so any credential that could read status could also `POST /rollback`.

`GET /api/v1/operate/status` returns a server-computed verdict (`healthy`/`degraded`/`unhealthy`) with the machine-readable `reasons` that drove it, self-describing per-domain rollups (deploys, jobs, alerts, migrations, findings, telemetry backends) each carrying a `source` drill-down hint, plus `schemaVersion`/`generatedAt`, and — when configured — an availability SLO / error-budget block. The verdict rules live server-side in `OperateStatusVerdictEvaluator`; the aggregation composes the existing `IOpsHealthSnapshotService` + `IOpsFindingsService` rather than re-wiring low-level seams.

A read-only `ops:read` scope, distinct from the admin family, authorizes the ops read surfaces for safe methods but is rejected on every mutating ops endpoint (which keep the admin policy). Enforcement extends the shared admin permission grammar — no parallel auth mechanism.

## Changes Made
- Added `GET /api/v1/operate/status` (`Features/Operations/Status/`): aggregation service, response DTOs, source-gen JSON, DI, endpoint mapping in `Program.cs`, and `EndpointRegistry.Operate.cs`.
- Server-side verdict rules (`OperateStatusVerdictEvaluator`) and a minimal honest v1 SLO/error-budget evaluator (`OperateSloEvaluator`) computed from the in-process serving-latency rolling window (no metrics DB); explicit `not configured` state when unset.
- New `ops:read` grammar + method-aware `OpsRead` policy (`RequireOpsReadAuthorization`) in `Honua.Hosting`; applied to the operate-status, ops-observability, and observability-alert groups so reads admit `ops:read` while mutations stay admin-only.
- Advertised the `operate.status` capability across the registry + both pinned conformance rosters + the manifest service; added the route to the public-interface proof ledger and regenerated `feature-catalog.json`.
- Documented the SLO config and ops-reader credential setup in `docs/guides/deploy/monitoring.md`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Unit: verdict rules under composed conditions, SLO math + not-configured, `ops:read` grammar. Integration: aggregated verdict shape + SLO block, and the reader-scope split (reader can GET status/findings; 403 on rollback/propose and on non-ops admin surfaces). Also ran the capability conformance (Core + Ai), full architecture suite (122), the affected existing ops/alert/api-key endpoint tests, and `dotnet format --verify-no-changes` on the changed files.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [x] Documentation updated

New `GET /api/v1/operate/status` route (under `/api/v1/...`, not an `/ogc/...` OpenAPI-drift-governed path); capability manifest gains `operate.status`.

## Release/Deploy Impact
- [x] Requires environment variable or secret changes

Optional `Slo:Availability:Target` to enable the SLO block; optional `ops:read`-scoped API keys for read-only monitoring integrations. Both are additive and default-off/absent.

## Breaking Changes
None. The `ops:read` scope is additive; mutating ops endpoints retain the admin policy; full-admin and `admin:read` keys are unaffected.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
