### PR TITLE
test: regenerate feature catalog over combined trunk

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5061,9 +5061,11 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
-        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithValidSession_OpensEventStream",
-        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithoutEventStreamAccept_Returns405",
-        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_WithoutValidSession_Returns404"
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Get_ByDefault_Returns405WithAllowHeader",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpServerInitiatedStreamTests.GetStreamTeardown_LeavesSessionUsable_ToolsListStill200",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpServerInitiatedStreamTests.Get_WhenEnabledWithValidSession_OpensEventStream",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpServerInitiatedStreamTests.Get_WhenEnabledWithoutEventStreamAccept_Returns405",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpServerInitiatedStreamTests.Get_WhenEnabledWithoutValidSession_Returns404"
       ],
       "proof_ledger_surface": "mcp-operator",
       "maturity": "implemented"
@@ -14581,6 +14583,8 @@
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.PromptsList_AdvertisesCuratedCatalog",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithEventStreamAccept_ReturnsSseMessageFrame",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithIssuedSessionId_IsAccepted",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithSessionBoundToDifferentPrincipal_ReturnsStructuredAuthError",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithSessionBoundToSamePrincipal_IsAccepted",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.Request_WithUnknownSessionId_Returns404",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourceTemplatesList_AdvertisesParameterizedUris",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.ResourcesList_ExcludesParameterizedUris",


### PR DESCRIPTION
## Issue Link
Related to #2526

## Summary
The serially-landed program PRs each carried a feature catalog consistent with their own base; the combined tree drifts on per-endpoint test lists (the exact failure batch CI hit at line 5064). Single regeneration over final trunk; catalog + endpoint-registry architecture tests 12/12 locally.

## Changes Made
- Regenerate docs/gis/data/feature-catalog.json via scripts/generate-feature-catalog.sh

## Testing
- [x] Architecture tests pass

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality