### PR TITLE
feat(migrations): safe single-node upgrade — journal-scoped contract gate + pre-migration backup hook + compose upgrade docs

### DIFF
--- a/docs/guides/deploy/docker-compose.md
+++ b/docs/guides/deploy/docker-compose.md
@@ -120,8 +120,60 @@ source .env && curl -s -H "X-API-Key: $HONUA_ADMIN_PASSWORD" http://127.0.0.1:80
 - **`503` on OGC Processes or import job routes** — those need Redis; enable the `redis` profile and set `ConnectionStrings__Redis`.
 - **Container restarts in a loop** — check `docker compose logs honua` for migration failures; the server applies database migrations at startup.
 
+## Upgrade & Rollback
+
+A single-node compose deployment cannot upgrade with zero downtime — there is one server process, so stopping the old container and starting the new one always leaves a brief gap. Plan the short outage rather than expecting a seamless roll. The safe order is **preflight → backup → pull → verify**, with rollback to the previous tag first and a database restore only if a schema-narrowing migration actually ran. See [Upgrade and roll back](upgrade-and-rollback.md) for the full policy (and Kubernetes/cloud rollouts).
+
+1. Preflight against the running instance before pulling anything. Proceed only when `readyForCoordinatedDeploy` is `true` and no unexpected migrations are pending.
+
+```bash
+source .env
+curl -s -H "X-API-Key: $HONUA_ADMIN_PASSWORD" http://127.0.0.1:8080/api/v1/admin/deploy/preflight?includeDiagnostics=true
+curl -s -H "X-API-Key: $HONUA_ADMIN_PASSWORD" http://127.0.0.1:8080/api/v1/admin/observability/migrations
+```
+
+2. Back up the database (this is your rollback floor for any destructive migration).
+
+```bash
+docker compose exec -T postgres pg_dump -U honua -d honua -Fc > "honua-$(date +%F).dump"
+```
+
+3. Pull the new tag and recreate the server. Migrations run automatically when the new container starts.
+
+```bash
+sed -i 's/^HONUA_TAG=.*/HONUA_TAG=vX.Y.Z/' .env   # pin the new version
+docker compose pull honua
+docker compose up -d honua
+```
+
+4. Verify readiness, then confirm no migration failure in the logs.
+
+```bash
+curl -s http://127.0.0.1:8080/healthz/ready   # expect: Ready
+docker compose logs --tail=50 honua
+```
+
+**Roll back:** re-pin `HONUA_TAG` to the previous version and `docker compose up -d honua`. Additive (expand) migrations leave the schema backward-compatible, so the previous image runs against it unchanged. Restore the database (`pg_restore` from your dump) **only** when a contract-phase (schema-narrowing) migration ran and made the old version unusable — stop the container first, restore, then start the previous tag.
+
+### Gating contract-phase migrations (optional)
+
+By default the server applies reviewed contract-phase migrations automatically at startup. To turn a schema-narrowing upgrade into a deliberate, approved step on this existing database, set the journal-scoped gate — it applies only to an already-migrated database, so a first install still provisions fully with no extra config:
+
+```yaml
+    environment:
+      # ... existing env ...
+      Database__MigrationSafety__ContractApplyPolicy: Gate
+      # Optional: run a backup automatically, just before any contract-phase script applies.
+      # A non-zero exit aborts the upgrade (fail closed). This value is read only from
+      # configuration/env — it is never settable through the admin API or database.
+      Database__MigrationSafety__BackupCommand: "pg_dump -h postgres -U honua -d honua -Fc -f /tmp/honua-pre-migrate.dump"
+```
+
+Under `Gate`, a pending reviewed contract migration blocks startup with a message naming the scripts and the preflight endpoints above. Approve it for one upgrade by starting the container with `HONUA_APPROVE_CONTRACT_MIGRATIONS=true`; unset it again afterward. Setting `HONUA_SKIP_MIGRATIONS=true` bypasses migrations entirely (for out-of-band migration flows such as serverless) and is **outside** this policy — those paths own their own upgrade safety.
+
 ## Next steps
 
+- [Upgrade and roll back](upgrade-and-rollback.md)
 - [Monitor Honua Server](monitoring.md)
 - [Back up and restore](backup-and-restore.md)
 - [Production checklist](../secure/production-checklist.md)

--- a/docs/guides/deploy/upgrade-and-rollback.md
+++ b/docs/guides/deploy/upgrade-and-rollback.md
@@ -6,7 +6,7 @@ You'll roll a new Honua version forward safely — preflight first, backward-com
 
 ## Policy
 
-1. Zero-downtime upgrades are supported only for backward-compatible (expand-contract) migrations: add columns/tables first, deploy, drop old columns in a later release. Potentially breaking migrations carry an explicit `-- honua:compatibility-review` marker in the SQL — treat those as gated rollouts with a documented rollback path.
+1. Zero-downtime upgrades are supported only for backward-compatible (expand-contract) migrations: add columns/tables first, deploy, drop old columns in a later release. Potentially breaking migrations carry an explicit `-- honua:compatibility-review` marker in the SQL — treat those as gated rollouts with a documented rollback path. On an existing database you can require explicit approval before those apply: set `Database__MigrationSafety__ContractApplyPolicy=Gate` (fresh installs are unaffected), approve one upgrade with `HONUA_APPROVE_CONTRACT_MIGRATIONS=true`, and optionally run a pre-migration backup hook via `Database__MigrationSafety__BackupCommand` — see [Deploy with Docker Compose — Upgrade & Rollback](docker-compose.md#upgrade--rollback).
 2. The default recovery is rolling back the application image; the previous version keeps working against the expanded schema.
 3. Database restore is the last resort, only when a destructive migration or data corruption makes the previous version unusable.
 

--- a/docs/reference/configuration/environment-variables.md
+++ b/docs/reference/configuration/environment-variables.md
@@ -158,7 +158,10 @@ The effective import limits are also served at `GET /api/v1/admin/import/limits`
 | --- | --- | --- |
 | `HONUA_SERVE_API_DOCS` (`ServeApiDocs`) | `true` in Development, else `false` | Serve the interactive API explorer at `/docs` ([details](../openapi-and-explorer.md)). |
 | `HONUA_SERVE_STAC_DEMO` (`ServeStacOpsDemo`) | `true` in Development/Test, else `false` | Serve the hosted STAC operations demo at `/samples/stac-ops/`. |
-| `HONUA_SKIP_MIGRATIONS` | `false` | Skip database migrations on startup. |
+| `HONUA_SKIP_MIGRATIONS` | `false` | Skip database migrations on startup (out-of-band migration flows own their own upgrade safety — the migration-safety settings below do not apply). |
+| `Database__MigrationSafety__ContractApplyPolicy` | `Auto` | `Gate` requires explicit approval before pending reviewed contract-phase (schema-narrowing) migrations apply on an existing database. Journal-scoped: fresh installs always provision fully. See [Deploy with Docker Compose — Upgrade & Rollback](../../guides/deploy/docker-compose.md#upgrade--rollback). |
+| `HONUA_APPROVE_CONTRACT_MIGRATIONS` | `false` | One-shot operator approval that lets gated contract-phase migrations apply under `ContractApplyPolicy=Gate`. Unset it after the upgrade. |
+| `Database__MigrationSafety__BackupCommand` | — (none) | Optional shell command run immediately before contract-phase migrations apply on an existing database (e.g. `pg_dump ...`); non-zero exit aborts the migration run. Configuration-source only — never settable via the admin API or database. |
 | `FeatureChangeEvents__Webhook__Enabled` | `false` | Enable outbound webhook delivery of feature-change events. |
 | `FeatureChangeEvents__Webhook__Url` / `FeatureChangeEvents__Webhook__Secret` | — | Webhook target URL and HMAC signing secret. |
 | `FeatureChangeEvents__Webhook__MaxAttempts` | `5` | Delivery attempts per event (exponential backoff). |

--- a/src/Honua.Core/Configuration/MigrationSafetyOptions.cs
+++ b/src/Honua.Core/Configuration/MigrationSafetyOptions.cs
@@ -4,9 +4,33 @@
 namespace Honua.Core.Configuration;
 
 /// <summary>
-/// Controls enforcement of the expand/contract migration-safety gate (ADR-0060, principle #3a).
+/// Governs how pending annotated (reviewed) contract-phase migrations are applied when the migration
+/// runner boots against an <em>existing</em> database (non-empty migration journal).
+/// </summary>
+public enum ContractApplyPolicy
+{
+    /// <summary>
+    /// Apply annotated contract-phase migrations automatically at boot — today's behavior. Annotated
+    /// scripts have already passed the compatibility-review gate, so an unattended upgrade applies them.
+    /// </summary>
+    Auto = 0,
+
+    /// <summary>
+    /// On an existing database, refuse to apply pending annotated contract-phase migrations unless the
+    /// operator has explicitly approved them (<c>HONUA_APPROVE_CONTRACT_MIGRATIONS=true</c>). Fresh
+    /// installs (empty journal) are unaffected and always provision fully. This turns a single-node
+    /// image pull into a reviewed, deliberate step for schema-narrowing changes rather than an
+    /// unattended one.
+    /// </summary>
+    Gate = 1,
+}
+
+/// <summary>
+/// Controls enforcement of the expand/contract migration-safety gate (ADR-0060, principle #3a) and the
+/// journal-scoped contract-apply policy for safe single-node upgrades (#2565).
 /// </summary>
 /// <remarks>
+/// <para>
 /// When <see cref="Enforce"/> is <see langword="true"/> (the default), the migration runner
 /// fails closed if any pending script contains a potentially backward-incompatible ("contract")
 /// change that is not annotated with the
@@ -14,6 +38,20 @@ namespace Honua.Core.Configuration;
 /// every existing breaking migration is already annotated; the escape hatch
 /// (<c>Database:MigrationSafety:Enforce=false</c>) exists only for operators who must apply an
 /// unreviewed contract migration deliberately and accept the rolling-upgrade risk.
+/// </para>
+/// <para>
+/// <see cref="ContractApplyPolicy"/> governs how <em>annotated</em> contract migrations are applied on
+/// an existing database. Under <see cref="Core.Configuration.ContractApplyPolicy.Gate"/> they require an
+/// explicit operator approval (<c>HONUA_APPROVE_CONTRACT_MIGRATIONS=true</c>); the gate applies only when
+/// the migration journal is non-empty, so fresh installs always provision fully with zero configuration.
+/// </para>
+/// <para>
+/// <see cref="BackupCommand"/> is an optional pre-migration backup hook run just before contract-class
+/// scripts are applied. It is <strong>configuration-source only</strong> (bound once from
+/// appsettings/environment via <see cref="Microsoft.Extensions.Options.IOptions{TOptions}"/>) and is never
+/// settable through any admin API or database path — the runner shells out to it, so an API/DB-writable
+/// value would be a remote-code-execution vector.
+/// </para>
 /// </remarks>
 public sealed record MigrationSafetyOptions
 {
@@ -23,8 +61,31 @@ public sealed record MigrationSafetyOptions
     public const string SectionName = "Database:MigrationSafety";
 
     /// <summary>
+    /// Configuration key (top-level environment variable) an operator sets to <c>true</c> to approve
+    /// applying pending annotated contract-phase migrations while
+    /// <see cref="ContractApplyPolicy"/> is <see cref="Core.Configuration.ContractApplyPolicy.Gate"/>.
+    /// </summary>
+    public const string ApproveContractMigrationsKey = "HONUA_APPROVE_CONTRACT_MIGRATIONS";
+
+    /// <summary>
     /// When <see langword="true"/> (default), the migration runner rejects pending contract-phase
     /// migrations that lack the compatibility-review marker instead of applying them.
     /// </summary>
     public bool Enforce { get; init; } = true;
+
+    /// <summary>
+    /// Policy for applying pending <em>annotated</em> contract-phase migrations on an existing database
+    /// (non-empty journal). Defaults to <see cref="Core.Configuration.ContractApplyPolicy.Auto"/>, which
+    /// preserves today's behavior. Fresh installs always provision fully regardless of this setting.
+    /// </summary>
+    public ContractApplyPolicy ContractApplyPolicy { get; init; } = ContractApplyPolicy.Auto;
+
+    /// <summary>
+    /// Optional pre-migration backup command. When set, the runner executes it via the platform shell
+    /// immediately before applying pending contract-class scripts on an existing database (non-empty
+    /// journal). A non-zero exit fails the migration run closed (no script is applied). This value is
+    /// configuration-source only and is never writable through an admin API or the database (RCE guard).
+    /// A typical value is a <c>pg_dump</c> invocation.
+    /// </summary>
+    public string? BackupCommand { get; init; }
 }

--- a/src/Honua.Postgres/Features/Infrastructure/Migrations/PostgresDatabaseMigrationRunner.cs
+++ b/src/Honua.Postgres/Features/Infrastructure/Migrations/PostgresDatabaseMigrationRunner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Diagnostics;
 using System.Reflection;
 using DbUp;
 using DbUp.Engine;
@@ -8,6 +9,7 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Domain;
 using Honua.Core.Features.Infrastructure.Migrations;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Npgsql;
 
@@ -19,12 +21,24 @@ internal sealed class PostgresDatabaseMigrationRunner : IDatabaseMigrationRunner
     private const string SafeMigrationFailureMessage = "Database migration failed.";
     private static readonly TimeSpan _migrationLockWaitTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan _migrationLockRetryDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan _backupCommandTimeout = TimeSpan.FromHours(1);
 
     private readonly MigrationSafetyOptions _safetyOptions;
+    private readonly bool _contractMigrationsApproved;
 
-    public PostgresDatabaseMigrationRunner(IOptions<MigrationSafetyOptions>? safetyOptions = null)
+    public PostgresDatabaseMigrationRunner(
+        IOptions<MigrationSafetyOptions>? safetyOptions = null,
+        IConfiguration? configuration = null)
     {
         _safetyOptions = safetyOptions?.Value ?? new MigrationSafetyOptions();
+
+        // The contract-apply approval is an explicit top-level operator signal
+        // (HONUA_APPROVE_CONTRACT_MIGRATIONS=true), read via the IConfiguration indexer (Abstractions
+        // only, no Binder dependency). It intentionally lives outside the bound options record so an
+        // operator can grant one-shot approval for a single upgrade without editing config files.
+        _contractMigrationsApproved =
+            bool.TryParse(configuration?[MigrationSafetyOptions.ApproveContractMigrationsKey], out var approved)
+            && approved;
     }
 
     public Task<DatabaseMigrationPlan> PlanMigrationsAsync(
@@ -62,14 +76,15 @@ internal sealed class PostgresDatabaseMigrationRunner : IDatabaseMigrationRunner
     /// marker (ADR-0060 expand/contract gate). Returns <see langword="null"/> when enforcement is
     /// disabled or every pending contract script is annotated.
     /// </summary>
-    private InvalidOperationException? TryBuildSafetyRejection(UpgradeEngine upgrader)
+    private InvalidOperationException? TryBuildSafetyRejection(
+        IReadOnlyList<MigrationScriptClassification> classifications)
     {
         if (!_safetyOptions.Enforce)
         {
             return null;
         }
 
-        var unannotated = ClassifyScripts(upgrader.GetScriptsToExecute())
+        var unannotated = classifications
             .Where(c => c.Classification == MigrationSafetyClassification.ContractUnannotated)
             .Select(c => c.ScriptName)
             .ToArray();
@@ -85,6 +100,67 @@ internal sealed class PostgresDatabaseMigrationRunner : IDatabaseMigrationRunner
             $"'{MigrationSafetyClassifier.CompatibilityReviewMarkerConvention}' so its expand/contract " +
             "safety is reviewed, or set 'Database:MigrationSafety:Enforce=false' to override.");
     }
+
+    /// <summary>
+    /// Journal-scoped contract-apply gate (#2565). When
+    /// <see cref="MigrationSafetyOptions.ContractApplyPolicy"/> is
+    /// <see cref="ContractApplyPolicy.Gate"/> and the migration journal is <em>non-empty</em> (an
+    /// existing database, not a fresh install), pending annotated contract-phase scripts require the
+    /// operator's explicit <c>HONUA_APPROVE_CONTRACT_MIGRATIONS=true</c> approval. Returns
+    /// <see langword="null"/> under Auto policy, on a fresh install, when approved, or when nothing
+    /// pending is an annotated contract change. The resulting rejection is an
+    /// <see cref="InvalidOperationException"/> — a non-transient, terminal failure — so degraded-start
+    /// recovery (#1632) gives up rather than retrying a policy block with backoff.
+    /// </summary>
+    private InvalidOperationException? TryBuildContractGateRejection(
+        IReadOnlyList<MigrationScriptClassification> classifications,
+        bool journalIsNonEmpty)
+    {
+        if (_safetyOptions.ContractApplyPolicy != ContractApplyPolicy.Gate)
+        {
+            return null;
+        }
+
+        // Fresh installs (empty journal) always provision fully — quickstart stays zero-config and the
+        // annotated baseline scripts are never gated.
+        if (!journalIsNonEmpty)
+        {
+            return null;
+        }
+
+        if (_contractMigrationsApproved)
+        {
+            return null;
+        }
+
+        var pendingAnnotated = classifications
+            .Where(c => c.Classification == MigrationSafetyClassification.ContractAnnotated)
+            .Select(c => c.ScriptName)
+            .ToArray();
+
+        if (pendingAnnotated.Length == 0)
+        {
+            return null;
+        }
+
+        return new InvalidOperationException(
+            "Migration safety gate blocked pending contract-phase migration(s) on an existing database: " +
+            $"{string.Join(", ", pendingAnnotated)}. These reviewed (annotated) contract migrations narrow " +
+            "or drop schema and must not ride along an unattended upgrade (Database:MigrationSafety:" +
+            "ContractApplyPolicy=Gate). Review them first via 'GET /api/v1/admin/deploy/preflight' and " +
+            $"'GET /api/v1/admin/observability/migrations', then set '{MigrationSafetyOptions.ApproveContractMigrationsKey}" +
+            "=true' to apply them (or run migrations out-of-band with HONUA_SKIP_MIGRATIONS=true, which owns " +
+            "its own safety).");
+    }
+
+    /// <summary>
+    /// DbUp reports the migration journal via the same <see cref="UpgradeEngine"/> the runner already
+    /// uses: a non-empty executed-scripts list means the database has been migrated before (an upgrade),
+    /// while an empty list is a fresh install. On a fresh database the journal table does not yet exist
+    /// and DbUp returns an empty list rather than throwing.
+    /// </summary>
+    private static bool JournalIsNonEmpty(UpgradeEngine upgrader)
+        => upgrader.GetExecutedScripts().Count > 0;
 
     public async Task<DatabaseMigrationResult> RunMigrationsAsync(
         string connectionString,
@@ -111,9 +187,29 @@ internal sealed class PostgresDatabaseMigrationRunner : IDatabaseMigrationRunner
 
         try
         {
-            if (TryBuildSafetyRejection(upgrader) is { } rejection)
+            var classifications = ClassifyScripts(upgrader.GetScriptsToExecute());
+            var journalIsNonEmpty = JournalIsNonEmpty(upgrader);
+
+            // 1. ADR-0060 fail-closed: reject unannotated contract scripts (default Enforce=true).
+            if (TryBuildSafetyRejection(classifications) is { } rejection)
             {
                 return DatabaseMigrationResult.Failed(rejection, rejection.Message);
+            }
+
+            // 2. Journal-scoped contract-apply gate (#2565): block annotated contract scripts on an
+            //    existing database unless the operator approved them.
+            if (TryBuildContractGateRejection(classifications, journalIsNonEmpty) is { } gateRejection)
+            {
+                return DatabaseMigrationResult.Failed(gateRejection, gateRejection.Message);
+            }
+
+            // 3. Optional pre-migration backup hook: runs only when contract-class scripts are pending
+            //    on an existing database, immediately before they are applied. A hook failure fails the
+            //    run closed (nothing is applied).
+            if (await TryRunBackupHookAsync(classifications, journalIsNonEmpty, cancellationToken)
+                    .ConfigureAwait(false) is { } backupFailure)
+            {
+                return DatabaseMigrationResult.Failed(backupFailure, backupFailure.Message);
             }
 
             var result = upgrader.PerformUpgrade();
@@ -198,4 +294,129 @@ internal sealed class PostgresDatabaseMigrationRunner : IDatabaseMigrationRunner
             // The advisory lock is connection-scoped and will be released when the connection is disposed.
         }
     }
+
+    /// <summary>
+    /// Runs the optional pre-migration backup hook (<see cref="MigrationSafetyOptions.BackupCommand"/>)
+    /// via the platform shell, but only when contract-class scripts are pending on an existing database
+    /// (non-empty journal). A non-zero exit — or a failure launching the process — is returned as an
+    /// exception so the caller fails the migration run closed before any script is applied. Returns
+    /// <see langword="null"/> when no hook is configured or the run conditions are not met.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MigrationSafetyOptions.BackupCommand"/> is bound once from configuration sources and is
+    /// never writable through an admin API or the database, so shelling out to it is not an
+    /// injection/RCE surface (see the options remarks).
+    /// </remarks>
+    private async Task<Exception?> TryRunBackupHookAsync(
+        IReadOnlyList<MigrationScriptClassification> classifications,
+        bool journalIsNonEmpty,
+        CancellationToken cancellationToken)
+    {
+        var command = _safetyOptions.BackupCommand;
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return null;
+        }
+
+        // Back up only when a contract-class (potentially destructive) script is about to apply on an
+        // existing database. Fresh installs and additive-only (expand) upgrades never trigger the hook.
+        if (!journalIsNonEmpty || !classifications.Any(c => c.IsBreaking))
+        {
+            return null;
+        }
+
+        var isWindows = OperatingSystem.IsWindows();
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = isWindows ? "cmd.exe" : "/bin/sh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        if (isWindows)
+        {
+            // cmd.exe does not understand the backslash-escaped quotes ArgumentList emits, so pass the
+            // command line raw using the canonical `/d /s /c "<command>"` form: /s makes cmd strip only
+            // the first and last quote, preserving quoted paths inside the operator's command.
+            startInfo.Arguments = $"/d /s /c \"{command}\"";
+        }
+        else
+        {
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(command);
+        }
+
+        try
+        {
+            using var process = new Process { StartInfo = startInfo };
+            if (!process.Start())
+            {
+                return new InvalidOperationException(
+                    "The pre-migration backup command (Database:MigrationSafety:BackupCommand) failed to " +
+                    "start; the migration run was aborted before applying any contract-phase script.");
+            }
+
+            var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(_backupCommandTimeout);
+
+            try
+            {
+                await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                TryKill(process);
+                return new TimeoutException(
+                    $"The pre-migration backup command (Database:MigrationSafety:BackupCommand) exceeded " +
+                    $"{_backupCommandTimeout.TotalMinutes:F0} minute(s) and was terminated; the migration run " +
+                    "was aborted before applying any contract-phase script.");
+            }
+
+            var stderr = await stderrTask.ConfigureAwait(false);
+            _ = await stdoutTask.ConfigureAwait(false);
+
+            if (process.ExitCode != 0)
+            {
+                var detail = string.IsNullOrWhiteSpace(stderr)
+                    ? string.Empty
+                    : $" Details: {Truncate(stderr.Trim(), 500)}";
+                return new InvalidOperationException(
+                    "The pre-migration backup command (Database:MigrationSafety:BackupCommand) exited with " +
+                    $"code {process.ExitCode}; the migration run was aborted (fail closed) before applying any " +
+                    $"contract-phase script.{detail}");
+            }
+
+            return null;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return new InvalidOperationException(
+                "The pre-migration backup command (Database:MigrationSafety:BackupCommand) could not be run; " +
+                "the migration run was aborted (fail closed) before applying any contract-phase script.",
+                ex);
+        }
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup; the process may have already exited.
+        }
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value.Length <= maxLength ? value : value[..maxLength] + "…";
 }

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -347,7 +347,10 @@ internal static class ServiceCollectionExtensions
 
         // Expand/contract migration-safety gate (#2462, ADR-0060 principle #3a): the runner rejects
         // pending contract-phase migrations that lack the compatibility-review marker. Enforce
-        // defaults TRUE; set Database:MigrationSafety:Enforce=false to override.
+        // defaults TRUE; set Database:MigrationSafety:Enforce=false to override. The same options carry
+        // the journal-scoped contract-apply policy and the optional pre-migration backup hook for safe
+        // single-node upgrades (#2565): ContractApplyPolicy defaults to Auto (today's behavior), and
+        // BackupCommand is configuration-source only (never writable via API/DB — RCE guard).
         services.AddOptions<Honua.Core.Configuration.MigrationSafetyOptions>()
             .Bind(configuration.GetSection(Honua.Core.Configuration.MigrationSafetyOptions.SectionName))
             .ValidateDataAnnotations();

--- a/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateMigrationGateTests.cs
+++ b/tests/dotnet/Honua.CloudIntegration.Tests/LocalSubstrateMigrationGateTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Infrastructure.Migrations;
 using Honua.Postgres.Features.Infrastructure.Migrations;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Npgsql;
 using Xunit;
@@ -44,6 +45,11 @@ public sealed class LocalSubstrateMigrationGateTests : IClassFixture<LocalSubstr
         """
         -- honua:compatibility-review reason=legacy_name removed in the contract phase after v2 rollout
         ALTER TABLE honua_ci_demo DROP COLUMN legacy_name;
+        """;
+
+    private const string SecondExpandScript =
+        """
+        ALTER TABLE honua_ci_demo ADD COLUMN note TEXT;
         """;
 
     private readonly LocalSubstratePostgresFixture _postgres;
@@ -127,8 +133,226 @@ public sealed class LocalSubstrateMigrationGateTests : IClassFixture<LocalSubstr
         plan.UnannotatedBreakingScriptNames.Should().Contain(name => name.EndsWith("002_drop_legacy_unannotated.sql", StringComparison.Ordinal));
     }
 
+    [SkippableFact]
+    public async Task RunMigrations_FreshInstallUnderGate_ProvisionsFullyAndSkipsBackup()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        // A fresh install (empty journal) under Gate must provision fully with zero approval — the gate
+        // is journal-scoped — and the backup hook must NOT fire (nothing to protect on a brand-new DB).
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var sentinel = ReserveSentinelPath();
+        var runner = CreateRunner(
+            new MigrationSafetyOptions
+            {
+                Enforce = true,
+                ContractApplyPolicy = ContractApplyPolicy.Gate,
+                BackupCommand = SentinelCommand(sentinel),
+            });
+        var assembly = SyntheticMigrationsCompiler.Compile(
+            $"honua_synthetic_freshgate_{Guid.NewGuid():N}",
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_annotated.sql", AnnotatedContractScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, assembly);
+
+        result.Successful.Should().BeTrue(
+            $"a fresh install always provisions fully regardless of the gate. Error: {result.ErrorMessage}");
+        result.AppliedScripts.Should().HaveCount(2);
+        (await ColumnExistsAsync(connectionString, "honua_ci_demo", "legacy_name")).Should().BeFalse();
+        File.Exists(sentinel).Should().BeFalse("the backup hook does not run on a fresh install (empty journal)");
+    }
+
+    [SkippableFact]
+    public async Task RunMigrations_UpgradeUnderGate_BlocksAnnotatedContractWithoutApproval()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var assemblyName = $"honua_synthetic_upgradegate_{Guid.NewGuid():N}";
+
+        // First upgrade establishes a non-empty journal (this is now an existing database).
+        await ApplyExpandBaselineAsync(connectionString, assemblyName);
+
+        var runner = CreateRunner(new MigrationSafetyOptions
+        {
+            Enforce = true,
+            ContractApplyPolicy = ContractApplyPolicy.Gate,
+        });
+        var upgrade = SyntheticMigrationsCompiler.Compile(
+            assemblyName,
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_annotated.sql", AnnotatedContractScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, upgrade);
+
+        result.Successful.Should().BeFalse("the gate blocks pending annotated contract scripts on an existing database");
+        result.ErrorMessage.Should().NotBeNull();
+        result.ErrorMessage!.Should().Contain("002_drop_legacy_annotated.sql", "the block names the offending script");
+        result.ErrorMessage!.Should().Contain("/api/v1/admin/deploy/preflight", "the block names the preflight endpoint");
+        result.ErrorMessage!.Should().Contain("/api/v1/admin/observability/migrations", "the block names the migrations endpoint");
+        result.ErrorMessage!.Should().Contain("HONUA_APPROVE_CONTRACT_MIGRATIONS", "the block names the approval switch");
+
+        (await ColumnExistsAsync(connectionString, "honua_ci_demo", "legacy_name"))
+            .Should().BeTrue("the blocked contract migration must not have applied");
+    }
+
+    [SkippableFact]
+    public async Task RunMigrations_UpgradeUnderGate_AppliesAnnotatedContractWhenApproved()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var assemblyName = $"honua_synthetic_upgradeapprove_{Guid.NewGuid():N}";
+        await ApplyExpandBaselineAsync(connectionString, assemblyName);
+
+        var runner = CreateRunner(
+            new MigrationSafetyOptions
+            {
+                Enforce = true,
+                ContractApplyPolicy = ContractApplyPolicy.Gate,
+            },
+            approveContract: true);
+        var upgrade = SyntheticMigrationsCompiler.Compile(
+            assemblyName,
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_annotated.sql", AnnotatedContractScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, upgrade);
+
+        result.Successful.Should().BeTrue(
+            $"HONUA_APPROVE_CONTRACT_MIGRATIONS=true approves the gated contract migration. Error: {result.ErrorMessage}");
+        result.AppliedScripts.Should().ContainSingle(name => name.EndsWith("002_drop_legacy_annotated.sql", StringComparison.Ordinal));
+        (await ColumnExistsAsync(connectionString, "honua_ci_demo", "legacy_name"))
+            .Should().BeFalse("the approved contract migration dropped the legacy column");
+    }
+
+    [SkippableFact]
+    public async Task RunMigrations_BackupHookFailure_FailsClosedBeforeApplyingContract()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var assemblyName = $"honua_synthetic_backupfail_{Guid.NewGuid():N}";
+        await ApplyExpandBaselineAsync(connectionString, assemblyName);
+
+        // Auto policy so the gate is not what blocks; a failing backup hook (exit 1) must fail the run
+        // closed before the pending contract script is applied.
+        var runner = CreateRunner(new MigrationSafetyOptions
+        {
+            Enforce = true,
+            ContractApplyPolicy = ContractApplyPolicy.Auto,
+            BackupCommand = "exit 1",
+        });
+        var upgrade = SyntheticMigrationsCompiler.Compile(
+            assemblyName,
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_annotated.sql", AnnotatedContractScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, upgrade);
+
+        result.Successful.Should().BeFalse("a failing backup hook fails the migration run closed");
+        result.ErrorMessage.Should().NotBeNull();
+        result.ErrorMessage!.Should().Contain("BackupCommand", "the failure names the backup hook");
+        (await ColumnExistsAsync(connectionString, "honua_ci_demo", "legacy_name"))
+            .Should().BeTrue("no contract script may apply after the backup hook failed (fail closed, ordering)");
+    }
+
+    [SkippableFact]
+    public async Task RunMigrations_BackupHook_RunsBeforeContractApplyAndSucceeds()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var assemblyName = $"honua_synthetic_backupok_{Guid.NewGuid():N}";
+        await ApplyExpandBaselineAsync(connectionString, assemblyName);
+
+        var sentinel = ReserveSentinelPath();
+        var runner = CreateRunner(new MigrationSafetyOptions
+        {
+            Enforce = true,
+            ContractApplyPolicy = ContractApplyPolicy.Auto,
+            BackupCommand = SentinelCommand(sentinel),
+        });
+        var upgrade = SyntheticMigrationsCompiler.Compile(
+            assemblyName,
+            ("001_expand.sql", ExpandScript),
+            ("002_drop_legacy_annotated.sql", AnnotatedContractScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, upgrade);
+
+        result.Successful.Should().BeTrue($"the backup hook succeeded so the contract migration applies. Error: {result.ErrorMessage}");
+        File.Exists(sentinel).Should().BeTrue("the backup hook ran before the contract script applied");
+        (await ColumnExistsAsync(connectionString, "honua_ci_demo", "legacy_name")).Should().BeFalse();
+    }
+
+    [SkippableFact]
+    public async Task RunMigrations_BackupHook_SkippedWhenNoPendingContractScripts()
+    {
+        Skip.IfNot(_postgres.Available, "Docker/PostgreSQL is not available for the migration-gate lane.");
+
+        var connectionString = await _postgres.CreateFreshDatabaseAsync();
+        var assemblyName = $"honua_synthetic_backupskip_{Guid.NewGuid():N}";
+        await ApplyExpandBaselineAsync(connectionString, assemblyName);
+
+        var sentinel = ReserveSentinelPath();
+        var runner = CreateRunner(new MigrationSafetyOptions
+        {
+            Enforce = true,
+            ContractApplyPolicy = ContractApplyPolicy.Auto,
+            BackupCommand = SentinelCommand(sentinel),
+        });
+
+        // A purely additive (expand) upgrade — the backup hook must not fire.
+        var upgrade = SyntheticMigrationsCompiler.Compile(
+            assemblyName,
+            ("001_expand.sql", ExpandScript),
+            ("002_add_note_expand.sql", SecondExpandScript));
+
+        var result = await runner.RunMigrationsAsync(connectionString, upgrade);
+
+        result.Successful.Should().BeTrue($"an additive upgrade applies cleanly. Error: {result.ErrorMessage}");
+        result.AppliedScripts.Should().ContainSingle(name => name.EndsWith("002_add_note_expand.sql", StringComparison.Ordinal));
+        File.Exists(sentinel).Should().BeFalse("the backup hook is skipped when no contract-class script is pending");
+    }
+
+    private async Task ApplyExpandBaselineAsync(string connectionString, string assemblyName)
+    {
+        // Applies only the 001 expand script under the SAME assembly name so its journal entry matches
+        // the later upgrade's 001 (DbUp journals by script name); the follow-up run then sees only the
+        // 002 script as pending against a non-empty journal.
+        var baseline = SyntheticMigrationsCompiler.Compile(assemblyName, ("001_expand.sql", ExpandScript));
+        var result = await CreateRunner(new MigrationSafetyOptions { Enforce = true })
+            .RunMigrationsAsync(connectionString, baseline);
+        result.Successful.Should().BeTrue($"the expand baseline must apply. Error: {result.ErrorMessage}");
+    }
+
     private static PostgresDatabaseMigrationRunner CreateEnforcingRunner()
         => new(Options.Create(new MigrationSafetyOptions { Enforce = true }));
+
+    private static PostgresDatabaseMigrationRunner CreateRunner(
+        MigrationSafetyOptions options,
+        bool approveContract = false)
+    {
+        IConfiguration? configuration = null;
+        if (approveContract)
+        {
+            configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [MigrationSafetyOptions.ApproveContractMigrationsKey] = "true",
+                })
+                .Build();
+        }
+
+        return new PostgresDatabaseMigrationRunner(Options.Create(options), configuration);
+    }
+
+    private static string ReserveSentinelPath()
+        => Path.Combine(Path.GetTempPath(), $"honua_backup_{Guid.NewGuid():N}.marker");
+
+    private static string SentinelCommand(string path)
+        => OperatingSystem.IsWindows() ? $"type nul > \"{path}\"" : $": > '{path}'";
 
     private static async Task<bool> TableExistsAsync(string connectionString, string table)
     {

--- a/tests/dotnet/Honua.Core.Tests/Configuration/MigrationSafetyOptionsTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Configuration/MigrationSafetyOptionsTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Configuration;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Configuration;
+
+/// <summary>
+/// Unit tests for <see cref="MigrationSafetyOptions"/> defaults — the safe single-node upgrade policy
+/// (#2565) must preserve today's behavior out of the box.
+/// </summary>
+public sealed class MigrationSafetyOptionsTests
+{
+    [UnitTest]
+    public void Defaults_PreserveTodaysBehavior()
+    {
+        var options = new MigrationSafetyOptions();
+
+        options.Enforce.Should().BeTrue("unannotated contract migrations stay fail-closed by default");
+        options.ContractApplyPolicy.Should().Be(ContractApplyPolicy.Auto,
+            "annotated contract migrations apply automatically by default (no gate)");
+        options.BackupCommand.Should().BeNull("the pre-migration backup hook is opt-in");
+    }
+}

--- a/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Resilience/StartupDatabaseResilienceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Infrastructure/Resilience/StartupDatabaseResilienceTests.cs
@@ -53,6 +53,18 @@ public sealed class StartupDatabaseResilienceTests
     }
 
     [UnitTest]
+    public void IsTransientConnectivityError_WithContractGatePolicyBlock_ReturnsFalse()
+    {
+        // A migration-safety policy block (#2565 gate rejection, or the ADR-0060 unannotated fail-closed)
+        // surfaces as an InvalidOperationException. It must classify as terminal/non-retryable so
+        // degraded-start recovery (#1632) gives up rather than retrying a policy block with backoff.
+        var gateBlock = new InvalidOperationException(
+            "Migration safety gate blocked pending contract-phase migration(s) on an existing database.");
+
+        StartupDatabaseResilience.IsTransientConnectivityError(gateBlock).Should().BeFalse();
+    }
+
+    [UnitTest]
     public void IsTransientConnectivityError_WithAggregateOfAllTransient_ReturnsTrue()
     {
         var aggregate = new AggregateException(new TimeoutException(), new SocketException());


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2565

## Summary
Makes single-node upgrades safe by default-preserving policy: adds a journal-scoped contract-apply gate (`Database:MigrationSafety:ContractApplyPolicy` = `Auto` | `Gate`) so pending reviewed (annotated) contract-phase migrations on an *existing* database can require explicit operator approval (`HONUA_APPROVE_CONTRACT_MIGRATIONS=true`) instead of riding along an unattended image pull. Fresh installs (empty DbUp journal) always provision fully with zero config, so the quickstart is unaffected and the annotated baseline scripts (038/057) are never gated. Adds an optional pre-migration backup hook (`Database:MigrationSafety:BackupCommand`, config-source only — never settable via API/DB) that runs only when contract-class scripts are pending on an existing database and fails the run closed on failure. The gate rejection surfaces as a non-transient `InvalidOperationException`, so degraded-start recovery (#1632) gives up instead of retrying a policy block with backoff. `docs/guides/deploy/docker-compose.md` gains an Upgrade & Rollback section (preflight-first flow, backup, pull, verify, rollback = previous tag + DB restore only if contract scripts ran), honest about single-node downtime, cross-linked to `upgrade-and-rollback.md`.

## Changes Made
- `MigrationSafetyOptions` (Honua.Core): new `ContractApplyPolicy` enum (`Auto` default = today's behavior, `Gate`), `BackupCommand`, and the `HONUA_APPROVE_CONTRACT_MIGRATIONS` key constant; XML docs spell out the journal scoping and the RCE guard (config-source only)
- `PostgresDatabaseMigrationRunner`: journal-scoped gate via the existing DbUp `UpgradeEngine` (`GetExecutedScripts()` — non-empty journal = existing DB); Gate rejection lists the blocked scripts, both preflight endpoints (`GET /api/v1/admin/deploy/preflight`, `GET /api/v1/admin/observability/migrations`), the approval switch, and the out-of-band `HONUA_SKIP_MIGRATIONS` note
- `PostgresDatabaseMigrationRunner`: optional pre-migration backup hook — executes only when pending contract-class scripts exist AND the journal is non-empty, before any script applies; non-zero exit / launch failure / 1h timeout fail the migration run closed
- Runner now takes an optional `IConfiguration` (indexer only, no Binder dependency) to read the one-shot approval env var
- `ServiceCollectionExtensions` (Honua.Postgres): options-registration comment documents the new policy + RCE guard
- `docs/guides/deploy/docker-compose.md`: new "Upgrade & Rollback" section — preflight-first upgrade flow, `pg_dump` backup, pinned-tag pull, `/healthz/ready` verify, rollback = previous tag (+ DB restore only if a contract migration ran), explicit "single-node zero-downtime is impossible" statement, optional `Gate` + `BackupCommand` compose snippet with documented pg_dump example, `HONUA_SKIP_MIGRATIONS` documented as outside this policy, cross-link to `upgrade-and-rollback.md`
- Tests: `LocalSubstrateMigrationGateTests` (real runner + real Postgres via Testcontainers) — fresh-install-under-Gate provisions fully and skips the backup hook; upgrade-under-Gate blocks without approval (message asserts scripts + endpoints + switch) and applies with approval; backup hook fail-closed ordering (contract script NOT applied after hook failure); backup hook runs before contract apply on success; backup hook skipped on additive-only upgrades
- Tests: `StartupDatabaseResilienceTests` — gate policy block classifies as non-transient (terminal for degraded-start); `MigrationSafetyOptionsTests` — defaults preserve today's behavior

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] None — standard merge-and-release flow

New optional env/config only; defaults preserve current behavior (`ContractApplyPolicy=Auto`, no backup hook). Quickstart compose adoption of `ContractApplyPolicy=Gate` is owned by #2558.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
