### PR TITLE
feat(observability): persisted ops-health rollup store with cluster-wide aggregation

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -2722,6 +2722,21 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-admin-observability-ops-health-history",
+      "route": "/api/v1/admin/observability/ops-health/history",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetOpsHealthHistory_WithAdminAuth_ReturnsClusterAggregatedSeries",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetOpsHealthHistory_WithInvalidResolution_Returns400",
+        "Honua.Server.Tests.Features.Admin.OpsObservabilityEndpointsTests.GetOpsHealthHistory_WithoutAdminAuth_IsUnauthorized"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-admin-observability-telemetry",
       "route": "/api/v1/admin/observability/telemetry",
       "method": "GET",

--- a/src/Honua.Core/Features/Observability/Abstractions/IOpsHealthRollupStore.cs
+++ b/src/Honua.Core/Features/Observability/Abstractions/IOpsHealthRollupStore.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Core.Features.Observability.Abstractions;
+
+/// <summary>
+/// Persisted, bounded rollup store for ops-health sections (#2553). Each replica flushes its local
+/// serving-latency percentiles and ops vitals into the finest (1-minute) tier; coarser tiers are derived
+/// by downsampling and every tier is pruned to a hard retention cap. The store never sits on a serving
+/// path — callers treat it as fail-open (a missing registration or an outage degrades to snapshot-only).
+/// </summary>
+/// <remarks>
+/// Only registered for the PostgreSQL provider (the shared metadata store). Consumers resolve it as an
+/// optional dependency so DuckDB/MySQL deployments simply run without persisted history.
+/// </remarks>
+public interface IOpsHealthRollupStore
+{
+    /// <summary>
+    /// Writes (upserts) a per-replica flush into the 1-minute tier. The sample's capture time is truncated
+    /// to the minute; a later flush within the same minute replaces the earlier one (last-write-wins).
+    /// </summary>
+    /// <param name="sample">The per-replica flush to persist.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that completes when the flush is persisted.</returns>
+    Task WriteSampleAsync(OpsHealthRollupSample sample, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Materializes the coarser (5-minute, hourly) tiers from the 1-minute tier and prunes every tier past
+    /// its retention cap. Idempotent: coarser buckets are recomputed on each pass until their source rows age
+    /// out. Returns the number of pruned rows.
+    /// </summary>
+    /// <param name="now">The current time used to compute prune cut-offs.</param>
+    /// <param name="policy">The per-tier retention caps.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The total number of pruned rows across all tiers/tables.</returns>
+    Task<int> DownsampleAndPruneAsync(DateTimeOffset now, OpsHealthRollupRetentionPolicy policy, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads per-replica latency rows for a tier within an inclusive time window, ordered by bucket.
+    /// </summary>
+    /// <param name="tier">The rollup tier (resolution).</param>
+    /// <param name="from">The inclusive lower bucket bound (UTC).</param>
+    /// <param name="to">The inclusive upper bucket bound (UTC).</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The matching latency rows.</returns>
+    Task<IReadOnlyList<OpsHealthLatencyRow>> ReadLatencyAsync(OpsHealthRollupTier tier, DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads per-replica vitals rows for a tier within an inclusive time window, ordered by bucket.
+    /// </summary>
+    /// <param name="tier">The rollup tier (resolution).</param>
+    /// <param name="from">The inclusive lower bucket bound (UTC).</param>
+    /// <param name="to">The inclusive upper bucket bound (UTC).</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The matching vitals rows.</returns>
+    Task<IReadOnlyList<OpsHealthVitalsRow>> ReadVitalsAsync(OpsHealthRollupTier tier, DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads recent 1-minute latency rows since <paramref name="since"/>, optionally excluding one replica.
+    /// Used by the live snapshot to merge other replicas' recent flushes with the responding instance's
+    /// live in-process window.
+    /// </summary>
+    /// <param name="since">The inclusive lower bucket bound (UTC).</param>
+    /// <param name="excludeReplicaId">A replica id to exclude (the responding instance), or <c>null</c>.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The recent latency rows.</returns>
+    Task<IReadOnlyList<OpsHealthLatencyRow>> ReadRecentLatencyAsync(DateTimeOffset since, string? excludeReplicaId, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupAggregation.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupAggregation.cs
@@ -77,6 +77,12 @@ public static class OpsHealthRollupAggregation
     /// Merges per-replica vitals into one whole-cluster point: worst overall status, summed active DB
     /// connections, peak (max) queue/backlog signals, and averaged utilization/ratio gauges.
     /// </summary>
+    /// <remarks>
+    /// The GP queue breakdown (<c>"&lt;status&gt;|&lt;backend&gt;"</c> keys) is merged with a per-key SUM
+    /// across replicas within a bucket (each replica reports its own view of the shared queue at flush time;
+    /// summing keeps the breakdown consistent with the per-key peak stored when downsampling to coarser
+    /// tiers, which uses a per-key MAX — the same peak-counts semantics as the latency counts).
+    /// </remarks>
     /// <param name="points">The per-replica vitals points (must be non-empty).</param>
     /// <returns>The merged whole-cluster vitals point.</returns>
     public static OpsHealthVitalsPoint MergeVitalsAcrossReplicas(IReadOnlyList<OpsHealthVitalsPoint> points)
@@ -102,9 +108,17 @@ public static class OpsHealthRollupAggregation
         var dbActive = 0;
         double cacheSum = 0;
         double errorSum = 0;
+        var breakdown = new Dictionary<string, int>(StringComparer.Ordinal);
 
         foreach (var point in points)
         {
+            foreach (var bucket in point.GpQueueBreakdown)
+            {
+                breakdown[bucket.Key] = breakdown.TryGetValue(bucket.Key, out var existing)
+                    ? existing + bucket.Value
+                    : bucket.Value;
+            }
+
             var rank = StatusRank(point.OverallStatus);
             if (rank > worstRank)
             {
@@ -138,6 +152,7 @@ public static class OpsHealthRollupAggregation
         {
             OverallStatus = worstStatus,
             GpQueueTotal = gpQueueTotal,
+            GpQueueBreakdown = breakdown,
             AlertPending = alertPending,
             AlertDeadLettered = alertDeadLettered,
             DbPoolUtilization = poolCount > 0 ? poolSum / poolCount : null,

--- a/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupAggregation.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupAggregation.cs
@@ -78,10 +78,12 @@ public static class OpsHealthRollupAggregation
     /// connections, peak (max) queue/backlog signals, and averaged utilization/ratio gauges.
     /// </summary>
     /// <remarks>
-    /// The GP queue breakdown (<c>"&lt;status&gt;|&lt;backend&gt;"</c> keys) is merged with a per-key SUM
-    /// across replicas within a bucket (each replica reports its own view of the shared queue at flush time;
-    /// summing keeps the breakdown consistent with the per-key peak stored when downsampling to coarser
-    /// tiers, which uses a per-key MAX — the same peak-counts semantics as the latency counts).
+    /// GP queue depth (total and the <c>"&lt;status&gt;|&lt;backend&gt;"</c> breakdown) and the alert-dispatch
+    /// backlog are GLOBAL-view sections: every replica queries the same shared job/backlog store, so each
+    /// point reports the whole cluster's queue, not a per-replica share. Merging them across replicas is a
+    /// dedup, taken as a per-key MAX (summing would overcount by the replica count). Genuinely per-replica
+    /// sections merge differently: active DB connections are summed, utilization/ratio gauges are averaged.
+    /// Downsampling to coarser time tiers also stores the per-key MAX (peak within the bucket).
     /// </remarks>
     /// <param name="points">The per-replica vitals points (must be non-empty).</param>
     /// <returns>The merged whole-cluster vitals point.</returns>
@@ -114,8 +116,9 @@ public static class OpsHealthRollupAggregation
         {
             foreach (var bucket in point.GpQueueBreakdown)
             {
+                // Global view reported by every replica — dedup with per-key max, never sum.
                 breakdown[bucket.Key] = breakdown.TryGetValue(bucket.Key, out var existing)
-                    ? existing + bucket.Value
+                    ? Math.Max(existing, bucket.Value)
                     : bucket.Value;
             }
 

--- a/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupAggregation.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupAggregation.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Observability.Domain;
+
+/// <summary>
+/// Pure aggregation helpers for the ops-health rollup store. Used to merge per-replica rollup points into
+/// a whole-cluster view (both for the live snapshot and the history read API).
+/// </summary>
+/// <remarks>
+/// Percentiles cannot be recombined exactly from pre-aggregated percentiles without the raw distribution
+/// (a NON-GOAL here — that stays in the optional Prometheus bundle). Cross-replica merging therefore uses a
+/// request-count-weighted mean of each percentile (falling back to the max when no in-window requests were
+/// observed) and sums the request/error counts, since replicas serve disjoint traffic. This is a documented
+/// approximation suitable for whole-cluster trend and SLO review.
+/// </remarks>
+public static class OpsHealthRollupAggregation
+{
+    /// <summary>
+    /// Merges per-replica latency points for a single protocol into one whole-cluster point. Counts are
+    /// summed (disjoint traffic); percentiles use a request-count-weighted mean and the max feeds the max.
+    /// </summary>
+    /// <param name="protocol">The protocol the merged point describes.</param>
+    /// <param name="points">The per-replica points (must be non-empty).</param>
+    /// <returns>The merged whole-cluster latency point.</returns>
+    public static OpsHealthLatencyPoint MergeAcrossReplicas(string protocol, IReadOnlyList<OpsHealthLatencyPoint> points)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(protocol);
+        ArgumentNullException.ThrowIfNull(points);
+        if (points.Count == 0)
+        {
+            throw new ArgumentException("At least one point is required to merge.", nameof(points));
+        }
+
+        if (points.Count == 1)
+        {
+            return points[0] with { Protocol = protocol };
+        }
+
+        long requestCount = 0;
+        long errorCount = 0;
+        double weightedP50 = 0;
+        double weightedP95 = 0;
+        double weightedP99 = 0;
+        double maxP50 = 0;
+        double maxP95 = 0;
+        double maxP99 = 0;
+        double maxMs = 0;
+
+        foreach (var point in points)
+        {
+            requestCount += point.RequestCount;
+            errorCount += point.ErrorCount;
+            var weight = point.RequestCount;
+            weightedP50 += point.P50Ms * weight;
+            weightedP95 += point.P95Ms * weight;
+            weightedP99 += point.P99Ms * weight;
+            maxP50 = Math.Max(maxP50, point.P50Ms);
+            maxP95 = Math.Max(maxP95, point.P95Ms);
+            maxP99 = Math.Max(maxP99, point.P99Ms);
+            maxMs = Math.Max(maxMs, point.MaxMs);
+        }
+
+        return new OpsHealthLatencyPoint
+        {
+            Protocol = protocol,
+            RequestCount = requestCount,
+            ErrorCount = errorCount,
+            P50Ms = requestCount > 0 ? weightedP50 / requestCount : maxP50,
+            P95Ms = requestCount > 0 ? weightedP95 / requestCount : maxP95,
+            P99Ms = requestCount > 0 ? weightedP99 / requestCount : maxP99,
+            MaxMs = maxMs,
+        };
+    }
+
+    /// <summary>
+    /// Merges per-replica vitals into one whole-cluster point: worst overall status, summed active DB
+    /// connections, peak (max) queue/backlog signals, and averaged utilization/ratio gauges.
+    /// </summary>
+    /// <param name="points">The per-replica vitals points (must be non-empty).</param>
+    /// <returns>The merged whole-cluster vitals point.</returns>
+    public static OpsHealthVitalsPoint MergeVitalsAcrossReplicas(IReadOnlyList<OpsHealthVitalsPoint> points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+        if (points.Count == 0)
+        {
+            throw new ArgumentException("At least one point is required to merge.", nameof(points));
+        }
+
+        if (points.Count == 1)
+        {
+            return points[0];
+        }
+
+        var worstStatus = "Healthy";
+        var worstRank = int.MinValue;
+        var gpQueueTotal = 0;
+        long? alertPending = null;
+        long? alertDeadLettered = null;
+        double poolSum = 0;
+        var poolCount = 0;
+        var dbActive = 0;
+        double cacheSum = 0;
+        double errorSum = 0;
+
+        foreach (var point in points)
+        {
+            var rank = StatusRank(point.OverallStatus);
+            if (rank > worstRank)
+            {
+                worstRank = rank;
+                worstStatus = point.OverallStatus;
+            }
+
+            gpQueueTotal = Math.Max(gpQueueTotal, point.GpQueueTotal);
+            if (point.AlertPending is { } pending)
+            {
+                alertPending = Math.Max(alertPending ?? 0, pending);
+            }
+
+            if (point.AlertDeadLettered is { } dead)
+            {
+                alertDeadLettered = Math.Max(alertDeadLettered ?? 0, dead);
+            }
+
+            if (point.DbPoolUtilization is { } pool)
+            {
+                poolSum += pool;
+                poolCount++;
+            }
+
+            dbActive += point.DbActiveConnections;
+            cacheSum += point.CacheHitRatio;
+            errorSum += point.ErrorRate;
+        }
+
+        return new OpsHealthVitalsPoint
+        {
+            OverallStatus = worstStatus,
+            GpQueueTotal = gpQueueTotal,
+            AlertPending = alertPending,
+            AlertDeadLettered = alertDeadLettered,
+            DbPoolUtilization = poolCount > 0 ? poolSum / poolCount : null,
+            DbActiveConnections = dbActive,
+            CacheHitRatio = cacheSum / points.Count,
+            ErrorRate = errorSum / points.Count,
+        };
+    }
+
+    /// <summary>
+    /// Ranks a health status string by severity so the worst can be selected when merging. Unknown strings
+    /// rank between healthy and degraded.
+    /// </summary>
+    /// <param name="status">The status string.</param>
+    /// <returns>A severity rank (higher is worse).</returns>
+    public static int StatusRank(string? status) => status switch
+    {
+        "Unhealthy" => 3,
+        "Degraded" => 2,
+        "Healthy" => 0,
+        _ => 1,
+    };
+}

--- a/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupModels.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupModels.cs
@@ -68,14 +68,22 @@ public sealed record OpsHealthVitalsPoint
     /// <summary>
     /// Gets the GP queue depth broken down by status and backend, keyed <c>"&lt;status&gt;|&lt;backend&gt;"</c>
     /// (e.g. <c>"Queued|local"</c>) — the flattened form of the live snapshot's status×backend buckets.
-    /// Empty when no jobs are active or no execution-job store is registered.
+    /// Like <see cref="GpQueueTotal"/>, this is a GLOBAL view (every replica queries the same shared job
+    /// store), so cross-replica merges dedup with a per-key max rather than summing. Empty when no jobs are
+    /// active or no execution-job store is registered.
     /// </summary>
     public IReadOnlyDictionary<string, int> GpQueueBreakdown { get; init; } = EmptyBreakdown;
 
-    /// <summary>Gets the alert-dispatch pending backlog count, when available.</summary>
+    /// <summary>
+    /// Gets the alert-dispatch pending backlog count, when available. Global-view section (shared backlog
+    /// store): cross-replica merges dedup with a max.
+    /// </summary>
     public long? AlertPending { get; init; }
 
-    /// <summary>Gets the alert-dispatch dead-lettered count, when available.</summary>
+    /// <summary>
+    /// Gets the alert-dispatch dead-lettered count, when available. Global-view section (shared backlog
+    /// store): cross-replica merges dedup with a max.
+    /// </summary>
     public long? AlertDeadLettered { get; init; }
 
     /// <summary>Gets the database connection-pool utilization ratio (0.0 to 1.0), when available.</summary>

--- a/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupModels.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupModels.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Observability.Domain;
+
+/// <summary>
+/// Downsampled retention tier for the persisted ops-health rollup store (#2553). Coarser tiers are
+/// derived from the finest tier by the background sampler's maintenance pass and retained longer.
+/// </summary>
+public enum OpsHealthRollupTier
+{
+    /// <summary>1-minute buckets, retained ~24h. Written directly by each replica's sampler flush.</summary>
+    OneMinute = 0,
+
+    /// <summary>5-minute buckets, retained ~14d. Downsampled from <see cref="OneMinute"/>.</summary>
+    FiveMinute = 1,
+
+    /// <summary>Hourly buckets, retained ~90d. Downsampled from <see cref="OneMinute"/>.</summary>
+    Hourly = 2,
+}
+
+/// <summary>
+/// Per-protocol serving-latency rollup point. Percentiles are the rolling-window values observed by a
+/// replica's <c>ServingLatencyAggregator</c> at flush time (not per-bucket deltas).
+/// </summary>
+public sealed record OpsHealthLatencyPoint
+{
+    /// <summary>Gets the GIS protocol family.</summary>
+    public required string Protocol { get; init; }
+
+    /// <summary>Gets the in-window request count.</summary>
+    public required long RequestCount { get; init; }
+
+    /// <summary>Gets the in-window server-error count (HTTP status &gt;= 500).</summary>
+    public required long ErrorCount { get; init; }
+
+    /// <summary>Gets the 50th-percentile duration in milliseconds.</summary>
+    public required double P50Ms { get; init; }
+
+    /// <summary>Gets the 95th-percentile duration in milliseconds.</summary>
+    public required double P95Ms { get; init; }
+
+    /// <summary>Gets the 99th-percentile duration in milliseconds.</summary>
+    public required double P99Ms { get; init; }
+
+    /// <summary>Gets the maximum duration in milliseconds.</summary>
+    public required double MaxMs { get; init; }
+
+    /// <summary>Gets the server-error rate over the window (0.0 to 1.0).</summary>
+    public double ErrorRate => RequestCount > 0 ? (double)ErrorCount / RequestCount : 0d;
+}
+
+/// <summary>
+/// Non-latency ops vitals captured in a single rollup flush: overall status, GP queue depth,
+/// alert-dispatch backlog / dead-letters, and DB pool / cache utilization.
+/// </summary>
+public sealed record OpsHealthVitalsPoint
+{
+    /// <summary>Gets the overall health roll-up status string (<c>Healthy</c>/<c>Degraded</c>/<c>Unhealthy</c>).</summary>
+    public required string OverallStatus { get; init; }
+
+    /// <summary>Gets the total active geoprocessing jobs (queued + provisioning + running).</summary>
+    public required int GpQueueTotal { get; init; }
+
+    /// <summary>Gets the alert-dispatch pending backlog count, when available.</summary>
+    public long? AlertPending { get; init; }
+
+    /// <summary>Gets the alert-dispatch dead-lettered count, when available.</summary>
+    public long? AlertDeadLettered { get; init; }
+
+    /// <summary>Gets the database connection-pool utilization ratio (0.0 to 1.0), when available.</summary>
+    public double? DbPoolUtilization { get; init; }
+
+    /// <summary>Gets the number of active database connections.</summary>
+    public required int DbActiveConnections { get; init; }
+
+    /// <summary>Gets the cache hit ratio (0.0 to 1.0).</summary>
+    public required double CacheHitRatio { get; init; }
+
+    /// <summary>Gets the live HTTP server error rate (0.0 to 1.0).</summary>
+    public required double ErrorRate { get; init; }
+}
+
+/// <summary>
+/// A single per-replica ops-health flush: the local serving-latency percentiles per protocol plus the
+/// local ops vitals, captured at <see cref="CapturedAt"/> and keyed by <see cref="ReplicaId"/>.
+/// </summary>
+public sealed record OpsHealthRollupSample
+{
+    /// <summary>Gets the flushing replica identifier.</summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>Gets the capture (flush) time; the store truncates it to the 1-minute bucket boundary.</summary>
+    public required DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>Gets the per-protocol serving-latency points (may be empty when no traffic was observed).</summary>
+    public required IReadOnlyList<OpsHealthLatencyPoint> Latency { get; init; }
+
+    /// <summary>Gets the ops vitals point.</summary>
+    public required OpsHealthVitalsPoint Vitals { get; init; }
+}
+
+/// <summary>A stored latency point tagged with its bucket and replica.</summary>
+public sealed record OpsHealthLatencyRow
+{
+    /// <summary>Gets the replica the row was flushed by.</summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>Gets the (UTC) bucket start.</summary>
+    public required DateTimeOffset BucketStart { get; init; }
+
+    /// <summary>Gets the latency point.</summary>
+    public required OpsHealthLatencyPoint Point { get; init; }
+}
+
+/// <summary>A stored vitals point tagged with its bucket and replica.</summary>
+public sealed record OpsHealthVitalsRow
+{
+    /// <summary>Gets the replica the row was flushed by.</summary>
+    public required string ReplicaId { get; init; }
+
+    /// <summary>Gets the (UTC) bucket start.</summary>
+    public required DateTimeOffset BucketStart { get; init; }
+
+    /// <summary>Gets the vitals point.</summary>
+    public required OpsHealthVitalsPoint Point { get; init; }
+}
+
+/// <summary>
+/// Hard retention caps per tier. Rows older than the cap are pruned automatically so the footprint stays
+/// bounded (documented default footprint: single-digit MB for a small cluster).
+/// </summary>
+public sealed record OpsHealthRollupRetentionPolicy
+{
+    /// <summary>Gets the maximum age of retained 1-minute rows.</summary>
+    public required TimeSpan OneMinuteRetention { get; init; }
+
+    /// <summary>Gets the maximum age of retained 5-minute rows.</summary>
+    public required TimeSpan FiveMinuteRetention { get; init; }
+
+    /// <summary>Gets the maximum age of retained hourly rows.</summary>
+    public required TimeSpan HourlyRetention { get; init; }
+
+    /// <summary>Gets the default policy (1-min × 24h, 5-min × 14d, hourly × 90d).</summary>
+    public static OpsHealthRollupRetentionPolicy Default { get; } = new()
+    {
+        OneMinuteRetention = TimeSpan.FromHours(24),
+        FiveMinuteRetention = TimeSpan.FromDays(14),
+        HourlyRetention = TimeSpan.FromDays(90),
+    };
+
+    /// <summary>Returns the retention cap for the given tier.</summary>
+    /// <param name="tier">The rollup tier.</param>
+    /// <returns>The maximum retained age for <paramref name="tier"/>.</returns>
+    public TimeSpan RetentionFor(OpsHealthRollupTier tier) => tier switch
+    {
+        OpsHealthRollupTier.OneMinute => OneMinuteRetention,
+        OpsHealthRollupTier.FiveMinute => FiveMinuteRetention,
+        OpsHealthRollupTier.Hourly => HourlyRetention,
+        _ => OneMinuteRetention,
+    };
+}

--- a/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupModels.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsHealthRollupModels.cs
@@ -56,11 +56,21 @@ public sealed record OpsHealthLatencyPoint
 /// </summary>
 public sealed record OpsHealthVitalsPoint
 {
+    private static readonly IReadOnlyDictionary<string, int> EmptyBreakdown =
+        new Dictionary<string, int>(capacity: 0);
+
     /// <summary>Gets the overall health roll-up status string (<c>Healthy</c>/<c>Degraded</c>/<c>Unhealthy</c>).</summary>
     public required string OverallStatus { get; init; }
 
     /// <summary>Gets the total active geoprocessing jobs (queued + provisioning + running).</summary>
     public required int GpQueueTotal { get; init; }
+
+    /// <summary>
+    /// Gets the GP queue depth broken down by status and backend, keyed <c>"&lt;status&gt;|&lt;backend&gt;"</c>
+    /// (e.g. <c>"Queued|local"</c>) — the flattened form of the live snapshot's status×backend buckets.
+    /// Empty when no jobs are active or no execution-job store is registered.
+    /// </summary>
+    public IReadOnlyDictionary<string, int> GpQueueBreakdown { get; init; } = EmptyBreakdown;
 
     /// <summary>Gets the alert-dispatch pending backlog count, when available.</summary>
     public long? AlertPending { get; init; }

--- a/src/Honua.Postgres/Features/Observability/PostgresOpsHealthRollupStore.cs
+++ b/src/Honua.Postgres/Features/Observability/PostgresOpsHealthRollupStore.cs
@@ -1,0 +1,345 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Observability;
+
+/// <summary>
+/// PostgreSQL implementation of <see cref="IOpsHealthRollupStore"/> (#2553). Persists per-replica
+/// ops-health flushes into two bounded rollup tables (serving latency and vitals), downsamples the
+/// 5-minute and hourly tiers from the 1-minute tier, and prunes each tier to its retention cap.
+/// </summary>
+internal sealed class PostgresOpsHealthRollupStore : IOpsHealthRollupStore
+{
+    // Tier discriminators persisted in the smallint `tier` column.
+    private const short TierOneMinute = 0;
+    private const short TierFiveMinute = 1;
+    private const short TierHourly = 2;
+
+    private const int FiveMinuteSeconds = 300;
+    private const int HourSeconds = 3600;
+
+    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly string _latencyTable;
+    private readonly string _vitalsTable;
+
+    public PostgresOpsHealthRollupStore(IAdoNetDatabaseConnectionProvider connectionProvider, string? schemaName = null)
+    {
+        _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
+        _latencyTable = SchemaSearchPath.QualifyTable("ops_health_rollup_latency", schemaName);
+        _vitalsTable = SchemaSearchPath.QualifyTable("ops_health_rollup_vitals", schemaName);
+    }
+
+    public async Task WriteSampleAsync(OpsHealthRollupSample sample, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sample);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sample.ReplicaId);
+
+        var bucketStart = TruncateToMinute(sample.CapturedAt);
+        var now = DateTimeOffset.UtcNow;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        var latencySql = $"""
+            INSERT INTO {_latencyTable}
+                (replica_id, tier, bucket_start, protocol, request_count, error_count, p50_ms, p95_ms, p99_ms, max_ms, updated_at)
+            VALUES (@replica_id, @tier, @bucket_start, @protocol, @request_count, @error_count, @p50_ms, @p95_ms, @p99_ms, @max_ms, @updated_at)
+            ON CONFLICT (replica_id, tier, bucket_start, protocol) DO UPDATE SET
+                request_count = EXCLUDED.request_count,
+                error_count = EXCLUDED.error_count,
+                p50_ms = EXCLUDED.p50_ms,
+                p95_ms = EXCLUDED.p95_ms,
+                p99_ms = EXCLUDED.p99_ms,
+                max_ms = EXCLUDED.max_ms,
+                updated_at = EXCLUDED.updated_at
+            """;
+
+        foreach (var point in sample.Latency)
+        {
+            await using var command = new NpgsqlCommand(latencySql, connection, transaction);
+            command.Parameters.AddWithValue("replica_id", NpgsqlDbType.Text, sample.ReplicaId);
+            command.Parameters.AddWithValue("tier", NpgsqlDbType.Smallint, TierOneMinute);
+            command.Parameters.AddWithValue("bucket_start", NpgsqlDbType.TimestampTz, bucketStart);
+            command.Parameters.AddWithValue("protocol", NpgsqlDbType.Text, point.Protocol);
+            command.Parameters.AddWithValue("request_count", NpgsqlDbType.Bigint, point.RequestCount);
+            command.Parameters.AddWithValue("error_count", NpgsqlDbType.Bigint, point.ErrorCount);
+            command.Parameters.AddWithValue("p50_ms", NpgsqlDbType.Double, point.P50Ms);
+            command.Parameters.AddWithValue("p95_ms", NpgsqlDbType.Double, point.P95Ms);
+            command.Parameters.AddWithValue("p99_ms", NpgsqlDbType.Double, point.P99Ms);
+            command.Parameters.AddWithValue("max_ms", NpgsqlDbType.Double, point.MaxMs);
+            command.Parameters.AddWithValue("updated_at", NpgsqlDbType.TimestampTz, now);
+            _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var vitalsSql = $"""
+            INSERT INTO {_vitalsTable}
+                (replica_id, tier, bucket_start, overall_status, gp_queue_total, alert_pending, alert_dead_lettered,
+                 db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate, updated_at)
+            VALUES (@replica_id, @tier, @bucket_start, @overall_status, @gp_queue_total, @alert_pending, @alert_dead_lettered,
+                    @db_pool_utilization, @db_active_connections, @cache_hit_ratio, @error_rate, @updated_at)
+            ON CONFLICT (replica_id, tier, bucket_start) DO UPDATE SET
+                overall_status = EXCLUDED.overall_status,
+                gp_queue_total = EXCLUDED.gp_queue_total,
+                alert_pending = EXCLUDED.alert_pending,
+                alert_dead_lettered = EXCLUDED.alert_dead_lettered,
+                db_pool_utilization = EXCLUDED.db_pool_utilization,
+                db_active_connections = EXCLUDED.db_active_connections,
+                cache_hit_ratio = EXCLUDED.cache_hit_ratio,
+                error_rate = EXCLUDED.error_rate,
+                updated_at = EXCLUDED.updated_at
+            """;
+
+        await using (var vitalsCommand = new NpgsqlCommand(vitalsSql, connection, transaction))
+        {
+            var vitals = sample.Vitals;
+            vitalsCommand.Parameters.AddWithValue("replica_id", NpgsqlDbType.Text, sample.ReplicaId);
+            vitalsCommand.Parameters.AddWithValue("tier", NpgsqlDbType.Smallint, TierOneMinute);
+            vitalsCommand.Parameters.AddWithValue("bucket_start", NpgsqlDbType.TimestampTz, bucketStart);
+            vitalsCommand.Parameters.AddWithValue("overall_status", NpgsqlDbType.Text, vitals.OverallStatus);
+            vitalsCommand.Parameters.AddWithValue("gp_queue_total", NpgsqlDbType.Integer, vitals.GpQueueTotal);
+            vitalsCommand.Parameters.AddWithValue("alert_pending", NpgsqlDbType.Bigint, (object?)vitals.AlertPending ?? DBNull.Value);
+            vitalsCommand.Parameters.AddWithValue("alert_dead_lettered", NpgsqlDbType.Bigint, (object?)vitals.AlertDeadLettered ?? DBNull.Value);
+            vitalsCommand.Parameters.AddWithValue("db_pool_utilization", NpgsqlDbType.Double, (object?)vitals.DbPoolUtilization ?? DBNull.Value);
+            vitalsCommand.Parameters.AddWithValue("db_active_connections", NpgsqlDbType.Integer, vitals.DbActiveConnections);
+            vitalsCommand.Parameters.AddWithValue("cache_hit_ratio", NpgsqlDbType.Double, vitals.CacheHitRatio);
+            vitalsCommand.Parameters.AddWithValue("error_rate", NpgsqlDbType.Double, vitals.ErrorRate);
+            vitalsCommand.Parameters.AddWithValue("updated_at", NpgsqlDbType.TimestampTz, now);
+            _ = await vitalsCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> DownsampleAndPruneAsync(DateTimeOffset now, OpsHealthRollupRetentionPolicy policy, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        await DownsampleLatencyAsync(connection, transaction, TierFiveMinute, FiveMinuteSeconds, now, cancellationToken).ConfigureAwait(false);
+        await DownsampleLatencyAsync(connection, transaction, TierHourly, HourSeconds, now, cancellationToken).ConfigureAwait(false);
+        await DownsampleVitalsAsync(connection, transaction, TierFiveMinute, FiveMinuteSeconds, now, cancellationToken).ConfigureAwait(false);
+        await DownsampleVitalsAsync(connection, transaction, TierHourly, HourSeconds, now, cancellationToken).ConfigureAwait(false);
+
+        var pruned = 0;
+        pruned += await PruneAsync(connection, transaction, _latencyTable, TierOneMinute, now - policy.OneMinuteRetention, cancellationToken).ConfigureAwait(false);
+        pruned += await PruneAsync(connection, transaction, _latencyTable, TierFiveMinute, now - policy.FiveMinuteRetention, cancellationToken).ConfigureAwait(false);
+        pruned += await PruneAsync(connection, transaction, _latencyTable, TierHourly, now - policy.HourlyRetention, cancellationToken).ConfigureAwait(false);
+        pruned += await PruneAsync(connection, transaction, _vitalsTable, TierOneMinute, now - policy.OneMinuteRetention, cancellationToken).ConfigureAwait(false);
+        pruned += await PruneAsync(connection, transaction, _vitalsTable, TierFiveMinute, now - policy.FiveMinuteRetention, cancellationToken).ConfigureAwait(false);
+        pruned += await PruneAsync(connection, transaction, _vitalsTable, TierHourly, now - policy.HourlyRetention, cancellationToken).ConfigureAwait(false);
+
+        await transaction.CommitSafelyAsync(cancellationToken).ConfigureAwait(false);
+        return pruned;
+    }
+
+    public Task<IReadOnlyList<OpsHealthLatencyRow>> ReadLatencyAsync(OpsHealthRollupTier tier, DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default)
+        => ReadLatencyCoreAsync(ToTier(tier), from, to, excludeReplicaId: null, cancellationToken);
+
+    public Task<IReadOnlyList<OpsHealthLatencyRow>> ReadRecentLatencyAsync(DateTimeOffset since, string? excludeReplicaId, CancellationToken cancellationToken = default)
+        => ReadLatencyCoreAsync(TierOneMinute, since, DateTimeOffset.UtcNow.AddMinutes(1), excludeReplicaId, cancellationToken);
+
+    public async Task<IReadOnlyList<OpsHealthVitalsRow>> ReadVitalsAsync(OpsHealthRollupTier tier, DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default)
+    {
+        var sql = $"""
+            SELECT replica_id, bucket_start, overall_status, gp_queue_total, alert_pending, alert_dead_lettered,
+                   db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate
+            FROM {_vitalsTable}
+            WHERE tier = @tier AND bucket_start >= @from AND bucket_start <= @to
+            ORDER BY bucket_start, replica_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("tier", NpgsqlDbType.Smallint, ToTier(tier));
+        command.Parameters.AddWithValue("from", NpgsqlDbType.TimestampTz, from);
+        command.Parameters.AddWithValue("to", NpgsqlDbType.TimestampTz, to);
+
+        var rows = new List<OpsHealthVitalsRow>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            rows.Add(new OpsHealthVitalsRow
+            {
+                ReplicaId = reader.GetString(0),
+                BucketStart = reader.GetFieldValue<DateTimeOffset>(1),
+                Point = new OpsHealthVitalsPoint
+                {
+                    OverallStatus = reader.GetString(2),
+                    GpQueueTotal = reader.GetInt32(3),
+                    AlertPending = reader.IsDBNull(4) ? null : reader.GetInt64(4),
+                    AlertDeadLettered = reader.IsDBNull(5) ? null : reader.GetInt64(5),
+                    DbPoolUtilization = reader.IsDBNull(6) ? null : reader.GetDouble(6),
+                    DbActiveConnections = reader.GetInt32(7),
+                    CacheHitRatio = reader.GetDouble(8),
+                    ErrorRate = reader.GetDouble(9),
+                },
+            });
+        }
+
+        return rows;
+    }
+
+    private async Task<IReadOnlyList<OpsHealthLatencyRow>> ReadLatencyCoreAsync(short tier, DateTimeOffset from, DateTimeOffset to, string? excludeReplicaId, CancellationToken cancellationToken)
+    {
+        var filter = string.IsNullOrWhiteSpace(excludeReplicaId) ? string.Empty : " AND replica_id <> @exclude_replica_id";
+        var sql = $"""
+            SELECT replica_id, bucket_start, protocol, request_count, error_count, p50_ms, p95_ms, p99_ms, max_ms
+            FROM {_latencyTable}
+            WHERE tier = @tier AND bucket_start >= @from AND bucket_start <= @to{filter}
+            ORDER BY bucket_start, protocol, replica_id
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("tier", NpgsqlDbType.Smallint, tier);
+        command.Parameters.AddWithValue("from", NpgsqlDbType.TimestampTz, from);
+        command.Parameters.AddWithValue("to", NpgsqlDbType.TimestampTz, to);
+        if (!string.IsNullOrWhiteSpace(excludeReplicaId))
+        {
+            command.Parameters.AddWithValue("exclude_replica_id", NpgsqlDbType.Text, excludeReplicaId);
+        }
+
+        var rows = new List<OpsHealthLatencyRow>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            rows.Add(new OpsHealthLatencyRow
+            {
+                ReplicaId = reader.GetString(0),
+                BucketStart = reader.GetFieldValue<DateTimeOffset>(1),
+                Point = new OpsHealthLatencyPoint
+                {
+                    Protocol = reader.GetString(2),
+                    RequestCount = reader.GetInt64(3),
+                    ErrorCount = reader.GetInt64(4),
+                    P50Ms = reader.GetDouble(5),
+                    P95Ms = reader.GetDouble(6),
+                    P99Ms = reader.GetDouble(7),
+                    MaxMs = reader.GetDouble(8),
+                },
+            });
+        }
+
+        return rows;
+    }
+
+    // Downsamples the 1-minute latency tier into a coarser tier using an epoch-floor bucket (UTC-stable,
+    // independent of the session TimeZone). Percentiles use a request-count-weighted mean; counts store the
+    // peak (max) rolling-window observation within the coarse bucket. Idempotent via upsert.
+    private async Task DownsampleLatencyAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, short targetTier, int bucketSeconds, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            INSERT INTO {_latencyTable}
+                (replica_id, tier, bucket_start, protocol, request_count, error_count, p50_ms, p95_ms, p99_ms, max_ms, updated_at)
+            SELECT
+                replica_id,
+                @target_tier,
+                to_timestamp(floor(extract(epoch FROM bucket_start) / @bucket_seconds) * @bucket_seconds),
+                protocol,
+                MAX(request_count),
+                MAX(error_count),
+                CASE WHEN SUM(request_count) > 0 THEN SUM(p50_ms * request_count) / SUM(request_count) ELSE MAX(p50_ms) END,
+                CASE WHEN SUM(request_count) > 0 THEN SUM(p95_ms * request_count) / SUM(request_count) ELSE MAX(p95_ms) END,
+                CASE WHEN SUM(request_count) > 0 THEN SUM(p99_ms * request_count) / SUM(request_count) ELSE MAX(p99_ms) END,
+                MAX(max_ms),
+                @updated_at
+            FROM {_latencyTable}
+            WHERE tier = @source_tier
+            GROUP BY replica_id, to_timestamp(floor(extract(epoch FROM bucket_start) / @bucket_seconds) * @bucket_seconds), protocol
+            ON CONFLICT (replica_id, tier, bucket_start, protocol) DO UPDATE SET
+                request_count = EXCLUDED.request_count,
+                error_count = EXCLUDED.error_count,
+                p50_ms = EXCLUDED.p50_ms,
+                p95_ms = EXCLUDED.p95_ms,
+                p99_ms = EXCLUDED.p99_ms,
+                max_ms = EXCLUDED.max_ms,
+                updated_at = EXCLUDED.updated_at
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("target_tier", NpgsqlDbType.Smallint, targetTier);
+        command.Parameters.AddWithValue("source_tier", NpgsqlDbType.Smallint, TierOneMinute);
+        command.Parameters.AddWithValue("bucket_seconds", NpgsqlDbType.Integer, bucketSeconds);
+        command.Parameters.AddWithValue("updated_at", NpgsqlDbType.TimestampTz, now);
+        _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task DownsampleVitalsAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, short targetTier, int bucketSeconds, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        var sql = $"""
+            INSERT INTO {_vitalsTable}
+                (replica_id, tier, bucket_start, overall_status, gp_queue_total, alert_pending, alert_dead_lettered,
+                 db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate, updated_at)
+            SELECT
+                replica_id,
+                @target_tier,
+                to_timestamp(floor(extract(epoch FROM bucket_start) / @bucket_seconds) * @bucket_seconds),
+                CASE
+                    WHEN bool_or(overall_status = 'Unhealthy') THEN 'Unhealthy'
+                    WHEN bool_or(overall_status = 'Degraded') THEN 'Degraded'
+                    WHEN bool_or(overall_status = 'Healthy') THEN 'Healthy'
+                    ELSE MAX(overall_status)
+                END,
+                MAX(gp_queue_total),
+                MAX(alert_pending),
+                MAX(alert_dead_lettered),
+                AVG(db_pool_utilization),
+                MAX(db_active_connections),
+                AVG(cache_hit_ratio),
+                MAX(error_rate),
+                @updated_at
+            FROM {_vitalsTable}
+            WHERE tier = @source_tier
+            GROUP BY replica_id, to_timestamp(floor(extract(epoch FROM bucket_start) / @bucket_seconds) * @bucket_seconds)
+            ON CONFLICT (replica_id, tier, bucket_start) DO UPDATE SET
+                overall_status = EXCLUDED.overall_status,
+                gp_queue_total = EXCLUDED.gp_queue_total,
+                alert_pending = EXCLUDED.alert_pending,
+                alert_dead_lettered = EXCLUDED.alert_dead_lettered,
+                db_pool_utilization = EXCLUDED.db_pool_utilization,
+                db_active_connections = EXCLUDED.db_active_connections,
+                cache_hit_ratio = EXCLUDED.cache_hit_ratio,
+                error_rate = EXCLUDED.error_rate,
+                updated_at = EXCLUDED.updated_at
+            """;
+
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("target_tier", NpgsqlDbType.Smallint, targetTier);
+        command.Parameters.AddWithValue("source_tier", NpgsqlDbType.Smallint, TierOneMinute);
+        command.Parameters.AddWithValue("bucket_seconds", NpgsqlDbType.Integer, bucketSeconds);
+        command.Parameters.AddWithValue("updated_at", NpgsqlDbType.TimestampTz, now);
+        _ = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<int> PruneAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, string table, short tier, DateTimeOffset cutoff, CancellationToken cancellationToken)
+    {
+        var sql = $"DELETE FROM {table} WHERE tier = @tier AND bucket_start < @cutoff";
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.Parameters.AddWithValue("tier", NpgsqlDbType.Smallint, tier);
+        command.Parameters.AddWithValue("cutoff", NpgsqlDbType.TimestampTz, cutoff);
+        return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static DateTimeOffset TruncateToMinute(DateTimeOffset value)
+    {
+        var utc = value.ToUniversalTime();
+        return new DateTimeOffset(utc.Year, utc.Month, utc.Day, utc.Hour, utc.Minute, 0, TimeSpan.Zero);
+    }
+
+    private static short ToTier(OpsHealthRollupTier tier) => tier switch
+    {
+        OpsHealthRollupTier.OneMinute => TierOneMinute,
+        OpsHealthRollupTier.FiveMinute => TierFiveMinute,
+        OpsHealthRollupTier.Hourly => TierHourly,
+        _ => TierOneMinute,
+    };
+}

--- a/src/Honua.Postgres/Features/Observability/PostgresOpsHealthRollupStore.cs
+++ b/src/Honua.Postgres/Features/Observability/PostgresOpsHealthRollupStore.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Text;
+using System.Text.Json;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Observability.Abstractions;
 using Honua.Core.Features.Observability.Domain;
@@ -80,13 +82,14 @@ internal sealed class PostgresOpsHealthRollupStore : IOpsHealthRollupStore
 
         var vitalsSql = $"""
             INSERT INTO {_vitalsTable}
-                (replica_id, tier, bucket_start, overall_status, gp_queue_total, alert_pending, alert_dead_lettered,
+                (replica_id, tier, bucket_start, overall_status, gp_queue_total, gp_queue_breakdown, alert_pending, alert_dead_lettered,
                  db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate, updated_at)
-            VALUES (@replica_id, @tier, @bucket_start, @overall_status, @gp_queue_total, @alert_pending, @alert_dead_lettered,
+            VALUES (@replica_id, @tier, @bucket_start, @overall_status, @gp_queue_total, @gp_queue_breakdown, @alert_pending, @alert_dead_lettered,
                     @db_pool_utilization, @db_active_connections, @cache_hit_ratio, @error_rate, @updated_at)
             ON CONFLICT (replica_id, tier, bucket_start) DO UPDATE SET
                 overall_status = EXCLUDED.overall_status,
                 gp_queue_total = EXCLUDED.gp_queue_total,
+                gp_queue_breakdown = EXCLUDED.gp_queue_breakdown,
                 alert_pending = EXCLUDED.alert_pending,
                 alert_dead_lettered = EXCLUDED.alert_dead_lettered,
                 db_pool_utilization = EXCLUDED.db_pool_utilization,
@@ -104,6 +107,7 @@ internal sealed class PostgresOpsHealthRollupStore : IOpsHealthRollupStore
             vitalsCommand.Parameters.AddWithValue("bucket_start", NpgsqlDbType.TimestampTz, bucketStart);
             vitalsCommand.Parameters.AddWithValue("overall_status", NpgsqlDbType.Text, vitals.OverallStatus);
             vitalsCommand.Parameters.AddWithValue("gp_queue_total", NpgsqlDbType.Integer, vitals.GpQueueTotal);
+            vitalsCommand.Parameters.AddWithValue("gp_queue_breakdown", NpgsqlDbType.Jsonb, SerializeBreakdown(vitals.GpQueueBreakdown));
             vitalsCommand.Parameters.AddWithValue("alert_pending", NpgsqlDbType.Bigint, (object?)vitals.AlertPending ?? DBNull.Value);
             vitalsCommand.Parameters.AddWithValue("alert_dead_lettered", NpgsqlDbType.Bigint, (object?)vitals.AlertDeadLettered ?? DBNull.Value);
             vitalsCommand.Parameters.AddWithValue("db_pool_utilization", NpgsqlDbType.Double, (object?)vitals.DbPoolUtilization ?? DBNull.Value);
@@ -151,7 +155,7 @@ internal sealed class PostgresOpsHealthRollupStore : IOpsHealthRollupStore
     {
         var sql = $"""
             SELECT replica_id, bucket_start, overall_status, gp_queue_total, alert_pending, alert_dead_lettered,
-                   db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate
+                   db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate, gp_queue_breakdown
             FROM {_vitalsTable}
             WHERE tier = @tier AND bucket_start >= @from AND bucket_start <= @to
             ORDER BY bucket_start, replica_id
@@ -181,6 +185,7 @@ internal sealed class PostgresOpsHealthRollupStore : IOpsHealthRollupStore
                     DbActiveConnections = reader.GetInt32(7),
                     CacheHitRatio = reader.GetDouble(8),
                     ErrorRate = reader.GetDouble(9),
+                    GpQueueBreakdown = ParseBreakdown(reader.IsDBNull(10) ? null : reader.GetString(10)),
                 },
             });
         }
@@ -275,34 +280,69 @@ internal sealed class PostgresOpsHealthRollupStore : IOpsHealthRollupStore
 
     private async Task DownsampleVitalsAsync(NpgsqlConnection connection, NpgsqlTransaction transaction, short targetTier, int bucketSeconds, DateTimeOffset now, CancellationToken cancellationToken)
     {
+        // The GP queue breakdown map is downsampled with a per-key MAX (peak depth per status|backend key
+        // within the coarse bucket), consistent with the peak-counts semantics used for the scalar columns.
         var sql = $"""
+            WITH source AS (
+                SELECT replica_id,
+                       to_timestamp(floor(extract(epoch FROM bucket_start) / @bucket_seconds) * @bucket_seconds) AS bucket,
+                       overall_status, gp_queue_total, gp_queue_breakdown, alert_pending, alert_dead_lettered,
+                       db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate
+                FROM {_vitalsTable}
+                WHERE tier = @source_tier
+            ),
+            breakdown AS (
+                SELECT replica_id, bucket, jsonb_object_agg(key, peak) AS gp_queue_breakdown
+                FROM (
+                    SELECT s.replica_id, s.bucket, kv.key, MAX((kv.value)::int) AS peak
+                    FROM source s
+                    CROSS JOIN LATERAL jsonb_each_text(s.gp_queue_breakdown) AS kv
+                    GROUP BY s.replica_id, s.bucket, kv.key
+                ) per_key
+                GROUP BY replica_id, bucket
+            )
             INSERT INTO {_vitalsTable}
-                (replica_id, tier, bucket_start, overall_status, gp_queue_total, alert_pending, alert_dead_lettered,
+                (replica_id, tier, bucket_start, overall_status, gp_queue_total, gp_queue_breakdown, alert_pending, alert_dead_lettered,
                  db_pool_utilization, db_active_connections, cache_hit_ratio, error_rate, updated_at)
             SELECT
-                replica_id,
+                agg.replica_id,
                 @target_tier,
-                to_timestamp(floor(extract(epoch FROM bucket_start) / @bucket_seconds) * @bucket_seconds),
-                CASE
-                    WHEN bool_or(overall_status = 'Unhealthy') THEN 'Unhealthy'
-                    WHEN bool_or(overall_status = 'Degraded') THEN 'Degraded'
-                    WHEN bool_or(overall_status = 'Healthy') THEN 'Healthy'
-                    ELSE MAX(overall_status)
-                END,
-                MAX(gp_queue_total),
-                MAX(alert_pending),
-                MAX(alert_dead_lettered),
-                AVG(db_pool_utilization),
-                MAX(db_active_connections),
-                AVG(cache_hit_ratio),
-                MAX(error_rate),
+                agg.bucket,
+                agg.overall_status,
+                agg.gp_queue_total,
+                COALESCE(b.gp_queue_breakdown, jsonb_build_object()),
+                agg.alert_pending,
+                agg.alert_dead_lettered,
+                agg.db_pool_utilization,
+                agg.db_active_connections,
+                agg.cache_hit_ratio,
+                agg.error_rate,
                 @updated_at
-            FROM {_vitalsTable}
-            WHERE tier = @source_tier
-            GROUP BY replica_id, to_timestamp(floor(extract(epoch FROM bucket_start) / @bucket_seconds) * @bucket_seconds)
+            FROM (
+                SELECT
+                    replica_id,
+                    bucket,
+                    CASE
+                        WHEN bool_or(overall_status = 'Unhealthy') THEN 'Unhealthy'
+                        WHEN bool_or(overall_status = 'Degraded') THEN 'Degraded'
+                        WHEN bool_or(overall_status = 'Healthy') THEN 'Healthy'
+                        ELSE MAX(overall_status)
+                    END AS overall_status,
+                    MAX(gp_queue_total) AS gp_queue_total,
+                    MAX(alert_pending) AS alert_pending,
+                    MAX(alert_dead_lettered) AS alert_dead_lettered,
+                    AVG(db_pool_utilization) AS db_pool_utilization,
+                    MAX(db_active_connections) AS db_active_connections,
+                    AVG(cache_hit_ratio) AS cache_hit_ratio,
+                    MAX(error_rate) AS error_rate
+                FROM source
+                GROUP BY replica_id, bucket
+            ) agg
+            LEFT JOIN breakdown b ON b.replica_id = agg.replica_id AND b.bucket = agg.bucket
             ON CONFLICT (replica_id, tier, bucket_start) DO UPDATE SET
                 overall_status = EXCLUDED.overall_status,
                 gp_queue_total = EXCLUDED.gp_queue_total,
+                gp_queue_breakdown = EXCLUDED.gp_queue_breakdown,
                 alert_pending = EXCLUDED.alert_pending,
                 alert_dead_lettered = EXCLUDED.alert_dead_lettered,
                 db_pool_utilization = EXCLUDED.db_pool_utilization,
@@ -328,6 +368,53 @@ internal sealed class PostgresOpsHealthRollupStore : IOpsHealthRollupStore
         command.Parameters.AddWithValue("cutoff", NpgsqlDbType.TimestampTz, cutoff);
         return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    // Manual (reflection-free) JSON shaping for the flat {"<status>|<backend>": count} breakdown map,
+    // keeping the store AOT-safe without a serializer context.
+    private static string SerializeBreakdown(IReadOnlyDictionary<string, int> breakdown)
+    {
+        if (breakdown.Count == 0)
+        {
+            return "{}";
+        }
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            foreach (var pair in breakdown)
+            {
+                writer.WriteNumber(pair.Key, pair.Value);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static IReadOnlyDictionary<string, int> ParseBreakdown(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "{}")
+        {
+            return EmptyBreakdown;
+        }
+
+        var result = new Dictionary<string, int>(StringComparer.Ordinal);
+        using var document = JsonDocument.Parse(json);
+        foreach (var property in document.RootElement.EnumerateObject())
+        {
+            if (property.Value.TryGetInt32(out var count))
+            {
+                result[property.Name] = count;
+            }
+        }
+
+        return result;
+    }
+
+    private static readonly IReadOnlyDictionary<string, int> EmptyBreakdown =
+        new Dictionary<string, int>(capacity: 0);
 
     private static DateTimeOffset TruncateToMinute(DateTimeOffset value)
     {

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -176,6 +176,13 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IAuditLogExporter, PostgresAuditLogExporter>();
         services.AddScoped<IAuditLogIntegrityVerifier, PostgresAuditLogIntegrityVerifier>();
         services.AddScoped<IInvestigationStore, PostgresInvestigationStore>();
+
+        // Persisted ops-health rollup store (#2553). Schema-qualified so it targets the configured
+        // metadata schema; consumers resolve it as optional so non-Postgres deployments run without history.
+        services.AddScoped<IOpsHealthRollupStore>(serviceProvider =>
+            new PostgresOpsHealthRollupStore(
+                serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
         services.AddScoped<IShareExportStore>(serviceProvider =>
             new PostgresShareExportStore(
                 serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),

--- a/src/Honua.Server/EndpointRegistry.AdminObservability.cs
+++ b/src/Honua.Server/EndpointRegistry.AdminObservability.cs
@@ -11,6 +11,7 @@ public static partial class EndpointRegistry
     private static IReadOnlyList<EndpointDefinition> AdminObservabilityEndpoints =>
     [
         new("GET", "/api/v1/admin/observability/ops-health"),
+        new("GET", "/api/v1/admin/observability/ops-health/history"),
         new("GET", "/api/v1/admin/observability/findings"),
         new("POST", "/api/v1/admin/observability/findings/{findingId}/propose"),
     ];

--- a/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
@@ -38,6 +38,12 @@ internal static class OpsObservabilityEndpoints
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
             .Produces<OpsHealthSnapshotResponse>();
 
+        group.MapGet("/ops-health/history", HandleGetOpsHealthHistory)
+            .WithDisplayName("Get Ops Health History")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<OpsHealthHistoryResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
         group.MapGet("/findings", HandleGetFindings)
             .WithDisplayName("Get Ops Findings")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
@@ -56,6 +62,32 @@ internal static class OpsObservabilityEndpoints
     {
         var snapshot = await service.GetAsync(context.RequestAborted).ConfigureAwait(false);
         return Results.Json(snapshot, OpsObservabilityJsonContext.Default.OpsHealthSnapshotResponse);
+    }
+
+    /// <summary>
+    /// Handles the ops-health history read: an admin-authed, cluster-aggregated time series of serving
+    /// latency and ops vitals at the requested <c>resolution</c> over the requested <c>window</c>, with an
+    /// optional per-replica breakdown (<c>perReplica=true</c>). This endpoint is the reconnect gap-fill
+    /// contract for realtime <c>ops-health</c> hub clients (#2554) — clients backfill a dropped interval by
+    /// requesting the window rather than replaying per-event cursors.
+    /// </summary>
+    private static async Task<IResult> HandleGetOpsHealthHistory(
+        [FromServices] IOpsHealthHistoryService service,
+        HttpContext context,
+        string? window = null,
+        string? resolution = null,
+        bool perReplica = false)
+    {
+        if (!OpsHealthHistoryQuery.TryParse(window, resolution, perReplica, out var error, out var query))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                StatusCodes.Status400BadRequest,
+                ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                error ?? "Invalid history query.");
+        }
+
+        var response = await service.GetAsync(query, context.RequestAborted).ConfigureAwait(false);
+        return Results.Json(response, OpsObservabilityJsonContext.Default.OpsHealthHistoryResponse);
     }
 
     private static async Task<IResult> HandleGetFindings(

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -58,6 +58,19 @@ internal static class ObservabilityServiceCollectionExtensions
         services.AddScoped<IOpsHealthSnapshotService, OpsHealthSnapshotService>();
         services.AddScoped<IOpsFindingsService, OpsFindingsService>();
 
+        // Persisted ops-health rollup store + per-replica sampler (#2553). The store itself is registered by
+        // the Postgres provider; the sampler and history service resolve it as optional so non-Postgres
+        // deployments still expose the (empty) history surface and the realtime flush seam. The flush signal
+        // is the in-process seam the realtime broadcast layer (#2554) subscribes to.
+        services.AddOptions<OpsHealthRollupOptions>()
+            .Bind(configuration.GetSection(OpsHealthRollupOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddSingleton<OpsHealthFlushSignal>();
+        services.AddScoped<IOpsHealthHistoryService, OpsHealthHistoryService>();
+        services.AddHostedService<OpsHealthRollupSampler>();
+
         // Aggregated operate-status surface (A12): composes the ops-health snapshot + findings into
         // one server-authoritative verdict, and binds the SLO/error-budget contract.
         services.AddOperateStatus(configuration);

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthFlushSignal.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthFlushSignal.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// In-process event seam raised by the ops-health rollup sampler after each flush, carrying the freshly
+/// cluster-aggregated ops-health snapshot DTO (the same shape as <c>GET ops-health</c>). It is a plain
+/// event with no realtime/hub reference — the realtime broadcast layer (#2554) subscribes to it and pushes
+/// on the <c>ops-health</c> hub group. Keeping the seam here means this ticket carries no SignalR dependency.
+/// </summary>
+internal sealed class OpsHealthFlushSignal
+{
+    /// <summary>
+    /// Raised on every sampler flush (and immediately whenever the flush is produced) with the latest
+    /// cluster-aggregated snapshot. Subscribers must not throw; the sampler swallows subscriber exceptions.
+    /// </summary>
+    public event EventHandler<OpsHealthFlushedEventArgs>? Flushed;
+
+    /// <summary>
+    /// Raises <see cref="Flushed"/> with the supplied snapshot. Subscriber exceptions are the caller's
+    /// responsibility to isolate (the sampler runs this inside its fail-open guard).
+    /// </summary>
+    /// <param name="snapshot">The freshly cluster-aggregated ops-health snapshot.</param>
+    internal void Raise(OpsHealthSnapshotResponse snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        Flushed?.Invoke(this, new OpsHealthFlushedEventArgs(snapshot));
+    }
+}
+
+/// <summary>Event payload for <see cref="OpsHealthFlushSignal.Flushed"/>.</summary>
+internal sealed class OpsHealthFlushedEventArgs : EventArgs
+{
+    /// <summary>Initializes a new instance of the <see cref="OpsHealthFlushedEventArgs"/> class.</summary>
+    /// <param name="snapshot">The cluster-aggregated ops-health snapshot for this flush.</param>
+    public OpsHealthFlushedEventArgs(OpsHealthSnapshotResponse snapshot)
+    {
+        Snapshot = snapshot;
+    }
+
+    /// <summary>Gets the cluster-aggregated ops-health snapshot for this flush.</summary>
+    public OpsHealthSnapshotResponse Snapshot { get; }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthHistoryService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthHistoryService.cs
@@ -1,0 +1,293 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Builds the cluster-aggregated ops-health history response from the persisted rollup store (#2553).
+/// </summary>
+internal interface IOpsHealthHistoryService
+{
+    /// <summary>Reads a history window and shapes it into the API response.</summary>
+    /// <param name="query">The parsed window/resolution/breakdown query.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The history response (empty series when no store is registered or a read fails).</returns>
+    Task<OpsHealthHistoryResponse> GetAsync(OpsHealthHistoryQuery query, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Parsed, validated query for the ops-health history endpoint.</summary>
+internal sealed record OpsHealthHistoryQuery
+{
+    /// <summary>Gets the resolution tier.</summary>
+    public required OpsHealthRollupTier Tier { get; init; }
+
+    /// <summary>Gets the look-back window.</summary>
+    public required TimeSpan Window { get; init; }
+
+    /// <summary>Gets a value indicating whether to return a per-replica breakdown instead of a cluster merge.</summary>
+    public required bool PerReplica { get; init; }
+
+    /// <summary>Parses raw query parameters, clamping the window to the tier's retention cap.</summary>
+    /// <param name="window">The window string (e.g. <c>1h</c>, <c>24h</c>, <c>7d</c>, <c>90m</c>), or <c>null</c> for the tier default.</param>
+    /// <param name="resolution">The resolution string (<c>1m</c>/<c>5m</c>/<c>1h</c>), or <c>null</c> for <c>1m</c>.</param>
+    /// <param name="perReplica">Whether to break the series down per replica.</param>
+    /// <param name="error">Set to a message when a parameter is invalid.</param>
+    /// <param name="query">The parsed query when successful.</param>
+    /// <returns><see langword="true"/> when parsing succeeds.</returns>
+    public static bool TryParse(string? window, string? resolution, bool perReplica, out string? error, out OpsHealthHistoryQuery query)
+    {
+        error = null;
+        query = default!;
+
+        if (!TryParseTier(resolution, out var tier))
+        {
+            error = $"Unsupported resolution '{resolution}'. Use one of: 1m, 5m, 1h.";
+            return false;
+        }
+
+        var policy = OpsHealthRollupRetentionPolicy.Default;
+        var cap = policy.RetentionFor(tier);
+
+        TimeSpan windowSpan;
+        if (string.IsNullOrWhiteSpace(window))
+        {
+            windowSpan = DefaultWindow(tier);
+        }
+        else if (!TryParseDuration(window, out windowSpan))
+        {
+            error = $"Invalid window '{window}'. Use a number with a unit: s, m, h, or d (e.g. 24h).";
+            return false;
+        }
+
+        if (windowSpan <= TimeSpan.Zero)
+        {
+            error = "Window must be positive.";
+            return false;
+        }
+
+        if (windowSpan > cap)
+        {
+            windowSpan = cap;
+        }
+
+        query = new OpsHealthHistoryQuery { Tier = tier, Window = windowSpan, PerReplica = perReplica };
+        return true;
+    }
+
+    private static TimeSpan DefaultWindow(OpsHealthRollupTier tier) => tier switch
+    {
+        OpsHealthRollupTier.OneMinute => TimeSpan.FromHours(1),
+        OpsHealthRollupTier.FiveMinute => TimeSpan.FromDays(1),
+        OpsHealthRollupTier.Hourly => TimeSpan.FromDays(7),
+        _ => TimeSpan.FromHours(1),
+    };
+
+    private static bool TryParseTier(string? resolution, out OpsHealthRollupTier tier)
+    {
+        switch (resolution?.Trim().ToLowerInvariant())
+        {
+            case null or "" or "1m" or "60s" or "1min":
+                tier = OpsHealthRollupTier.OneMinute;
+                return true;
+            case "5m" or "300s" or "5min":
+                tier = OpsHealthRollupTier.FiveMinute;
+                return true;
+            case "1h" or "60m" or "hour" or "hourly":
+                tier = OpsHealthRollupTier.Hourly;
+                return true;
+            default:
+                tier = OpsHealthRollupTier.OneMinute;
+                return false;
+        }
+    }
+
+    private static bool TryParseDuration(string value, out TimeSpan duration)
+    {
+        duration = TimeSpan.Zero;
+        var trimmed = value.Trim();
+        if (trimmed.Length < 2)
+        {
+            return false;
+        }
+
+        var unit = trimmed[^1];
+        var numberPart = trimmed[..^1];
+        if (!long.TryParse(numberPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out var amount) || amount <= 0)
+        {
+            return false;
+        }
+
+        duration = unit switch
+        {
+            's' or 'S' => TimeSpan.FromSeconds(amount),
+            'm' or 'M' => TimeSpan.FromMinutes(amount),
+            'h' or 'H' => TimeSpan.FromHours(amount),
+            'd' or 'D' => TimeSpan.FromDays(amount),
+            _ => TimeSpan.Zero,
+        };
+
+        return duration > TimeSpan.Zero;
+    }
+}
+
+/// <inheritdoc />
+internal sealed class OpsHealthHistoryService : IOpsHealthHistoryService
+{
+    private readonly IOpsHealthRollupStore? _store;
+
+    public OpsHealthHistoryService(IOpsHealthRollupStore? store = null)
+    {
+        _store = store;
+    }
+
+    public async Task<OpsHealthHistoryResponse> GetAsync(OpsHealthHistoryQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var now = DateTimeOffset.UtcNow;
+        var from = now - query.Window;
+
+        IReadOnlyList<OpsHealthLatencyRow> latencyRows = [];
+        IReadOnlyList<OpsHealthVitalsRow> vitalsRows = [];
+
+        if (_store is not null)
+        {
+            // Fail-open: a store outage returns an empty history rather than a 500.
+            try
+            {
+                latencyRows = await _store.ReadLatencyAsync(query.Tier, from, now, cancellationToken).ConfigureAwait(false);
+                vitalsRows = await _store.ReadVitalsAsync(query.Tier, from, now, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                latencyRows = [];
+                vitalsRows = [];
+            }
+        }
+
+        return new OpsHealthHistoryResponse
+        {
+            GeneratedAt = now,
+            Resolution = ResolutionLabel(query.Tier),
+            WindowSeconds = query.Window.TotalSeconds,
+            From = from,
+            To = now,
+            PerReplica = query.PerReplica,
+            Latency = BuildLatencySeries(latencyRows, query.PerReplica),
+            Vitals = BuildVitalsSeries(vitalsRows, query.PerReplica),
+        };
+    }
+
+    private static List<OpsHealthHistoryLatencySeries> BuildLatencySeries(IReadOnlyList<OpsHealthLatencyRow> rows, bool perReplica)
+    {
+        var series = new List<OpsHealthHistoryLatencySeries>();
+
+        if (perReplica)
+        {
+            foreach (var group in rows
+                .GroupBy(row => (row.Point.Protocol, row.ReplicaId))
+                .OrderBy(group => group.Key.Protocol, StringComparer.Ordinal)
+                .ThenBy(group => group.Key.ReplicaId, StringComparer.Ordinal))
+            {
+                var points = group
+                    .OrderBy(row => row.BucketStart)
+                    .Select(row => ToLatencyPoint(row.BucketStart, row.Point))
+                    .ToList();
+                series.Add(new OpsHealthHistoryLatencySeries
+                {
+                    Protocol = group.Key.Protocol,
+                    ReplicaId = group.Key.ReplicaId,
+                    Points = points,
+                });
+            }
+
+            return series;
+        }
+
+        foreach (var protocolGroup in rows
+            .GroupBy(row => row.Point.Protocol)
+            .OrderBy(group => group.Key, StringComparer.Ordinal))
+        {
+            var points = protocolGroup
+                .GroupBy(row => row.BucketStart)
+                .OrderBy(bucket => bucket.Key)
+                .Select(bucket =>
+                {
+                    var merged = OpsHealthRollupAggregation.MergeAcrossReplicas(
+                        protocolGroup.Key,
+                        bucket.Select(row => row.Point).ToList());
+                    return ToLatencyPoint(bucket.Key, merged);
+                })
+                .ToList();
+
+            series.Add(new OpsHealthHistoryLatencySeries
+            {
+                Protocol = protocolGroup.Key,
+                ReplicaId = null,
+                Points = points,
+            });
+        }
+
+        return series;
+    }
+
+    private static List<OpsHealthHistoryVitalsPoint> BuildVitalsSeries(IReadOnlyList<OpsHealthVitalsRow> rows, bool perReplica)
+    {
+        if (perReplica)
+        {
+            return rows
+                .OrderBy(row => row.BucketStart)
+                .ThenBy(row => row.ReplicaId, StringComparer.Ordinal)
+                .Select(row => ToVitalsPoint(row.BucketStart, row.ReplicaId, row.Point))
+                .ToList();
+        }
+
+        return rows
+            .GroupBy(row => row.BucketStart)
+            .OrderBy(bucket => bucket.Key)
+            .Select(bucket =>
+            {
+                var merged = OpsHealthRollupAggregation.MergeVitalsAcrossReplicas(bucket.Select(row => row.Point).ToList());
+                return ToVitalsPoint(bucket.Key, replicaId: null, merged);
+            })
+            .ToList();
+    }
+
+    private static OpsHealthHistoryLatencyPoint ToLatencyPoint(DateTimeOffset bucketStart, OpsHealthLatencyPoint point) => new()
+    {
+        BucketStart = bucketStart,
+        RequestCount = point.RequestCount,
+        ErrorCount = point.ErrorCount,
+        ErrorRate = point.ErrorRate,
+        P50Ms = point.P50Ms,
+        P95Ms = point.P95Ms,
+        P99Ms = point.P99Ms,
+        MaxMs = point.MaxMs,
+    };
+
+    private static OpsHealthHistoryVitalsPoint ToVitalsPoint(DateTimeOffset bucketStart, string? replicaId, OpsHealthVitalsPoint point) => new()
+    {
+        BucketStart = bucketStart,
+        ReplicaId = replicaId,
+        OverallStatus = point.OverallStatus,
+        GpQueueTotal = point.GpQueueTotal,
+        AlertPending = point.AlertPending,
+        AlertDeadLettered = point.AlertDeadLettered,
+        DbPoolUtilization = point.DbPoolUtilization,
+        DbActiveConnections = point.DbActiveConnections,
+        CacheHitRatio = point.CacheHitRatio,
+        ErrorRate = point.ErrorRate,
+    };
+
+    private static string ResolutionLabel(OpsHealthRollupTier tier) => tier switch
+    {
+        OpsHealthRollupTier.OneMinute => "1m",
+        OpsHealthRollupTier.FiveMinute => "5m",
+        OpsHealthRollupTier.Hourly => "1h",
+        _ => "1m",
+    };
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthHistoryService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthHistoryService.cs
@@ -275,6 +275,7 @@ internal sealed class OpsHealthHistoryService : IOpsHealthHistoryService
         ReplicaId = replicaId,
         OverallStatus = point.OverallStatus,
         GpQueueTotal = point.GpQueueTotal,
+        GpQueueBreakdown = point.GpQueueBreakdown,
         AlertPending = point.AlertPending,
         AlertDeadLettered = point.AlertDeadLettered,
         DbPoolUtilization = point.DbPoolUtilization,

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupOptions.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Options for the persisted ops-health rollup store and its per-replica sampler (<c>Observability:OpsHealthRollup</c>, #2553).
+/// </summary>
+public sealed class OpsHealthRollupOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Observability:OpsHealthRollup";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the background sampler runs. Default is <c>true</c>. The sampler
+    /// is additionally a no-op when no rollup store is registered (non-Postgres providers).
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the sampler flush interval in seconds. Default is 45s (within the ~30–60s target band).
+    /// </summary>
+    [Range(5, 3600)]
+    public int FlushIntervalSeconds { get; set; } = 45;
+
+    /// <summary>
+    /// Gets or sets the interval, in seconds, between downsample-and-prune maintenance passes. Default is 300s.
+    /// </summary>
+    [Range(30, 86_400)]
+    public int MaintenanceIntervalSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Gets or sets the recency window, in seconds, over which the live snapshot merges other replicas' most
+    /// recent flushes. Default is 120s (two flush intervals of headroom).
+    /// </summary>
+    [Range(30, 3600)]
+    public int LiveMergeRecencyWindowSeconds { get; set; } = 120;
+
+    /// <summary>Gets or sets the 1-minute-tier retention in hours. Default is 24.</summary>
+    [Range(1, 168)]
+    public int OneMinuteRetentionHours { get; set; } = 24;
+
+    /// <summary>Gets or sets the 5-minute-tier retention in days. Default is 14.</summary>
+    [Range(1, 90)]
+    public int FiveMinuteRetentionDays { get; set; } = 14;
+
+    /// <summary>Gets or sets the hourly-tier retention in days. Default is 90.</summary>
+    [Range(1, 730)]
+    public int HourlyRetentionDays { get; set; } = 90;
+
+    /// <summary>
+    /// Gets or sets an explicit replica identifier. When blank, a stable per-process identifier
+    /// (<c>{MachineName}-{ProcessId}</c>) is used, matching the server's other per-replica components.
+    /// </summary>
+    public string? ReplicaId { get; set; }
+
+    /// <summary>Gets the resolved retention policy.</summary>
+    /// <returns>The retention policy derived from the configured caps.</returns>
+    public OpsHealthRollupRetentionPolicy ToRetentionPolicy() => new()
+    {
+        OneMinuteRetention = TimeSpan.FromHours(OneMinuteRetentionHours),
+        FiveMinuteRetention = TimeSpan.FromDays(FiveMinuteRetentionDays),
+        HourlyRetention = TimeSpan.FromDays(HourlyRetentionDays),
+    };
+
+    /// <summary>Resolves the effective replica identifier.</summary>
+    /// <returns>The configured replica id, or the default per-process identifier.</returns>
+    public string ResolveReplicaId()
+        => string.IsNullOrWhiteSpace(ReplicaId)
+            ? string.Create(CultureInfo.InvariantCulture, $"{Environment.MachineName}-{Environment.ProcessId}")
+            : ReplicaId.Trim();
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupSampler.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupSampler.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
+using Honua.ServiceDefaults;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Per-replica background sampler (#2553). On a configurable interval it captures this replica's local
+/// ops-health sections (per-protocol serving latency + vitals), flushes them into the persisted rollup
+/// store, periodically downsamples/prunes the store, and raises the in-process
+/// <see cref="OpsHealthFlushSignal"/> with the freshly cluster-aggregated snapshot.
+/// </summary>
+/// <remarks>
+/// The sampler is strictly fail-open: it never runs on a serving path, and any rollup-store outage is
+/// caught and logged so serving is unaffected — the deployment simply degrades to snapshot-only. When no
+/// rollup store is registered (non-Postgres providers) it still raises the flush signal so realtime
+/// consumers keep working; only persistence and history are unavailable.
+/// </remarks>
+internal sealed partial class OpsHealthRollupSampler : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptions<OpsHealthRollupOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly OpsHealthFlushSignal _flushSignal;
+    private readonly ILogger<OpsHealthRollupSampler> _logger;
+
+    private DateTimeOffset _nextMaintenanceUtc = DateTimeOffset.MinValue;
+
+    public OpsHealthRollupSampler(
+        IServiceScopeFactory scopeFactory,
+        IOptions<OpsHealthRollupOptions> options,
+        TimeProvider timeProvider,
+        OpsHealthFlushSignal flushSignal,
+        ILogger<OpsHealthRollupSampler> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _flushSignal = flushSignal ?? throw new ArgumentNullException(nameof(flushSignal));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var options = _options.Value;
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        var interval = TimeSpan.FromSeconds(options.FlushIntervalSeconds);
+        if (interval <= TimeSpan.Zero)
+        {
+            interval = TimeSpan.FromSeconds(45);
+        }
+
+        try
+        {
+            // First flush runs after one interval so startup is never blocked.
+            using var timer = new PeriodicTimer(interval);
+            while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+            {
+                await RunFlushAsync(stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    /// <summary>Runs a single flush pass. Exposed for deterministic testing.</summary>
+    /// <param name="cancellationToken">A token to cancel the flush.</param>
+    /// <returns>A task that completes when the flush pass finishes.</returns>
+    internal async Task RunFlushAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var provider = scope.ServiceProvider;
+            var snapshotService = provider.GetRequiredService<IOpsHealthSnapshotService>();
+            var store = provider.GetService<IOpsHealthRollupStore>();
+
+            // The cluster-aggregated snapshot (same DTO as GET ops-health) drives the realtime seam.
+            var snapshot = await snapshotService.GetAsync(cancellationToken).ConfigureAwait(false);
+
+            if (store is not null)
+            {
+                await PersistAsync(store, snapshot, cancellationToken).ConfigureAwait(false);
+            }
+
+            RaiseFlushed(snapshot);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Fail-open: a rollup outage must never disturb serving. Degrade to snapshot-only.
+            FlushFailed(_logger, ex);
+        }
+    }
+
+    private async Task PersistAsync(IOpsHealthRollupStore store, OpsHealthSnapshotResponse snapshot, CancellationToken cancellationToken)
+    {
+        var options = _options.Value;
+        var now = _timeProvider.GetUtcNow();
+
+        // Persist THIS replica's local serving latency (not the cluster-merged view) so cross-replica
+        // aggregation on read never double-counts. Vitals come from the composed snapshot.
+        var local = HonuaTelemetry.GetServingLatencySnapshot();
+        var latency = new List<OpsHealthLatencyPoint>(local.Protocols.Count);
+        foreach (var protocol in local.Protocols)
+        {
+            latency.Add(new OpsHealthLatencyPoint
+            {
+                Protocol = protocol.Protocol,
+                RequestCount = protocol.RequestCount,
+                ErrorCount = protocol.ErrorCount,
+                P50Ms = protocol.P50Ms,
+                P95Ms = protocol.P95Ms,
+                P99Ms = protocol.P99Ms,
+                MaxMs = protocol.MaxMs,
+            });
+        }
+
+        var sample = new OpsHealthRollupSample
+        {
+            ReplicaId = options.ResolveReplicaId(),
+            CapturedAt = now,
+            Latency = latency,
+            Vitals = new OpsHealthVitalsPoint
+            {
+                OverallStatus = snapshot.OverallStatus,
+                GpQueueTotal = snapshot.Geoprocessing.TotalActive,
+                AlertPending = snapshot.AlertDispatch.PendingCount,
+                AlertDeadLettered = snapshot.AlertDispatch.DeadLetteredCount,
+                DbPoolUtilization = snapshot.Database.ConnectionPoolUtilization,
+                DbActiveConnections = snapshot.Database.ActiveConnections,
+                CacheHitRatio = snapshot.Database.CacheHitRatio,
+                ErrorRate = snapshot.Database.ErrorRate,
+            },
+        };
+
+        await store.WriteSampleAsync(sample, cancellationToken).ConfigureAwait(false);
+
+        if (now >= _nextMaintenanceUtc)
+        {
+            var pruned = await store.DownsampleAndPruneAsync(now, options.ToRetentionPolicy(), cancellationToken).ConfigureAwait(false);
+            _nextMaintenanceUtc = now.AddSeconds(options.MaintenanceIntervalSeconds);
+            MaintenanceCompleted(_logger, pruned);
+        }
+    }
+
+    private void RaiseFlushed(OpsHealthSnapshotResponse snapshot)
+    {
+        try
+        {
+            _flushSignal.Raise(snapshot);
+        }
+        catch (Exception ex)
+        {
+            // A misbehaving subscriber must not break the sampler loop.
+            FlushSubscriberFailed(_logger, ex);
+        }
+    }
+
+    [LoggerMessage(EventId = 7460, Level = LogLevel.Warning, Message = "Ops-health rollup flush failed; degrading to snapshot-only for this interval.")]
+    private static partial void FlushFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 7461, Level = LogLevel.Warning, Message = "Ops-health rollup flush subscriber threw.")]
+    private static partial void FlushSubscriberFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 7462, Level = LogLevel.Debug, Message = "Ops-health rollup maintenance pruned {PrunedRows} rows.")]
+    private static partial void MaintenanceCompleted(ILogger logger, int prunedRows);
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupSampler.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupSampler.cs
@@ -64,7 +64,15 @@ internal sealed partial class OpsHealthRollupSampler : BackgroundService
 
         try
         {
-            // First flush runs after one interval so startup is never blocked.
+            // Randomized initial delay (5-15s) before the periodic loop. Two reasons: (a) it staggers
+            // replicas that all restarted together so their flush/downsample/prune passes do not land on
+            // the database in lockstep, and (b) short-lived hosts — integration-test servers especially —
+            // are torn down before the first flush ever fires, keeping the sampler's background load off
+            // hosts that never live long enough to produce useful history.
+            var initialJitter = TimeSpan.FromSeconds(Random.Shared.Next(5, 16));
+            await Task.Delay(initialJitter, stoppingToken).ConfigureAwait(false);
+
+            // First flush runs one interval after the jitter so startup is never blocked.
             using var timer = new PeriodicTimer(interval);
             while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
             {

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupSampler.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthRollupSampler.cs
@@ -133,6 +133,14 @@ internal sealed partial class OpsHealthRollupSampler : BackgroundService
             });
         }
 
+        // Flatten the live snapshot's status×backend GP queue buckets into the persisted breakdown map
+        // ("<status>|<backend>" keys) so history can answer which backend/status was backing up.
+        var gpBreakdown = new Dictionary<string, int>(snapshot.Geoprocessing.Buckets.Count, StringComparer.Ordinal);
+        foreach (var bucket in snapshot.Geoprocessing.Buckets)
+        {
+            gpBreakdown[$"{bucket.Status}|{bucket.Backend}"] = bucket.Count;
+        }
+
         var sample = new OpsHealthRollupSample
         {
             ReplicaId = options.ResolveReplicaId(),
@@ -142,6 +150,7 @@ internal sealed partial class OpsHealthRollupSampler : BackgroundService
             {
                 OverallStatus = snapshot.OverallStatus,
                 GpQueueTotal = snapshot.Geoprocessing.TotalActive,
+                GpQueueBreakdown = gpBreakdown,
                 AlertPending = snapshot.AlertDispatch.PendingCount,
                 AlertDeadLettered = snapshot.AlertDispatch.DeadLetteredCount,
                 DbPoolUtilization = snapshot.Database.ConnectionPoolUtilization,

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
@@ -4,6 +4,8 @@
 using Honua.Alerts;
 using Honua.ControlPlane;
 using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
 using Honua.ServiceDefaults;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -33,7 +35,9 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
     private readonly IOptionsMonitor<ControlPlaneOptions> _controlPlaneOptions;
     private readonly IAlertDispatchHealth _alertHealth;
     private readonly ProductionMetricsCollector _metricsCollector;
+    private readonly IOptions<OpsHealthRollupOptions> _rollupOptions;
     private readonly IExecutionJobStore? _jobStore;
+    private readonly IOpsHealthRollupStore? _rollupStore;
 
     public OpsHealthSnapshotService(
         HealthCheckService healthCheckService,
@@ -41,14 +45,18 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
         IOptionsMonitor<ControlPlaneOptions> controlPlaneOptions,
         IAlertDispatchHealth alertHealth,
         ProductionMetricsCollector metricsCollector,
-        IExecutionJobStore? jobStore = null)
+        IOptions<OpsHealthRollupOptions> rollupOptions,
+        IExecutionJobStore? jobStore = null,
+        IOpsHealthRollupStore? rollupStore = null)
     {
         _healthCheckService = healthCheckService;
         _deployProbe = deployProbe;
         _controlPlaneOptions = controlPlaneOptions;
         _alertHealth = alertHealth;
         _metricsCollector = metricsCollector;
+        _rollupOptions = rollupOptions;
         _jobStore = jobStore;
+        _rollupStore = rollupStore;
     }
 
     public async Task<OpsHealthSnapshotResponse> GetAsync(CancellationToken cancellationToken = default)
@@ -57,13 +65,14 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
         var deploySnapshot = await _deployProbe.ProbeAsync(cancellationToken).ConfigureAwait(false);
         var gpQueue = await BuildGpQueueViewAsync(cancellationToken).ConfigureAwait(false);
         var healthMetrics = _metricsCollector.GetHealthMetrics();
+        var servingLatency = await BuildServingLatencyViewAsync(cancellationToken).ConfigureAwait(false);
 
         return new OpsHealthSnapshotResponse
         {
             GeneratedAt = DateTimeOffset.UtcNow,
             OverallStatus = healthReport.Status.ToString(),
             Health = BuildHealthView(healthReport),
-            ServingLatency = BuildServingLatencyView(),
+            ServingLatency = servingLatency,
             Geoprocessing = gpQueue,
             AlertDispatch = BuildAlertDispatchView(),
             Deploy = BuildDeployView(deploySnapshot),
@@ -103,20 +112,87 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
         };
     }
 
-    private static OpsServingLatencyView BuildServingLatencyView()
+    // Builds the serving-latency view. On a multi-node deployment the responding instance's live in-process
+    // window is merged with peers' most-recent persisted rollup flushes so the snapshot reports whole-cluster
+    // health, not just the instance that served the request (#2553). Fail-open: a rollup-store outage or a
+    // missing store (non-Postgres) transparently degrades to the local-only view.
+    private async Task<OpsServingLatencyView> BuildServingLatencyViewAsync(CancellationToken cancellationToken)
     {
         var snapshot = HonuaTelemetry.GetServingLatencySnapshot();
-        var protocols = snapshot.Protocols
-            .Select(protocol => new OpsServingLatencyProtocolView
+
+        // Seed the per-protocol accumulator with this replica's live points.
+        var local = new Dictionary<string, List<OpsHealthLatencyPoint>>(StringComparer.Ordinal);
+        foreach (var protocol in snapshot.Protocols)
+        {
+            local[protocol.Protocol] = new List<OpsHealthLatencyPoint>
             {
-                Protocol = protocol.Protocol,
-                RequestCount = protocol.RequestCount,
-                ErrorCount = protocol.ErrorCount,
-                ErrorRate = protocol.ErrorRate,
-                P50Ms = protocol.P50Ms,
-                P95Ms = protocol.P95Ms,
-                P99Ms = protocol.P99Ms,
-                MaxMs = protocol.MaxMs,
+                new()
+                {
+                    Protocol = protocol.Protocol,
+                    RequestCount = protocol.RequestCount,
+                    ErrorCount = protocol.ErrorCount,
+                    P50Ms = protocol.P50Ms,
+                    P95Ms = protocol.P95Ms,
+                    P99Ms = protocol.P99Ms,
+                    MaxMs = protocol.MaxMs,
+                },
+            };
+        }
+
+        var clusterReplicaCount = 1;
+        if (_rollupStore is not null)
+        {
+            try
+            {
+                var options = _rollupOptions.Value;
+                var since = DateTimeOffset.UtcNow.AddSeconds(-options.LiveMergeRecencyWindowSeconds);
+                var selfReplicaId = options.ResolveReplicaId();
+                var recent = await _rollupStore.ReadRecentLatencyAsync(since, selfReplicaId, cancellationToken).ConfigureAwait(false);
+
+                // Keep only the most recent bucket per (replica, protocol) so overlapping rolling-window
+                // flushes are not double-counted.
+                var latestPerReplicaProtocol = recent
+                    .GroupBy(row => (row.ReplicaId, row.Point.Protocol))
+                    .Select(group => group.OrderByDescending(row => row.BucketStart).First());
+
+                var peerReplicas = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var row in latestPerReplicaProtocol)
+                {
+                    peerReplicas.Add(row.ReplicaId);
+                    if (!local.TryGetValue(row.Point.Protocol, out var list))
+                    {
+                        list = new List<OpsHealthLatencyPoint>();
+                        local[row.Point.Protocol] = list;
+                    }
+
+                    list.Add(row.Point);
+                }
+
+                clusterReplicaCount += peerReplicas.Count;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Fail-open: report the responding instance only.
+                clusterReplicaCount = 1;
+            }
+        }
+
+        var protocols = local
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair =>
+            {
+                var merged = OpsHealthRollupAggregation.MergeAcrossReplicas(pair.Key, pair.Value);
+                return new OpsServingLatencyProtocolView
+                {
+                    Protocol = merged.Protocol,
+                    RequestCount = merged.RequestCount,
+                    ErrorCount = merged.ErrorCount,
+                    ErrorRate = merged.ErrorRate,
+                    P50Ms = merged.P50Ms,
+                    P95Ms = merged.P95Ms,
+                    P99Ms = merged.P99Ms,
+                    MaxMs = merged.MaxMs,
+                };
             })
             .ToList();
 
@@ -124,6 +200,7 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
         {
             WindowSeconds = snapshot.WindowSeconds,
             Protocols = protocols,
+            ClusterReplicaCount = clusterReplicaCount,
         };
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityJsonContext.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityJsonContext.cs
@@ -14,6 +14,7 @@ namespace Honua.Infrastructure.Monitoring;
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     WriteIndented = false)]
 [JsonSerializable(typeof(OpsHealthSnapshotResponse))]
+[JsonSerializable(typeof(OpsHealthHistoryResponse))]
 [JsonSerializable(typeof(OpsFindingsListResponse))]
 [JsonSerializable(typeof(OpsFindingProposeResponse))]
 internal sealed partial class OpsObservabilityJsonContext : JsonSerializerContext

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
@@ -390,6 +390,15 @@ public sealed class OpsHealthHistoryVitalsPoint
     [JsonPropertyName("gpQueueTotal")]
     public required int GpQueueTotal { get; init; }
 
+    /// <summary>
+    /// Gets the GP queue depth broken down by status and backend, keyed
+    /// <c>"&lt;status&gt;|&lt;backend&gt;"</c> (e.g. <c>"Queued|local"</c>) — the flattened form of the live
+    /// snapshot's status×backend buckets. Cluster-merged points sum each key across replicas; coarser
+    /// resolutions carry the per-key peak within the bucket.
+    /// </summary>
+    [JsonPropertyName("gpQueueBreakdown")]
+    public required IReadOnlyDictionary<string, int> GpQueueBreakdown { get; init; }
+
     /// <summary>Gets the alert-dispatch pending backlog, when available.</summary>
     [JsonPropertyName("alertPending")]
     public long? AlertPending { get; init; }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
@@ -393,8 +393,9 @@ public sealed class OpsHealthHistoryVitalsPoint
     /// <summary>
     /// Gets the GP queue depth broken down by status and backend, keyed
     /// <c>"&lt;status&gt;|&lt;backend&gt;"</c> (e.g. <c>"Queued|local"</c>) — the flattened form of the live
-    /// snapshot's status×backend buckets. Cluster-merged points sum each key across replicas; coarser
-    /// resolutions carry the per-key peak within the bucket.
+    /// snapshot's status×backend buckets. The GP queue is a GLOBAL view (every replica queries the same
+    /// shared job store), so cluster-merged points dedup each key across replicas with a max — matching
+    /// <c>gpQueueTotal</c> — and coarser resolutions carry the per-key peak within the bucket.
     /// </summary>
     [JsonPropertyName("gpQueueBreakdown")]
     public required IReadOnlyDictionary<string, int> GpQueueBreakdown { get; init; }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
@@ -92,6 +92,14 @@ public sealed class OpsServingLatencyView
     /// <summary>Gets the per-protocol latency entries.</summary>
     [JsonPropertyName("protocols")]
     public required IReadOnlyList<OpsServingLatencyProtocolView> Protocols { get; init; }
+
+    /// <summary>
+    /// Gets the number of replicas merged into this view (the responding instance plus any peers whose recent
+    /// rollup flushes were folded in), when cluster aggregation is active. <c>null</c> or <c>1</c> means the
+    /// view reflects only the responding instance (single-node, or the rollup store is unavailable).
+    /// </summary>
+    [JsonPropertyName("clusterReplicaCount")]
+    public int? ClusterReplicaCount { get; init; }
 }
 
 /// <summary>Per-protocol serving latency entry.</summary>
@@ -256,6 +264,147 @@ public sealed class OpsDatabaseView
     /// <summary>Gets the connection acquisition failure count.</summary>
     [JsonPropertyName("connectionAcquisitionFailures")]
     public required long ConnectionAcquisitionFailures { get; init; }
+
+    /// <summary>Gets the cache hit ratio (0.0 to 1.0).</summary>
+    [JsonPropertyName("cacheHitRatio")]
+    public required double CacheHitRatio { get; init; }
+
+    /// <summary>Gets the live HTTP server error rate (0.0 to 1.0).</summary>
+    [JsonPropertyName("errorRate")]
+    public required double ErrorRate { get; init; }
+}
+
+/// <summary>
+/// Response for <c>GET /api/v{version}/admin/observability/ops-health/history</c> (#2553). Returns a
+/// cluster-aggregated (or per-replica) time series of serving latency and ops vitals at the requested
+/// resolution over the requested window.
+/// </summary>
+/// <remarks>
+/// This endpoint is also the reconnect gap-fill contract for realtime <c>ops-health</c> hub clients
+/// (#2554): after a dropped connection a client backfills the missed interval by requesting the history
+/// window rather than replaying a per-event cursor (there is no Last-Event-ID semantics).
+/// </remarks>
+public sealed class OpsHealthHistoryResponse
+{
+    /// <summary>Gets the UTC time the response was produced.</summary>
+    [JsonPropertyName("generatedAt")]
+    public required DateTimeOffset GeneratedAt { get; init; }
+
+    /// <summary>Gets the resolution label (<c>1m</c>/<c>5m</c>/<c>1h</c>).</summary>
+    [JsonPropertyName("resolution")]
+    public required string Resolution { get; init; }
+
+    /// <summary>Gets the returned window length in seconds (clamped to the tier's retention cap).</summary>
+    [JsonPropertyName("windowSeconds")]
+    public required double WindowSeconds { get; init; }
+
+    /// <summary>Gets the inclusive lower bound of the returned window.</summary>
+    [JsonPropertyName("from")]
+    public required DateTimeOffset From { get; init; }
+
+    /// <summary>Gets the inclusive upper bound of the returned window.</summary>
+    [JsonPropertyName("to")]
+    public required DateTimeOffset To { get; init; }
+
+    /// <summary>Gets a value indicating whether the series is broken down per replica rather than cluster-merged.</summary>
+    [JsonPropertyName("perReplica")]
+    public required bool PerReplica { get; init; }
+
+    /// <summary>Gets the per-protocol serving-latency series.</summary>
+    [JsonPropertyName("latency")]
+    public required IReadOnlyList<OpsHealthHistoryLatencySeries> Latency { get; init; }
+
+    /// <summary>Gets the ops-vitals series (one entry per bucket, or per bucket/replica when broken down).</summary>
+    [JsonPropertyName("vitals")]
+    public required IReadOnlyList<OpsHealthHistoryVitalsPoint> Vitals { get; init; }
+}
+
+/// <summary>A serving-latency series for one protocol (and optionally one replica).</summary>
+public sealed class OpsHealthHistoryLatencySeries
+{
+    /// <summary>Gets the protocol family.</summary>
+    [JsonPropertyName("protocol")]
+    public required string Protocol { get; init; }
+
+    /// <summary>Gets the replica identifier when broken down per replica; <c>null</c> for a cluster-merged series.</summary>
+    [JsonPropertyName("replicaId")]
+    public string? ReplicaId { get; init; }
+
+    /// <summary>Gets the ordered time-series points.</summary>
+    [JsonPropertyName("points")]
+    public required IReadOnlyList<OpsHealthHistoryLatencyPoint> Points { get; init; }
+}
+
+/// <summary>A single serving-latency time-series point.</summary>
+public sealed class OpsHealthHistoryLatencyPoint
+{
+    /// <summary>Gets the bucket start (UTC).</summary>
+    [JsonPropertyName("bucketStart")]
+    public required DateTimeOffset BucketStart { get; init; }
+
+    /// <summary>Gets the request count.</summary>
+    [JsonPropertyName("requestCount")]
+    public required long RequestCount { get; init; }
+
+    /// <summary>Gets the server-error count.</summary>
+    [JsonPropertyName("errorCount")]
+    public required long ErrorCount { get; init; }
+
+    /// <summary>Gets the server-error rate (0.0 to 1.0).</summary>
+    [JsonPropertyName("errorRate")]
+    public required double ErrorRate { get; init; }
+
+    /// <summary>Gets the 50th-percentile duration in milliseconds.</summary>
+    [JsonPropertyName("p50Ms")]
+    public required double P50Ms { get; init; }
+
+    /// <summary>Gets the 95th-percentile duration in milliseconds.</summary>
+    [JsonPropertyName("p95Ms")]
+    public required double P95Ms { get; init; }
+
+    /// <summary>Gets the 99th-percentile duration in milliseconds.</summary>
+    [JsonPropertyName("p99Ms")]
+    public required double P99Ms { get; init; }
+
+    /// <summary>Gets the maximum duration in milliseconds.</summary>
+    [JsonPropertyName("maxMs")]
+    public required double MaxMs { get; init; }
+}
+
+/// <summary>A single ops-vitals time-series point.</summary>
+public sealed class OpsHealthHistoryVitalsPoint
+{
+    /// <summary>Gets the bucket start (UTC).</summary>
+    [JsonPropertyName("bucketStart")]
+    public required DateTimeOffset BucketStart { get; init; }
+
+    /// <summary>Gets the replica identifier when broken down per replica; <c>null</c> for a cluster-merged point.</summary>
+    [JsonPropertyName("replicaId")]
+    public string? ReplicaId { get; init; }
+
+    /// <summary>Gets the overall health status.</summary>
+    [JsonPropertyName("overallStatus")]
+    public required string OverallStatus { get; init; }
+
+    /// <summary>Gets the total active geoprocessing jobs.</summary>
+    [JsonPropertyName("gpQueueTotal")]
+    public required int GpQueueTotal { get; init; }
+
+    /// <summary>Gets the alert-dispatch pending backlog, when available.</summary>
+    [JsonPropertyName("alertPending")]
+    public long? AlertPending { get; init; }
+
+    /// <summary>Gets the alert-dispatch dead-lettered count, when available.</summary>
+    [JsonPropertyName("alertDeadLettered")]
+    public long? AlertDeadLettered { get; init; }
+
+    /// <summary>Gets the database connection-pool utilization ratio, when available.</summary>
+    [JsonPropertyName("dbPoolUtilization")]
+    public double? DbPoolUtilization { get; init; }
+
+    /// <summary>Gets the number of active database connections.</summary>
+    [JsonPropertyName("dbActiveConnections")]
+    public required int DbActiveConnections { get; init; }
 
     /// <summary>Gets the cache hit ratio (0.0 to 1.0).</summary>
     [JsonPropertyName("cacheHitRatio")]

--- a/src/Honua.Server/Migrations/077_CreateOpsHealthRollup.sql
+++ b/src/Honua.Server/Migrations/077_CreateOpsHealthRollup.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS honua.ops_health_rollup_vitals (
     bucket_start          TIMESTAMPTZ      NOT NULL,
     overall_status        TEXT             NOT NULL DEFAULT 'Unknown',
     gp_queue_total        INTEGER          NOT NULL DEFAULT 0,
+    gp_queue_breakdown    JSONB            NOT NULL DEFAULT '{}',
     alert_pending         BIGINT           NULL,
     alert_dead_lettered   BIGINT           NULL,
     db_pool_utilization   DOUBLE PRECISION NULL,
@@ -64,3 +65,5 @@ COMMENT ON TABLE honua.ops_health_rollup_vitals IS
     'Persisted per-replica ops-vitals rollup (queue depth, alert backlog, DB/cache vitals) with retention tiers (#2553).';
 COMMENT ON COLUMN honua.ops_health_rollup_vitals.tier IS
     '0=1-minute (retained 24h), 1=5-minute (14d), 2=hourly (90d).';
+COMMENT ON COLUMN honua.ops_health_rollup_vitals.gp_queue_breakdown IS
+    'GP queue depth by status and backend: {"<status>|<backend>": count} (flattened live-snapshot buckets). Cross-replica reads sum per key; downsampling stores the per-key peak.';

--- a/src/Honua.Server/Migrations/077_CreateOpsHealthRollup.sql
+++ b/src/Honua.Server/Migrations/077_CreateOpsHealthRollup.sql
@@ -1,0 +1,66 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Migration: 077_CreateOpsHealthRollup.sql
+-- Description: Persisted ops-health rollup store (#2553). Each replica's background sampler flushes
+--              per-protocol serving-latency percentiles and ops vitals into the 1-minute tier keyed by
+--              replica_id; coarser tiers (5-minute, hourly) are downsampled from it and every tier is
+--              pruned to a hard retention cap (1-min x 24h, 5-min x 14d, hourly x 90d) so the footprint
+--              stays bounded. Backs GET /api/v1/admin/observability/ops-health/history and the
+--              cluster-wide serving-latency aggregation in the live ops-health snapshot.
+-- Dependencies: none (standalone rollup tables in the honua schema).
+
+-- Per-protocol serving-latency rollup. tier: 0=1-minute, 1=5-minute, 2=hourly. bucket_start is the
+-- UTC bucket boundary. Percentiles/counts are the values observed by the replica's rolling-window
+-- ServingLatencyAggregator at flush time (coarser tiers store request-count-weighted percentiles and
+-- peak counts; exact historical percentiles remain in the optional Prometheus bundle).
+CREATE TABLE IF NOT EXISTS honua.ops_health_rollup_latency (
+    replica_id     TEXT             NOT NULL,
+    tier           SMALLINT         NOT NULL,
+    bucket_start   TIMESTAMPTZ      NOT NULL,
+    protocol       TEXT             NOT NULL,
+    request_count  BIGINT           NOT NULL DEFAULT 0,
+    error_count    BIGINT           NOT NULL DEFAULT 0,
+    p50_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+    p95_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+    p99_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+    max_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+    updated_at     TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    CONSTRAINT ops_health_rollup_latency_pk PRIMARY KEY (replica_id, tier, bucket_start, protocol),
+    CONSTRAINT ops_health_rollup_latency_valid_tier CHECK (tier IN (0, 1, 2))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ops_health_rollup_latency_tier_bucket
+    ON honua.ops_health_rollup_latency (tier, bucket_start);
+
+COMMENT ON TABLE honua.ops_health_rollup_latency IS
+    'Persisted per-replica serving-latency rollup with downsampled retention tiers (#2553).';
+COMMENT ON COLUMN honua.ops_health_rollup_latency.tier IS
+    '0=1-minute (retained 24h), 1=5-minute (14d), 2=hourly (90d).';
+
+-- Per-replica ops vitals rollup: overall status, GP queue depth, alert-dispatch backlog / dead-letters,
+-- and DB pool / cache / error vitals. Same tier/bucket keying as the latency table.
+CREATE TABLE IF NOT EXISTS honua.ops_health_rollup_vitals (
+    replica_id            TEXT             NOT NULL,
+    tier                  SMALLINT         NOT NULL,
+    bucket_start          TIMESTAMPTZ      NOT NULL,
+    overall_status        TEXT             NOT NULL DEFAULT 'Unknown',
+    gp_queue_total        INTEGER          NOT NULL DEFAULT 0,
+    alert_pending         BIGINT           NULL,
+    alert_dead_lettered   BIGINT           NULL,
+    db_pool_utilization   DOUBLE PRECISION NULL,
+    db_active_connections INTEGER          NOT NULL DEFAULT 0,
+    cache_hit_ratio       DOUBLE PRECISION NOT NULL DEFAULT 0,
+    error_rate            DOUBLE PRECISION NOT NULL DEFAULT 0,
+    updated_at            TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    CONSTRAINT ops_health_rollup_vitals_pk PRIMARY KEY (replica_id, tier, bucket_start),
+    CONSTRAINT ops_health_rollup_vitals_valid_tier CHECK (tier IN (0, 1, 2))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ops_health_rollup_vitals_tier_bucket
+    ON honua.ops_health_rollup_vitals (tier, bucket_start);
+
+COMMENT ON TABLE honua.ops_health_rollup_vitals IS
+    'Persisted per-replica ops-vitals rollup (queue depth, alert backlog, DB/cache vitals) with retention tiers (#2553).';
+COMMENT ON COLUMN honua.ops_health_rollup_vitals.tier IS
+    '0=1-minute (retained 24h), 1=5-minute (14d), 2=hourly (90d).';

--- a/src/Honua.Server/Migrations/077_CreateOpsHealthRollup.sql
+++ b/src/Honua.Server/Migrations/077_CreateOpsHealthRollup.sql
@@ -66,4 +66,4 @@ COMMENT ON TABLE honua.ops_health_rollup_vitals IS
 COMMENT ON COLUMN honua.ops_health_rollup_vitals.tier IS
     '0=1-minute (retained 24h), 1=5-minute (14d), 2=hourly (90d).';
 COMMENT ON COLUMN honua.ops_health_rollup_vitals.gp_queue_breakdown IS
-    'GP queue depth by status and backend: {"<status>|<backend>": count} (flattened live-snapshot buckets). Cross-replica reads sum per key; downsampling stores the per-key peak.';
+    'GP queue depth by status and backend: {"<status>|<backend>": count} (flattened live-snapshot buckets). Every replica reports the same GLOBAL queue view, so cross-replica reads dedup with a per-key max; downsampling over time also stores the per-key peak.';

--- a/tests/dotnet/Honua.Core.Tests/Features/Observability/OpsHealthRollupAggregationTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Observability/OpsHealthRollupAggregationTests.cs
@@ -124,6 +124,44 @@ public class OpsHealthRollupAggregationTests
         merged.ErrorRate.Should().BeApproximately(0.02, 1e-9);
     }
 
+    [Fact]
+    public void MergeVitalsAcrossReplicas_SumsGpQueueBreakdownPerKey()
+    {
+        var a = new OpsHealthVitalsPoint
+        {
+            OverallStatus = "Healthy",
+            GpQueueTotal = 5,
+            GpQueueBreakdown = new Dictionary<string, int>
+            {
+                ["Queued|local"] = 3,
+                ["Running|local"] = 2,
+            },
+            DbActiveConnections = 1,
+            CacheHitRatio = 1,
+            ErrorRate = 0,
+        };
+        var b = new OpsHealthVitalsPoint
+        {
+            OverallStatus = "Healthy",
+            GpQueueTotal = 4,
+            GpQueueBreakdown = new Dictionary<string, int>
+            {
+                ["Queued|local"] = 1,
+                ["Queued|aws-batch"] = 3,
+            },
+            DbActiveConnections = 1,
+            CacheHitRatio = 1,
+            ErrorRate = 0,
+        };
+
+        var merged = OpsHealthRollupAggregation.MergeVitalsAcrossReplicas([a, b]);
+
+        merged.GpQueueBreakdown.Should().HaveCount(3);
+        merged.GpQueueBreakdown["Queued|local"].Should().Be(4);
+        merged.GpQueueBreakdown["Running|local"].Should().Be(2);
+        merged.GpQueueBreakdown["Queued|aws-batch"].Should().Be(3);
+    }
+
     [Theory]
     [InlineData("Unhealthy", 3)]
     [InlineData("Degraded", 2)]

--- a/tests/dotnet/Honua.Core.Tests/Features/Observability/OpsHealthRollupAggregationTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Observability/OpsHealthRollupAggregationTests.cs
@@ -125,8 +125,10 @@ public class OpsHealthRollupAggregationTests
     }
 
     [Fact]
-    public void MergeVitalsAcrossReplicas_SumsGpQueueBreakdownPerKey()
+    public void MergeVitalsAcrossReplicas_DedupsGpQueueBreakdownWithPerKeyMax()
     {
+        // The GP queue is a GLOBAL view: every replica queries the same shared job store, so two replicas
+        // reporting the identical queue must merge to that queue (dedup by max), never to double the depth.
         var a = new OpsHealthVitalsPoint
         {
             OverallStatus = "Healthy",
@@ -140,14 +142,17 @@ public class OpsHealthRollupAggregationTests
             CacheHitRatio = 1,
             ErrorRate = 0,
         };
+        // Same global queue observed slightly later by a second replica: one queued job started running on
+        // aws-batch, so its per-key values differ but describe the same queue.
         var b = new OpsHealthVitalsPoint
         {
             OverallStatus = "Healthy",
-            GpQueueTotal = 4,
+            GpQueueTotal = 5,
             GpQueueBreakdown = new Dictionary<string, int>
             {
-                ["Queued|local"] = 1,
-                ["Queued|aws-batch"] = 3,
+                ["Queued|local"] = 3,
+                ["Running|local"] = 1,
+                ["Running|aws-batch"] = 1,
             },
             DbActiveConnections = 1,
             CacheHitRatio = 1,
@@ -157,9 +162,11 @@ public class OpsHealthRollupAggregationTests
         var merged = OpsHealthRollupAggregation.MergeVitalsAcrossReplicas([a, b]);
 
         merged.GpQueueBreakdown.Should().HaveCount(3);
-        merged.GpQueueBreakdown["Queued|local"].Should().Be(4);
+        // Identical global observation is deduped, not summed (3, never 6).
+        merged.GpQueueBreakdown["Queued|local"].Should().Be(3);
+        // Differing observations of the same key keep the peak.
         merged.GpQueueBreakdown["Running|local"].Should().Be(2);
-        merged.GpQueueBreakdown["Queued|aws-batch"].Should().Be(3);
+        merged.GpQueueBreakdown["Running|aws-batch"].Should().Be(1);
     }
 
     [Theory]

--- a/tests/dotnet/Honua.Core.Tests/Features/Observability/OpsHealthRollupAggregationTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Observability/OpsHealthRollupAggregationTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Core.Tests.Features.Observability;
+
+/// <summary>
+/// Unit tests for <see cref="OpsHealthRollupAggregation"/>: the cross-replica merge helpers that back the
+/// cluster-wide serving-latency aggregation and the history read API (#2553).
+/// </summary>
+public class OpsHealthRollupAggregationTests
+{
+    [Fact]
+    public void MergeAcrossReplicas_Singlepoint_ReturnsSamePointWithProtocol()
+    {
+        var point = new OpsHealthLatencyPoint
+        {
+            Protocol = "FeatureServer",
+            RequestCount = 10,
+            ErrorCount = 1,
+            P50Ms = 5,
+            P95Ms = 20,
+            P99Ms = 40,
+            MaxMs = 80,
+        };
+
+        var merged = OpsHealthRollupAggregation.MergeAcrossReplicas("FeatureServer", [point]);
+
+        merged.Should().Be(point);
+    }
+
+    [Fact]
+    public void MergeAcrossReplicas_SumsCountsAndWeightsPercentilesByRequestCount()
+    {
+        var a = new OpsHealthLatencyPoint
+        {
+            Protocol = "OGC-Features",
+            RequestCount = 100,
+            ErrorCount = 5,
+            P50Ms = 10,
+            P95Ms = 100,
+            P99Ms = 200,
+            MaxMs = 300,
+        };
+        var b = new OpsHealthLatencyPoint
+        {
+            Protocol = "OGC-Features",
+            RequestCount = 300,
+            ErrorCount = 15,
+            P50Ms = 20,
+            P95Ms = 200,
+            P99Ms = 400,
+            MaxMs = 250,
+        };
+
+        var merged = OpsHealthRollupAggregation.MergeAcrossReplicas("OGC-Features", [a, b]);
+
+        merged.RequestCount.Should().Be(400);
+        merged.ErrorCount.Should().Be(20);
+        // Request-count-weighted mean: (10*100 + 20*300) / 400 = 17.5
+        merged.P50Ms.Should().BeApproximately(17.5, 1e-9);
+        // (100*100 + 200*300) / 400 = 175
+        merged.P95Ms.Should().BeApproximately(175, 1e-9);
+        // (200*100 + 400*300) / 400 = 350
+        merged.P99Ms.Should().BeApproximately(350, 1e-9);
+        // Max feeds the max.
+        merged.MaxMs.Should().Be(300);
+        merged.ErrorRate.Should().BeApproximately(20d / 400d, 1e-9);
+    }
+
+    [Fact]
+    public void MergeAcrossReplicas_WithZeroRequests_FallsBackToMaxPercentiles()
+    {
+        var a = new OpsHealthLatencyPoint { Protocol = "WFS-2.0", RequestCount = 0, ErrorCount = 0, P50Ms = 5, P95Ms = 9, P99Ms = 12, MaxMs = 20 };
+        var b = new OpsHealthLatencyPoint { Protocol = "WFS-2.0", RequestCount = 0, ErrorCount = 0, P50Ms = 7, P95Ms = 11, P99Ms = 15, MaxMs = 18 };
+
+        var merged = OpsHealthRollupAggregation.MergeAcrossReplicas("WFS-2.0", [a, b]);
+
+        merged.RequestCount.Should().Be(0);
+        merged.P50Ms.Should().Be(7);
+        merged.P95Ms.Should().Be(11);
+        merged.P99Ms.Should().Be(15);
+        merged.MaxMs.Should().Be(20);
+        merged.ErrorRate.Should().Be(0);
+    }
+
+    [Fact]
+    public void MergeVitalsAcrossReplicas_TakesWorstStatusPeakBacklogAndAveragedRatios()
+    {
+        var a = new OpsHealthVitalsPoint
+        {
+            OverallStatus = "Healthy",
+            GpQueueTotal = 3,
+            AlertPending = 10,
+            AlertDeadLettered = 0,
+            DbPoolUtilization = 0.4,
+            DbActiveConnections = 5,
+            CacheHitRatio = 0.9,
+            ErrorRate = 0.01,
+        };
+        var b = new OpsHealthVitalsPoint
+        {
+            OverallStatus = "Degraded",
+            GpQueueTotal = 8,
+            AlertPending = 25,
+            AlertDeadLettered = 2,
+            DbPoolUtilization = 0.6,
+            DbActiveConnections = 7,
+            CacheHitRatio = 0.7,
+            ErrorRate = 0.03,
+        };
+
+        var merged = OpsHealthRollupAggregation.MergeVitalsAcrossReplicas([a, b]);
+
+        merged.OverallStatus.Should().Be("Degraded");
+        merged.GpQueueTotal.Should().Be(8);
+        merged.AlertPending.Should().Be(25);
+        merged.AlertDeadLettered.Should().Be(2);
+        merged.DbActiveConnections.Should().Be(12);
+        merged.DbPoolUtilization.Should().BeApproximately(0.5, 1e-9);
+        merged.CacheHitRatio.Should().BeApproximately(0.8, 1e-9);
+        merged.ErrorRate.Should().BeApproximately(0.02, 1e-9);
+    }
+
+    [Theory]
+    [InlineData("Unhealthy", 3)]
+    [InlineData("Degraded", 2)]
+    [InlineData("Healthy", 0)]
+    [InlineData("Weird", 1)]
+    [InlineData(null, 1)]
+    public void StatusRank_OrdersBySeverity(string? status, int expected)
+    {
+        OpsHealthRollupAggregation.StatusRank(status).Should().Be(expected);
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Observability/PostgresOpsHealthRollupStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Observability/PostgresOpsHealthRollupStoreTests.cs
@@ -47,6 +47,9 @@ public sealed class PostgresOpsHealthRollupStoreTests(PostgresFixture fixture)
             vitals.Should().HaveCount(1);
             vitals[0].Point.OverallStatus.Should().Be("Healthy");
             vitals[0].Point.GpQueueTotal.Should().Be(4);
+            vitals[0].Point.GpQueueBreakdown.Should().HaveCount(2);
+            vitals[0].Point.GpQueueBreakdown["Queued|local"].Should().Be(3);
+            vitals[0].Point.GpQueueBreakdown["Running|local"].Should().Be(1);
             vitals[0].Point.AlertPending.Should().Be(7);
         }
         finally
@@ -89,9 +92,13 @@ public sealed class PostgresOpsHealthRollupStoreTests(PostgresFixture fixture)
             var store = new PostgresOpsHealthRollupStore(new TestConnectionProvider(fixture.DataSource, schema), schema);
             var windowStart = new DateTimeOffset(2026, 7, 7, 12, 0, 0, TimeSpan.Zero);
 
-            // Two minute buckets inside the same 5-minute window.
-            await store.WriteSampleAsync(Sample("replica-a", windowStart.AddMinutes(0), ("FeatureServer", 100, 0, 10, 100, 200, 300)));
-            await store.WriteSampleAsync(Sample("replica-a", windowStart.AddMinutes(1), ("FeatureServer", 300, 0, 20, 200, 400, 250)));
+            // Two minute buckets inside the same 5-minute window, with differing GP queue breakdowns.
+            await store.WriteSampleAsync(Sample(
+                "replica-a", windowStart.AddMinutes(0), ("FeatureServer", 100, 0, 10, 100, 200, 300),
+                new Dictionary<string, int> { ["Queued|local"] = 5, ["Running|local"] = 2 }));
+            await store.WriteSampleAsync(Sample(
+                "replica-a", windowStart.AddMinutes(1), ("FeatureServer", 300, 0, 20, 200, 400, 250),
+                new Dictionary<string, int> { ["Queued|local"] = 3, ["Queued|aws-batch"] = 9 }));
 
             var now = windowStart.AddMinutes(30);
             await store.DownsampleAndPruneAsync(now, OpsHealthRollupRetentionPolicy.Default);
@@ -104,6 +111,15 @@ public sealed class PostgresOpsHealthRollupStoreTests(PostgresFixture fixture)
             // Counts store the peak observation.
             fiveMin[0].Point.RequestCount.Should().Be(300);
             fiveMin[0].Point.MaxMs.Should().Be(300);
+
+            // Breakdown is downsampled with a per-key peak (max) across the coarse bucket's minutes.
+            var fiveMinVitals = await store.ReadVitalsAsync(OpsHealthRollupTier.FiveMinute, windowStart.AddMinutes(-1), now);
+            fiveMinVitals.Should().HaveCount(1);
+            var breakdown = fiveMinVitals[0].Point.GpQueueBreakdown;
+            breakdown.Should().HaveCount(3);
+            breakdown["Queued|local"].Should().Be(5);
+            breakdown["Running|local"].Should().Be(2);
+            breakdown["Queued|aws-batch"].Should().Be(9);
 
             var hourly = await store.ReadVitalsAsync(OpsHealthRollupTier.Hourly, windowStart.AddMinutes(-1), now);
             hourly.Should().NotBeEmpty();
@@ -168,7 +184,8 @@ public sealed class PostgresOpsHealthRollupStoreTests(PostgresFixture fixture)
     private static OpsHealthRollupSample Sample(
         string replicaId,
         DateTimeOffset capturedAt,
-        (string Protocol, long Requests, long Errors, double P50, double P95, double P99, double Max) latency)
+        (string Protocol, long Requests, long Errors, double P50, double P95, double P99, double Max) latency,
+        IReadOnlyDictionary<string, int>? gpBreakdown = null)
     {
         return new OpsHealthRollupSample
         {
@@ -191,6 +208,7 @@ public sealed class PostgresOpsHealthRollupStoreTests(PostgresFixture fixture)
             {
                 OverallStatus = "Healthy",
                 GpQueueTotal = 4,
+                GpQueueBreakdown = gpBreakdown ?? new Dictionary<string, int> { ["Queued|local"] = 3, ["Running|local"] = 1 },
                 AlertPending = 7,
                 AlertDeadLettered = 0,
                 DbPoolUtilization = 0.5,
@@ -226,6 +244,7 @@ public sealed class PostgresOpsHealthRollupStoreTests(PostgresFixture fixture)
                 bucket_start          TIMESTAMPTZ      NOT NULL,
                 overall_status        TEXT             NOT NULL DEFAULT 'Unknown',
                 gp_queue_total        INTEGER          NOT NULL DEFAULT 0,
+                gp_queue_breakdown    JSONB            NOT NULL DEFAULT jsonb_build_object(),
                 alert_pending         BIGINT           NULL,
                 alert_dead_lettered   BIGINT           NULL,
                 db_pool_utilization   DOUBLE PRECISION NULL,

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Observability/PostgresOpsHealthRollupStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Observability/PostgresOpsHealthRollupStoreTests.cs
@@ -1,0 +1,278 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Observability.Domain;
+using Honua.Postgres.Features.Observability;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Observability;
+
+/// <summary>
+/// Integration tests for <see cref="PostgresOpsHealthRollupStore"/> (#2553): the write/upsert,
+/// downsample, prune, and read paths against an isolated per-test schema mirroring migration 077.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresOpsHealthRollupStoreTests(PostgresFixture fixture)
+{
+    [IntegrationTest]
+    public async Task WriteSample_RoundTripsLatencyAndVitals()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresOpsHealthRollupStoreTests));
+        try
+        {
+            await EnsureSchemaAsync(schema);
+            var store = new PostgresOpsHealthRollupStore(new TestConnectionProvider(fixture.DataSource, schema), schema);
+            var capturedAt = new DateTimeOffset(2026, 7, 7, 12, 0, 30, TimeSpan.Zero);
+
+            await store.WriteSampleAsync(Sample("replica-a", capturedAt, ("FeatureServer", 100, 3, 12, 40, 90, 150)));
+
+            var rows = await store.ReadLatencyAsync(OpsHealthRollupTier.OneMinute, capturedAt.AddMinutes(-1), capturedAt.AddMinutes(1));
+            rows.Should().HaveCount(1);
+            rows[0].ReplicaId.Should().Be("replica-a");
+            rows[0].BucketStart.Should().Be(new DateTimeOffset(2026, 7, 7, 12, 0, 0, TimeSpan.Zero));
+            rows[0].Point.Protocol.Should().Be("FeatureServer");
+            rows[0].Point.RequestCount.Should().Be(100);
+            rows[0].Point.P50Ms.Should().Be(12);
+            rows[0].Point.P95Ms.Should().Be(40);
+            rows[0].Point.P99Ms.Should().Be(90);
+            rows[0].Point.MaxMs.Should().Be(150);
+
+            var vitals = await store.ReadVitalsAsync(OpsHealthRollupTier.OneMinute, capturedAt.AddMinutes(-1), capturedAt.AddMinutes(1));
+            vitals.Should().HaveCount(1);
+            vitals[0].Point.OverallStatus.Should().Be("Healthy");
+            vitals[0].Point.GpQueueTotal.Should().Be(4);
+            vitals[0].Point.AlertPending.Should().Be(7);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task WriteSample_SameMinute_IsLastWriteWins()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresOpsHealthRollupStoreTests));
+        try
+        {
+            await EnsureSchemaAsync(schema);
+            var store = new PostgresOpsHealthRollupStore(new TestConnectionProvider(fixture.DataSource, schema), schema);
+            var minute = new DateTimeOffset(2026, 7, 7, 12, 5, 0, TimeSpan.Zero);
+
+            await store.WriteSampleAsync(Sample("replica-a", minute.AddSeconds(5), ("FeatureServer", 10, 0, 5, 5, 5, 5)));
+            await store.WriteSampleAsync(Sample("replica-a", minute.AddSeconds(50), ("FeatureServer", 999, 9, 42, 42, 42, 42)));
+
+            var rows = await store.ReadLatencyAsync(OpsHealthRollupTier.OneMinute, minute.AddMinutes(-1), minute.AddMinutes(1));
+            rows.Should().HaveCount(1);
+            rows[0].Point.RequestCount.Should().Be(999);
+            rows[0].Point.P95Ms.Should().Be(42);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task DownsampleAndPrune_MaterializesFiveMinuteTierWithWeightedPercentiles()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresOpsHealthRollupStoreTests));
+        try
+        {
+            await EnsureSchemaAsync(schema);
+            var store = new PostgresOpsHealthRollupStore(new TestConnectionProvider(fixture.DataSource, schema), schema);
+            var windowStart = new DateTimeOffset(2026, 7, 7, 12, 0, 0, TimeSpan.Zero);
+
+            // Two minute buckets inside the same 5-minute window.
+            await store.WriteSampleAsync(Sample("replica-a", windowStart.AddMinutes(0), ("FeatureServer", 100, 0, 10, 100, 200, 300)));
+            await store.WriteSampleAsync(Sample("replica-a", windowStart.AddMinutes(1), ("FeatureServer", 300, 0, 20, 200, 400, 250)));
+
+            var now = windowStart.AddMinutes(30);
+            await store.DownsampleAndPruneAsync(now, OpsHealthRollupRetentionPolicy.Default);
+
+            var fiveMin = await store.ReadLatencyAsync(OpsHealthRollupTier.FiveMinute, windowStart.AddMinutes(-1), now);
+            fiveMin.Should().HaveCount(1);
+            fiveMin[0].BucketStart.Should().Be(windowStart);
+            // Weighted p95 = (100*100 + 200*300) / 400 = 175
+            fiveMin[0].Point.P95Ms.Should().BeApproximately(175, 1e-6);
+            // Counts store the peak observation.
+            fiveMin[0].Point.RequestCount.Should().Be(300);
+            fiveMin[0].Point.MaxMs.Should().Be(300);
+
+            var hourly = await store.ReadVitalsAsync(OpsHealthRollupTier.Hourly, windowStart.AddMinutes(-1), now);
+            hourly.Should().NotBeEmpty();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task DownsampleAndPrune_DropsExpiredOneMinuteRowsButKeepsHourly()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresOpsHealthRollupStoreTests));
+        try
+        {
+            await EnsureSchemaAsync(schema);
+            var store = new PostgresOpsHealthRollupStore(new TestConnectionProvider(fixture.DataSource, schema), schema);
+            var now = DateTimeOffset.UtcNow;
+            var stale = now.AddHours(-48);
+
+            await store.WriteSampleAsync(Sample("replica-a", stale, ("FeatureServer", 50, 1, 10, 20, 30, 40)));
+
+            var pruned = await store.DownsampleAndPruneAsync(now, OpsHealthRollupRetentionPolicy.Default);
+            pruned.Should().BeGreaterThan(0);
+
+            var oneMin = await store.ReadLatencyAsync(OpsHealthRollupTier.OneMinute, stale.AddMinutes(-1), now);
+            oneMin.Should().BeEmpty();
+
+            // Hourly (retained 90d) survives the 24h one-minute prune.
+            var hourly = await store.ReadLatencyAsync(OpsHealthRollupTier.Hourly, stale.AddHours(-1), now);
+            hourly.Should().NotBeEmpty();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task ReadRecentLatency_ExcludesSelfReplica()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresOpsHealthRollupStoreTests));
+        try
+        {
+            await EnsureSchemaAsync(schema);
+            var store = new PostgresOpsHealthRollupStore(new TestConnectionProvider(fixture.DataSource, schema), schema);
+            var now = DateTimeOffset.UtcNow;
+
+            await store.WriteSampleAsync(Sample("replica-self", now, ("FeatureServer", 10, 0, 5, 5, 5, 5)));
+            await store.WriteSampleAsync(Sample("replica-peer", now, ("FeatureServer", 20, 0, 6, 6, 6, 6)));
+
+            var recent = await store.ReadRecentLatencyAsync(now.AddMinutes(-5), "replica-self");
+            recent.Should().OnlyContain(row => row.ReplicaId == "replica-peer");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    private static OpsHealthRollupSample Sample(
+        string replicaId,
+        DateTimeOffset capturedAt,
+        (string Protocol, long Requests, long Errors, double P50, double P95, double P99, double Max) latency)
+    {
+        return new OpsHealthRollupSample
+        {
+            ReplicaId = replicaId,
+            CapturedAt = capturedAt,
+            Latency =
+            [
+                new OpsHealthLatencyPoint
+                {
+                    Protocol = latency.Protocol,
+                    RequestCount = latency.Requests,
+                    ErrorCount = latency.Errors,
+                    P50Ms = latency.P50,
+                    P95Ms = latency.P95,
+                    P99Ms = latency.P99,
+                    MaxMs = latency.Max,
+                },
+            ],
+            Vitals = new OpsHealthVitalsPoint
+            {
+                OverallStatus = "Healthy",
+                GpQueueTotal = 4,
+                AlertPending = 7,
+                AlertDeadLettered = 0,
+                DbPoolUtilization = 0.5,
+                DbActiveConnections = 6,
+                CacheHitRatio = 0.9,
+                ErrorRate = 0.01,
+            },
+        };
+    }
+
+    private async Task EnsureSchemaAsync(string schema)
+    {
+        await fixture.ExecuteAsync($"""
+            CREATE TABLE IF NOT EXISTS "{schema}".ops_health_rollup_latency (
+                replica_id     TEXT             NOT NULL,
+                tier           SMALLINT         NOT NULL,
+                bucket_start   TIMESTAMPTZ      NOT NULL,
+                protocol       TEXT             NOT NULL,
+                request_count  BIGINT           NOT NULL DEFAULT 0,
+                error_count    BIGINT           NOT NULL DEFAULT 0,
+                p50_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+                p95_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+                p99_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+                max_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+                updated_at     TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+                CONSTRAINT ops_health_rollup_latency_pk PRIMARY KEY (replica_id, tier, bucket_start, protocol),
+                CONSTRAINT ops_health_rollup_latency_valid_tier CHECK (tier IN (0, 1, 2))
+            );
+
+            CREATE TABLE IF NOT EXISTS "{schema}".ops_health_rollup_vitals (
+                replica_id            TEXT             NOT NULL,
+                tier                  SMALLINT         NOT NULL,
+                bucket_start          TIMESTAMPTZ      NOT NULL,
+                overall_status        TEXT             NOT NULL DEFAULT 'Unknown',
+                gp_queue_total        INTEGER          NOT NULL DEFAULT 0,
+                alert_pending         BIGINT           NULL,
+                alert_dead_lettered   BIGINT           NULL,
+                db_pool_utilization   DOUBLE PRECISION NULL,
+                db_active_connections INTEGER          NOT NULL DEFAULT 0,
+                cache_hit_ratio       DOUBLE PRECISION NOT NULL DEFAULT 0,
+                error_rate            DOUBLE PRECISION NOT NULL DEFAULT 0,
+                updated_at            TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+                CONSTRAINT ops_health_rollup_vitals_pk PRIMARY KEY (replica_id, tier, bucket_start),
+                CONSTRAINT ops_health_rollup_vitals_valid_tier CHECK (tier IN (0, 1, 2))
+            );
+            """);
+    }
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schema) : IAdoNetDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var conn = await dataSource.OpenConnectionAsync(cancellationToken);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SET search_path TO \"{schema}\", public;";
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+            return conn;
+        }
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var conn = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var tx = await conn.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (conn, tx);
+            }
+            catch
+            {
+                await conn.DisposeAsync();
+                throw;
+            }
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(Func<Task> operation, CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
@@ -80,6 +80,44 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/ops-health/history")]
+    public async Task GetOpsHealthHistory_WithAdminAuth_ReturnsClusterAggregatedSeries()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/observability/ops-health/history?window=1h&resolution=1m");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+        root.GetProperty("resolution").GetString().Should().Be("1m");
+        root.GetProperty("perReplica").GetBoolean().Should().BeFalse();
+        root.GetProperty("windowSeconds").GetDouble().Should().BeGreaterThan(0);
+        root.GetProperty("latency").ValueKind.Should().Be(JsonValueKind.Array);
+        root.GetProperty("vitals").ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/ops-health/history")]
+    public async Task GetOpsHealthHistory_WithInvalidResolution_Returns400()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/observability/ops-health/history?resolution=13m");
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/ops-health/history")]
+    public async Task GetOpsHealthHistory_WithoutAdminAuth_IsUnauthorized()
+    {
+        using var anonymous = _fixture.CreateClient();
+
+        var response = await anonymous.GetAsync("/api/v1/admin/observability/ops-health/history");
+
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /api/v1/admin/observability/findings")]
     public async Task GetFindings_WithAdminAuth_ReturnsFindingsEnvelope()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
@@ -37,7 +37,16 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
                 builder.UseEnvironment("Test");
                 builder.UseSetting("HONUA_DEV_AUTH", "false");
                 builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
-            });
+            })
+            // The shared test configuration defaults the ops-health rollup sampler OFF for every
+            // integration host (it would otherwise add background Postgres load across the whole
+            // parallel test fleet). This suite owns the rollup surface, so it opts back in —
+            // PostConfigure wins over the config binding — keeping the enabled/hosted sampler path
+            // booted by at least one host. The sampler's initial jitter + flush interval keep it from
+            // flushing mid-test; the history assertions seed the store directly instead.
+            .ConfigureServices(services =>
+                services.PostConfigure<Honua.Infrastructure.Monitoring.OpsHealthRollupOptions>(
+                    options => options.Enabled = true));
     }
 
     public async Task InitializeAsync()

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
@@ -4,10 +4,13 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Observability.Abstractions;
+using Honua.Core.Features.Observability.Domain;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Server.Tests.Features.Admin;
 
@@ -83,6 +86,10 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
     [Endpoint("GET /api/v1/admin/observability/ops-health/history")]
     public async Task GetOpsHealthHistory_WithAdminAuth_ReturnsClusterAggregatedSeries()
     {
+        // Seed one persisted flush through the app's rollup store (when the Postgres store is registered)
+        // so the read path returns a non-empty series including the GP queue breakdown.
+        await SeedRollupSampleAsync();
+
         var response = await _client.GetAsync("/api/v1/admin/observability/ops-health/history?window=1h&resolution=1m");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -94,7 +101,40 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
         root.GetProperty("perReplica").GetBoolean().Should().BeFalse();
         root.GetProperty("windowSeconds").GetDouble().Should().BeGreaterThan(0);
         root.GetProperty("latency").ValueKind.Should().Be(JsonValueKind.Array);
-        root.GetProperty("vitals").ValueKind.Should().Be(JsonValueKind.Array);
+        var vitals = root.GetProperty("vitals");
+        vitals.ValueKind.Should().Be(JsonValueKind.Array);
+        vitals.GetArrayLength().Should().BeGreaterThan(0);
+        var point = vitals[0];
+        point.GetProperty("gpQueueTotal").GetInt32().Should().Be(4);
+        var breakdown = point.GetProperty("gpQueueBreakdown");
+        breakdown.ValueKind.Should().Be(JsonValueKind.Object);
+        breakdown.GetProperty("Queued|local").GetInt32().Should().Be(3);
+        breakdown.GetProperty("Running|local").GetInt32().Should().Be(1);
+    }
+
+    private async Task SeedRollupSampleAsync()
+    {
+        using var scope = _fixture.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IOpsHealthRollupStore>();
+        await store.WriteSampleAsync(new OpsHealthRollupSample
+        {
+            ReplicaId = "test-replica",
+            CapturedAt = DateTimeOffset.UtcNow,
+            Latency = [],
+            Vitals = new OpsHealthVitalsPoint
+            {
+                OverallStatus = "Healthy",
+                GpQueueTotal = 4,
+                GpQueueBreakdown = new Dictionary<string, int>
+                {
+                    ["Queued|local"] = 3,
+                    ["Running|local"] = 1,
+                },
+                DbActiveConnections = 2,
+                CacheHitRatio = 0.9,
+                ErrorRate = 0.0,
+            },
+        });
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsHealthRollupSamplerTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsHealthRollupSamplerTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using FluentAssertions;
+using Honua.Core.Features.Observability.Domain;
+using Honua.Infrastructure.Monitoring;
+using Honua.ServiceDefaults;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Unit tests for the ops-health rollup sampler surface (#2553): history-query parsing, and a perf
+/// assertion bounding the sampler's per-flush in-process capture overhead so it stays off serving paths.
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class OpsHealthRollupSamplerTests
+{
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void HistoryQuery_DefaultsToOneMinuteWindow()
+    {
+        OpsHealthHistoryQuery.TryParse(window: null, resolution: null, perReplica: false, out var error, out var query)
+            .Should().BeTrue();
+        error.Should().BeNull();
+        query.Tier.Should().Be(OpsHealthRollupTier.OneMinute);
+        query.Window.Should().Be(TimeSpan.FromHours(1));
+        query.PerReplica.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("1m", OpsHealthRollupTier.OneMinute)]
+    [InlineData("5m", OpsHealthRollupTier.FiveMinute)]
+    [InlineData("1h", OpsHealthRollupTier.Hourly)]
+    [Operation(Operations.TestInfrastructure)]
+    public void HistoryQuery_ParsesResolution(string resolution, OpsHealthRollupTier expected)
+    {
+        OpsHealthHistoryQuery.TryParse("2h", resolution, perReplica: true, out _, out var query).Should().BeTrue();
+        query.Tier.Should().Be(expected);
+        query.PerReplica.Should().BeTrue();
+    }
+
+    [Fact]
+    [Operation(Operations.TestInfrastructure)]
+    public void HistoryQuery_ClampsWindowToTierRetentionCap()
+    {
+        // 1-minute tier is retained 24h, so a 90d request is clamped down.
+        OpsHealthHistoryQuery.TryParse("90d", "1m", perReplica: false, out _, out var query).Should().BeTrue();
+        query.Window.Should().Be(TimeSpan.FromHours(24));
+    }
+
+    [Theory]
+    [InlineData("13m")]
+    [InlineData("nonsense")]
+    [Operation(Operations.TestInfrastructure)]
+    public void HistoryQuery_RejectsUnsupportedResolution(string resolution)
+    {
+        OpsHealthHistoryQuery.TryParse("1h", resolution, perReplica: false, out var error, out _).Should().BeFalse();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("0h")]
+    [InlineData("abc")]
+    [InlineData("10")]
+    [Operation(Operations.TestInfrastructure)]
+    public void HistoryQuery_RejectsInvalidWindow(string window)
+    {
+        OpsHealthHistoryQuery.TryParse(window, "1m", perReplica: false, out var error, out _).Should().BeFalse();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void SamplerCapture_FromTelemetry_HasBoundedOverhead()
+    {
+        // Warm the shared in-process aggregator with representative traffic.
+        for (var i = 0; i < 5000; i++)
+        {
+            HonuaTelemetry.RecordServingRequest(
+                HonuaTelemetry.Protocols.FeatureServer,
+                operation: "query",
+                statusCode: i % 50 == 0 ? 500 : 200,
+                durationMs: 5 + (i % 40));
+        }
+
+        // The sampler's per-flush capture cost is dominated by snapshotting the aggregator and shaping the
+        // rollup sample. It must be cheap and never touch serving code — assert a generous upper bound.
+        const int iterations = 200;
+        var stopwatch = Stopwatch.StartNew();
+        for (var i = 0; i < iterations; i++)
+        {
+            var snapshot = HonuaTelemetry.GetServingLatencySnapshot();
+            var latency = snapshot.Protocols
+                .Select(p => new OpsHealthLatencyPoint
+                {
+                    Protocol = p.Protocol,
+                    RequestCount = p.RequestCount,
+                    ErrorCount = p.ErrorCount,
+                    P50Ms = p.P50Ms,
+                    P95Ms = p.P95Ms,
+                    P99Ms = p.P99Ms,
+                    MaxMs = p.MaxMs,
+                })
+                .ToList();
+            latency.Should().NotBeNull();
+        }
+
+        stopwatch.Stop();
+        var perCaptureMs = stopwatch.Elapsed.TotalMilliseconds / iterations;
+        perCaptureMs.Should().BeLessThan(25);
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
+++ b/tests/dotnet/Honua.TestKit/Mixins/WebAppFixturePostgresWiringMixin.cs
@@ -83,6 +83,13 @@ internal static class WebAppFixturePostgresWiringMixin
             ["FileStorage:LocalStorage:BasePath"] = attachmentsPath,
             ["Security:ConnectionEncryption:MasterKey"] = TestEncryptionMasterKey,
             ["Security:ConnectionEncryption:Salt"] = TestEncryptionSalt,
+            // The ops-health rollup sampler (#2553) is a hosted background service that would
+            // otherwise boot in EVERY integration-test host and add constant background
+            // Postgres sampling/flush/downsample/prune load across the whole parallel
+            // Server.Tests fleet — enough to time out already-contended CI shards. Default it
+            // OFF in test hosts; the rollup's own tests opt back in explicitly (see
+            // OpsObservabilityEndpointsTests) and the production default stays enabled.
+            ["Observability:OpsHealthRollup:Enabled"] = "false",
         };
 
         if (extraSettings is not null)

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -1264,6 +1264,7 @@ sql:
           bucket_start          TIMESTAMPTZ      NOT NULL,
           overall_status        TEXT             NOT NULL DEFAULT 'Unknown',
           gp_queue_total        INTEGER          NOT NULL DEFAULT 0,
+          gp_queue_breakdown    JSONB            NOT NULL DEFAULT '{}',
           alert_pending         BIGINT           NULL,
           alert_dead_lettered   BIGINT           NULL,
           db_pool_utilization   DOUBLE PRECISION NULL,

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -1236,6 +1236,45 @@ sql:
           CONSTRAINT investigation_links_valid_resource CHECK (length(resource_id) > 0)
       );
   - "CREATE INDEX IF NOT EXISTS idx_investigation_links_investigation ON honua.investigation_links(investigation_id, link_id);"
+  # Persisted ops-health rollup store (#2553). Mirrors migration
+  # 077_CreateOpsHealthRollup.sql so the migration-skipping integration fixture has the tables;
+  # PostgresOpsHealthRollupStore persists per-replica serving-latency + vitals rollups here and the
+  # history endpoint / live-snapshot cluster aggregation read them back.
+  - |
+      CREATE TABLE IF NOT EXISTS honua.ops_health_rollup_latency (
+          replica_id     TEXT             NOT NULL,
+          tier           SMALLINT         NOT NULL,
+          bucket_start   TIMESTAMPTZ      NOT NULL,
+          protocol       TEXT             NOT NULL,
+          request_count  BIGINT           NOT NULL DEFAULT 0,
+          error_count    BIGINT           NOT NULL DEFAULT 0,
+          p50_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+          p95_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+          p99_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+          max_ms         DOUBLE PRECISION NOT NULL DEFAULT 0,
+          updated_at     TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+          CONSTRAINT ops_health_rollup_latency_pk PRIMARY KEY (replica_id, tier, bucket_start, protocol),
+          CONSTRAINT ops_health_rollup_latency_valid_tier CHECK (tier IN (0, 1, 2))
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_ops_health_rollup_latency_tier_bucket ON honua.ops_health_rollup_latency(tier, bucket_start);"
+  - |
+      CREATE TABLE IF NOT EXISTS honua.ops_health_rollup_vitals (
+          replica_id            TEXT             NOT NULL,
+          tier                  SMALLINT         NOT NULL,
+          bucket_start          TIMESTAMPTZ      NOT NULL,
+          overall_status        TEXT             NOT NULL DEFAULT 'Unknown',
+          gp_queue_total        INTEGER          NOT NULL DEFAULT 0,
+          alert_pending         BIGINT           NULL,
+          alert_dead_lettered   BIGINT           NULL,
+          db_pool_utilization   DOUBLE PRECISION NULL,
+          db_active_connections INTEGER          NOT NULL DEFAULT 0,
+          cache_hit_ratio       DOUBLE PRECISION NOT NULL DEFAULT 0,
+          error_rate            DOUBLE PRECISION NOT NULL DEFAULT 0,
+          updated_at            TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+          CONSTRAINT ops_health_rollup_vitals_pk PRIMARY KEY (replica_id, tier, bucket_start),
+          CONSTRAINT ops_health_rollup_vitals_valid_tier CHECK (tier IN (0, 1, 2))
+      );
+  - "CREATE INDEX IF NOT EXISTS idx_ops_health_rollup_vitals_tier_bucket ON honua.ops_health_rollup_vitals(tier, bucket_start);"
   - |
       CREATE TABLE IF NOT EXISTS honua.operate_fixture_execution_jobs (
           operation_id     TEXT        PRIMARY KEY,


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2553

## Summary
Persists ops-health history so a self-contained ops dashboard (epic #2552, Phase B) can answer "p95 over the last 24h" without the external Prometheus/Grafana bundle. Each replica runs a background sampler that flushes its ops-health sections into a bounded Postgres rollup store keyed by `replicaId`; downsampled retention tiers are auto-pruned; a new admin-authed history endpoint returns cluster-aggregated (or per-replica) time series; the live snapshot now aggregates serving latency across the whole cluster; and a plain in-process flush event seam carries the freshly cluster-aggregated snapshot for the realtime hub (#2554) to consume.

## Changes Made
- Added `IOpsHealthRollupStore` (Core) + `PostgresOpsHealthRollupStore`: per-replica serving-latency and vitals rollups, 1-min/5-min/hourly tiers downsampled via UTC epoch-floor buckets, pruned to hard caps (1-min×24h, 5-min×14d, hourly×90d).
- Added `OpsHealthRollupSampler` background service: configurable flush interval (default 45s), fail-open (rollup outages never touch serving paths), periodic downsample-and-prune, raises `OpsHealthFlushSignal` with the cluster-aggregated snapshot DTO.
- Added `GET /api/v1/admin/observability/ops-health/history`: admin-authed, versioned, `window`/`resolution` params, cluster-aggregated with optional `perReplica` breakdown; XML-documented as the hub reconnect gap-fill contract (no Last-Event-ID).
- Live `ops-health` snapshot now merges peers' recent flushes into serving latency (request-count-weighted percentiles) and reports `clusterReplicaCount`; falls back to local-only on store outage/absence.
- Persisted the GP queue depth breakdown by status×backend (`gp_queue_breakdown JSONB`, keyed `"<status>|<backend>"`): flushed by the sampler from the live snapshot's buckets, deduped across replicas with a per-key max (the queue is a global view every replica reports; summing would overcount), downsampled over time with a per-key peak (max), and surfaced additively as `gpQueueBreakdown` on history vitals points (review follow-up).
- Added migration `077_CreateOpsHealthRollup.sql` and mirrored the two rollup tables into `tests/seed/server.yaml`.
- Added Core aggregation unit tests, Postgres store integration tests (write/upsert/downsample/prune/read), endpoint integration tests, a sampler-overhead perf assertion, and regenerated `docs/gis/data/feature-catalog.json`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] OpenAPI spec changed

## Release/Deploy Impact
- [x] Requires database migration

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality



