### PR TITLE
feat(control-plane): deploy-operations list API, workflow-transition seam, and Release events in the operate timeline

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -1369,6 +1369,20 @@
       "maturity": "implemented"
     },
     {
+      "id": "get-api-v1-admin-deploy-operations",
+      "route": "/api/v1/admin/deploy/operations",
+      "method": "GET",
+      "family": "Admin API",
+      "protocol": "http-route-family",
+      "code_location": "src/Honua.Server/EndpointRegistry.cs",
+      "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.DeployControlEndpointsTests.ListDeployOperations_PagesAndFiltersNewestFirst",
+        "Honua.Server.Tests.Features.Admin.DeployControlEndpointsTests.ListDeployOperations_WithUnsupportedFilterValue_ReturnsBadRequest"
+      ],
+      "proof_ledger_surface": "control-plane-admin",
+      "maturity": "implemented"
+    },
+    {
       "id": "get-api-v1-admin-deploy-operations-operationid",
       "route": "/api/v1/admin/deploy/operations/{operationId}",
       "method": "GET",
@@ -2655,6 +2669,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.DeployReleaseTimelineTests.DeployLifecycle_RaisesReleaseTimelineEvents_FilterableByReleaseId",
         "Honua.Server.Tests.Features.Admin.Jobs.ConsoleJobEndpointsTests.OperateEvents_FilterByCorrelation_ReturnsDurableJobEvent",
         "Honua.Server.Tests.Features.Admin.ObservabilityEventEndpointsTests.ListEvents_NormalizesItemsAndPropagatesPartialResult",
         "Honua.Server.Tests.Features.Admin.ObservabilityEventEndpointsTests.ListEvents_RejectsDefinedNumericKind",

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IWorkflowOperationTransitionListener.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IWorkflowOperationTransitionListener.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Observes durable workflow-operation transitions (created / submitted / promoted / rolled-back /
+/// manual-intervention). Implementations are invoked, best-effort, after the authoritative store write
+/// by the transition-observing store decorator, so a single seam fans a transition out to every
+/// registered consumer regardless of whether the write came from the deploy workflow service or the
+/// reconciler. Consumers must be side-effect isolated: a listener throwing must never fail the write or
+/// starve sibling listeners.
+/// </summary>
+public interface IWorkflowOperationTransitionListener
+{
+    /// <summary>
+    /// Handles an observed workflow-operation transition.
+    /// </summary>
+    /// <param name="transition">The observed transition, carrying the persisted record and its classified kind.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task OnTransitionAsync(
+        WorkflowOperationTransition transition,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/OperationInterfaces.cs
@@ -123,6 +123,41 @@ public interface IWorkflowOperationStore : IOperationStore
     Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(
         WorkflowOperationKind? kind = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Queries durable workflow operations newest-first with optional kind and status filters, drawing
+    /// from both the active-set index and the terminal-operations index. The default implementation
+    /// returns an empty page so lightweight test doubles need not implement paging; the durable
+    /// Redis-backed store overrides it.
+    /// </summary>
+    /// <param name="query">Filter and paging criteria.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A page of workflow operations ordered newest-first by creation time.</returns>
+    Task<WorkflowOperationPage> QueryAsync(
+        WorkflowOperationQuery query,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(new WorkflowOperationPage
+        {
+            Items = Array.Empty<WorkflowOperationRecord>(),
+            Page = query.Page,
+            PageSize = query.PageSize,
+            TotalCount = 0,
+            HasMore = false
+        });
+
+    /// <summary>
+    /// Returns the most recent terminal-<see cref="WorkflowOperationStatus.Succeeded"/> deploy operation
+    /// for a target, or null when none exists. Backs the platform-release converge API's "what revision
+    /// last landed on this target" lookup. The default implementation returns null; the durable
+    /// Redis-backed store overrides it using a per-target succeeded index.
+    /// </summary>
+    /// <param name="targetId">Deploy target identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The most recent succeeded deploy operation for the target, or null.</returns>
+    Task<WorkflowOperationRecord?> GetMostRecentSucceededDeployByTargetAsync(
+        string targetId,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<WorkflowOperationRecord?>(null);
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/ControlPlane/Domain/WorkflowOperationQuery.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/WorkflowOperationQuery.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Domain;
+
+/// <summary>
+/// Filter and paging criteria for listing durable workflow operations newest-first.
+/// </summary>
+public sealed record WorkflowOperationQuery
+{
+    /// <summary>
+    /// Optional workflow-kind filter. When null, operations of every kind are returned.
+    /// </summary>
+    public WorkflowOperationKind? Kind { get; init; }
+
+    /// <summary>
+    /// Optional status filter. When null, operations in every status are returned.
+    /// </summary>
+    public WorkflowOperationStatus? Status { get; init; }
+
+    /// <summary>
+    /// One-based page number.
+    /// </summary>
+    public int Page { get; init; } = 1;
+
+    /// <summary>
+    /// Requested page size. Implementations clamp this to a server-side maximum.
+    /// </summary>
+    public int PageSize { get; init; } = 50;
+}
+
+/// <summary>
+/// A single page of durable workflow operations ordered newest-first.
+/// </summary>
+public sealed record WorkflowOperationPage
+{
+    /// <summary>
+    /// Items on this page, ordered newest-first by <see cref="WorkflowOperationRecord.CreatedAt"/>.
+    /// </summary>
+    public required IReadOnlyList<WorkflowOperationRecord> Items { get; init; }
+
+    /// <summary>
+    /// One-based page number that produced this page.
+    /// </summary>
+    public required int Page { get; init; }
+
+    /// <summary>
+    /// Effective page size applied when producing this page.
+    /// </summary>
+    public required int PageSize { get; init; }
+
+    /// <summary>
+    /// Total number of operations matching the filter within the materialized window.
+    /// </summary>
+    public required int TotalCount { get; init; }
+
+    /// <summary>
+    /// Whether at least one more page exists after this one.
+    /// </summary>
+    public bool HasMore { get; init; }
+}

--- a/src/Honua.Core/Features/ControlPlane/Domain/WorkflowOperationTransition.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/WorkflowOperationTransition.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.ControlPlane.Domain;
+
+/// <summary>
+/// Coarse classification of an observed durable workflow-operation transition. These are the
+/// operator-meaningful lifecycle moments surfaced to observers (the operate timeline and, later,
+/// the realtime deploy-operations hub) rather than every intermediate status write.
+/// </summary>
+public enum WorkflowOperationTransitionKind
+{
+    /// <summary>
+    /// The operation record was durably created.
+    /// </summary>
+    Created,
+
+    /// <summary>
+    /// The operation was submitted to its provider backend.
+    /// </summary>
+    Submitted,
+
+    /// <summary>
+    /// The operation reached its desired outcome (promoted / succeeded cutover).
+    /// </summary>
+    Promoted,
+
+    /// <summary>
+    /// A rollback was requested or completed for the operation.
+    /// </summary>
+    RolledBack,
+
+    /// <summary>
+    /// The operation requires explicit operator action beyond automatic reconciliation.
+    /// </summary>
+    ManualInterventionRequired
+}
+
+/// <summary>
+/// An observed durable workflow-operation transition. Raised by the store decorator after the
+/// authoritative write so observers (for example an operate-timeline producer or the realtime hub)
+/// can react without the writer knowing about them. Carries the full <see cref="WorkflowOperationRecord"/>
+/// plus the classified <see cref="Kind"/> and the correlation identifiers callers most commonly key on.
+/// </summary>
+public sealed record WorkflowOperationTransition
+{
+    /// <summary>
+    /// The operation record as persisted by the transition.
+    /// </summary>
+    public required WorkflowOperationRecord Operation { get; init; }
+
+    /// <summary>
+    /// Classified transition kind.
+    /// </summary>
+    public required WorkflowOperationTransitionKind Kind { get; init; }
+
+    /// <summary>
+    /// Wall-clock time the transition was observed.
+    /// </summary>
+    public required DateTimeOffset OccurredAt { get; init; }
+
+    /// <summary>
+    /// Durable operation identifier.
+    /// </summary>
+    public string OperationId => Operation.OperationId;
+
+    /// <summary>
+    /// Deploy target identifier when the operation carries a deploy spec.
+    /// </summary>
+    public string? TargetId => Operation.Deploy?.TargetId;
+
+    /// <summary>
+    /// Release identifier associated with the operation: the desired revision for a deploy, or the
+    /// metadata release package identifier for a metadata release.
+    /// </summary>
+    public string? ReleaseId =>
+        Operation.Deploy?.DesiredRevision ?? Operation.MetadataRelease?.PackageId;
+
+    /// <summary>
+    /// Correlation identifier propagated from the originating request, when known.
+    /// </summary>
+    public string? CorrelationId => Operation.Audit.CorrelationId;
+}

--- a/src/Honua.Server/EndpointRegistry.Admin.cs
+++ b/src/Honua.Server/EndpointRegistry.Admin.cs
@@ -92,6 +92,7 @@ public static partial class EndpointRegistry
         new("POST", "/api/v1/admin/metadata/prevalidate"),
         new("GET", "/api/v1/admin/deploy/preflight"),
         new("POST", "/api/v1/admin/deploy/plan"),
+        new("GET", "/api/v1/admin/deploy/operations"),
         new("POST", "/api/v1/admin/deploy/operations"),
         new("GET", "/api/v1/admin/deploy/operations/{operationId}"),
         new("POST", "/api/v1/admin/deploy/operations/{operationId}/submit"),

--- a/src/Honua.Server/Features/Admin/DeployControlEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/DeployControlEndpoints.cs
@@ -42,6 +42,12 @@ internal static class DeployControlEndpoints
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
             .Produces<DeployPlanResponse>();
 
+        group.MapGet("/operations", HandleListDeployOperations)
+            .WithDisplayName("List Deploy Operations")
+            .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Get }))
+            .Produces<DeployOperationListResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
         group.MapPost("/operations", HandleCreateDeployOperation)
             .WithDisplayName("Create Deploy Operation")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
@@ -275,6 +281,88 @@ internal static class DeployControlEndpoints
                 StatusCodes.Status409Conflict,
                 ProblemDetailsHelpers.GetTitle(StatusCodes.Status409Conflict),
                 DeployConflictMessage);
+        }
+        catch (InvalidOperationException)
+        {
+            return Results.Problem(
+                title: ProblemDetailsHelpers.GetTitle(StatusCodes.Status503ServiceUnavailable),
+                detail: DeployControlUnavailableMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    private static async Task<IResult> HandleListDeployOperations(
+        HttpRequest request,
+        [FromServices] DeployWorkflowService deployWorkflowService,
+        CancellationToken cancellationToken)
+    {
+        var query = request.Query;
+
+        WorkflowOperationKind? kind = null;
+        var rawKind = QueryFilterParsers.GetString(query, "kind");
+        if (!string.IsNullOrWhiteSpace(rawKind))
+        {
+            if (!QueryFilterParsers.TryParseDefinedEnum<WorkflowOperationKind>(rawKind, out var parsedKind))
+            {
+                return ProblemDetailsHelpers.CreateAdminProblem(
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    $"'kind' contains unsupported value '{rawKind}'.");
+            }
+
+            kind = parsedKind;
+        }
+
+        WorkflowOperationStatus? status = null;
+        var rawStatus = QueryFilterParsers.GetString(query, "status");
+        if (!string.IsNullOrWhiteSpace(rawStatus))
+        {
+            if (!QueryFilterParsers.TryParseDefinedEnum<WorkflowOperationStatus>(rawStatus, out var parsedStatus))
+            {
+                return ProblemDetailsHelpers.CreateAdminProblem(
+                    StatusCodes.Status400BadRequest,
+                    ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                    $"'status' contains unsupported value '{rawStatus}'.");
+            }
+
+            status = parsedStatus;
+        }
+
+        if (!QueryFilterParsers.TryParseInt(query, "page", out var pageValue, out var parseError) ||
+            !QueryFilterParsers.TryParseInt(query, "pageSize", out var pageSizeValue, out parseError))
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                StatusCodes.Status400BadRequest,
+                ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                parseError);
+        }
+
+        var page = pageValue ?? 1;
+        var pageSize = pageSizeValue ?? 50;
+        if (page < 1 || pageSize < 1)
+        {
+            return ProblemDetailsHelpers.CreateAdminProblem(
+                StatusCodes.Status400BadRequest,
+                ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
+                "'page' and 'pageSize' must be greater than or equal to 1.");
+        }
+
+        try
+        {
+            var result = await deployWorkflowService
+                .ListDeployOperationsAsync(status, kind, page, pageSize, cancellationToken)
+                .ConfigureAwait(false);
+
+            var response = new DeployOperationListResponse
+            {
+                Items = result.Items.Select(MapOperationResponse).ToArray(),
+                Page = result.Page,
+                PageSize = result.PageSize,
+                TotalCount = result.TotalCount,
+                HasMore = result.HasMore
+            };
+
+            return Results.Json(response, DeployControlJsonContext.Default.DeployOperationListResponse);
         }
         catch (InvalidOperationException)
         {

--- a/src/Honua.Server/Features/Admin/Models/DeployControlJsonContext.cs
+++ b/src/Honua.Server/Features/Admin/Models/DeployControlJsonContext.cs
@@ -29,6 +29,7 @@ namespace Honua.Server.Features.Admin.Models;
 [JsonSerializable(typeof(DeployPlanTargetResponse))]
 [JsonSerializable(typeof(DeployBackendCapabilitiesResponse))]
 [JsonSerializable(typeof(DeployOperationResponse))]
+[JsonSerializable(typeof(DeployOperationListResponse))]
 [JsonSerializable(typeof(MetadataReleaseContextResponse))]
 [JsonSerializable(typeof(MetadataRollbackPlanResponse))]
 [JsonSerializable(typeof(MetadataEvidenceRefResponse))]

--- a/src/Honua.Server/Features/Admin/Models/DeployControlModels.cs
+++ b/src/Honua.Server/Features/Admin/Models/DeployControlModels.cs
@@ -517,6 +517,42 @@ public sealed class DeployOperationResponse
 }
 
 /// <summary>
+/// Paged, newest-first collection of durable deploy workflow operations.
+/// </summary>
+public sealed class DeployOperationListResponse
+{
+    /// <summary>
+    /// Operations on this page, ordered newest-first by creation time.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public IReadOnlyList<DeployOperationResponse> Items { get; init; } = Array.Empty<DeployOperationResponse>();
+
+    /// <summary>
+    /// One-based page number that produced this page.
+    /// </summary>
+    [JsonPropertyName("page")]
+    public int Page { get; init; }
+
+    /// <summary>
+    /// Effective page size applied when producing this page.
+    /// </summary>
+    [JsonPropertyName("pageSize")]
+    public int PageSize { get; init; }
+
+    /// <summary>
+    /// Total number of operations matching the filter within the materialized window.
+    /// </summary>
+    [JsonPropertyName("totalCount")]
+    public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Whether at least one more page exists after this one.
+    /// </summary>
+    [JsonPropertyName("hasMore")]
+    public bool HasMore { get; init; }
+}
+
+/// <summary>
 /// Metadata release lifecycle context embedded in a workflow operation response.
 /// </summary>
 public sealed class MetadataReleaseContextResponse

--- a/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/Alerts/Ops/NotifyingWorkflowOperationStore.cs
@@ -143,6 +143,12 @@ internal sealed partial class NotifyingWorkflowOperationStore : IWorkflowOperati
     public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
         => _inner.ListActiveAsync(kind, cancellationToken);
 
+    public Task<WorkflowOperationPage> QueryAsync(WorkflowOperationQuery query, CancellationToken cancellationToken = default)
+        => _inner.QueryAsync(query, cancellationToken);
+
+    public Task<WorkflowOperationRecord?> GetMostRecentSucceededDeployByTargetAsync(string targetId, CancellationToken cancellationToken = default)
+        => _inner.GetMostRecentSucceededDeployByTargetAsync(targetId, cancellationToken);
+
     public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
         => _inner.TryAcquireLeaseAsync(operationId, ownerId, leaseDuration, cancellationToken);
 

--- a/src/Honua.Server/Features/ControlPlane/DeployWorkflowService.cs
+++ b/src/Honua.Server/Features/ControlPlane/DeployWorkflowService.cs
@@ -132,6 +132,42 @@ internal sealed partial class DeployWorkflowService
         return await _workflowStore!.GetAsync(operationId, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Lists durable deploy workflow operations newest-first with optional status and kind filters. Draws
+    /// from both the active-set and terminal-operations indexes maintained by the durable store.
+    /// </summary>
+    public async Task<WorkflowOperationPage> ListDeployOperationsAsync(
+        WorkflowOperationStatus? status,
+        WorkflowOperationKind? kind,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureDurableStoreConfigured();
+        return await _workflowStore!.QueryAsync(
+                new WorkflowOperationQuery
+                {
+                    Kind = kind,
+                    Status = status,
+                    Page = page,
+                    PageSize = pageSize
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the most recent terminal-<see cref="WorkflowOperationStatus.Succeeded"/> deploy operation
+    /// for a target, or null when none exists. Backs the platform-release converge API lookup (#2564).
+    /// </summary>
+    public async Task<WorkflowOperationRecord?> GetMostRecentSucceededDeployAsync(
+        string targetId,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureDurableStoreConfigured();
+        return await _workflowStore!.GetMostRecentSucceededDeployByTargetAsync(targetId, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<WorkflowOperationRecord?> CreateAsync(
         string targetId,
         string desiredRevision,

--- a/src/Honua.Server/Features/ControlPlane/RedisWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/ControlPlane/RedisWorkflowOperationStore.cs
@@ -184,6 +184,138 @@ internal sealed partial class RedisWorkflowOperationStore(
             .ToArray();
     }
 
+    public async Task<WorkflowOperationPage> QueryAsync(
+        WorkflowOperationQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var page = Math.Max(1, query.Page);
+        var pageSize = Math.Clamp(query.PageSize <= 0 ? DefaultPageSize : query.PageSize, 1, MaxPageSize);
+
+        // Candidate identifiers: the active-set index (unordered, non-terminal) unioned with the
+        // terminal-operations index (newest-completed first, bounded to a materialization window).
+        var activeKey = query.Kind.HasValue ? GetKindActiveKey(query.Kind.Value) : ActiveOperationsKey;
+        var activeIds = await _database.SetMembersAsync(activeKey).ConfigureAwait(false);
+        var terminalIds = await _database
+            .SortedSetRangeByRankAsync(TerminalOperationsKey, 0, MaterializationCap - 1, Order.Descending)
+            .ConfigureAwait(false);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var records = new List<WorkflowOperationRecord>(activeIds.Length + terminalIds.Length);
+        var staleActive = new List<RedisValue>();
+        var staleTerminal = new List<RedisValue>();
+
+        foreach (var id in activeIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await CollectCandidateAsync(id, records, seen, staleActive, cancellationToken).ConfigureAwait(false);
+        }
+
+        foreach (var id in terminalIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await CollectCandidateAsync(id, records, seen, staleTerminal, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (staleActive.Count > 0)
+        {
+            await RemoveStaleMembersAsync(activeKey, staleActive).ConfigureAwait(false);
+        }
+
+        foreach (var staleId in staleTerminal)
+        {
+            await _database.SortedSetRemoveAsync(TerminalOperationsKey, staleId).ConfigureAwait(false);
+        }
+
+        var filtered = records
+            .Where(record => (!query.Kind.HasValue || record.Kind == query.Kind.Value)
+                && (!query.Status.HasValue || record.Status == query.Status.Value))
+            .OrderByDescending(record => record.CreatedAt)
+            .ThenByDescending(record => record.OperationId, StringComparer.Ordinal)
+            .ToArray();
+
+        var skip = (page - 1) * pageSize;
+        var items = filtered.Skip(skip).Take(pageSize).ToArray();
+
+        return new WorkflowOperationPage
+        {
+            Items = items,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = filtered.Length,
+            HasMore = skip + items.Length < filtered.Length
+        };
+    }
+
+    public async Task<WorkflowOperationRecord?> GetMostRecentSucceededDeployByTargetAsync(
+        string targetId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(targetId))
+        {
+            return null;
+        }
+
+        var normalizedTargetId = targetId.Trim();
+        var indexKey = GetDeploySucceededTargetKey(normalizedTargetId);
+        var operationIds = await _database
+            .SortedSetRangeByRankAsync(indexKey, 0, DeploySucceededTargetCap - 1, Order.Descending)
+            .ConfigureAwait(false);
+
+        foreach (var operationId in operationIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!operationId.HasValue)
+            {
+                continue;
+            }
+
+            var record = await GetAsync(operationId.ToString(), cancellationToken).ConfigureAwait(false);
+            if (record is { Kind: WorkflowOperationKind.Deploy, Status: WorkflowOperationStatus.Succeeded }
+                && string.Equals(record.Deploy?.TargetId, normalizedTargetId, StringComparison.Ordinal))
+            {
+                return record;
+            }
+
+            // The index member expired or the operation is no longer a succeeded deploy for this target
+            // (for example it was subsequently rolled back). Prune it so the newest match stays cheap.
+            await _database.SortedSetRemoveAsync(indexKey, operationId).ConfigureAwait(false);
+        }
+
+        return null;
+    }
+
+    private async Task CollectCandidateAsync(
+        RedisValue operationId,
+        List<WorkflowOperationRecord> records,
+        HashSet<string> seen,
+        List<RedisValue> staleSink,
+        CancellationToken cancellationToken)
+    {
+        if (!operationId.HasValue)
+        {
+            return;
+        }
+
+        var id = operationId.ToString();
+        if (!seen.Add(id))
+        {
+            return;
+        }
+
+        var record = await GetAsync(id, cancellationToken).ConfigureAwait(false);
+        if (record == null)
+        {
+            staleSink.Add(operationId);
+            return;
+        }
+
+        records.Add(record);
+    }
+
     public async Task<bool> TrySetAsync(
         WorkflowOperationRecord operation,
         TimeSpan? ttl = null,
@@ -253,12 +385,36 @@ internal sealed partial class RedisWorkflowOperationStore(
         {
             transaction.SetRemoveAsync(ActiveOperationsKey, operationId);
             transaction.SetRemoveAsync(GetKindActiveKey(operation.Kind), operationId);
+
+            // Terminal-operations index: newest-completed first, scored by completion time and bounded so
+            // the list endpoint can surface terminal results and the sweep never grows without limit.
+            var score = GetIndexScore(operation);
+            transaction.SortedSetAddAsync(TerminalOperationsKey, operationId, score);
+            transaction.SortedSetRemoveRangeByRankAsync(TerminalOperationsKey, 0, -(TerminalIndexCap + 1));
+
+            // Per-target succeeded-deploy index backs the converge API's "revision last landed here"
+            // lookup. Only successful deploys are pinned; rollbacks/failures are pruned lazily on read.
+            if (operation.Kind == WorkflowOperationKind.Deploy
+                && operation.Status == WorkflowOperationStatus.Succeeded
+                && operation.Deploy is { TargetId: { Length: > 0 } targetId })
+            {
+                var targetKey = GetDeploySucceededTargetKey(targetId);
+                transaction.SortedSetAddAsync(targetKey, operationId, score);
+                transaction.SortedSetRemoveRangeByRankAsync(targetKey, 0, -(DeploySucceededTargetCap + 1));
+            }
+
             return;
         }
 
         transaction.SetAddAsync(ActiveOperationsKey, operationId);
         transaction.SetAddAsync(GetKindActiveKey(operation.Kind), operationId);
+
+        // Guard against a rare re-activation from a terminal state leaving a stale terminal-index member.
+        transaction.SortedSetRemoveAsync(TerminalOperationsKey, operationId);
     }
+
+    private static double GetIndexScore(WorkflowOperationRecord operation)
+        => (operation.CompletedAt ?? operation.UpdatedAt).ToUnixTimeMilliseconds();
 
     private static void QueueMetadataPackageIndexUpdate(
         ITransaction transaction,
@@ -335,7 +491,16 @@ internal sealed partial class RedisWorkflowOperationStore(
     private static string GetKindActiveKey(WorkflowOperationKind kind)
         => $"controlplane:workflow:active:{kind.ToString().ToLowerInvariant()}";
 
+    private static string GetDeploySucceededTargetKey(string targetId)
+        => $"controlplane:workflow:deploy-succeeded:{targetId}";
+
     private const string ActiveOperationsKey = "controlplane:workflow:active";
+    private const string TerminalOperationsKey = "controlplane:workflow:terminal";
+    private const int DefaultPageSize = 50;
+    private const int MaxPageSize = 200;
+    private const int MaterializationCap = 1000;
+    private const int TerminalIndexCap = 5000;
+    private const int DeploySucceededTargetCap = 50;
 
     private static partial class Log
     {

--- a/src/Honua.Server/Features/ControlPlane/TransitionObservingWorkflowOperationStore.cs
+++ b/src/Honua.Server/Features/ControlPlane/TransitionObservingWorkflowOperationStore.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Decorates the durable workflow-operation store to raise <see cref="IWorkflowOperationTransitionListener"/>
+/// observers on operator-meaningful transitions (created / submitted / promoted / rolled-back /
+/// manual-intervention). Every persisted transition from both <c>DeployWorkflowService</c> and
+/// <c>DeployWorkflowReconciler</c> funnels through <see cref="IWorkflowOperationStore.SetAsync"/> /
+/// <see cref="IWorkflowOperationStore.TrySetAsync"/> / <see cref="IWorkflowOperationStore.TryCreateAsync"/>,
+/// so decorating those three write points is a single seam that covers them all without scattering
+/// notification calls across the reconciler. Listeners are invoked best-effort AFTER the authoritative
+/// inner write; a throwing listener is isolated and never fails the write or starves siblings. Reads,
+/// leases, and queries pass straight through.
+/// </summary>
+internal sealed partial class TransitionObservingWorkflowOperationStore : IWorkflowOperationStore
+{
+    private readonly IWorkflowOperationStore _inner;
+    private readonly IWorkflowOperationTransitionListener[] _listeners;
+    private readonly ILogger<TransitionObservingWorkflowOperationStore> _logger;
+
+    public TransitionObservingWorkflowOperationStore(
+        IWorkflowOperationStore inner,
+        IEnumerable<IWorkflowOperationTransitionListener> listeners,
+        ILogger<TransitionObservingWorkflowOperationStore> logger)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _listeners = (listeners ?? throw new ArgumentNullException(nameof(listeners))).ToArray();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<bool> TryCreateAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var created = await _inner.TryCreateAsync(operation, ttl, cancellationToken).ConfigureAwait(false);
+        if (created)
+        {
+            await RaiseAsync(operation, WorkflowOperationTransitionKind.Created, cancellationToken).ConfigureAwait(false);
+        }
+
+        return created;
+    }
+
+    public async Task SetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        await _inner.SetAsync(operation, ttl, cancellationToken).ConfigureAwait(false);
+        await RaiseClassifiedAsync(operation, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var updated = await _inner.TrySetAsync(operation, ttl, cancellationToken).ConfigureAwait(false);
+        if (updated)
+        {
+            await RaiseClassifiedAsync(operation, cancellationToken).ConfigureAwait(false);
+        }
+
+        return updated;
+    }
+
+    private Task RaiseClassifiedAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken)
+        => TryClassify(operation.Status, out var kind)
+            ? RaiseAsync(operation, kind, cancellationToken)
+            : Task.CompletedTask;
+
+    /// <summary>
+    /// Maps a persisted status to a transition kind. Intermediate states (planned / awaiting approval /
+    /// reconciling / failed) are intentionally not surfaced: the seam reports operator-meaningful
+    /// lifecycle moments, and mapping only <see cref="WorkflowOperationStatus.Submitted"/> (not the
+    /// repeatedly-written <see cref="WorkflowOperationStatus.Reconciling"/>) keeps in-flight polling from
+    /// emitting duplicate submitted events.
+    /// </summary>
+    private static bool TryClassify(WorkflowOperationStatus status, out WorkflowOperationTransitionKind kind)
+    {
+        switch (status)
+        {
+            case WorkflowOperationStatus.Submitted:
+                kind = WorkflowOperationTransitionKind.Submitted;
+                return true;
+            case WorkflowOperationStatus.Succeeded:
+                kind = WorkflowOperationTransitionKind.Promoted;
+                return true;
+            case WorkflowOperationStatus.RollbackRequested:
+            case WorkflowOperationStatus.RolledBack:
+                kind = WorkflowOperationTransitionKind.RolledBack;
+                return true;
+            case WorkflowOperationStatus.ManualInterventionRequired:
+                kind = WorkflowOperationTransitionKind.ManualInterventionRequired;
+                return true;
+            default:
+                kind = default;
+                return false;
+        }
+    }
+
+    private async Task RaiseAsync(WorkflowOperationRecord operation, WorkflowOperationTransitionKind kind, CancellationToken cancellationToken)
+    {
+        if (_listeners.Length == 0)
+        {
+            return;
+        }
+
+        var transition = new WorkflowOperationTransition
+        {
+            Operation = operation,
+            Kind = kind,
+            OccurredAt = DateTimeOffset.UtcNow
+        };
+
+        foreach (var listener in _listeners)
+        {
+            try
+            {
+                await listener.OnTransitionAsync(transition, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                LogListenerFailed(_logger, operation.OperationId, kind.ToString(), ex);
+            }
+        }
+    }
+
+    // Straight pass-through for the remaining store surface.
+    public Task<WorkflowOperationRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
+        => _inner.GetAsync(operationId, cancellationToken);
+
+    public Task<WorkflowOperationRecord?> GetByMetadataPackageIdAsync(string packageId, CancellationToken cancellationToken = default)
+        => _inner.GetByMetadataPackageIdAsync(packageId, cancellationToken);
+
+    public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
+        => _inner.ListActiveAsync(kind, cancellationToken);
+
+    public Task<WorkflowOperationPage> QueryAsync(WorkflowOperationQuery query, CancellationToken cancellationToken = default)
+        => _inner.QueryAsync(query, cancellationToken);
+
+    public Task<WorkflowOperationRecord?> GetMostRecentSucceededDeployByTargetAsync(string targetId, CancellationToken cancellationToken = default)
+        => _inner.GetMostRecentSucceededDeployByTargetAsync(targetId, cancellationToken);
+
+    public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+        => _inner.TryAcquireLeaseAsync(operationId, ownerId, leaseDuration, cancellationToken);
+
+    public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+        => _inner.RenewLeaseAsync(operationId, ownerId, leaseDuration, cancellationToken);
+
+    public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+        => _inner.ReleaseLeaseAsync(operationId, ownerId, cancellationToken);
+
+    [LoggerMessage(EventId = 9460, Level = LogLevel.Warning, Message = "Workflow transition listener failed for operation {OperationId} ({TransitionKind}).")]
+    private static partial void LogListenerFailed(ILogger logger, string operationId, string transitionKind, Exception exception);
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/LocalOperateEventFeed.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/LocalOperateEventFeed.cs
@@ -60,6 +60,7 @@ internal sealed class LocalOperateEventFeed : IOperateEventFeed
     private readonly IAuditLogReader? _auditReader;
     private readonly IUniversalProgressStore? _progressStore;
     private readonly IExecutionJobStore? _jobStore;
+    private readonly ReleaseTimelineBuffer? _releaseTimeline;
     private readonly ILogger<LocalOperateEventFeed> _logger;
 
     public LocalOperateEventFeed(
@@ -67,13 +68,15 @@ internal sealed class LocalOperateEventFeed : IOperateEventFeed
         IAlertEventQuery? alertQuery = null,
         IAuditLogReader? auditReader = null,
         IUniversalProgressStore? progressStore = null,
-        IExecutionJobStore? jobStore = null)
+        IExecutionJobStore? jobStore = null,
+        ReleaseTimelineBuffer? releaseTimeline = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _alertQuery = alertQuery;
         _auditReader = auditReader;
         _progressStore = progressStore;
         _jobStore = jobStore;
+        _releaseTimeline = releaseTimeline;
     }
 
     public async Task<OperateEventPage> ListAsync(OperateEventFilter filter, CancellationToken cancellationToken = default)
@@ -98,6 +101,10 @@ internal sealed class LocalOperateEventFeed : IOperateEventFeed
 
         var jobTask = Wanted(OperateEventKind.Job) && (_progressStore is not null || _jobStore is not null)
             ? LoadJobsAsync(filter, pageSize, cancellationToken)
+            : Task.FromResult<IReadOnlyList<OperateEvent>>(Array.Empty<OperateEvent>());
+
+        var releaseTask = Wanted(OperateEventKind.Release) && _releaseTimeline is not null && ReleaseSourceCanMatch(filter)
+            ? LoadReleasesAsync(filter, pageSize)
             : Task.FromResult<IReadOnlyList<OperateEvent>>(Array.Empty<OperateEvent>());
 
         try
@@ -134,6 +141,18 @@ internal sealed class LocalOperateEventFeed : IOperateEventFeed
             sourceErrors ??= new();
             sourceErrors[OperateEventKind.Job] = "job source unavailable";
             ObservabilityFeedLog.JobSourceFailed(_logger, ex);
+        }
+
+        try
+        {
+            collected.AddRange(await releaseTask.ConfigureAwait(false));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            partial = true;
+            sourceErrors ??= new();
+            sourceErrors[OperateEventKind.Release] = "release source unavailable";
+            ObservabilityFeedLog.ReleaseSourceFailed(_logger, ex);
         }
 
         collected.RemoveAll(item => !MatchesFilter(filter, item, matchResourceRef: false));
@@ -323,6 +342,28 @@ internal sealed class LocalOperateEventFeed : IOperateEventFeed
         }
 
         return results.GetRange(0, pageSize);
+    }
+
+    private Task<IReadOnlyList<OperateEvent>> LoadReleasesAsync(OperateEventFilter filter, int pageSize)
+    {
+        Debug.Assert(_releaseTimeline is not null);
+
+        var results = new List<OperateEvent>(pageSize);
+        foreach (var value in _releaseTimeline!.Snapshot())
+        {
+            if (!MatchesFilter(filter, value))
+            {
+                continue;
+            }
+
+            results.Add(value);
+            if (results.Count == pageSize)
+            {
+                break;
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<OperateEvent>>(results);
     }
 
     private async Task<IReadOnlyList<OperateEvent>> LoadProgressJobsAsync(
@@ -665,6 +706,13 @@ internal sealed class LocalOperateEventFeed : IOperateEventFeed
            string.IsNullOrWhiteSpace(filter.RequestId) &&
            filter.MinimumSeverity != OperateEventSeverity.Critical;
 
+    private static bool ReleaseSourceCanMatch(OperateEventFilter filter)
+        => string.IsNullOrWhiteSpace(filter.ServiceId) &&
+           filter.LayerId is null &&
+           string.IsNullOrWhiteSpace(filter.TraceId) &&
+           string.IsNullOrWhiteSpace(filter.RequestId) &&
+           string.IsNullOrWhiteSpace(filter.ChangeSetId);
+
     private static bool ProgressJobSourceCanMatch(OperateEventFilter filter)
         => string.IsNullOrWhiteSpace(filter.ServiceId) &&
            filter.LayerId is null &&
@@ -883,6 +931,9 @@ internal static partial class ObservabilityFeedLog
 
     [LoggerMessage(EventId = 7403, Level = LogLevel.Warning, Message = "Operate event feed failed to load job/operation events.")]
     public static partial void JobSourceFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 7405, Level = LogLevel.Warning, Message = "Operate event feed failed to load release/deploy events.")]
+    public static partial void ReleaseSourceFailed(ILogger logger, Exception exception);
 
     [LoggerMessage(EventId = 7404, Level = LogLevel.Debug, Message = "Operate event feed could not fetch progress for operation {OperationId}.")]
     public static partial void ProgressFetchFailed(ILogger logger, string operationId, Exception exception);

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineBuffer.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineBuffer.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Bounded, in-memory ring buffer of recent <see cref="OperateEventKind.Release"/> events produced by
+/// deploy workflow transitions. It is the <see cref="LocalOperateEventFeed"/> source for release events,
+/// mirroring the in-process <c>RecentErrorBuffer</c> that backs the same Operate timeline for logs.
+/// </summary>
+/// <remarks>
+/// This buffer is per-instance and non-durable by design: the durable source of truth for deploy
+/// operations is the Redis workflow store (queryable via the deploy-operations list API), and cross-replica
+/// realtime fan-out is the realtime hub's concern (#2554). The timeline surfaces the most recent release
+/// activity observed by this instance so the Operate cockpit's <c>ReleaseId</c> filter returns data.
+/// </remarks>
+internal sealed class ReleaseTimelineBuffer
+{
+    internal const int DefaultCapacity = 500;
+
+    private readonly object _gate = new();
+    private readonly Queue<OperateEvent> _events;
+    private readonly int _capacity;
+
+    public ReleaseTimelineBuffer()
+        : this(DefaultCapacity)
+    {
+    }
+
+    public ReleaseTimelineBuffer(int capacity)
+    {
+        _capacity = capacity < 1 ? DefaultCapacity : capacity;
+        _events = new Queue<OperateEvent>(_capacity);
+    }
+
+    /// <summary>
+    /// Appends a release event, evicting the oldest entry when the buffer is full.
+    /// </summary>
+    public void Append(OperateEvent value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        lock (_gate)
+        {
+            if (_events.Count >= _capacity)
+            {
+                _events.Dequeue();
+            }
+
+            _events.Enqueue(value);
+        }
+    }
+
+    /// <summary>
+    /// Returns a newest-first snapshot of the buffered release events.
+    /// </summary>
+    public IReadOnlyList<OperateEvent> Snapshot()
+    {
+        lock (_gate)
+        {
+            if (_events.Count == 0)
+            {
+                return Array.Empty<OperateEvent>();
+            }
+
+            var snapshot = _events.ToArray();
+            Array.Reverse(snapshot);
+            return snapshot;
+        }
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineTransitionListener.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineTransitionListener.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// The in-repo consumer of the workflow-transition seam: maps each observed deploy/release transition to
+/// an <see cref="OperateEventKind.Release"/> event and appends it to the <see cref="ReleaseTimelineBuffer"/>
+/// so it appears on the unified Operate timeline (#2562). The realtime hub (#2554) attaches to the SAME
+/// seam as a second, independent listener.
+/// </summary>
+internal sealed class ReleaseTimelineTransitionListener : IWorkflowOperationTransitionListener
+{
+    private readonly ReleaseTimelineBuffer _buffer;
+
+    public ReleaseTimelineTransitionListener(ReleaseTimelineBuffer buffer)
+    {
+        _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+    }
+
+    public Task OnTransitionAsync(WorkflowOperationTransition transition, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+
+        _buffer.Append(MapEvent(transition));
+        return Task.CompletedTask;
+    }
+
+    private static OperateEvent MapEvent(WorkflowOperationTransition transition)
+    {
+        var operation = transition.Operation;
+        var occurredTicks = transition.OccurredAt.UtcTicks.ToString(CultureInfo.InvariantCulture);
+
+        return new OperateEvent
+        {
+            EventId = $"release:{operation.OperationId}:{transition.Kind}:{occurredTicks}",
+            Kind = OperateEventKind.Release,
+            Severity = MapSeverity(transition.Kind),
+            OccurredAt = transition.OccurredAt,
+            Title = BuildTitle(transition),
+            Summary = operation.CurrentPhase,
+            Actor = operation.Audit.RequestedBy,
+            CorrelationId = transition.CorrelationId,
+            OperationId = transition.OperationId,
+            ReleaseId = transition.ReleaseId,
+            ResourceRef = "release/" + operation.OperationId
+        };
+    }
+
+    private static string BuildTitle(WorkflowOperationTransition transition)
+    {
+        var subject = transition.TargetId
+            ?? transition.Operation.MetadataRelease?.PackageId
+            ?? transition.OperationId;
+        var action = transition.Kind switch
+        {
+            WorkflowOperationTransitionKind.Created => "Deploy operation created",
+            WorkflowOperationTransitionKind.Submitted => "Deploy submitted",
+            WorkflowOperationTransitionKind.Promoted => "Deploy promoted",
+            WorkflowOperationTransitionKind.RolledBack => "Deploy rolled back",
+            WorkflowOperationTransitionKind.ManualInterventionRequired => "Deploy needs manual intervention",
+            _ => "Deploy transition"
+        };
+
+        return $"{action}: {subject}";
+    }
+
+    private static OperateEventSeverity MapSeverity(WorkflowOperationTransitionKind kind) => kind switch
+    {
+        WorkflowOperationTransitionKind.Created => OperateEventSeverity.Info,
+        WorkflowOperationTransitionKind.Submitted => OperateEventSeverity.Info,
+        WorkflowOperationTransitionKind.Promoted => OperateEventSeverity.Notice,
+        WorkflowOperationTransitionKind.RolledBack => OperateEventSeverity.Warning,
+        WorkflowOperationTransitionKind.ManualInterventionRequired => OperateEventSeverity.Error,
+        _ => OperateEventSeverity.Info
+    };
+}

--- a/src/Honua.Server/Startup/ControlPlaneReconcileRegistration.cs
+++ b/src/Honua.Server/Startup/ControlPlaneReconcileRegistration.cs
@@ -35,13 +35,26 @@ internal static class ControlPlaneReconcileRegistration
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        // Decorate the workflow-operation store so deploy terminal transitions raise ops
-        // notifications through the shared alert outbox. SetAsync is the single choke point
-        // for every persisted transition (service + reconciler), so this one seam covers
-        // them all; the decorator no-ops when ops notifications are disabled (the default).
+        // Decorate the workflow-operation store so every persisted deploy transition fans out through a
+        // single seam. TryCreate/Set/TrySet are the choke point for every persisted transition (service +
+        // reconciler), so decorating them once covers them all without scattering notification calls
+        // across the reconciler. Two decorators compose over the durable Redis store:
+        //   * TransitionObservingWorkflowOperationStore raises IWorkflowOperationTransitionListener
+        //     observers (created / submitted / promoted / rolled-back / manual-intervention). This ticket
+        //     registers the operate-timeline release producer; the realtime hub (#2554) attaches to the
+        //     same seam as a second listener.
+        //   * NotifyingWorkflowOperationStore raises ops-alert notifications on terminal transitions (it
+        //     no-ops when ops notifications are disabled, the default).
         services.AddSingleton<RedisWorkflowOperationStore>();
+        services.AddSingleton<Honua.Infrastructure.Monitoring.ReleaseTimelineBuffer>();
+        services.AddSingleton<IWorkflowOperationTransitionListener>(sp =>
+            new Honua.Infrastructure.Monitoring.ReleaseTimelineTransitionListener(
+                sp.GetRequiredService<Honua.Infrastructure.Monitoring.ReleaseTimelineBuffer>()));
         services.AddSingleton<IWorkflowOperationStore>(sp => new Honua.Alerts.Ops.NotifyingWorkflowOperationStore(
-            sp.GetRequiredService<RedisWorkflowOperationStore>(),
+            new Honua.ControlPlane.TransitionObservingWorkflowOperationStore(
+                sp.GetRequiredService<RedisWorkflowOperationStore>(),
+                sp.GetServices<IWorkflowOperationTransitionListener>(),
+                sp.GetRequiredService<ILogger<Honua.ControlPlane.TransitionObservingWorkflowOperationStore>>()),
             sp.GetRequiredService<IServiceScopeFactory>(),
             sp.GetRequiredService<IOptions<Honua.Core.Features.Alerts.Domain.AlertOptions>>(),
             sp.GetRequiredService<ILogger<Honua.Alerts.Ops.NotifyingWorkflowOperationStore>>()));

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/DeployControlEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/DeployControlEndpointsTests.cs
@@ -278,6 +278,69 @@ public sealed class DeployControlEndpointsTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/deploy/operations")]
+    public async Task ListDeployOperations_PagesAndFiltersNewestFirst()
+    {
+        // Three deploy operations created oldest-first; the newest must sort to the front.
+        for (var i = 0; i < 3; i++)
+        {
+            var createResponse = await _client.PostAsJsonAsync("/api/v1/admin/deploy/operations", new
+            {
+                targetId = "prod-api",
+                desiredRevision = $"sha256:list{i}",
+                submitImmediately = false
+            });
+            createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        }
+
+        // Page 1 with pageSize 2: newest-first, has-more true, two items.
+        var firstPage = await _client.GetAsync("/api/v1/admin/deploy/operations?kind=Deploy&status=Planned&page=1&pageSize=2");
+        firstPage.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var firstDocument = JsonDocument.Parse(await firstPage.Content.ReadAsStringAsync());
+        var firstRoot = firstDocument.RootElement;
+        firstRoot.GetProperty("page").GetInt32().Should().Be(1);
+        firstRoot.GetProperty("pageSize").GetInt32().Should().Be(2);
+        firstRoot.GetProperty("totalCount").GetInt32().Should().Be(3);
+        firstRoot.GetProperty("hasMore").GetBoolean().Should().BeTrue();
+        var firstItems = firstRoot.GetProperty("items");
+        firstItems.GetArrayLength().Should().Be(2);
+        firstItems[0].GetProperty("kind").GetString().Should().Be("Deploy");
+        firstItems[0].GetProperty("status").GetString().Should().Be("Planned");
+
+        // Page 2 completes the set with the final item and no further pages.
+        var secondPage = await _client.GetAsync("/api/v1/admin/deploy/operations?page=2&pageSize=2");
+        secondPage.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var secondDocument = JsonDocument.Parse(await secondPage.Content.ReadAsStringAsync());
+        var secondRoot = secondDocument.RootElement;
+        secondRoot.GetProperty("items").GetArrayLength().Should().Be(1);
+        secondRoot.GetProperty("hasMore").GetBoolean().Should().BeFalse();
+
+        // The two pages together cover exactly the three created revisions, newest-first by creation time.
+        var pagedItems = firstItems.EnumerateArray().Concat(secondRoot.GetProperty("items").EnumerateArray()).ToArray();
+        pagedItems.Select(item => item.GetProperty("target").GetProperty("desiredRevision").GetString())
+            .Should().BeEquivalentTo(new[] { "sha256:list0", "sha256:list1", "sha256:list2" });
+        var createdAt = pagedItems.Select(item => item.GetProperty("createdAt").GetDateTimeOffset()).ToArray();
+        createdAt.Should().BeInDescendingOrder();
+
+        // Status filter that matches nothing returns an empty page.
+        var emptyPage = await _client.GetAsync("/api/v1/admin/deploy/operations?status=RolledBack");
+        emptyPage.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var emptyDocument = JsonDocument.Parse(await emptyPage.Content.ReadAsStringAsync());
+        emptyDocument.RootElement.GetProperty("items").GetArrayLength().Should().Be(0);
+        emptyDocument.RootElement.GetProperty("totalCount").GetInt32().Should().Be(0);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/deploy/operations")]
+    public async Task ListDeployOperations_WithUnsupportedFilterValue_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/deploy/operations?status=NotARealStatus");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
     [Endpoint("POST /api/v1/admin/deploy/plan")]
     public async Task PlanDeployOperation_WhenTargetDoesNotExist_ReturnsErrorStatus()
     {
@@ -786,6 +849,42 @@ public sealed class DeployControlEndpointsTests : IAsyncLifetime
                 .ToArray();
 
             return Task.FromResult<IReadOnlyList<WorkflowOperationRecord>>(operations);
+        }
+
+        public Task<WorkflowOperationPage> QueryAsync(WorkflowOperationQuery query, CancellationToken cancellationToken = default)
+        {
+            var filtered = _operations.Values
+                .Where(operation => (!query.Kind.HasValue || operation.Kind == query.Kind.Value)
+                    && (!query.Status.HasValue || operation.Status == query.Status.Value))
+                .OrderByDescending(operation => operation.CreatedAt)
+                .ThenByDescending(operation => operation.OperationId, StringComparer.Ordinal)
+                .ToArray();
+
+            var page = Math.Max(1, query.Page);
+            var pageSize = query.PageSize <= 0 ? 50 : query.PageSize;
+            var skip = (page - 1) * pageSize;
+            var items = filtered.Skip(skip).Take(pageSize).ToArray();
+
+            return Task.FromResult(new WorkflowOperationPage
+            {
+                Items = items,
+                Page = page,
+                PageSize = pageSize,
+                TotalCount = filtered.Length,
+                HasMore = skip + items.Length < filtered.Length
+            });
+        }
+
+        public Task<WorkflowOperationRecord?> GetMostRecentSucceededDeployByTargetAsync(string targetId, CancellationToken cancellationToken = default)
+        {
+            var match = _operations.Values
+                .Where(operation => operation.Kind == WorkflowOperationKind.Deploy
+                    && operation.Status == WorkflowOperationStatus.Succeeded
+                    && string.Equals(operation.Deploy?.TargetId, targetId, StringComparison.Ordinal))
+                .OrderByDescending(operation => operation.CompletedAt ?? operation.UpdatedAt)
+                .FirstOrDefault();
+
+            return Task.FromResult<WorkflowOperationRecord?>(match);
         }
 
         private void IndexMetadataReleaseOperation(WorkflowOperationRecord operation)

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/DeployReleaseTimelineTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/DeployReleaseTimelineTests.cs
@@ -1,0 +1,275 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Honua.ControlPlane;
+using Honua.Infrastructure.Monitoring;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// End-to-end coverage for the workflow-transition seam (#2562): deploy lifecycle transitions raised
+/// through <see cref="IWorkflowOperationTransitionListener"/> surface as <c>Release</c> events on the
+/// Operate timeline and are filterable via the existing observability events endpoint.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Configuration)]
+public sealed class DeployReleaseTimelineTests : IAsyncLifetime
+{
+    private readonly ReleaseTimelineBuffer _buffer = new();
+    private readonly InMemoryWorkflowOperationStore _inner = new();
+    private readonly TimelineDeployBackend _backend = new();
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public DeployReleaseTimelineTests()
+    {
+        var store = new TransitionObservingWorkflowOperationStore(
+            _inner,
+            new IWorkflowOperationTransitionListener[] { new ReleaseTimelineTransitionListener(_buffer) },
+            NullLogger<TransitionObservingWorkflowOperationStore>.Instance);
+
+        _fixture = new WebAppFixture()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IDatabaseMigrationRunner>();
+                services.AddSingleton<IDatabaseMigrationRunner>(new StubDatabaseMigrationRunner());
+                services.RemoveAll<IDeployTargetRegistry>();
+                services.AddSingleton<IDeployTargetRegistry>(new TimelineTargetRegistry());
+                services.RemoveAll<IWorkflowOperationStore>();
+                services.AddSingleton<IWorkflowOperationStore>(store);
+                services.RemoveAll<IWorkflowOperationReconciler>();
+                services.AddSingleton<IWorkflowOperationReconciler>(new StubReconciler());
+                services.AddSingleton<IDeployBackend>(_backend);
+                // Ensure the operate feed reads the same buffer the transition listener writes to.
+                services.RemoveAll<ReleaseTimelineBuffer>();
+                services.AddSingleton(_buffer);
+            });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.CreateAdminClient();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/observability/events")]
+    public async Task DeployLifecycle_RaisesReleaseTimelineEvents_FilterableByReleaseId()
+    {
+        // Operation 1: created -> submitted -> promoted -> rolled back.
+        var releaseOne = $"sha256:timeline-{Guid.NewGuid():N}";
+        var operationOne = await CreateAndDriveAsync(releaseOne, rollbackToManualIntervention: false);
+
+        // Operation 2: created -> submitted -> manual intervention (rollback with no backend recovery).
+        var releaseTwo = $"sha256:manual-{Guid.NewGuid():N}";
+        var operationTwo = await CreateAndDriveAsync(releaseTwo, rollbackToManualIntervention: true);
+
+        // All release events are visible on the timeline when filtering by kind.
+        var allReleaseEvents = await GetReleaseEventsAsync("kind=Release&pageSize=200");
+        var titlesForOne = allReleaseEvents
+            .Where(e => e.GetProperty("operationId").GetString() == operationOne)
+            .Select(e => e.GetProperty("title").GetString())
+            .ToList();
+        titlesForOne.Should().Contain(t => t!.StartsWith("Deploy operation created"));
+        titlesForOne.Should().Contain(t => t!.StartsWith("Deploy submitted"));
+        titlesForOne.Should().Contain(t => t!.StartsWith("Deploy promoted"));
+        titlesForOne.Should().Contain(t => t!.StartsWith("Deploy rolled back"));
+
+        var titlesForTwo = allReleaseEvents
+            .Where(e => e.GetProperty("operationId").GetString() == operationTwo)
+            .Select(e => e.GetProperty("title").GetString())
+            .ToList();
+        titlesForTwo.Should().Contain(t => t!.StartsWith("Deploy needs manual intervention"));
+
+        // The ReleaseId filter now returns data and scopes to a single release.
+        var scoped = await GetReleaseEventsAsync($"releaseId={Uri.EscapeDataString(releaseOne)}&pageSize=200");
+        scoped.Should().NotBeEmpty();
+        scoped.Should().OnlyContain(e => e.GetProperty("releaseId").GetString() == releaseOne);
+        scoped.Should().OnlyContain(e => e.GetProperty("operationId").GetString() == operationOne);
+    }
+
+    private async Task<string> CreateAndDriveAsync(string desiredRevision, bool rollbackToManualIntervention)
+    {
+        var createResponse = await _client.PostAsJsonAsync("/api/v1/admin/deploy/operations", new
+        {
+            targetId = "timeline-target",
+            desiredRevision,
+            submitImmediately = false
+        });
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        using var createDocument = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
+        var operationId = createDocument.RootElement.GetProperty("operationId").GetString()!;
+
+        var submitResponse = await _client.PostAsJsonAsync(
+            $"/api/v1/admin/deploy/operations/{operationId}/submit", new { reason = "Approved" });
+        submitResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        if (rollbackToManualIntervention)
+        {
+            _backend.NextRollbackStatus = WorkflowOperationStatus.ManualInterventionRequired;
+        }
+        else
+        {
+            var promoteResponse = await _client.PostAsJsonAsync(
+                $"/api/v1/admin/deploy/operations/{operationId}/promote", new { reason = "Cutover" });
+            promoteResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            _backend.NextRollbackStatus = WorkflowOperationStatus.RolledBack;
+        }
+
+        var rollbackResponse = await _client.PostAsJsonAsync(
+            $"/api/v1/admin/deploy/operations/{operationId}/rollback", new { reason = "Verification failed" });
+        rollbackResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        return operationId;
+    }
+
+    private async Task<List<JsonElement>> GetReleaseEventsAsync(string queryString)
+    {
+        var response = await _client.GetAsync($"/api/v1/admin/observability/events?{queryString}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return document.RootElement.GetProperty("items")
+            .EnumerateArray()
+            .Where(item => item.GetProperty("kind").GetString() == "release")
+            .Select(item => item.Clone())
+            .ToList();
+    }
+
+    private sealed class TimelineDeployBackend : IDeployBackend
+    {
+        public WorkflowOperationStatus NextRollbackStatus { get; set; } = WorkflowOperationStatus.RolledBack;
+
+        public string BackendName => "timeline-backend";
+
+        public DeployTargetKind TargetKind => DeployTargetKind.Kubernetes;
+
+        public Task<DeployBackendCapabilities> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployBackendCapabilities { SupportsRollback = true, SupportsProgressPolling = true });
+
+        public Task<DeployPlan> PlanAsync(DeployOperationSpec spec, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployPlan { IsReadyToSubmit = true });
+
+        public Task<DeploySubmissionResult> StartAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeploySubmissionResult { Status = WorkflowOperationStatus.Submitted, Message = "Submitted" });
+
+        public Task<DeployObservation> ObserveAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployObservation { Status = WorkflowOperationStatus.Reconciling });
+
+        public Task<DeployObservation> PromoteAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployObservation
+            {
+                Status = WorkflowOperationStatus.Succeeded,
+                ObservedRevision = operation.Deploy?.DesiredRevision,
+                Message = "Promoted"
+            });
+
+        public Task<DeployObservation> RollbackAsync(WorkflowOperationRecord operation, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DeployObservation
+            {
+                Status = NextRollbackStatus,
+                Message = NextRollbackStatus == WorkflowOperationStatus.ManualInterventionRequired
+                    ? "Rollback requires manual intervention"
+                    : "Rolled back"
+            });
+    }
+
+    private sealed class TimelineTargetRegistry : IDeployTargetRegistry
+    {
+        private static readonly DeployTargetDefinition Target = new()
+        {
+            TargetId = "timeline-target",
+            TargetKind = DeployTargetKind.Kubernetes,
+            Backend = "timeline-backend",
+            Environment = "production",
+            TargetName = "honua-server",
+            Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        };
+
+        public Task<IReadOnlyList<DeployTargetDefinition>> ListAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<DeployTargetDefinition>>([Target]);
+
+        public Task<DeployTargetDefinition?> GetAsync(string targetId, CancellationToken cancellationToken = default)
+            => Task.FromResult(targetId == Target.TargetId ? Target : null);
+    }
+
+    private sealed class StubReconciler : IWorkflowOperationReconciler
+    {
+        public Task ReconcileWorkflowOperationAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class StubDatabaseMigrationRunner : IDatabaseMigrationRunner
+    {
+        public Task<DatabaseMigrationPlan> PlanMigrationsAsync(string connectionString, Assembly migrationsAssembly, CancellationToken cancellationToken = default)
+            => Task.FromResult(DatabaseMigrationPlan.Succeeded());
+
+        public Task<DatabaseMigrationResult> RunMigrationsAsync(string connectionString, Assembly migrationsAssembly, CancellationToken cancellationToken = default)
+            => Task.FromResult(DatabaseMigrationResult.Succeeded());
+    }
+
+    private sealed class InMemoryWorkflowOperationStore : IWorkflowOperationStore
+    {
+        private readonly Dictionary<string, WorkflowOperationRecord> _operations = new(StringComparer.Ordinal);
+
+        public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> TryCreateAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            if (_operations.ContainsKey(operation.OperationId))
+            {
+                return Task.FromResult(false);
+            }
+
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
+        public Task<WorkflowOperationRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_operations.TryGetValue(operationId, out var operation) ? operation : null);
+
+        public Task<WorkflowOperationRecord?> GetByMetadataPackageIdAsync(string packageId, CancellationToken cancellationToken = default)
+            => Task.FromResult<WorkflowOperationRecord?>(null);
+
+        public Task SetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<WorkflowOperationRecord>>(
+                _operations.Values.Where(op => !kind.HasValue || op.Kind == kind.Value).ToArray());
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisWorkflowOperationStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/RedisWorkflowOperationStoreIntegrationTests.cs
@@ -168,6 +168,129 @@ public sealed class RedisWorkflowOperationStoreIntegrationTests(RedisFixture red
         result.Should().BeNull();
     }
 
+    [Fact]
+    public async Task WorkflowStore_QueryAsync_IncludesActiveAndTerminalOperationsNewestFirst()
+    {
+        await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(redis.ConnectionString);
+        var store = new RedisWorkflowOperationStore(multiplexer, NullLogger<RedisWorkflowOperationStore>.Instance);
+        var targetId = $"query-target-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+
+        var activeOperation = CreateDeployOperationRecord(
+            $"deploy-active-{Guid.NewGuid():N}", targetId, now, WorkflowOperationStatus.Submitted);
+        var terminalOperation = CreateDeployOperationRecord(
+            $"deploy-terminal-{Guid.NewGuid():N}", targetId, now.AddMinutes(-2), WorkflowOperationStatus.Submitted);
+
+        (await store.TryCreateAsync(activeOperation)).Should().BeTrue();
+        (await store.TryCreateAsync(terminalOperation)).Should().BeTrue();
+        await store.SetAsync(terminalOperation with
+        {
+            Status = WorkflowOperationStatus.Succeeded,
+            UpdatedAt = now,
+            CompletedAt = now
+        });
+
+        var page = await store.QueryAsync(new WorkflowOperationQuery
+        {
+            Kind = WorkflowOperationKind.Deploy,
+            Page = 1,
+            PageSize = 200
+        });
+
+        var ids = page.Items.Select(item => item.OperationId).ToList();
+        ids.Should().Contain(activeOperation.OperationId);
+        ids.Should().Contain(terminalOperation.OperationId);
+
+        // Newest-created (active) must sort ahead of the older terminal operation.
+        ids.IndexOf(activeOperation.OperationId).Should().BeLessThan(ids.IndexOf(terminalOperation.OperationId));
+
+        // Status filter narrows to the terminal operation and excludes the still-active one.
+        var succeededPage = await store.QueryAsync(new WorkflowOperationQuery
+        {
+            Kind = WorkflowOperationKind.Deploy,
+            Status = WorkflowOperationStatus.Succeeded,
+            Page = 1,
+            PageSize = 200
+        });
+        var succeededIds = succeededPage.Items.Select(item => item.OperationId).ToList();
+        succeededIds.Should().Contain(terminalOperation.OperationId);
+        succeededIds.Should().NotContain(activeOperation.OperationId);
+    }
+
+    [Fact]
+    public async Task WorkflowStore_GetMostRecentSucceededDeployByTarget_ReturnsLatestAndPrunesRolledBack()
+    {
+        await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(redis.ConnectionString);
+        var store = new RedisWorkflowOperationStore(multiplexer, NullLogger<RedisWorkflowOperationStore>.Instance);
+        var targetId = $"succeeded-target-{Guid.NewGuid():N}";
+        var now = DateTimeOffset.UtcNow;
+
+        (await store.GetMostRecentSucceededDeployByTargetAsync(targetId)).Should().BeNull();
+
+        var older = CreateDeployOperationRecord(
+            $"deploy-old-{Guid.NewGuid():N}", targetId, now.AddMinutes(-30), WorkflowOperationStatus.Submitted);
+        var newer = CreateDeployOperationRecord(
+            $"deploy-new-{Guid.NewGuid():N}", targetId, now.AddMinutes(-10), WorkflowOperationStatus.Submitted);
+
+        (await store.TryCreateAsync(older)).Should().BeTrue();
+        (await store.TryCreateAsync(newer)).Should().BeTrue();
+
+        await store.SetAsync(older with
+        {
+            Status = WorkflowOperationStatus.Succeeded,
+            UpdatedAt = now.AddMinutes(-25),
+            CompletedAt = now.AddMinutes(-25),
+            Deploy = older.Deploy! with { CurrentRevision = older.Deploy!.DesiredRevision }
+        });
+        await store.SetAsync(newer with
+        {
+            Status = WorkflowOperationStatus.Succeeded,
+            UpdatedAt = now.AddMinutes(-5),
+            CompletedAt = now.AddMinutes(-5)
+        });
+
+        var latest = await store.GetMostRecentSucceededDeployByTargetAsync(targetId);
+        latest.Should().NotBeNull();
+        latest!.OperationId.Should().Be(newer.OperationId);
+
+        // Rolling the latest back demotes it; the prior succeeded deploy becomes the landed revision.
+        await store.SetAsync(newer with
+        {
+            Status = WorkflowOperationStatus.RolledBack,
+            UpdatedAt = now,
+            CompletedAt = now
+        });
+
+        var afterRollback = await store.GetMostRecentSucceededDeployByTargetAsync(targetId);
+        afterRollback.Should().NotBeNull();
+        afterRollback!.OperationId.Should().Be(older.OperationId);
+    }
+
+    private static WorkflowOperationRecord CreateDeployOperationRecord(
+        string operationId,
+        string targetId,
+        DateTimeOffset createdAt,
+        WorkflowOperationStatus status)
+        => new()
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.Deploy,
+            Status = status,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+            CurrentPhase = "Test operation.",
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = targetId,
+                TargetKind = DeployTargetKind.Kubernetes,
+                Backend = "honua-gitops-kubernetes",
+                Environment = "production",
+                TargetName = "honua-server",
+                DesiredRevision = "sha256:" + operationId,
+                Parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+            }
+        };
+
     private static WorkflowOperationRecord CreateOperationRecord()
     {
         var now = DateTimeOffset.UtcNow;


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2562

## Summary
Closes the three coupled deploy-observability gaps in #2562: (1) adds a paged, newest-first deploy-operations list API; (2) adds a terminal-operations index (plus a most-recent-terminal-Succeeded-Deploy-per-TargetId lookup) to `RedisWorkflowOperationStore`; and (3) introduces a single workflow-transition observation seam (`IWorkflowOperationTransitionListener`) whose one in-repo consumer produces `OperateEventKind.Release` events onto the Operate timeline — so the existing `GET /api/v1/admin/observability/events` `ReleaseId` filter now returns data. The seam is designed so #2554's realtime hub attaches as a second consumer with no producer changes. No SQL migration (Redis index only).

## Changes Made
- Added `GET /api/v1/admin/deploy/operations?status=&kind=&page=&pageSize=` — admin-authed, versioned, newest-first `DeployOperationResponse[]` (reuses the existing DTO) in a paged envelope; EndpointRegistry entry, `.Produces<DeployOperationListResponse>()` OpenAPI metadata, and `[Endpoint]`-attributed integration tests (ADR-0011).
- Added a terminal-operations index (bounded sorted set scored by completion time) and a per-target succeeded-deploy index to `RedisWorkflowOperationStore`, maintained atomically in the same transaction as the existing active-set index; stale members are pruned lazily on read. `DesiredRevision` is retained on terminal records (unchanged).
- Added `IWorkflowOperationStore.QueryAsync` (paged, merges active + terminal candidates) and `GetMostRecentSucceededDeployByTargetAsync` (backs the #2564 converge lookup; a rolled-back latest deploy is demoted and the prior succeeded deploy is returned). Both ship as default-interface methods so existing store implementations and test doubles compile unchanged.
- Added the workflow-transition seam: `IWorkflowOperationTransitionListener` + `WorkflowOperationTransition` (Core) raised by a new `TransitionObservingWorkflowOperationStore` decorator on created / submitted / promoted / rolled-back / manual-intervention transitions — a single choke point covering both `DeployWorkflowService` and `DeployWorkflowReconciler` writes; listeners are best-effort and exception-isolated after the authoritative write.
- Wired ONE in-repo consumer: `ReleaseTimelineTransitionListener` maps transitions to `OperateEventKind.Release` events carrying `operationId`, `targetId`, `releaseId`, `correlationId` into a bounded `ReleaseTimelineBuffer`, which `LocalOperateEventFeed` reads as a new Release source (with per-source failure isolation like the existing sources). No hub/SignalR code in this PR.
- Composed the decorator chain in DI: `NotifyingWorkflowOperationStore(TransitionObservingWorkflowOperationStore(RedisWorkflowOperationStore))`.
- Regenerated `docs/gis/data/feature-catalog.json` for the new route (`scripts/generate-feature-catalog.sh`).
- Tests: list paging/filtering + invalid-filter 400 (`DeployControlEndpointsTests`); Redis terminal-index query ordering/status filtering and per-target succeeded lookup incl. rollback demotion (`RedisWorkflowOperationStoreIntegrationTests`, Testcontainers); full deploy lifecycle — created → submitted → promoted → rolled-back plus a manual-intervention path — asserting Release events on the observability events endpoint and `ReleaseId` scoping (`DeployReleaseTimelineTests`).

## Pinned wire contract (copied verbatim into the geospatial-mcp spec ticket)

**Request:** `GET /api/v1/admin/deploy/operations` (admin auth required; API version 1.0)

Query parameters (all optional):
- `status` — `WorkflowOperationStatus` name (case-insensitive): `Planned | AwaitingApproval | Submitted | Reconciling | Succeeded | Failed | RollbackRequested | RolledBack | ManualInterventionRequired`
- `kind` — `WorkflowOperationKind` name (case-insensitive): `Deploy | Rollback | Migration | MetadataRelease | CoordinatedRelease`
- `page` — 1-based integer, default `1`, must be >= 1
- `pageSize` — integer, default `50`, clamped server-side to `1..200`

Invalid enum value or non-integer / out-of-range `page`/`pageSize` returns `400` Problem+JSON; durable store unavailable returns `503` Problem+JSON.

**Response `200` (`application/json`), camelCase; `null`-valued properties are OMITTED from the payload (`DefaultIgnoreCondition = WhenWritingNull`):**

```jsonc
{
  "items": [                       // DeployOperationResponse[], newest-first by createdAt
    {
      "operationId": "string",     // non-null
      "kind": "string",            // enum name, e.g. "Deploy"
      "status": "string",          // enum name, e.g. "Submitted"
      "priority": "string",        // enum name, e.g. "Normal"
      "target": {                  // nullable object (omitted when null)
        "targetId": "string",            // non-null
        "targetKind": "string",          // enum name, non-null
        "backend": "string",             // non-null
        "environment": "string",         // non-null
        "targetName": "string",          // non-null
        "artifactReference": "string",   // nullable (omitted when null)
        "runtimeProfile": "string",      // nullable (omitted when null)
        "currentRevision": "string",     // nullable (omitted when null)
        "desiredRevision": "string",     // non-null
        "parameters": { "key": "value" } // non-null object (may be empty)
      },
      "metadataRelease": {         // nullable object (omitted when null)
        "packageId": "string",             // non-null
        "gitOperationId": "string",        // nullable (omitted)
        "prUrl": "string",                 // nullable (omitted)
        "commitSha": "string",             // nullable (omitted)
        "desiredRevision": "string",       // non-null
        "targetEnvironment": "string",     // non-null
        "deployOperationId": "string",     // nullable (omitted)
        "jobIds": ["string"],              // non-null array (may be empty)
        "evidenceRefs": [                  // non-null array (may be empty)
          { "kind": "string", "refId": "string", "uri": "string" /* nullable, omitted */, "at": "date-time" }
        ],
        "currentStage": "string",          // enum name, non-null
        "rollbackPlan": {                  // nullable object (omitted when null)
          "class": "string",                     // enum name, non-null
          "isDataAffecting": false,              // bool
          "requiresExplicitApproval": false,     // bool
          "steps": ["string"],                   // non-null array
          "evidenceRequired": ["string"],        // non-null array
          "approvalPolicyRef": "string"          // nullable (omitted)
        },
        "blockers": ["string"],            // non-null array (may be empty)
        "warnings": ["string"]             // non-null array (may be empty)
      },
      "providerOperationId": "string",   // nullable (omitted when null)
      "currentPhase": "string",          // nullable (omitted when null)
      "observedState": "string",         // nullable (omitted when null)
      "errorMessage": "string",          // nullable (omitted when null)
      "warnings": ["string"],            // non-null array (may be empty)
      "blockingReasons": ["string"],     // non-null array (may be empty)
      "requestedBy": "string",           // nullable (omitted when null)
      "reason": "string",                // nullable (omitted when null)
      "correlationId": "string",         // nullable (omitted when null)
      "createdAt": "2026-07-07T09:00:00+00:00",  // date-time, non-null
      "updatedAt": "2026-07-07T09:05:00+00:00",  // date-time, non-null
      "completedAt": "2026-07-07T09:10:00+00:00" // date-time, nullable (omitted when null)
    }
  ],
  "page": 1,          // int, effective 1-based page
  "pageSize": 50,     // int, effective (clamped) page size
  "totalCount": 3,    // int, matches within the materialized window
  "hasMore": false    // bool, at least one more page exists
}
```

Consumer notes: because nulls are omitted, treat "key missing" as "null". `warnings` / `blockingReasons` / `target.parameters` / `metadataRelease.jobIds|evidenceRefs|blockers|warnings` are always present (possibly empty). Timestamps are ISO-8601 `DateTimeOffset` values. `totalCount` / `hasMore` are computed over a bounded materialization window (all active operations + the most recent terminal operations), so unbounded historical paging past the window is not guaranteed.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow (Redis index only; no SQL migration)

## Breaking Changes
None. The two new `IWorkflowOperationStore` methods are default-interface methods (empty page / null), so existing implementations and test doubles compile unchanged.

## Design notes
- The seam is raised by a store decorator rather than by scattering calls through the reconciler: every persisted transition from both `DeployWorkflowService` and `DeployWorkflowReconciler` funnels through `TryCreateAsync`/`SetAsync`/`TrySetAsync`, so one decorator is the single seam. Intermediate writes (`Planned`, `AwaitingApproval`, `Reconciling`, `Failed`) are intentionally not surfaced; mapping only `Submitted` (not the repeatedly-rewritten `Reconciling`) keeps in-flight polling from emitting duplicate events.
- `releaseId` on Release events maps to the deploy's `DesiredRevision` (metadata releases map to `PackageId`).
- The release-timeline source is a bounded, per-instance in-memory buffer, mirroring the in-process `RecentErrorBuffer` that already backs the same timeline for logs. The durable source of truth remains the Redis workflow store (queryable via the new list API); cross-replica realtime fan-out is #2554's concern.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (see note)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Pre-PR note: `scripts/ci/pre-pr-check.sh` step 1 (`check-instructions-sync.sh`) cannot pass on this Windows checkout because `core.symlinks=false` materializes the committed `CLAUDE.md` symlink as a plain file; every subsequent step was run individually and passed: full-solution Release build with `TreatWarningsAsErrors` (0 warnings / 0 errors), `dotnet format --verify-no-changes` over the changed files, `Honua.Core.Tests` (3457 passed), `Honua.Architecture.Tests` (122/122 incl. EndpointRegistry/ApiSurface/OpenAPI/feature-catalog drift), and the affected `Honua.Server.Tests` (deploy endpoints + release timeline + Redis workflow store: 30/30; observability feed/events: 26/26) against Testcontainers Redis/Postgres.
