### PR TITLE
chore(mcp): re-vendor geospatial-mcp schemas wholesale to eb53989 (#2496)

### DIFF
--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
@@ -20,6 +20,11 @@ implementation.
   (`conformance/fixtures/` at the same commit), minus the upstream `README.md`
   and `validate.py` (not test inputs), plus the two Honua-extension fixture
   directories noted below.
+- The pin is deliberately held at `eb53989` (pre geospatial-mcp#58): the #58
+  platform-ops schemas are marked implemented in the manifest but honua-server
+  does not serve those tools yet, so re-vendoring past #58 would introduce
+  conformance failures. The post-#58 bump is owned by #2555/#2566, which
+  implement the new tools and vendor their schemas together.
 - Do not hand-edit. Re-vendor the whole tree from a single pinned upstream
   commit when the schemas change, and update this note with the new commit.
 - Files are copied to the test output directory (`CopyToOutputDirectory`) and

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
@@ -7,18 +7,21 @@ Honua's live `/mcp` advertised tool input schemas and resource payload shapes
 **conform to the open standard Honua champions** — Honua is the reference
 implementation.
 
-- Source: `geospatial-mcp` `spec/schemas/` (branch `feat/json-schemas-conformance`,
-  PR honua-io/geospatial-mcp#21). `tools/query_features.schema.json` (and the
-  paired paging fixture) were re-vendored from PR honua-io/geospatial-mcp#46,
-  which adds the optional `resultOffset` / `returnGeometry` / `returnCountOnly`
-  params.
-- `tools/geocode_addresses.schema.json`, `tools/ingest_dataset.schema.json`,
-  their fixtures, and the matching `index.json` entries are vendored from
-  the `geospatial-mcp` branch `spec/ingest-dataset-geocode-addresses`. Note:
-  upstream trunk has since revised other schema descriptions/enums (PR
-  geospatial-mcp#44); those files are deliberately NOT re-vendored here —
-  reconciling that drift is a separate alignment task.
-- Do not hand-edit. Re-vendor when the upstream schemas change.
+## Provenance
+
+- `geospatial-mcp/` is byte-identical to `spec/schemas/` of `geospatial-mcp`
+  trunk commit **`eb53989cc61c856261cf017b4b5a8e721317dc41`**
+  ("feat: direct geoprocessing verbs (analysis profile) +
+  geometryPrecision/maxInlineBytes (#55)", 2026-07-06), re-vendored wholesale
+  per honua-server#2496. Verify with
+  `diff -r <geospatial-mcp>/spec/schemas geospatial-mcp/` (compare LF blob
+  content; this repo normalizes to LF).
+- `fixtures/` mirrors the standard's own conformance fixture tree
+  (`conformance/fixtures/` at the same commit), minus the upstream `README.md`
+  and `validate.py` (not test inputs), plus the two Honua-extension fixture
+  directories noted below.
+- Do not hand-edit. Re-vendor the whole tree from a single pinned upstream
+  commit when the schemas change, and update this note with the new commit.
 - Files are copied to the test output directory (`CopyToOutputDirectory`) and
   loaded at test time.
 
@@ -26,9 +29,10 @@ The conformance tests validate representative valid argument/payload instances
 against both Honua's live schema and the vendored standard schema, and assert
 structural alignment (required fields, enum values) for the tools Honua
 implements today. Standard tools Honua does not yet implement as discrete MCP
-tools (the map/app composition and publish families) are tracked as
-**known-gaps**: their absence does not fail the suite; only NON-CONFORMANCE of
-an implemented tool fails.
+tools (the map/app composition and publish families, the `mutation` profile's
+`edit_features` per ADR-0028, and the `analysis` profile's direct
+geoprocessing verbs) are tracked as **known-gaps**: their absence does not
+fail the suite; only NON-CONFORMANCE of an implemented tool fails.
 
 ## Honua extensions (`x-honua-extension`)
 
@@ -48,4 +52,6 @@ These are exposed as first-class reference-implementation tools while the
 upstream standard publishes canonical schemas for them, re-vendor and drop the
 extension marker. They participate in the full conformance assertions (required
 fields + fixture validation) because their live and vendored shapes are authored
-together.
+together; their fixtures under `fixtures/tools/resolve_entity/` and
+`fixtures/tools/list_capabilities/` are maintained here (the upstream fixture
+tree does not carry them yet).

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/artifact/artifact-reference-wire-kind.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/artifact/artifact-reference-wire-kind.json
@@ -1,0 +1,19 @@
+{
+  "id": "artifact.workspace_view_reference_wire_kind",
+  "schemaRef": "resources/artifact.schema.json",
+  "validates": "inputs",
+  "uri": "honua://workspaces/ws_91/artifacts/artifact_exposed_facilities",
+  "inputs": {
+    "artifactId": "artifact_exposed_facilities",
+    "kind": "FeatureLayer",
+    "label": "Exposed facilities",
+    "uri": "honua://workspaces/ws_91/layers/exposed_facilities",
+    "contentType": "application/geo+json",
+    "metadata": { "count": "23" },
+    "lifecycleState": "Available",
+    "promotionSourceReady": true,
+    "sourceWorkspaceKind": "temp_layer"
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["ArtifactRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/artifact/artifact_wire_spelling.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/artifact/artifact_wire_spelling.json
@@ -1,0 +1,19 @@
+{
+  "id": "artifact.feature_layer_wire_spelling",
+  "schemaRef": "resources/artifact.schema.json",
+  "validates": "inputs",
+  "uri": "honua://workspaces/ws_91/artifacts/artifact_exposed_facilities_snake",
+  "inputs": {
+    "artifactId": "artifact_exposed_facilities_snake",
+    "kind": "FeatureLayer",
+    "label": "Exposed facilities (reference wire spelling)",
+    "uri": "honua://workspaces/ws_91/layers/exposed_facilities_snake",
+    "contentType": "application/geo+json",
+    "metadata": { "count": "23" },
+    "lifecycleState": "available",
+    "promotionSourceReady": true,
+    "sourceWorkspaceKind": "temp_layer"
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["ArtifactRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/deployment/deployment.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/deployment/deployment.json
@@ -1,0 +1,18 @@
+{
+  "id": "deployment.app_package",
+  "schemaRef": "resources/deployment.schema.json",
+  "validates": "inputs",
+  "uri": "honua://deployments/dep_4c12",
+  "deferred": true,
+  "inputs": {
+    "deploymentId": "dep_4c12",
+    "kind": "app_package",
+    "targetRef": "app_8801",
+    "hostingMode": "static_site",
+    "revisionId": "rev_01",
+    "publicationState": "live"
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["Deployment", "AppPackage"],
+  "notes": "Responsibility-level: concrete Deployment field set finalizes upstream (honua-server#732); stable deploymentId, kind, and target binding are scoreable now."
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/published-service/published-service.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/published-service/published-service.json
@@ -1,0 +1,15 @@
+{
+  "id": "published-service.multi_protocol",
+  "schemaRef": "resources/published-service.schema.json",
+  "validates": "inputs",
+  "uri": "honua://services/county_parcels_published",
+  "deferred": true,
+  "inputs": {
+    "serviceId": "county_parcels_published",
+    "protocols": ["GeoServices", "OGC API Features", "WMS", "WFS"],
+    "refreshState": "current"
+  },
+  "expected": "resource_projection",
+  "canonicalRefs": ["PublishedService"],
+  "notes": "Responsibility-level: concrete PublishedService field set finalizes upstream (honua-server#730); stable serviceId and protocol enumeration are scoreable now."
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/workspace/workspace.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/resources/workspace/workspace.json
@@ -9,8 +9,8 @@
     "label": "Flood analysis scratch",
     "uri": "honua://workspaces/ws_91",
     "expiresAt": "2026-06-28T00:00:00Z",
-    "status": "active",
-    "resultsUri": "honua://jobs/job_7f3a/results"
+    "lifecycleState": "active",
+    "resultsUri": "honua://results/result_3f21"
   },
   "expected": "resource_projection",
   "canonicalRefs": ["WorkspaceRef"]

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/buffer_features/buffer_features.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/buffer_features/buffer_features.json
@@ -1,0 +1,15 @@
+{
+  "id": "buffer_features.layer_500m_dissolved",
+  "schemaRef": "tools/buffer_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "source": { "serviceId": "county_roads", "layerId": 0 },
+    "distance": 500,
+    "unit": "meters",
+    "dissolve": true,
+    "where": "road_class = 'arterial'",
+    "outSrid": 3857
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/create_app_package/create_app_package.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/create_app_package/create_app_package.json
@@ -1,0 +1,16 @@
+{
+  "id": "create_app_package.dashboard",
+  "schemaRef": "tools/create_app_package.schema.json",
+  "validates": "inputs",
+  "deferred": true,
+  "inputs": {
+    "templateId": "analysis_dashboard",
+    "targetSdk": "honua-sdk-js",
+    "mapPackageId": "map_5a90",
+    "boundArtifactIds": ["artifact_summary_report"],
+    "runtimeConfig": { "title": "Flood Exposure Dashboard" }
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["BuilderIntent", "AppPackage", "MapPackage", "ArtifactRef"],
+  "notes": "Reference implementation does not yet ship create_app_package as a discrete tool; responsibility-level shape, marked deferred per spec/conformance.md §2.4."
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/create_map_package/create_map_package.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/create_map_package/create_map_package.json
@@ -1,0 +1,18 @@
+{
+  "id": "create_map_package.from_template",
+  "schemaRef": "tools/create_map_package.schema.json",
+  "validates": "inputs",
+  "deferred": true,
+  "inputs": {
+    "templateId": "analysis_default",
+    "sourceBindings": [
+      { "bindingId": "b1", "datasetId": "buffered_parcels", "protocol": "ogc_api_features" }
+    ],
+    "styleId": "style_choropleth_acreage",
+    "themeId": "theme_operational_dark",
+    "initialView": { "bbox": [-97.95, 30.15, -97.55, 30.55], "crs": 4326 }
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["BuilderIntent", "MapPackage", "SourceBinding", "StyleRef", "ThemeSpec", "MapTemplate"],
+  "notes": "Reference implementation does not yet ship create_map_package as a discrete tool; responsibility-level shape, marked deferred per spec/conformance.md §2.4."
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/export_dataset/export_dataset.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/export_dataset/export_dataset.json
@@ -1,0 +1,13 @@
+{
+  "id": "export_dataset.result_to_geopackage",
+  "schemaRef": "tools/export_dataset.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "source": { "artifactId": "artifact_intersect_result" },
+    "format": "geopackage",
+    "returnGeometry": true,
+    "outSrid": 4326
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["ArtifactRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/join_features/join_features_attribute.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/join_features/join_features_attribute.json
@@ -1,0 +1,15 @@
+{
+  "id": "join_features.attribute_demographics",
+  "schemaRef": "tools/join_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "target": { "serviceId": "census_tracts", "layerId": 0 },
+    "join": { "serviceId": "demographics_table", "layerId": 0 },
+    "joinType": "attribute",
+    "targetField": "geoid",
+    "joinField": "tract_geoid",
+    "joinOperation": "one_to_one"
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/join_features/join_features_spatial.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/join_features/join_features_spatial.json
@@ -1,0 +1,15 @@
+{
+  "id": "join_features.spatial_point_in_county",
+  "schemaRef": "tools/join_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "target": { "serviceId": "incidents", "layerId": 0 },
+    "join": { "serviceId": "counties", "layerId": 0 },
+    "joinType": "spatial",
+    "spatialRelationship": "within",
+    "joinOperation": "one_to_one",
+    "joinAggregation": "first"
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/overlay_features/overlay_features.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/overlay_features/overlay_features.json
@@ -1,0 +1,13 @@
+{
+  "id": "overlay_features.intersect_layer_with_artifact",
+  "schemaRef": "tools/overlay_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "source": { "serviceId": "county_parcels", "layerId": 0 },
+    "overlay": { "artifactId": "artifact_flood_100yr" },
+    "operation": "intersect",
+    "outSrid": 4326
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef", "ArtifactRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/query_features/query_features_geometry_precision.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/query_features/query_features_geometry_precision.json
@@ -1,0 +1,15 @@
+{
+  "id": "query_features.geometry_precision",
+  "schemaRef": "tools/query_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "serviceId": "county_parcels",
+    "layerId": 0,
+    "where": "zoning = 'R1'",
+    "limit": 200,
+    "geometryPrecision": 6,
+    "outSrid": 4326
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/render_map/render_map_inline_bytes.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/render_map/render_map_inline_bytes.json
@@ -1,0 +1,17 @@
+{
+  "id": "render_map.max_inline_bytes",
+  "schemaRef": "tools/render_map.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "layers": [
+      { "serviceId": "county_parcels", "layerId": 0 }
+    ],
+    "bbox": [-97.75, 30.26, -97.73, 30.28],
+    "bboxSrid": 4326,
+    "width": 512,
+    "height": 512,
+    "maxInlineBytes": 65536
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/reproject_features/reproject_features.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/reproject_features/reproject_features.json
@@ -1,0 +1,11 @@
+{
+  "id": "reproject_features.artifact_to_3857",
+  "schemaRef": "tools/reproject_features.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "source": { "artifactId": "artifact_buffer_result" },
+    "targetSrid": 3857
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["ArtifactRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/summarize_statistics/summarize_statistics.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/summarize_statistics/summarize_statistics.json
@@ -1,0 +1,17 @@
+{
+  "id": "summarize_statistics.population_by_county",
+  "schemaRef": "tools/summarize_statistics.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "source": { "serviceId": "census_tracts", "layerId": 0 },
+    "groupByFields": ["county_fips"],
+    "statistics": [
+      { "statisticType": "sum", "onField": "population", "outField": "total_population" },
+      { "statisticType": "mean", "onField": "median_income", "outField": "avg_median_income" },
+      { "statisticType": "count", "onField": "tract_id" }
+    ],
+    "where": "population > 0"
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["LayerRef"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/README.md
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/README.md
@@ -1,0 +1,90 @@
+# Machine-Readable JSON Schemas
+
+**Status:** Draft
+**Date:** 2026-06-21
+**Scope:** Implementable JSON Schema (draft 2020-12) bindings for the geospatial MCP standard
+
+This directory makes the prose specification **implementable**. It publishes
+[JSON Schema](https://json-schema.org/) (draft 2020-12) documents describing:
+
+- each core MCP **tool** `inputSchema` (the argument shape an agent sends on a
+  `tools/call`), under [`tools/`](tools/);
+- each core MCP **resource** payload shape (the read-only projection a
+  `resources/read` returns), under [`resources/`](resources/).
+
+A machine-readable [`index.json`](index.json) maps every standard tool name and
+resource family URI to its schema file, so a harness can resolve a schema from
+a vocabulary key without hard-coding paths.
+
+A self-check **conformance fixture tree** lives under
+[`../../conformance/fixtures/`](../../conformance/fixtures/): example tool-call
+inputs and resource payloads that validate against these schemas. An
+implementer can run their JSON Schema validator over the fixtures to confirm the
+schemas load and that the examples conform, before testing their own server.
+
+## Relationship to the prose
+
+These schemas are **derived from**, and faithful to, the normative prose:
+
+- Tool families and names come from
+  [`spec/taxonomy.md` §MCP Tools to Workflow Family Mapping](../taxonomy.md#mcp-tools-to-workflow-family-mapping).
+- Resource families, URI grammar, and inspection fields come from
+  [`spec/resources.md`](../resources.md).
+- The canonical concept model (`AnalysisPlan`, `ArtifactRef`, `WorkspaceRef`,
+  `GeoprocessingError`, …) comes from
+  [`spec/taxonomy.md` §Canonical Concept Model](../taxonomy.md#canonical-concept-model).
+
+### Where the prose is intentionally upstream-owned
+
+The prose **defers concrete field spellings** for several canonical objects to
+`honua-server` (`MapPackage`, `AppPackage`, `PublishedService`, `Deployment`
+— see [`resources.md` §2.4 Deferred-Shape Fixtures](../conformance.md#24-deferred-shape-fixtures)
+and the responsibility-level projections in `resources.md`). For those, the
+prose deliberately gives **responsibilities**, not a frozen field table.
+
+Per the task of making the standard implementable, where the prose is ambiguous
+or upstream-owned, **these schemas adopt the shape the reference implementation
+(Honua's `/mcp`) already emits**, and mark it as such with a
+`x-honua-reference-shape: true` annotation and a `description` note. This keeps
+the standard constructible today while remaining honest that the concrete field
+names track the reference implementation until the upstream ticket lands.
+
+Resources whose concrete shape is still fully deferred upstream (e.g.
+`MapPackage`, `AppPackage`, `PublishedService`, `Deployment`,
+`PublishingResultPackage`) carry **responsibility-level** schemas: the stable
+identifier and `honua://` URI are pinned and required, additional properties are
+permitted (`additionalProperties: true`), and the responsibility fields are
+described but not over-constrained. This matches the conformance rubric, which
+scores those resources on stable identifiers, URI grammar, and
+responsibility-level projection while marking concrete-field assertions
+`not_applicable`.
+
+## Draft and dialect
+
+All schemas declare:
+
+```json
+"$schema": "https://json-schema.org/draft/2020-12/schema"
+```
+
+and a stable `$id` of the form
+`https://geospatial-mcp.honua.io/spec/schemas/{tools|resources}/{name}.schema.json`.
+
+## Tool-name prefixing
+
+The standard names tools without a vendor prefix (`plan_analysis`,
+`ground_candidates`, …; see `taxonomy.md`). A conformant server MAY advertise
+the tools under a vendor-namespaced name — the reference implementation
+advertises e.g. `honua_plan_analysis`. The `index.json` lists both the bare
+standard name and the reference implementation's advertised name so a harness
+can resolve either. The schemas validate the **argument object**, which is
+prefix-independent.
+
+## Files
+
+| File | Describes |
+|---|---|
+| [`index.json`](index.json) | Machine-readable tool/resource → schema map |
+| [`common/geoprocessing-error.schema.json`](common/geoprocessing-error.schema.json) | The canonical `GeoprocessingError` envelope (shared) |
+| [`tools/*.schema.json`](tools/) | One `inputSchema` per core tool family |
+| [`resources/*.schema.json`](resources/) | One payload schema per core resource family |

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/conformance/manifest.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/conformance/manifest.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/conformance/manifest.schema.json",
+  "title": "geospatial-mcp conformance manifest",
+  "description": "Static, server-emitted declaration of the MCP tool and resource surface an implementation advertises, used to check coverage of the geospatial-mcp standard vocabulary without running a live scenario harness. A conformant server produces this manifest from its own tools/list and resources/templates/list capability advertisement. See /CONFORMANCE.md and spec/conformance.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["specDate", "implementation", "tools", "resources"],
+  "properties": {
+    "specDate": {
+      "type": "string",
+      "description": "The Date header of the spec/conformance.md document this manifest was produced against (e.g. 2026-04-19), per spec/conformance.md §8 'Conformance spec identifier per run'.",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "implementation": {
+      "type": "object",
+      "description": "Identity of the implementation under test.",
+      "additionalProperties": true,
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "description": "Implementation name (e.g. 'Honua /mcp')." },
+        "version": { "type": "string", "description": "Optional implementation version or build identifier." },
+        "isReferenceImplementation": {
+          "type": "boolean",
+          "description": "True only for the reference implementation named in /CONFORMANCE.md (Honua). Other implementations omit this or set it false."
+        },
+        "profiles": {
+          "type": "array",
+          "description": "Conformance profiles this implementation claims (default ['base'] when omitted). 'base' is the read-only floor; additive profiles such as 'mutation' require the implementation to advertise every tool the index assigns to that profile to reach FULL. See /CONFORMANCE.md §Conformance Profiles.",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        }
+      }
+    },
+    "tools": {
+      "type": "array",
+      "description": "The tools the implementation advertises that map onto standard vocabulary.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["standardName", "advertisedName"],
+        "properties": {
+          "standardName": {
+            "type": "string",
+            "description": "The bare taxonomy.md tool name this advertised tool implements (e.g. 'plan_analysis'). MUST match a tools[].standardName in spec/schemas/index.json."
+          },
+          "advertisedName": {
+            "type": "string",
+            "description": "The name the server advertises on tools/list (e.g. 'honua_plan_analysis'). MAY be vendor-prefixed."
+          },
+          "workflowFamily": {
+            "type": "string",
+            "description": "Optional workflow-family tag the server attaches to the tool, for coverage reporting."
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "array",
+      "description": "The resource families the implementation advertises that map onto standard vocabulary.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["family", "uriForm"],
+        "properties": {
+          "family": {
+            "type": "string",
+            "description": "Resource family name. MUST match a resources[].family in spec/schemas/index.json."
+          },
+          "uriForm": {
+            "type": "string",
+            "description": "The honua:// URI template the server advertises for the family (e.g. honua://results/{result_package_id}).",
+            "pattern": "^honua://"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "geospatial-mcp JSON Schema index",
-  "description": "Machine-readable map from standard MCP tool names and resource family URIs to their JSON Schema (draft 2020-12) files. 'standardName' is the bare taxonomy.md tool name; 'referenceToolName' is the name the reference implementation (Honua /mcp) advertises. 'implementationStatus' records whether the reference implementation ships the tool/resource family today (implemented) or whether it is a standard family not yet served by the reference (known-gap). For resources, 'implementationStatus' gates the FULL conformance level the same way it does for tools: a manifest must advertise every 'implemented' resource family to reach FULL; 'known-gap' families are reported as informational notes only.",
-  "date": "2026-07-01",
+  "description": "Machine-readable map from standard MCP tool names and resource family URIs to their JSON Schema (draft 2020-12) files. 'standardName' is the bare taxonomy.md tool name; 'referenceToolName' is the name the reference implementation (Honua /mcp) advertises. 'implementationStatus' records whether the reference implementation ships the tool/resource family today (implemented) or whether it is a standard family not yet served by the reference (known-gap). For resources, 'implementationStatus' gates the FULL conformance level the same way it does for tools: a manifest must advertise every 'implemented' resource family to reach FULL; 'known-gap' families are reported as informational notes only. 'profile' (optional; default 'base') assigns a tool to a conformance profile: 'base' tools are required for the base FULL verdict; tools in an additive profile such as 'mutation' are required for FULL only when a manifest declares that profile, and are otherwise reported as informational notes (see /CONFORMANCE.md §Conformance Profiles).",
+  "date": "2026-07-06",
   "dialect": "https://json-schema.org/draft/2020-12/schema",
   "tools": [
     {
@@ -125,10 +125,11 @@
     {
       "standardName": "edit_features",
       "referenceToolName": null,
-      "family": "Transactional editing (Honua extension)",
+      "family": "Feature editing",
       "schema": "tools/edit_features.schema.json",
       "implementationStatus": "known-gap",
-      "notes": "Honua does NOT implement this tool: the MCP surface exposes no AI-facing feature-mutation verb per ADR-0028 (AI operational data editing is not supported; founder-reaffirmed 2026-07-06). The schema is retained so the gap stays real and closeable by other adopters of the standard's optional mutation profile, but the reference implementation serves the shared edit pipeline only through its human-facing HTTP adapters. (State-only known-gap edit; a full re-vendor to the current geospatial-mcp pin lands separately.)"
+      "profile": "mutation",
+      "notes": "Sole member of the optional mutation conformance profile (docs/adr/0028-governed-feature-mutation.md). Governed transactional editing: an implementation must require an authenticated, authorized caller and authorize each edit type (insert/update/delete) independently. The reference implementation (Honua) does NOT serve this tool — Honua does not support AI operational data editing (honua-server ADR-0028, founder-reaffirmed 2026-07-06); its referenceToolName is null and its implementationStatus is known-gap. Base-profile (read-only) implementations conform without advertising this tool; it is required for FULL only when an adopter's manifest declares the mutation profile."
     },
     {
       "standardName": "render_map",
@@ -157,6 +158,60 @@
       "family": "Analysis and geoprocessing (reference shape)",
       "schema": "tools/solve_route.schema.json",
       "implementationStatus": "implemented"
+    },
+    {
+      "standardName": "buffer_features",
+      "referenceToolName": null,
+      "family": "Analysis verbs",
+      "schema": "tools/buffer_features.schema.json",
+      "implementationStatus": "known-gap",
+      "profile": "analysis",
+      "notes": "Direct geoprocessing verb; member of the opt-in analysis conformance profile (docs/adr/0029-direct-geoprocessing-verbs.md, geospatial-mcp#53). Single-step buffer, an alternative to a plan_analysis/execute_plan Geoprocess step. The reference implementation does not ship a direct verb yet; required for FULL only when a manifest declares the analysis profile."
+    },
+    {
+      "standardName": "overlay_features",
+      "referenceToolName": null,
+      "family": "Analysis verbs",
+      "schema": "tools/overlay_features.schema.json",
+      "implementationStatus": "known-gap",
+      "profile": "analysis",
+      "notes": "Direct geoprocessing verb (analysis profile; docs/adr/0029-direct-geoprocessing-verbs.md, geospatial-mcp#53). Two-input overlay: intersect/union/difference/erase/clip. Not yet shipped by the reference; required for FULL only when a manifest declares the analysis profile."
+    },
+    {
+      "standardName": "summarize_statistics",
+      "referenceToolName": null,
+      "family": "Analysis verbs",
+      "schema": "tools/summarize_statistics.schema.json",
+      "implementationStatus": "known-gap",
+      "profile": "analysis",
+      "notes": "Direct geoprocessing verb (analysis profile; docs/adr/0029-direct-geoprocessing-verbs.md, geospatial-mcp#53). Group-by + statistics over a layer or a prior overlay/verb result. Not yet shipped by the reference; required for FULL only when a manifest declares the analysis profile."
+    },
+    {
+      "standardName": "reproject_features",
+      "referenceToolName": null,
+      "family": "Analysis verbs",
+      "schema": "tools/reproject_features.schema.json",
+      "implementationStatus": "known-gap",
+      "profile": "analysis",
+      "notes": "Direct geoprocessing verb (analysis profile; docs/adr/0029-direct-geoprocessing-verbs.md, geospatial-mcp#53). Reproject a dataset to a targetSrid; the sibling verbs also carry an optional outSrid output-CRS param. Not yet shipped by the reference; required for FULL only when a manifest declares the analysis profile."
+    },
+    {
+      "standardName": "join_features",
+      "referenceToolName": null,
+      "family": "Analysis verbs",
+      "schema": "tools/join_features.schema.json",
+      "implementationStatus": "known-gap",
+      "profile": "analysis",
+      "notes": "Direct geoprocessing verb (analysis profile; docs/adr/0029-direct-geoprocessing-verbs.md, geospatial-mcp#53). Attribute or spatial join of two datasets. Not yet shipped by the reference; required for FULL only when a manifest declares the analysis profile."
+    },
+    {
+      "standardName": "export_dataset",
+      "referenceToolName": null,
+      "family": "Analysis verbs",
+      "schema": "tools/export_dataset.schema.json",
+      "implementationStatus": "known-gap",
+      "profile": "analysis",
+      "notes": "Direct geoprocessing verb (analysis profile; docs/adr/0029-direct-geoprocessing-verbs.md, geospatial-mcp#53). Materialize a layer/result to a GeoJSON/GeoPackage/CSV/Parquet artifact. Advertised readOnlyHint:false (writes a new artifact) but non-destructive and not a mutation-profile tool. Not yet shipped by the reference; required for FULL only when a manifest declares the analysis profile."
     },
     {
       "standardName": "cancel_job",

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/app-package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/app-package.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/app-package.schema.json",
   "title": "App package resource payload",
-  "description": "Responsibility-level projection of an AppPackage at honua://apps/{app_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable appPackageId is pinned. Responsibilities: target SDK declaration, template binding, package format/manifest, bundle artifact, delivery asset manifest, map binding, runtime config schema, hosting/route hints, bound data artifacts. See resources.md §honua://apps/{app_package_id}.",
+  "description": "Responsibility-level projection of an AppPackage at honua://app-packages/{app_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable appPackageId is pinned. Responsibilities: target SDK declaration, template binding, package format/manifest, bundle artifact, delivery asset manifest, map binding, runtime config schema, hosting/route hints, bound data artifacts. See resources.md §honua://app-packages/{app_package_id}.",
   "type": "object",
   "additionalProperties": true,
   "required": ["appPackageId"],

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/app-template.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/app-template.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/app-template.schema.json",
+  "title": "App template resource payload",
+  "description": "Responsibility-level projection of an application scaffold template at honua://templates/apps/{app_template_id}. The identifier is registry-defined; the canonical app-template shape is deferred (see resources.md §honua://templates/apps/{app_template_id}), so only the identifier is fixed here. Sourced from AppPackage.templateId.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["appTemplateId"],
+  "properties": {
+    "appTemplateId": {
+      "type": "string",
+      "description": "Registry-defined app-template identifier."
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/artifact.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/artifact.schema.json
@@ -29,8 +29,20 @@
     },
     "lifecycleState": {
       "type": "string",
-      "description": "ArtifactLifecycleState (MCP-layer projection from the workspace lifecycle service).",
-      "enum": ["Pending", "Available", "Promoted", "Expired", "Deleted"]
+      "description": "ArtifactLifecycleState (MCP-layer projection from the workspace lifecycle service). Canonical enum names are Pending/Available/Promoted/Expired/Deleted; the reference implementation emits the lower_snake_case wire spelling, consistent with the sibling sourceWorkspaceKind projection and workspace.schema.json.",
+      "x-honua-reference-shape": true,
+      "enum": [
+        "pending",
+        "available",
+        "promoted",
+        "expired",
+        "deleted",
+        "Pending",
+        "Available",
+        "Promoted",
+        "Expired",
+        "Deleted"
+      ]
     },
     "promotionSourceReady": {
       "type": "boolean",
@@ -38,7 +50,20 @@
     },
     "sourceWorkspaceKind": {
       "type": "string",
-      "enum": ["Scratch", "Persistent", "TempLayer", "SavedLayer", "ResultCollection"]
+      "description": "WorkspaceKind of the owning workspace. Same canonical value set and reference wire spellings as workspace.schema.json.kind: canonical enum names are Scratch/Persistent/TempLayer/SavedLayer/ResultCollection; the reference implementation emits the lower_snake_case wire spelling. The same WorkspaceKind value must validate identically across both projections.",
+      "x-honua-reference-shape": true,
+      "enum": [
+        "scratch",
+        "persistent",
+        "temp_layer",
+        "saved_layer",
+        "result_collection",
+        "Scratch",
+        "Persistent",
+        "TempLayer",
+        "SavedLayer",
+        "ResultCollection"
+      ]
     }
   }
 }

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/map-package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/map-package.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/map-package.schema.json",
   "title": "Map package resource payload",
-  "description": "Responsibility-level projection of a MapPackage at honua://maps/{map_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable mapPackageId is pinned and additional properties are permitted. Responsibilities: package format/template binding, source bindings, styling composition, map-spec document, initial view, legend/popup/label composition, artifact bindings. See resources.md §honua://maps/{map_package_id}.",
+  "description": "Responsibility-level projection of a MapPackage at honua://map-packages/{map_package_id}. Concrete field spellings finalize upstream (honua-server#731); only the stable mapPackageId is pinned and additional properties are permitted. Responsibilities: package format/template binding, source bindings, styling composition, map-spec document, initial view, legend/popup/label composition, artifact bindings. See resources.md §honua://map-packages/{map_package_id}.",
   "type": "object",
   "additionalProperties": true,
   "required": ["mapPackageId"],

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/published-service.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/published-service.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/resources/published-service.schema.json",
   "title": "Published service resource payload",
-  "description": "Responsibility-level projection of a PublishedService at honua://services/{published_service_id}. Concrete field spellings finalize upstream (honua-server#730); only the stable serviceId is pinned. Responsibilities: protocol surface enumeration, styling composition, source-to-service lineage summary, refresh state (read-only). Read-only — no control paths. See resources.md §honua://services/{published_service_id}.",
+  "description": "Responsibility-level projection of a PublishedService at honua://published-services/{published_service_id}. Concrete field spellings finalize upstream (honua-server#730); only the stable serviceId is pinned. Responsibilities: protocol surface enumeration, styling composition, source-to-service lineage summary, refresh state (read-only). Read-only — no control paths. See resources.md §honua://published-services/{published_service_id}.",
   "type": "object",
   "additionalProperties": true,
   "required": ["serviceId"],

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/workspace.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/resources/workspace.schema.json
@@ -14,7 +14,7 @@
     },
     "kind": {
       "type": "string",
-      "description": "WorkspaceKind. Canonical enum names are Scratch/Persistent/TempLayer/SavedLayer/ResultCollection; the reference implementation emits the lower_snake_case wire spelling.",
+      "description": "WorkspaceKind. Canonical enum names are Scratch/Persistent/TempLayer/SavedLayer/ResultCollection; the reference implementation emits the lower_snake_case wire spelling. An empty/absent kind is not a legal value — omit the property rather than emitting an empty string.",
       "enum": [
         "scratch",
         "persistent",
@@ -25,8 +25,7 @@
         "Persistent",
         "TempLayer",
         "SavedLayer",
-        "ResultCollection",
-        ""
+        "ResultCollection"
       ]
     },
     "label": { "type": "string", "description": "Human-readable label." },
@@ -36,16 +35,29 @@
       "format": "date-time",
       "description": "Expiration timestamp when applicable."
     },
-    "status": {
+    "lifecycleState": {
       "type": "string",
-      "description": "WorkspaceLifecycleState projection. Reference wire spellings: active, cleanup_pending, sealed, not_found, degraded.",
-      "enum": ["active", "cleanup_pending", "sealed", "not_found", "degraded"]
+      "description": "WorkspaceLifecycleState projection (MCP-layer, not a field of WorkspaceRef — see resources.md §honua://workspaces/{workspace_id}). Canonical enum names are Active/Expired/Archived/Deleted; the reference implementation emits the lower_snake_case wire spelling. Field name matches artifact.schema.json.lifecycleState.",
+      "enum": [
+        "active",
+        "expired",
+        "archived",
+        "deleted",
+        "Active",
+        "Expired",
+        "Archived",
+        "Deleted"
+      ]
     },
     "cleanupScheduledAt": {
       "type": ["string", "null"],
       "format": "date-time"
     },
-    "resultsUri": { "type": ["string", "null"] },
+    "resultsUri": {
+      "type": ["string", "null"],
+      "description": "URI of the result package this workspace's outputs are projected into, when applicable. MUST use the defined honua://results/{result_package_id} route (resources.md §honua://results/{result_package_id}); the spec defines no honua://jobs family (execution/job state is the canonical ExecutionJob object reference, not an MCP resource URI — see planning.md §5.3, conformance.md resource_projection contract).",
+      "pattern": "^honua://results/[^/]+$"
+    },
     "notImplementedReason": { "type": "string" }
   }
 }

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/buffer_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/buffer_features.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/buffer_features.schema.json",
+  "title": "buffer_features inputSchema",
+  "description": "Direct geoprocessing verb (advertised name honua_buffer_features): buffer input features by a distance and return the buffer polygons. Use this for a single self-contained buffer step (\"buffer these roads by 500 m\"); for multi-step analysis with dependencies, clarification, and a packaged result, use plan_analysis + execute_plan instead. Member of the standard's opt-in **analysis** conformance profile (see /CONFORMANCE.md and docs/adr/0029-direct-geoprocessing-verbs.md). Long-running calls return an ExecutionJob handle (honua://jobs/{job_id}), pollable and cancelable via cancel_job; small/fast calls may return an inline result — the same handoff execute_plan uses. Advertised readOnlyHint: true (computes a derived result; mutates no server state). x-honua-reference-shape: the concrete source (serviceId/layerId, artifactId) spellings track the reference pipeline.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["source", "distance"],
+  "properties": {
+    "source": {
+      "description": "Dataset to buffer: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId) from an earlier analysis job or verb.",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "distance": {
+      "type": "number",
+      "description": "Buffer distance in the given unit. Negative distances buffer inward for polygon inputs."
+    },
+    "unit": {
+      "type": "string",
+      "default": "meters",
+      "enum": ["meters", "kilometers", "feet", "miles", "nautical_miles", "degrees"],
+      "description": "Linear unit of distance."
+    },
+    "dissolve": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, overlapping buffers are dissolved into a single geometry; when false, one buffer per input feature is returned."
+    },
+    "where": {
+      "type": "string",
+      "description": "Optional attribute filter (ArcGIS/SQL WHERE clause) selecting which input features to buffer."
+    },
+    "outSrid": {
+      "type": "integer",
+      "description": "Output spatial reference (SRID/WKID) for the returned buffers; defaults to the source CRS. Buffer distances are always measured in the given unit regardless of outSrid."
+    }
+  },
+  "$defs": {
+    "layerRef": {
+      "type": "object",
+      "required": ["serviceId", "layerId"],
+      "additionalProperties": false,
+      "properties": {
+        "serviceId": { "type": "string", "minLength": 1, "description": "Published service identifier or name (from list_layers.serviceId or resolve_entity)." },
+        "layerId": { "type": "integer", "minimum": 0, "description": "Service-local layer index (from list_layers.layerId)." }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "required": ["artifactId"],
+      "additionalProperties": false,
+      "properties": {
+        "artifactId": { "type": "string", "minLength": 1, "description": "Identifier (artifact_…) of a prior-result ArtifactRef produced by an earlier analysis job or verb. See resources/artifact.schema.json." }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_app_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_app_package.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/create_app_package.schema.json",
   "title": "create_app_package inputSchema",
-  "description": "Argument shape for create_app_package (Build App; returns an AppPackage). Composes an SDK-native application from a map package, artifacts, and an app template. V1 targets honua-sdk-js with MapLibre GL JS. Responsibility-level: the AppPackage authoring field set finalizes upstream (honua-server#731). See taxonomy.md §App composition and resources.md §honua://apps/{app_package_id}.",
+  "description": "Argument shape for create_app_package (Build App; returns an AppPackage). Composes an SDK-native application from a map package, artifacts, and an app template. V1 targets honua-sdk-js with MapLibre GL JS. Responsibility-level: the AppPackage authoring field set finalizes upstream (honua-server#731). See taxonomy.md §App composition and resources.md §honua://app-packages/{app_package_id}.",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_map_package.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/create_map_package.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/create_map_package.schema.json",
   "title": "create_map_package inputSchema",
-  "description": "Argument shape for create_map_package (Analyze, Build App map-composition family; returns a MapPackage). Responsibility-level: the concrete MapPackage authoring field set is finalizing upstream (honua-server#731), so this schema pins the stable composition inputs (source bindings, style/theme selection, template, initial view) and permits additional properties. See taxonomy.md §Map composition and resources.md §honua://maps/{map_package_id}.",
+  "description": "Argument shape for create_map_package (Analyze, Build App map-composition family; returns a MapPackage). Responsibility-level: the concrete MapPackage authoring field set is finalizing upstream (honua-server#731), so this schema pins the stable composition inputs (source bindings, style/theme selection, template, initial view) and permits additional properties. See taxonomy.md §Map composition and resources.md §honua://map-packages/{map_package_id}.",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/edit_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/edit_features.schema.json
@@ -2,8 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/edit_features.schema.json",
   "title": "edit_features inputSchema",
-  "description": "Argument shape for the transactional feature-editing tool (advertised name honua_edit_features). Applies adds/updates/deletes to a single published editable layer as one all-or-nothing transaction when rollbackOnFailure=true (the default). The bare taxonomy excludes direct data editing per ADR-0028 (AI must not autonomously mutate authoritative records); the reference implementation exposes editing as a discrete tool that requires an authenticated, authorized caller and routes through the shared server edit/transaction pipeline (validation, authorization, optimistic behavior, telemetry) rather than autonomous unapproved mutation. x-honua-extension: this is a documented Honua reference extension over the bare taxonomy, pending formalization (and ADR-0028 reconciliation) in the geospatial-mcp standard. x-honua-reference-shape: this shape tracks the reference implementation.",
-  "x-honua-extension": true,
+  "description": "Argument shape for the transactional feature-editing tool (advertised name honua_edit_features). edit_features is the sole member of the standard's **mutation** conformance profile (see /CONFORMANCE.md and docs/adr/0028-governed-feature-mutation.md): it applies adds/updates/deletes to a single published editable layer as one all-or-nothing transaction when rollbackOnFailure=true (the default). It is governed mutation, not autonomous mutation: an implementation MUST require an authenticated, authorized caller and MUST authorize each edit type independently (insert for adds, update for updates, delete for deletes), rejecting the whole request before any edit is applied if any required permission is missing. An implementation MAY be read-only and still conform to the base profile by not advertising this tool. x-honua-reference-shape: the concrete objectId/globalId/attributes spellings track the reference implementation's shared edit/transaction pipeline; see taxonomy.md §Feature editing (mutation profile).",
   "x-honua-reference-shape": true,
   "type": "object",
   "required": ["serviceId", "layerId"],
@@ -25,23 +24,23 @@
     },
     "adds": {
       "type": "array",
-      "description": "Features to insert. Object IDs are assigned by the store.",
+      "description": "Features to insert. Requires insert authorization on the target layer. Object IDs are assigned by the store.",
       "items": { "$ref": "#/$defs/editFeature" }
     },
     "updates": {
       "type": "array",
-      "description": "Features to update. Each MUST carry an objectId identifying the existing feature.",
+      "description": "Features to update. Requires update authorization on the target layer. Each MUST carry an objectId identifying the existing feature.",
       "items": { "$ref": "#/$defs/editFeature" }
     },
     "deletes": {
       "type": "array",
-      "description": "Object IDs of features to delete.",
+      "description": "Object IDs of features to delete. Requires delete authorization on the target layer.",
       "items": { "type": "integer" }
     },
     "rollbackOnFailure": {
       "type": "boolean",
       "default": true,
-      "description": "When true, any failed edit rolls back the whole transaction (all-or-nothing)."
+      "description": "When true (the default), any failed edit rolls back the whole transaction (all-or-nothing) and the layer is left unchanged; when false, successful edits commit independently and per-edit failures are reported."
     },
     "returnEditResults": {
       "type": "boolean",

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/export_dataset.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/export_dataset.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/export_dataset.schema.json",
+  "title": "export_dataset inputSchema",
+  "description": "Direct geoprocessing verb (advertised name honua_export_dataset): materialize a dataset — a published layer or a prior verb/job result — into a downloadable artifact in the requested format and return an ArtifactRef with a content locator. Use this for a single self-contained export step (\"export the intersect result as GeoPackage\"); for multi-step analysis with dependencies and a packaged result, use plan_analysis + execute_plan instead. Member of the standard's opt-in **analysis** conformance profile (see /CONFORMANCE.md and docs/adr/0029-direct-geoprocessing-verbs.md). Long-running calls return an ExecutionJob handle (honua://jobs/{job_id}), pollable and cancelable via cancel_job; small/fast calls may return an inline result referencing the produced artifact. Advertised readOnlyHint: false — it writes a new downloadable artifact — but non-destructive (it creates a new artifact and mutates no source records) and idempotent. It is NOT feature mutation and is not part of the mutation profile. x-honua-reference-shape: the concrete source (serviceId/layerId, artifactId) spellings track the reference pipeline.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["source", "format"],
+  "properties": {
+    "source": {
+      "description": "Dataset to export: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId) from an earlier analysis job or verb.",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "format": {
+      "type": "string",
+      "enum": ["geojson", "geopackage", "csv", "parquet"],
+      "description": "Output format. geojson: RFC 7946 features. geopackage: OGC GeoPackage (.gpkg). csv: attribute rows (geometry as WKT when returnGeometry). parquet: (Geo)Parquet columnar."
+    },
+    "where": {
+      "type": "string",
+      "description": "Optional attribute filter (ArcGIS/SQL WHERE clause) selecting which features to export."
+    },
+    "outFields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional attribute fields to include; omit for all fields."
+    },
+    "returnGeometry": {
+      "type": "boolean",
+      "default": true,
+      "description": "When false, export attributes only (no geometry). csv/parquet exports of attribute tables commonly set this false."
+    },
+    "outSrid": {
+      "type": "integer",
+      "description": "Output spatial reference (SRID/WKID) for exported geometries; defaults to the source CRS."
+    }
+  },
+  "$defs": {
+    "layerRef": {
+      "type": "object",
+      "required": ["serviceId", "layerId"],
+      "additionalProperties": false,
+      "properties": {
+        "serviceId": { "type": "string", "minLength": 1, "description": "Published service identifier or name (from list_layers.serviceId or resolve_entity)." },
+        "layerId": { "type": "integer", "minimum": 0, "description": "Service-local layer index (from list_layers.layerId)." }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "required": ["artifactId"],
+      "additionalProperties": false,
+      "properties": {
+        "artifactId": { "type": "string", "minLength": 1, "description": "Identifier (artifact_…) of a prior-result ArtifactRef produced by an earlier analysis job or verb. See resources/artifact.schema.json." }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/join_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/join_features.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/join_features.schema.json",
+  "title": "join_features inputSchema",
+  "description": "Direct geoprocessing verb (advertised name honua_join_features): join a second dataset onto a target dataset — either an attribute join on matching key fields or a spatial join by geometric relationship — and return the joined features. Use this for a single self-contained join step (\"attach the demographics table to the tracts\", \"tag each incident with the county it falls in\"); for multi-step analysis with dependencies and a packaged result, use plan_analysis + execute_plan instead. Member of the standard's opt-in **analysis** conformance profile (see /CONFORMANCE.md and docs/adr/0029-direct-geoprocessing-verbs.md). Long-running calls return an ExecutionJob handle (honua://jobs/{job_id}), pollable and cancelable via cancel_job; small/fast calls may return an inline result. Advertised readOnlyHint: true (computes a derived result; mutates no server state). x-honua-reference-shape: the concrete source (serviceId/layerId, artifactId) spellings track the reference pipeline.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["target", "join", "joinType"],
+  "properties": {
+    "target": {
+      "description": "Target (left) dataset whose features are kept and enriched: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId).",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "join": {
+      "description": "Join (right) dataset supplying attributes to append: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId).",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "joinType": {
+      "type": "string",
+      "enum": ["attribute", "spatial"],
+      "description": "attribute: match on equal key fields (targetField = joinField). spatial: match by geometric relationship (spatialRelationship)."
+    },
+    "targetField": {
+      "type": "string",
+      "description": "Attribute join only: key field on the target dataset. Required when joinType is attribute."
+    },
+    "joinField": {
+      "type": "string",
+      "description": "Attribute join only: key field on the join dataset matched against targetField. Required when joinType is attribute."
+    },
+    "spatialRelationship": {
+      "type": "string",
+      "enum": ["intersects", "contains", "within", "nearest"],
+      "description": "Spatial join only: geometric predicate relating a target feature to join features. Required when joinType is spatial."
+    },
+    "joinOperation": {
+      "type": "string",
+      "default": "one_to_one",
+      "enum": ["one_to_one", "one_to_many"],
+      "description": "one_to_one: one output row per target feature (matches aggregated per joinAggregation on conflict). one_to_many: one output row per matching pair."
+    },
+    "joinAggregation": {
+      "type": "string",
+      "enum": ["first", "count", "sum", "min", "max", "mean"],
+      "description": "one_to_one only: how to reduce multiple matches for a target feature. Defaults to an implementation-defined first-match when omitted."
+    }
+  },
+  "$defs": {
+    "layerRef": {
+      "type": "object",
+      "required": ["serviceId", "layerId"],
+      "additionalProperties": false,
+      "properties": {
+        "serviceId": { "type": "string", "minLength": 1, "description": "Published service identifier or name (from list_layers.serviceId or resolve_entity)." },
+        "layerId": { "type": "integer", "minimum": 0, "description": "Service-local layer index (from list_layers.layerId)." }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "required": ["artifactId"],
+      "additionalProperties": false,
+      "properties": {
+        "artifactId": { "type": "string", "minLength": 1, "description": "Identifier (artifact_…) of a prior-result ArtifactRef produced by an earlier analysis job or verb. See resources/artifact.schema.json." }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/overlay_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/overlay_features.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/overlay_features.schema.json",
+  "title": "overlay_features inputSchema",
+  "description": "Direct geoprocessing verb (advertised name honua_overlay_features): compute a two-input topological overlay (intersect, union, difference, erase, or clip) and return the result features. Use this for a single self-contained overlay step (\"intersect the flood zones with the parcels\"); for multi-step analysis with dependencies and a packaged result, use plan_analysis + execute_plan instead. Member of the standard's opt-in **analysis** conformance profile (see /CONFORMANCE.md and docs/adr/0029-direct-geoprocessing-verbs.md). Long-running calls return an ExecutionJob handle (honua://jobs/{job_id}), pollable and cancelable via cancel_job; small/fast calls may return an inline result. Advertised readOnlyHint: true (computes a derived result; mutates no server state). x-honua-reference-shape: the concrete source (serviceId/layerId, artifactId) spellings track the reference pipeline.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["source", "overlay", "operation"],
+  "properties": {
+    "source": {
+      "description": "Primary input dataset: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId).",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "overlay": {
+      "description": "Overlay dataset combined with source: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId).",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "operation": {
+      "type": "string",
+      "enum": ["intersect", "union", "difference", "erase", "clip"],
+      "description": "Overlay operation. intersect: geometry AND attributes of both where they overlap. union: full combination of both inputs. difference: source minus overlay (source attributes kept). erase: remove the overlay area from source. clip: cut source to the overlay boundary (source attributes only)."
+    },
+    "outSrid": {
+      "type": "integer",
+      "description": "Output spatial reference (SRID/WKID) for the returned overlay features; defaults to the source CRS."
+    }
+  },
+  "$defs": {
+    "layerRef": {
+      "type": "object",
+      "required": ["serviceId", "layerId"],
+      "additionalProperties": false,
+      "properties": {
+        "serviceId": { "type": "string", "minLength": 1, "description": "Published service identifier or name (from list_layers.serviceId or resolve_entity)." },
+        "layerId": { "type": "integer", "minimum": 0, "description": "Service-local layer index (from list_layers.layerId)." }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "required": ["artifactId"],
+      "additionalProperties": false,
+      "properties": {
+        "artifactId": { "type": "string", "minLength": 1, "description": "Identifier (artifact_…) of a prior-result ArtifactRef produced by an earlier analysis job or verb. See resources/artifact.schema.json." }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/publish_result.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/publish_result.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/publish_result.schema.json",
   "title": "publish_result inputSchema",
-  "description": "Argument shape for publish_result (Analyze, Publish Data, Build App). Promotes a result/package to a canonical promotion-surface target: PublishedService for Publish Data, Deployment for Analyze and Build App (resources.md §Promotion-Surface Resources). Publish/PolicyBoundary clarifications fire before handoff (planning.md). Responsibility-level: concrete promotion field set finalizes upstream (honua-server#730/#732).",
+  "description": "Argument shape for publish_result (Analyze, Publish Data, Build App). Promotes a result/package to a canonical promotion-surface target: PublishedService for Analyze and Publish Data, Deployment for Build App (resources.md §Promotion-Surface Resources). Publish/PolicyBoundary clarifications fire before handoff (planning.md). Responsibility-level: concrete promotion field set finalizes upstream (honua-server#730/#732).",
   "type": "object",
   "additionalProperties": true,
   "required": ["sourceId"],
@@ -13,7 +13,7 @@
     },
     "targetKind": {
       "type": "string",
-      "description": "Promotion-surface target family. Published_service for Publish Data; deployment for Analyze and Build App.",
+      "description": "Promotion-surface target family. published_service for Analyze and Publish Data; deployment for Build App.",
       "enum": ["published_service", "deployment"]
     },
     "visibility": {

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/query_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/query_features.schema.json
@@ -65,6 +65,10 @@
       "type": "integer",
       "default": 4326,
       "description": "Output spatial reference (SRID/WKID) for returned geometries."
+    },
+    "geometryPrecision": {
+      "type": "integer",
+      "description": "Optional number of decimal places to round returned GeoJSON coordinates to, trading positional precision for a smaller response/context budget. A negative value returns full precision. When omitted, precision is implementation-defined; the reference implementation defaults to 6 (~0.1 m), which cuts coordinate payload roughly 12% at the default and far more for dense geometries. Standardized from the honua-server x-honua extension (geospatial-mcp#52)."
     }
   }
 }

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/render_map.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/render_map.schema.json
@@ -50,6 +50,11 @@
       "type": "boolean",
       "default": false,
       "description": "Render a transparent background instead of an opaque one."
+    },
+    "maxInlineBytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional ceiling, in bytes, on inline base64 image content. When the rendered image is at or below this size it may be returned inline; above it, the tool returns a resource_link href to the image instead of inlining megabytes of PNG into model context. When omitted, inlining behavior is implementation-defined; the reference implementation defaults to returning a resource_link href rather than inlining. Standardized from the honua-server x-honua extension (geospatial-mcp#52)."
     }
   }
 }

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/reproject_features.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/reproject_features.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/reproject_features.schema.json",
+  "title": "reproject_features inputSchema",
+  "description": "Direct geoprocessing verb (advertised name honua_reproject_features): reproject a whole dataset into a target spatial reference and return the reprojected features. Use this when reprojection is the goal (\"give me this layer in EPSG:3857\"); when you only need another verb's output in a particular CRS, prefer that verb's optional outSrid param instead of a second call. For multi-step analysis with dependencies and a packaged result, use plan_analysis + execute_plan instead. Member of the standard's opt-in **analysis** conformance profile (see /CONFORMANCE.md and docs/adr/0029-direct-geoprocessing-verbs.md). Long-running calls return an ExecutionJob handle (honua://jobs/{job_id}), pollable and cancelable via cancel_job; small/fast calls may return an inline result. Advertised readOnlyHint: true (computes a derived result; mutates no server state). x-honua-reference-shape: the concrete source (serviceId/layerId, artifactId) spellings track the reference pipeline.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["source", "targetSrid"],
+  "properties": {
+    "source": {
+      "description": "Dataset to reproject: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId).",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "targetSrid": {
+      "type": "integer",
+      "description": "Target spatial reference (SRID/WKID) to reproject into. Required — it is the operation's defining parameter."
+    },
+    "sourceSrid": {
+      "type": "integer",
+      "description": "Spatial reference (SRID/WKID) of the input geometries; defaults to the dataset's declared CRS. Provide only to override a missing or incorrect source CRS."
+    },
+    "where": {
+      "type": "string",
+      "description": "Optional attribute filter (ArcGIS/SQL WHERE clause) selecting which input features to reproject."
+    }
+  },
+  "$defs": {
+    "layerRef": {
+      "type": "object",
+      "required": ["serviceId", "layerId"],
+      "additionalProperties": false,
+      "properties": {
+        "serviceId": { "type": "string", "minLength": 1, "description": "Published service identifier or name (from list_layers.serviceId or resolve_entity)." },
+        "layerId": { "type": "integer", "minimum": 0, "description": "Service-local layer index (from list_layers.layerId)." }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "required": ["artifactId"],
+      "additionalProperties": false,
+      "properties": {
+        "artifactId": { "type": "string", "minLength": 1, "description": "Identifier (artifact_…) of a prior-result ArtifactRef produced by an earlier analysis job or verb. See resources/artifact.schema.json." }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/summarize_statistics.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/summarize_statistics.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/summarize_statistics.schema.json",
+  "title": "summarize_statistics inputSchema",
+  "description": "Direct geoprocessing verb (advertised name honua_summarize_statistics): compute summary statistics over a dataset, optionally grouped by attribute fields, and return the summary rows. Use this for a single self-contained summary step (\"total population by county\", \"mean parcel value by zoning\") over a layer or a prior overlay/verb result; for multi-step analysis with dependencies and a packaged result, use plan_analysis + execute_plan instead. Member of the standard's opt-in **analysis** conformance profile (see /CONFORMANCE.md and docs/adr/0029-direct-geoprocessing-verbs.md). Long-running calls return an ExecutionJob handle (honua://jobs/{job_id}), pollable and cancelable via cancel_job; small/fast calls may return an inline result. Advertised readOnlyHint: true (computes a derived result; mutates no server state). x-honua-reference-shape: the concrete source (serviceId/layerId, artifactId) spellings track the reference pipeline.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["source", "statistics"],
+  "properties": {
+    "source": {
+      "description": "Dataset to summarize: EITHER a published layer (serviceId + layerId) OR a prior-result artifact (artifactId) such as an overlay_features or join_features result.",
+      "oneOf": [
+        { "$ref": "#/$defs/layerRef" },
+        { "$ref": "#/$defs/artifactRef" }
+      ]
+    },
+    "groupByFields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Attribute fields to group by. Omit for a single summary row over all matching features."
+    },
+    "statistics": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Statistics to compute. Each entry names a statistic type and the field it is computed on.",
+      "items": {
+        "type": "object",
+        "required": ["statisticType", "onField"],
+        "additionalProperties": false,
+        "properties": {
+          "statisticType": {
+            "type": "string",
+            "enum": ["count", "sum", "min", "max", "mean", "stddev", "var"],
+            "description": "Aggregate to compute. count ignores onField values (counts rows)."
+          },
+          "onField": {
+            "type": "string",
+            "description": "Attribute field the statistic is computed on."
+          },
+          "outField": {
+            "type": "string",
+            "description": "Optional name for the output column; defaults to an implementation-defined name derived from statisticType and onField."
+          }
+        }
+      }
+    },
+    "where": {
+      "type": "string",
+      "description": "Optional attribute filter (ArcGIS/SQL WHERE clause) selecting which input features are summarized."
+    }
+  },
+  "$defs": {
+    "layerRef": {
+      "type": "object",
+      "required": ["serviceId", "layerId"],
+      "additionalProperties": false,
+      "properties": {
+        "serviceId": { "type": "string", "minLength": 1, "description": "Published service identifier or name (from list_layers.serviceId or resolve_entity)." },
+        "layerId": { "type": "integer", "minimum": 0, "description": "Service-local layer index (from list_layers.layerId)." }
+      }
+    },
+    "artifactRef": {
+      "type": "object",
+      "required": ["artifactId"],
+      "additionalProperties": false,
+      "properties": {
+        "artifactId": { "type": "string", "minLength": 1, "description": "Identifier (artifact_…) of a prior-result ArtifactRef produced by an earlier analysis job or verb. See resources/artifact.schema.json." }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -106,6 +106,18 @@ public sealed partial class McpTaxonomyAlignmentTests
         // standard still publishes the schema, so the gap is real and closeable
         // by any adopter that makes a different trust decision — but not by Honua.
         "edit_features",
+        // Direct geoprocessing verbs: members of the standard's opt-in 'analysis'
+        // conformance profile (geospatial-mcp#55, upstream ADR-0029). The index
+        // marks them known-gap for the reference implementation; they are required
+        // for FULL only when a manifest declares the analysis profile. Honua does
+        // not ship direct verbs yet (#2555/#2566 and the A8/analysis track) —
+        // plan_analysis/execute_plan cover those workflows today.
+        "buffer_features",
+        "overlay_features",
+        "summarize_statistics",
+        "reproject_features",
+        "join_features",
+        "export_dataset",
     };
 
     /// <summary>


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2496

## Summary
Wholesale re-vendor of the `tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/` tree from a single pinned geospatial-mcp trunk commit, replacing the per-PR surgical syncs from the P1 tool wave. The vendored tree is now byte-identical to `spec/schemas/` at geospatial-mcp `eb53989cc61c856261cf017b4b5a8e721317dc41` ("feat: direct geoprocessing verbs (analysis profile) + geometryPrecision/maxInlineBytes (#55)", 2026-07-06) — verified with `diff -r` against the pinned commit's blobs — and the provenance note records the pin. The standard's own conformance fixtures were synced from the same commit so the fixture assertions exercise the new schema set.

Upstream drift absorbed by this pin (no vendored file was hand-edited):
- `edit_features` is now the mutation-profile known-gap with `referenceToolName: null` (upstream 0bb6fa3, matching ADR-0028 — already reflected in our harness).
- Six new analysis-profile direct geoprocessing verbs (`buffer_features`, `overlay_features`, `summarize_statistics`, `reproject_features`, `join_features`, `export_dataset`) enter as known-gap standard tools per the index conventions; the server does not implement them yet (#2555/#2566 and the A8/analysis track). They are registered in `KnownGapStandardTools` so their absence is recorded, not failed.
- `query_features.geometryPrecision` and `render_map.maxInlineBytes` were standardized from the honua-server x-honua extensions (geospatial-mcp#52/#55); the live tools already advertise them, so the new upstream fixtures validate against both schemas with no server change.
- New `resources/app-template.schema.json`, upstream `README.md`, and `conformance/manifest.schema.json` now ride along so the tree mirrors upstream exactly.

Note: geospatial-mcp trunk has since moved past this pin (geospatial-mcp#58, platform-ops schemas). The pin is deliberately held at `eb53989` (pre-#58): the #58 schemas are marked implemented in the manifest but honua-server does not serve those tools yet, so re-vendoring past #58 would introduce conformance failures. The post-#58 bump is owned by #2555/#2566, which implement the new tools and vendor their schemas together (recorded in the provenance note).

## Changes Made
- Replace `ConformanceSchemas/geospatial-mcp/` wholesale with a byte-identical copy of geospatial-mcp `eb53989` `spec/schemas/` (six new analysis-verb schemas, app-template resource schema, upstream README + conformance manifest schema, description/enum drift from upstream #44/#50/#54 reconciled).
- Sync `ConformanceSchemas/fixtures/` from the same commit's `conformance/fixtures/` (new geometry-precision, inline-bytes, wire-spelling, deployment, and published-service fixtures), keeping the two Honua-extension fixture dirs (`resolve_entity`, `list_capabilities`) that upstream does not carry yet.
- Add the six analysis-profile verbs to `KnownGapStandardTools` in `McpGeospatialMcpSchemaConformanceTests` with the profile/ADR rationale.
- Rewrite the `ConformanceSchemas/README.md` provenance note to record the pinned commit and the wholesale re-vendor policy.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`dotnet test tests/dotnet/Honua.Ai.Tests` — 476 passed, 0 failed, 0 skipped (conformance + taxonomy + capability-manifest suites all green against the new pin).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
