### PR TITLE
feat(mcp): map the clarification envelope onto MCP-native elicitation (#2484)

### DIFF
--- a/docs/internal/contributor/adr/0061-mcp-native-elicitation-mapping.md
+++ b/docs/internal/contributor/adr/0061-mcp-native-elicitation-mapping.md
@@ -1,0 +1,101 @@
+# ADR-0061: Map the clarification envelope onto MCP-native elicitation
+
+Status: Accepted
+Date: 2026-07-07
+
+## Context
+
+Honua's grounding surface asks the operator to disambiguate a natural-language
+goal through a **clarification envelope**: `honua_ground_candidates` /
+`honua_clarify_intent` return a `ClarificationRequest` (intentId, reason codes,
+and a list of typed questions — single-select, multi-select, free-text, or a
+confirmation/approval question), and the caller replays the answers through
+`honua_clarify_intent` (ADR-0027). This is a Honua-proprietary shape carried in
+the tool result's `structuredContent.clarification`.
+
+MCP 2025-06-18 standardized **elicitation**: a client that declares the
+`elicitation` capability at `initialize` can render a server-supplied
+`requestedSchema` (a flat object of primitive properties) as a native input
+form. Issue #1954 listed "map Honua's clarification envelope onto MCP-native
+elicitation" among its acceptance criteria but never delivered it; #2484 tracks
+the deferred work.
+
+Two constraints shape the design:
+
+- **ADR-0028 / the deterministic-server model.** The model/agent runs
+  client-side; the Honua MCP server is a deterministic, stateless-per-turn tool
+  provider. It does not own the interaction loop.
+- **The Streamable-HTTP transport is request/response for `tools/call` plus a
+  one-way server→client SSE notification channel.** It has no machinery to issue
+  a server-initiated JSON-RPC *request* and await a correlated client *response*
+  mid-tool-call. A literal server-initiated `elicitation/create` round-trip
+  would require a new bidirectional request/response subsystem.
+
+## Decision
+
+Map the clarification envelope onto the MCP elicitation **payload**, capability-
+detected per session, and hand it back to the client inside the tool result
+rather than performing a server-initiated round-trip.
+
+1. **Capability detection at `initialize`.** When the client's `capabilities`
+   object advertises `elicitation` (`"elicitation": {}`), the session issued on
+   the `Mcp-Session-Id` header records an `ElicitationSupported` flag
+   (`McpSessionManager`). The flag is negotiated once at handshake and read on
+   later `tools/call`s via the session id.
+
+2. **Projection in the grounding tools.** When a grounding/clarify turn produces
+   a clarification and the calling session supports elicitation, the tool emits
+   an `elicitation` object — the MCP `elicitation/create` `params` shape
+   (`message` + `requestedSchema`) — and clears the proprietary `clarification`
+   envelope (exactly one is populated). The client renders the form, collects
+   answers, and replays them through `honua_clarify_intent` (answers keyed by the
+   same `questionId`, so the round-trip is mechanical).
+
+3. **Graceful fallback.** A session that did not advertise elicitation, a
+   stateless request with no session id, or a clarification that is not
+   representable in the elicitation subset keeps the existing `clarification`
+   envelope unchanged. The default (no-elicitation) response is byte-identical to
+   today's behavior.
+
+4. **Question-kind mapping** (elicitation permits only flat primitive schemas):
+   - single-select with options → `string` with `enum` + `enumNames`
+   - free-text (and a degenerate option-less single-select) → `string`
+   - confirmation/approval → `boolean`
+   - **multi-select → not representable** (it needs an array, which the subset
+     forbids). Such envelopes fall back to the proprietary shape even when the
+     client supports elicitation.
+
+## Rationale / deviation from a literal reading
+
+"Uses MCP elicitation" is realized as *the client executing an
+elicitation the server supplied*, not as a server-initiated
+`elicitation/create` RPC. This is the sound interpretation for a deterministic,
+client-driven tool server on a request/response transport: the server produces a
+standards-shaped elicitation the elicitation-capable client renders natively,
+instead of a proprietary envelope it would have to special-case. It satisfies
+#2484's acceptance criteria (capability-detected, graceful fallback, tested)
+without building a bidirectional request/response subsystem that the transport
+and the deterministic-server model do not call for.
+
+## Consequences
+
+- The grounding output gains an optional `elicitation` field alongside the
+  optional `clarification` field; the two are mutually exclusive on a turn. The
+  published `outputSchema` documents both. Input schemas and the vendored
+  `geospatial-mcp` conformance schemas are untouched.
+- No new endpoint, migration, or transport method; the change is additive and
+  backward-compatible.
+
+## Follow-ups (geospatial-mcp standard)
+
+Recommended, not implemented here:
+
+- The `geospatial-mcp` standard should bless the tool-result-embedded elicitation
+  hand-off (server supplies `elicitation/create` params in the grounding result
+  for a client to execute) so reference clients handle it uniformly, and clarify
+  how elicitation `content` maps back onto `clarify_intent.response.answers`
+  (including boolean confirmation → answer string).
+- Consider a representation for **multi-select** clarifications, which the
+  current elicitation subset (flat primitives, no arrays) cannot express.
+- If a future transport/profile supports server-initiated request/response, a
+  literal `elicitation/create` round-trip could supersede the embedded hand-off.

--- a/docs/internal/contributor/adr/README.md
+++ b/docs/internal/contributor/adr/README.md
@@ -62,6 +62,8 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0056](0056-mcp-redesign-unified-governed-surface.md) | MCP Redesign — Unified, Client-Agnostic, Governed Surface (Sequencing Plan) | Proposed | 2026-06 |
 | [0058](0058-unified-capability-registry-single-source-of-truth.md) | Unified Capability Registry as Single Source of Truth for MCP, Spec Conformance, and Studio AI | Accepted | 2026-07 |
 | [0059](0059-first-release-scope-and-fix-forward-operate-model.md) | First-Release Scope and Fix-Forward Operate Model | Accepted | 2026-07 |
+| [0060](0060-two-plane-operability-architecture.md) | Two-Plane Operability Architecture — Substrate-Neutral Executors Over a Unified Catalog | Proposed | 2026-07 |
+| [0061](0061-mcp-native-elicitation-mapping.md) | Map the Clarification Envelope onto MCP-Native Elicitation | Accepted | 2026-07 |
 
 ## Template
 

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Grounding/ClarificationElicitationMapper.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Grounding/ClarificationElicitationMapper.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Ai.Protocols.Mcp.Grounding;
+
+// -----------------------------------------------------------------------
+// MCP-native elicitation payload (honua-server#2484)
+//
+// MCP 2025-06-18 elicitation lets a server request structured input from the
+// user through the client (`elicitation/create`: message + requestedSchema).
+// Honua's deterministic, stateless MCP tools do not own the interaction loop
+// (ADR-0028: the model/agent runs client-side), so rather than performing a
+// server-initiated round-trip the grounding tools hand the elicitation payload
+// back to the client inside the tool result. An elicitation-capable client
+// renders `requestedSchema` as a native form, collects the answers, and replays
+// them through honua_clarify_intent (answers keyed by the same questionId). When
+// the client did not advertise the elicitation capability the tools fall back to
+// the proprietary clarification envelope unchanged.
+// -----------------------------------------------------------------------
+
+/// <summary>
+/// An MCP <c>elicitation/create</c> request payload (the <c>params</c> object).
+/// Carries a human-readable <see cref="Message"/> and a
+/// <see cref="RequestedSchema"/> the client renders into an input form.
+/// </summary>
+internal sealed class McpElicitationRequest
+{
+    /// <summary>Human-readable prompt describing what is being requested and why.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The restricted JSON Schema (flat object of primitive properties) describing
+    /// the expected response, per the MCP elicitation schema subset.
+    /// </summary>
+    [JsonPropertyName("requestedSchema")]
+    public McpElicitationSchema RequestedSchema { get; set; } = new();
+}
+
+/// <summary>
+/// The <c>requestedSchema</c> of an elicitation request: a flat <c>object</c>
+/// whose properties are primitive schemas keyed by clarification questionId.
+/// </summary>
+internal sealed class McpElicitationSchema
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "object";
+
+    [JsonPropertyName("properties")]
+    public IReadOnlyDictionary<string, McpElicitationProperty> Properties { get; set; }
+        = new Dictionary<string, McpElicitationProperty>(StringComparer.Ordinal);
+
+    [JsonPropertyName("required")]
+    public IReadOnlyList<string> Required { get; set; } = [];
+}
+
+/// <summary>
+/// A single primitive property of an elicitation <c>requestedSchema</c>. Only the
+/// MCP-permitted primitive shapes are expressed: <c>string</c> (optionally an
+/// enum via <see cref="Enum"/>/<see cref="EnumNames"/>) and <c>boolean</c>.
+/// Arrays and nested objects are intentionally never emitted — the MCP
+/// elicitation subset forbids them.
+/// </summary>
+internal sealed class McpElicitationProperty
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "string";
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("enum")]
+    public IReadOnlyList<string>? Enum { get; set; }
+
+    [JsonPropertyName("enumNames")]
+    public IReadOnlyList<string>? EnumNames { get; set; }
+}
+
+/// <summary>
+/// Maps Honua's canonical clarification envelope onto an MCP-native elicitation
+/// request and gates the projection on the calling session having advertised the
+/// elicitation capability (honua-server#2484).
+/// </summary>
+internal static class ClarificationElicitationMapper
+{
+    private const string StringType = "string";
+    private const string BooleanType = "boolean";
+
+    /// <summary>
+    /// Projects a clarification envelope onto <paramref name="output"/> as an MCP
+    /// elicitation request when <paramref name="clientSupportsElicitation"/> is
+    /// <c>true</c> and every question is representable in the elicitation schema
+    /// subset. On a successful projection the proprietary
+    /// <see cref="McpGroundingOutput.Clarification"/> envelope is cleared so the
+    /// client drives the native elicitation path; otherwise the envelope is left
+    /// intact (graceful fallback) and no elicitation is emitted.
+    /// </summary>
+    public static void ProjectOntoOutput(
+        McpGroundingOutput output,
+        ClarificationRequest? clarification,
+        bool clientSupportsElicitation)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (!clientSupportsElicitation || clarification is null)
+        {
+            return;
+        }
+
+        var elicitation = TryMap(clarification);
+        if (elicitation is null)
+        {
+            // Not representable in the elicitation subset (e.g. a multi-select
+            // question, which would require an array the subset forbids). Keep the
+            // proprietary envelope so the turn still round-trips.
+            return;
+        }
+
+        output.Elicitation = elicitation;
+        output.Clarification = null;
+    }
+
+    /// <summary>
+    /// Maps a clarification envelope to an MCP elicitation request, or returns
+    /// <c>null</c> when any question cannot be expressed in the elicitation schema
+    /// subset (multi-select, blank/duplicate ids). Exposed for direct unit tests
+    /// of the mapping in isolation from the tool/session plumbing.
+    /// </summary>
+    public static McpElicitationRequest? TryMap(ClarificationRequest clarification)
+    {
+        ArgumentNullException.ThrowIfNull(clarification);
+
+        if (clarification.Questions.Count == 0)
+        {
+            return null;
+        }
+
+        var properties = new Dictionary<string, McpElicitationProperty>(StringComparer.Ordinal);
+        var required = new List<string>(clarification.Questions.Count);
+
+        foreach (var question in clarification.Questions)
+        {
+            if (string.IsNullOrWhiteSpace(question.QuestionId)
+                || properties.ContainsKey(question.QuestionId))
+            {
+                // Blank or duplicate ids would collide as object keys; fall back
+                // to the proprietary envelope rather than emit an ambiguous form.
+                return null;
+            }
+
+            if (!TryMapQuestion(question, out var property))
+            {
+                return null;
+            }
+
+            properties[question.QuestionId] = property;
+            required.Add(question.QuestionId);
+        }
+
+        return new McpElicitationRequest
+        {
+            Message = BuildMessage(clarification),
+            RequestedSchema = new McpElicitationSchema
+            {
+                Properties = properties,
+                Required = required
+            }
+        };
+    }
+
+    private static bool TryMapQuestion(ClarificationQuestion question, out McpElicitationProperty property)
+    {
+        switch (question.Kind)
+        {
+            case ClarificationQuestionKind.SingleSelect when question.Options is { Count: > 0 } options:
+                property = new McpElicitationProperty
+                {
+                    Type = StringType,
+                    Description = question.Prompt,
+                    Enum = options.Select(o => o.Id).ToArray(),
+                    EnumNames = options.Select(o => o.Label).ToArray()
+                };
+                return true;
+
+            case ClarificationQuestionKind.SingleSelect:
+            case ClarificationQuestionKind.FreeText:
+                property = new McpElicitationProperty
+                {
+                    Type = StringType,
+                    Description = question.Prompt
+                };
+                return true;
+
+            case ClarificationQuestionKind.Confirmation:
+                property = new McpElicitationProperty
+                {
+                    Type = BooleanType,
+                    Description = question.Prompt
+                };
+                return true;
+
+            case ClarificationQuestionKind.MultiSelect:
+            default:
+                // MultiSelect needs an array; the elicitation subset is flat
+                // primitives only, so it cannot be represented natively.
+                property = null!;
+                return false;
+        }
+    }
+
+    private static string BuildMessage(ClarificationRequest clarification)
+    {
+        var lead = string.IsNullOrWhiteSpace(clarification.IntentId)
+            ? "Additional detail is needed before Honua can continue."
+            : $"Additional detail is needed before Honua can continue with intent '{clarification.IntentId}'.";
+
+        if (clarification.ReasonCodes.Count == 0)
+        {
+            return lead;
+        }
+
+        var reasons = string.Join(", ", clarification.ReasonCodes.Select(r => r.ToString()));
+        return $"{lead} (reasons: {reasons})";
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the session identified by the request's
+    /// <c>Mcp-Session-Id</c> header advertised the MCP elicitation capability at
+    /// <c>initialize</c>. Resolves the process-wide
+    /// <see cref="McpSessionManager"/> from the request services; a request with
+    /// no session (stateless client) or a host without the manager registered
+    /// (isolated unit tests) reports <c>false</c>, i.e. graceful fallback.
+    /// </summary>
+    public static bool ClientSupportsElicitation(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var sessionId = httpContext.Request.Headers[McpSessionManager.SessionHeaderName].ToString();
+        if (string.IsNullOrEmpty(sessionId))
+        {
+            return false;
+        }
+
+        var sessions = httpContext.RequestServices?.GetService<McpSessionManager>();
+        return sessions is not null && sessions.SupportsElicitation(sessionId);
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Grounding/GroundingJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Grounding/GroundingJsonContext.cs
@@ -29,6 +29,9 @@ namespace Honua.Ai.Protocols.Mcp.Grounding;
 [JsonSerializable(typeof(McpClarificationEnvelope))]
 [JsonSerializable(typeof(McpClarificationQuestionView))]
 [JsonSerializable(typeof(McpClarificationOptionView))]
+[JsonSerializable(typeof(McpElicitationRequest))]
+[JsonSerializable(typeof(McpElicitationSchema))]
+[JsonSerializable(typeof(McpElicitationProperty))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Grounding/GroundingToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Grounding/GroundingToolModels.cs
@@ -139,6 +139,18 @@ internal sealed class McpGroundingOutput
     [JsonPropertyName("clarification")]
     public McpClarificationEnvelope? Clarification { get; set; }
 
+    /// <summary>
+    /// MCP-native elicitation request (honua-server#2484) emitted in place of the
+    /// proprietary <see cref="Clarification"/> envelope when the calling session
+    /// advertised the elicitation capability and the envelope is representable in
+    /// the elicitation schema subset. Mutually exclusive with
+    /// <see cref="Clarification"/>: exactly one is populated on a clarification
+    /// turn. Null when no clarification is needed or the client did not advertise
+    /// elicitation (graceful fallback to the envelope).
+    /// </summary>
+    [JsonPropertyName("elicitation")]
+    public McpElicitationRequest? Elicitation { get; set; }
+
     [JsonPropertyName("engine")]
     public string Engine { get; set; } = string.Empty;
 }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
@@ -186,7 +186,14 @@ internal static class McpEndpointExtensions
             // structured error instead of a session header (A3 hardening; #2537).
             if (isInitialize && response.Error is null)
             {
-                if (sessions.TryCreateSession(principalKey, out var sessionId))
+                // honua-server#2484: bind the client's advertised elicitation
+                // capability (recorded on HttpContext.Items during initialize) to
+                // the session so clarification-emitting tools can later choose the
+                // MCP-native elicitation projection over the proprietary envelope.
+                var elicitationSupported =
+                    context.Items.TryGetValue(McpOperatorSurface.ElicitationCapabilityItemKey, out var flag)
+                    && flag is true;
+                if (sessions.TryCreateSession(principalKey, elicitationSupported, out var sessionId))
                 {
                     context.Response.Headers[McpSessionManager.SessionHeaderName] = sessionId;
                     McpLog.SessionIssued(logger, sessionId);

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
@@ -155,7 +155,7 @@ internal sealed class McpOperatorSurface
         {
             return request.Method switch
             {
-                "initialize" => HandleInitialize(request),
+                "initialize" => HandleInitialize(httpContext, request),
                 "tools/list" => ListTools(request),
                 "tools/call" => await CallToolAsync(httpContext, request, cancellationToken).ConfigureAwait(false),
                 "resources/list" => ListResources(request),
@@ -173,7 +173,16 @@ internal sealed class McpOperatorSurface
         }
     }
 
-    private static McpJsonRpcResponse HandleInitialize(McpJsonRpcRequest request)
+    /// <summary>
+    /// <see cref="HttpContext.Items"/> key under which <c>initialize</c> records
+    /// whether the client advertised the MCP elicitation capability, so the
+    /// transport can bind the flag to the session it issues on success
+    /// (honua-server#2484). Request-scoped: initialize and the session-creating
+    /// code run within the same <see cref="HttpContext"/>.
+    /// </summary>
+    internal const string ElicitationCapabilityItemKey = "honua.mcp.client.elicitation";
+
+    private static McpJsonRpcResponse HandleInitialize(HttpContext httpContext, McpJsonRpcRequest request)
     {
         var parameters = ParseParams(request.Params, McpJsonContext.Default.McpInitializeParams);
         if (parameters is null)
@@ -206,6 +215,13 @@ internal sealed class McpOperatorSurface
                 McpErrorMapper.InvalidArgument("initialize.params.clientInfo.name is required."));
         }
 
+        // honua-server#2484: record whether the client advertised the elicitation
+        // capability so the session issued on success carries it. Per MCP
+        // 2025-06-18 an elicitation-capable client sends `capabilities.elicitation`
+        // as an object; presence of the key (as an object) is the signal.
+        httpContext.Items[ElicitationCapabilityItemKey] =
+            AdvertisesElicitation(parameters.Capabilities.Value);
+
         var negotiatedVersion = NegotiateProtocolVersion(parameters.ProtocolVersion);
         var result = new McpInitializeResult
         {
@@ -224,6 +240,18 @@ internal sealed class McpOperatorSurface
         };
         return SuccessResponse(request.Id, result, McpJsonContext.Default.McpInitializeResult);
     }
+
+    /// <summary>
+    /// Returns <c>true</c> when the client's <c>initialize</c> capabilities object
+    /// advertises the MCP elicitation capability (honua-server#2484). Per MCP
+    /// 2025-06-18 a supporting client declares <c>"elicitation": {}</c>; presence
+    /// of the key as an object is the contract. A non-object <c>elicitation</c>
+    /// value is treated as not advertised.
+    /// </summary>
+    private static bool AdvertisesElicitation(JsonElement capabilities) =>
+        capabilities.ValueKind == JsonValueKind.Object
+        && capabilities.TryGetProperty("elicitation", out var elicitation)
+        && elicitation.ValueKind == JsonValueKind.Object;
 
     private static string NegotiateProtocolVersion(string requestedVersion)
     {

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpSessionManager.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpSessionManager.cs
@@ -137,7 +137,8 @@ internal sealed class McpSessionManager
     /// Creates and registers a new session bound to the anonymous principal,
     /// returning its id. Retained for callers and tests that do not thread a
     /// principal; production <c>initialize</c> handling uses
-    /// <see cref="TryCreateSession"/> so it can honor the capacity policy.
+    /// <see cref="TryCreateSession(string?, bool, out string)"/> so it can honor
+    /// the capacity policy.
     /// </summary>
     public string CreateSession()
     {
@@ -155,7 +156,18 @@ internal sealed class McpSessionManager
     /// policy is <see cref="McpSessionEvictionPolicy.RejectNew"/>. Invoked when the
     /// server accepts an <c>initialize</c> request in stateful mode.
     /// </summary>
-    public bool TryCreateSession(string? principalKey, out string sessionId)
+    public bool TryCreateSession(string? principalKey, out string sessionId) =>
+        TryCreateSession(principalKey, elicitationSupported: false, out sessionId);
+
+    /// <summary>
+    /// Creates and registers a new session, additionally recording whether the
+    /// client advertised the MCP elicitation capability at <c>initialize</c>
+    /// (honua-server#2484). Behaves identically to
+    /// <see cref="TryCreateSession(string?, out string)"/> otherwise; the flag is
+    /// later read by <see cref="SupportsElicitation"/> so clarification-emitting
+    /// tools can choose the elicitation projection over the proprietary envelope.
+    /// </summary>
+    public bool TryCreateSession(string? principalKey, bool elicitationSupported, out string sessionId)
     {
         var now = _timeProvider.GetUtcNow();
         lock (_capacityGate)
@@ -174,10 +186,28 @@ internal sealed class McpSessionManager
             }
 
             var id = GenerateSessionId();
-            _sessions[id] = new McpSession(principalKey ?? AnonymousPrincipalKey, now);
+            _sessions[id] = new McpSession(principalKey ?? AnonymousPrincipalKey, now, elicitationSupported);
             sessionId = id;
             return true;
         }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the session identified by <paramref name="sessionId"/>
+    /// is active and its client advertised the MCP elicitation capability at
+    /// <c>initialize</c> (honua-server#2484). An unknown, terminated, or
+    /// idle-expired id — or a session whose client did not advertise elicitation —
+    /// reports <c>false</c>. Does not refresh the sliding idle window: this is a
+    /// read of state established at handshake, not client activity.
+    /// </summary>
+    public bool SupportsElicitation(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId) || !_sessions.TryGetValue(sessionId, out var session))
+        {
+            return false;
+        }
+
+        return !IsExpired(session, _timeProvider.GetUtcNow()) && session.ElicitationSupported;
     }
 
     /// <summary>
@@ -400,10 +430,11 @@ internal sealed class McpSessionManager
 
     private sealed class McpSession
     {
-        public McpSession(string principalKey, DateTimeOffset createdUtc)
+        public McpSession(string principalKey, DateTimeOffset createdUtc, bool elicitationSupported = false)
         {
             PrincipalKey = principalKey;
             LastAccessUtc = createdUtc;
+            ElicitationSupported = elicitationSupported;
         }
 
         /// <summary>
@@ -411,6 +442,13 @@ internal sealed class McpSessionManager
         /// (<see cref="AnonymousPrincipalKey"/> for an anonymous session).
         /// </summary>
         public string PrincipalKey { get; }
+
+        /// <summary>
+        /// Whether the client advertised the MCP elicitation capability at
+        /// <c>initialize</c> (honua-server#2484). Immutable for the session
+        /// lifetime — capabilities are negotiated once at handshake.
+        /// </summary>
+        public bool ElicitationSupported { get; }
 
         /// <summary>
         /// Last time a client request touched this session; drives the sliding idle

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ClarifyIntentTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ClarifyIntentTool.cs
@@ -74,6 +74,14 @@ internal sealed class ClarifyIntentTool : IMcpTool
         var result = await _groundingService.GroundAsync(request, principal, cancellationToken).ConfigureAwait(false);
         var output = GroundingToolMapper.ToWire(result);
 
+        // honua-server#2484: when the calling session advertised the MCP
+        // elicitation capability, project any residual clarification envelope onto
+        // a native elicitation request; otherwise the envelope is left intact.
+        ClarificationElicitationMapper.ProjectOntoOutput(
+            output,
+            result.Clarification,
+            ClarificationElicitationMapper.ClientSupportsElicitation(httpContext));
+
         McpTelemetry.RecordGroundingResult(
             engine: result.Engine,
             workflowFamily: result.WorkflowFamily.Value.ToString(),

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/GroundCandidatesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/GroundCandidatesTool.cs
@@ -69,6 +69,14 @@ internal sealed class GroundCandidatesTool : IMcpTool
         var result = await _groundingService.GroundAsync(request, principal, cancellationToken).ConfigureAwait(false);
         var output = GroundingToolMapper.ToWire(result);
 
+        // honua-server#2484: when the calling session advertised the MCP
+        // elicitation capability, project the clarification envelope onto a native
+        // elicitation request; otherwise the envelope is left intact (fallback).
+        ClarificationElicitationMapper.ProjectOntoOutput(
+            output,
+            result.Clarification,
+            ClarificationElicitationMapper.ClientSupportsElicitation(httpContext));
+
         McpTelemetry.RecordGroundingResult(
             engine: result.Engine,
             workflowFamily: result.WorkflowFamily.Value.ToString(),

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -258,7 +258,11 @@ internal static class McpToolOutputSchemas
     /// Schema for <c>McpGroundingOutput</c> (shared by honua_ground_candidates
     /// and honua_clarify_intent). The classification, draft intent, candidate
     /// ranking, and optional clarification envelope are deep nested shapes; the
-    /// schema pins the top-level envelope and leaves those sub-objects open.
+    /// schema pins the top-level envelope and leaves those sub-objects open. On a
+    /// clarification turn exactly one of <c>clarification</c> (proprietary
+    /// envelope) or <c>elicitation</c> (MCP-native elicitation request, emitted
+    /// when the session advertised the elicitation capability; honua-server#2484)
+    /// is populated.
     /// </summary>
     public static readonly JsonElement GroundingOutputSchema = Parse(
         """
@@ -270,6 +274,7 @@ internal static class McpToolOutputSchemas
             "draftIntent": { "type": "object" },
             "candidates": { "type": "object" },
             "clarification": { "type": ["object", "null"] },
+            "elicitation": { "type": ["object", "null"] },
             "engine": { "type": "string" }
           }
         }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpClarificationElicitationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpClarificationElicitationTests.cs
@@ -1,0 +1,380 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Grounding.Abstractions;
+using Honua.Core.Features.Grounding.Domain;
+using Honua.Geoprocessing;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Grounding;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Verifies the clarification-envelope → MCP-native elicitation mapping
+/// (honua-server#2484): the pure envelope-to-elicitation projection, and the
+/// grounding tools' capability-detected behavior with graceful fallback to the
+/// proprietary envelope when the client did not advertise elicitation.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class McpClarificationElicitationTests
+{
+    private readonly IGroundingService _groundingService = Substitute.For<IGroundingService>();
+    private readonly IGeoprocessingJobService _jobService = Substitute.For<IGeoprocessingJobService>();
+
+    // -------------------------------------------------------------------
+    // Pure mapper (ClarificationElicitationMapper.TryMap)
+    // -------------------------------------------------------------------
+
+    [UnitTest]
+    public void TryMap_SingleSelect_ProducesStringEnumWithNames()
+    {
+        var request = new ClarificationRequest
+        {
+            IntentId = "intent-1",
+            ReasonCodes = [ClarificationReasonCode.LowConfidence],
+            Questions =
+            [
+                new ClarificationQuestion
+                {
+                    QuestionId = "workflow_family",
+                    Kind = ClarificationQuestionKind.SingleSelect,
+                    Prompt = "Which workflow?",
+                    Options =
+                    [
+                        new ClarificationOption { Id = "Analyze", Label = "Analyze" },
+                        new ClarificationOption { Id = "PublishData", Label = "Publish data" }
+                    ]
+                }
+            ]
+        };
+
+        var elicitation = ClarificationElicitationMapper.TryMap(request);
+
+        elicitation.Should().NotBeNull();
+        elicitation!.Message.Should().Contain("intent-1").And.Contain("LowConfidence");
+        elicitation.RequestedSchema.Type.Should().Be("object");
+        elicitation.RequestedSchema.Required.Should().ContainSingle().Which.Should().Be("workflow_family");
+
+        var property = elicitation.RequestedSchema.Properties["workflow_family"];
+        property.Type.Should().Be("string");
+        property.Description.Should().Be("Which workflow?");
+        property.Enum.Should().Equal("Analyze", "PublishData");
+        property.EnumNames.Should().Equal("Analyze", "Publish data");
+    }
+
+    [UnitTest]
+    public void TryMap_FreeTextAndConfirmation_MapToStringAndBoolean()
+    {
+        var request = new ClarificationRequest
+        {
+            IntentId = "intent-2",
+            ReasonCodes = [ClarificationReasonCode.HeavyOperationConfirmation],
+            Questions =
+            [
+                new ClarificationQuestion
+                {
+                    QuestionId = "distance",
+                    Kind = ClarificationQuestionKind.FreeText,
+                    Prompt = "Buffer distance?"
+                },
+                new ClarificationQuestion
+                {
+                    QuestionId = "proceed",
+                    Kind = ClarificationQuestionKind.Confirmation,
+                    Prompt = "Run the heavy operation?"
+                }
+            ]
+        };
+
+        var elicitation = ClarificationElicitationMapper.TryMap(request);
+
+        elicitation.Should().NotBeNull();
+        elicitation!.RequestedSchema.Required.Should().Equal("distance", "proceed");
+
+        var freeText = elicitation.RequestedSchema.Properties["distance"];
+        freeText.Type.Should().Be("string");
+        freeText.Enum.Should().BeNull();
+
+        var confirmation = elicitation.RequestedSchema.Properties["proceed"];
+        confirmation.Type.Should().Be("boolean");
+    }
+
+    [UnitTest]
+    public void TryMap_MultiSelect_IsNotRepresentable_ReturnsNull()
+    {
+        // The MCP elicitation subset is flat primitives only — no arrays — so a
+        // multi-select question cannot be expressed and the whole envelope must
+        // fall back to the proprietary shape.
+        var request = new ClarificationRequest
+        {
+            IntentId = "intent-3",
+            ReasonCodes = [ClarificationReasonCode.LowConfidence],
+            Questions =
+            [
+                new ClarificationQuestion
+                {
+                    QuestionId = "layers",
+                    Kind = ClarificationQuestionKind.MultiSelect,
+                    Prompt = "Which layers?",
+                    Options =
+                    [
+                        new ClarificationOption { Id = "a", Label = "A" },
+                        new ClarificationOption { Id = "b", Label = "B" }
+                    ]
+                }
+            ]
+        };
+
+        ClarificationElicitationMapper.TryMap(request).Should().BeNull();
+    }
+
+    [UnitTest]
+    public void TryMap_BlankOrDuplicateQuestionId_ReturnsNull()
+    {
+        var blank = new ClarificationRequest
+        {
+            IntentId = "intent-4",
+            ReasonCodes = [],
+            Questions =
+            [
+                new ClarificationQuestion
+                {
+                    QuestionId = "   ",
+                    Kind = ClarificationQuestionKind.FreeText,
+                    Prompt = "?"
+                }
+            ]
+        };
+        ClarificationElicitationMapper.TryMap(blank).Should().BeNull();
+
+        var duplicate = new ClarificationRequest
+        {
+            IntentId = "intent-5",
+            ReasonCodes = [],
+            Questions =
+            [
+                new ClarificationQuestion { QuestionId = "q", Kind = ClarificationQuestionKind.FreeText, Prompt = "A?" },
+                new ClarificationQuestion { QuestionId = "q", Kind = ClarificationQuestionKind.FreeText, Prompt = "B?" }
+            ]
+        };
+        ClarificationElicitationMapper.TryMap(duplicate).Should().BeNull();
+    }
+
+    // -------------------------------------------------------------------
+    // Tool-level capability detection + fallback
+    // -------------------------------------------------------------------
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_ground_candidates")]
+    public async Task GroundCandidates_SessionSupportsElicitation_EmitsElicitationAndOmitsEnvelope()
+    {
+        _groundingService
+            .GroundAsync(Arg.Any<GroundingRequest>(), Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(ResultWithSingleSelectClarification());
+
+        var context = ElicitationContext(elicitationSupported: true);
+        var tool = new GroundCandidatesTool(_groundingService, _jobService, NullLogger<GroundCandidatesTool>.Instance);
+        JsonElement? arguments = McpTestFactory.ParseJson("""{"goal":"Do something vague"}""");
+
+        var result = await tool.InvokeAsync(context, arguments, CancellationToken.None);
+
+        var body = result.StructuredContent!.Value;
+        // The MCP-native elicitation replaces the proprietary envelope.
+        body.TryGetProperty("clarification", out var clarification)
+            .Should().BeFalse("the proprietary envelope is omitted once elicitation is emitted");
+        clarification.ValueKind.Should().Be(JsonValueKind.Undefined);
+
+        var elicitation = body.GetProperty("elicitation");
+        elicitation.GetProperty("message").GetString().Should().NotBeNullOrWhiteSpace();
+        var schema = elicitation.GetProperty("requestedSchema");
+        schema.GetProperty("type").GetString().Should().Be("object");
+        schema.GetProperty("properties").GetProperty("workflow_family").GetProperty("enum")
+            .GetArrayLength().Should().Be(2);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_ground_candidates")]
+    public async Task GroundCandidates_SessionWithoutElicitation_KeepsEnvelopeAndOmitsElicitation()
+    {
+        _groundingService
+            .GroundAsync(Arg.Any<GroundingRequest>(), Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(ResultWithSingleSelectClarification());
+
+        var context = ElicitationContext(elicitationSupported: false);
+        var tool = new GroundCandidatesTool(_groundingService, _jobService, NullLogger<GroundCandidatesTool>.Instance);
+        JsonElement? arguments = McpTestFactory.ParseJson("""{"goal":"Do something vague"}""");
+
+        var result = await tool.InvokeAsync(context, arguments, CancellationToken.None);
+
+        var body = result.StructuredContent!.Value;
+        body.TryGetProperty("elicitation", out _).Should().BeFalse(
+            "a client that did not advertise elicitation gets the proprietary envelope");
+        body.GetProperty("clarification").GetProperty("questions").GetArrayLength()
+            .Should().BeGreaterThan(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_ground_candidates")]
+    public async Task GroundCandidates_NoSessionHeader_KeepsEnvelope()
+    {
+        // A stateless request (no Mcp-Session-Id) can never be elicitation-capable,
+        // so the proprietary envelope is preserved (graceful fallback).
+        _groundingService
+            .GroundAsync(Arg.Any<GroundingRequest>(), Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(ResultWithSingleSelectClarification());
+
+        var tool = new GroundCandidatesTool(_groundingService, _jobService, NullLogger<GroundCandidatesTool>.Instance);
+        JsonElement? arguments = McpTestFactory.ParseJson("""{"goal":"Do something vague"}""");
+
+        var result = await tool.InvokeAsync(
+            McpTestFactory.AuthenticatedHttpContext(), arguments, CancellationToken.None);
+
+        var body = result.StructuredContent!.Value;
+        body.TryGetProperty("elicitation", out _).Should().BeFalse();
+        body.GetProperty("clarification").ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_ground_candidates")]
+    public async Task GroundCandidates_MultiSelectClarification_FallsBackToEnvelopeEvenWhenElicitationSupported()
+    {
+        _groundingService
+            .GroundAsync(Arg.Any<GroundingRequest>(), Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(ResultWithMultiSelectClarification());
+
+        var context = ElicitationContext(elicitationSupported: true);
+        var tool = new GroundCandidatesTool(_groundingService, _jobService, NullLogger<GroundCandidatesTool>.Instance);
+        JsonElement? arguments = McpTestFactory.ParseJson("""{"goal":"Do something vague"}""");
+
+        var result = await tool.InvokeAsync(context, arguments, CancellationToken.None);
+
+        var body = result.StructuredContent!.Value;
+        body.TryGetProperty("elicitation", out _).Should().BeFalse(
+            "a multi-select envelope is not representable in the elicitation subset");
+        body.GetProperty("clarification").GetProperty("questions").GetArrayLength()
+            .Should().BeGreaterThan(0);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /mcp tools/call honua_ground_candidates")]
+    public async Task GroundCandidates_NoClarification_EmitsNeitherFieldRegardlessOfCapability()
+    {
+        _groundingService
+            .GroundAsync(Arg.Any<GroundingRequest>(), Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(ResultWithoutClarification());
+
+        var context = ElicitationContext(elicitationSupported: true);
+        var tool = new GroundCandidatesTool(_groundingService, _jobService, NullLogger<GroundCandidatesTool>.Instance);
+        JsonElement? arguments = McpTestFactory.ParseJson("""{"goal":"Buffer parcels"}""");
+
+        var result = await tool.InvokeAsync(context, arguments, CancellationToken.None);
+
+        var body = result.StructuredContent!.Value;
+        body.TryGetProperty("elicitation", out _).Should().BeFalse();
+        body.TryGetProperty("clarification", out _).Should().BeFalse();
+    }
+
+    private static DefaultHttpContext ElicitationContext(bool elicitationSupported)
+    {
+        var sessions = new McpSessionManager();
+        sessions.TryCreateSession("sub:test-user", elicitationSupported, out var sessionId);
+
+        var services = new ServiceCollection()
+            .AddSingleton(sessions)
+            .BuildServiceProvider();
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services,
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, "test-user")], "Test"))
+        };
+        context.Request.Headers[McpSessionManager.SessionHeaderName] = sessionId;
+        return context;
+    }
+
+    private static GroundingResult ResultWithSingleSelectClarification() =>
+        BaseResult() with
+        {
+            Clarification = new ClarificationRequest
+            {
+                IntentId = "intent-abc",
+                ReasonCodes = [ClarificationReasonCode.LowConfidence],
+                Questions =
+                [
+                    new ClarificationQuestion
+                    {
+                        QuestionId = "workflow_family",
+                        Kind = ClarificationQuestionKind.SingleSelect,
+                        Prompt = "Which workflow?",
+                        Options =
+                        [
+                            new ClarificationOption { Id = "Analyze", Label = "Analyze" },
+                            new ClarificationOption { Id = "PublishData", Label = "Publish" }
+                        ]
+                    }
+                ]
+            }
+        };
+
+    private static GroundingResult ResultWithMultiSelectClarification() =>
+        BaseResult() with
+        {
+            Clarification = new ClarificationRequest
+            {
+                IntentId = "intent-abc",
+                ReasonCodes = [ClarificationReasonCode.LowConfidence],
+                Questions =
+                [
+                    new ClarificationQuestion
+                    {
+                        QuestionId = "layers",
+                        Kind = ClarificationQuestionKind.MultiSelect,
+                        Prompt = "Which layers?",
+                        Options =
+                        [
+                            new ClarificationOption { Id = "a", Label = "A" },
+                            new ClarificationOption { Id = "b", Label = "B" }
+                        ]
+                    }
+                ]
+            }
+        };
+
+    private static GroundingResult ResultWithoutClarification() => BaseResult();
+
+    private static GroundingResult BaseResult() => new()
+    {
+        WorkflowFamily = new WorkflowFamilyClassification
+        {
+            Value = WorkflowFamily.Analyze,
+            Confidence = 0.4
+        },
+        DraftIntent = new DraftIntent
+        {
+            IntentId = "intent-abc",
+            Goal = "Do something vague",
+            WorkflowFamily = WorkflowFamily.Analyze,
+            AssumptionPolicy = AssumptionPolicy.AskWhenMaterial,
+            Provenance = new ProvenanceRecord { Sources = [], ProcessDefinitions = [] }
+        },
+        Candidates = new CandidateRanking(),
+        Engine = "deterministic"
+    };
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpSessionManagerTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpSessionManagerTests.cs
@@ -42,6 +42,37 @@ public sealed class McpSessionManagerTests
     }
 
     [UnitTest]
+    public void SupportsElicitation_ReflectsCapabilityRecordedAtCreation()
+    {
+        // honua-server#2484: the elicitation capability advertised at initialize is
+        // bound to the session and read back by clarification-emitting tools.
+        var manager = new McpSessionManager();
+        manager.TryCreateSession("sub:alice", elicitationSupported: true, out var elicit)
+            .Should().BeTrue();
+        manager.TryCreateSession("sub:bob", elicitationSupported: false, out var plain)
+            .Should().BeTrue();
+
+        manager.SupportsElicitation(elicit).Should().BeTrue();
+        manager.SupportsElicitation(plain).Should().BeFalse();
+        // The default two-arg overload never advertises elicitation.
+        manager.SupportsElicitation(manager.CreateSession()).Should().BeFalse();
+        manager.SupportsElicitation("never-issued").Should().BeFalse();
+        manager.SupportsElicitation(string.Empty).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void SupportsElicitation_ReturnsFalseAfterTermination()
+    {
+        var manager = new McpSessionManager();
+        manager.TryCreateSession("sub:alice", elicitationSupported: true, out var id)
+            .Should().BeTrue();
+        manager.SupportsElicitation(id).Should().BeTrue();
+
+        manager.Terminate(id).Should().BeTrue();
+        manager.SupportsElicitation(id).Should().BeFalse();
+    }
+
+    [UnitTest]
     public void Terminate_RemovesSession_AndIsIdempotent()
     {
         var manager = new McpSessionManager();


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2484

## Summary
Maps Honua's clarification envelope onto MCP-native elicitation (MCP 2025-06-18), deferred from #1954. When a client advertises the `elicitation` capability at `initialize`, the grounding/clarify turns (`honua_ground_candidates` / `honua_clarify_intent`) return an MCP `elicitation/create` payload (`message` + restricted `requestedSchema`) instead of the proprietary clarification envelope, so an elicitation-capable client renders a native form and replays answers through `honua_clarify_intent`. The behavior is capability-detected per session with graceful, byte-identical fallback to the existing envelope when elicitation is not advertised.

Because the Streamable-HTTP transport is request/response for `tools/call` (no server-initiated request/response), and the server is deterministic with the model client-side (ADR-0028), the elicitation is handed to the client inside the tool result rather than via a server-initiated round-trip. This design and the recommended geospatial-mcp follow-ups are recorded in ADR-0061.

## Changes Made
- Detect the client `elicitation` capability at `initialize` and bind it to the issued session (`McpSessionManager.SupportsElicitation`; new `TryCreateSession` overload); the flag is threaded from `initialize` through `HttpContext.Items` to session creation.
- Add `ClarificationElicitationMapper`: single-select → `string` enum (`enum`/`enumNames`), free-text → `string`, confirmation → `boolean`; multi-select is not representable in the elicitation subset (arrays disallowed) and falls back to the envelope; blank/duplicate question ids fall back.
- `honua_ground_candidates` / `honua_clarify_intent` emit `elicitation` and omit `clarification` when the session supports it; the two output fields are mutually exclusive. Output schema documents the new field (input and vendored conformance schemas untouched).
- Add ADR-0061 (Accepted) documenting the mapping decision, the deviation from a literal server-initiated `elicitation/create`, and geospatial-mcp follow-ups; index it (and backfill ADR-0060) in the ADR README.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Ran locally (Release, `TreatWarningsAsErrors=true`): built `Honua.Ai` and `Honua.Ai.Tests` warnings-clean; `dotnet format --verify-no-changes` clean on all changed files. Ran the affected suites — `McpClarificationElicitationTests`, `McpSessionManagerTests`, `McpGroundingToolDelegationTests`, `McpGeospatialMcpSchemaConformanceTests`, `McpTaxonomyAlignmentTests`, and the `[Collection("Database")]` `McpEndpointIntegrationTests` (Testcontainers) — **121 passed, 0 failed**.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] None — no docs or contract impact

Additive MCP tool output field (`elicitation`); no input-schema, OpenAPI, or gRPC contract change. Vendored geospatial-mcp conformance schemas untouched.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — the default (no-elicitation) response is byte-identical to prior behavior.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract

Note: `scripts/ci/pre-pr-check.sh` cannot run on this host (known CLAUDE.md symlink / MSYS path issue); ran its equivalents instead — Release build with `TreatWarningsAsErrors=true`, `dotnet format --verify-no-changes`, and the affected test suites (all pass, per Testing above).
