### PR TITLE
feat(mcp): planner rollout tail + workflow-as-first-class-MCP-tool

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -56,6 +56,7 @@
   - [Excel & Power BI](guides/connect/excel-power-bi.md)
   - [MapLibre web maps](guides/connect/maplibre-web-maps.md)
   - [AI agents (MCP)](guides/connect/ai-agents-mcp.md)
+  - [Turn on the live MCP planner](guides/connect/mcp-live-planner.md)
 - Edit data
   - [Edit features](guides/edit/edit-features.md)
   - [Attachments & related records](guides/edit/attachments-and-related-records.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -42,6 +42,7 @@ Task-oriented guides, grouped by what you want to do. New to Honua? Start with t
 | Analyze layers in Excel or Power BI | [Excel and Power BI](connect/excel-power-bi.md) |
 | Build MapLibre web maps | [MapLibre web maps](connect/maplibre-web-maps.md) |
 | Let AI agents use the server via MCP | [AI agents (MCP)](connect/ai-agents-mcp.md) |
+| Turn on the live MCP planner (Honua-brings-LLM) | [Live MCP planner](connect/mcp-live-planner.md) |
 
 ## Edit data
 

--- a/docs/guides/connect/ai-agents-mcp.md
+++ b/docs/guides/connect/ai-agents-mcp.md
@@ -38,7 +38,7 @@ The endpoint is `POST /mcp`: JSON-RPC 2.0 over HTTP (single requests and batches
 3. Ask the agent to list tools and start with the safe ones — everything in the planning family is read-only:
 
    - `honua_ground_candidates` / `honua_clarify_intent` — turn a natural-language goal into a drafted intent with candidate datasets and processes
-   - `honua_plan_analysis` — draft an executable plan from an intent
+   - `honua_plan_analysis` — draft an executable plan from an intent. Runs in fixture (demo) mode by default (responses are flagged `engine: "fixture"`); [turn on the live planner](mcp-live-planner.md) to compile arbitrary intents.
    - `honua_validate_plan` — static validation: returns `isExecutable`, `requiresApproval`, violations, and warnings
    - `honua_dry_run_plan` — estimates duration, artifacts, and side effects without executing
    - `honua_validate_package` / `honua_preview_package` — review a map/app package before execute or publish
@@ -139,6 +139,7 @@ edge limiter remains the first line of defense.
 
 ## Next steps
 
+- [Turn on the live MCP planner (Honua-brings-LLM)](mcp-live-planner.md)
 - [Run geoprocessing](../query-analyze/run-geoprocessing.md)
 - [Authentication](../secure/authentication.md)
 - [Protocol overview](../../concepts/protocols.md)

--- a/docs/guides/connect/mcp-live-planner.md
+++ b/docs/guides/connect/mcp-live-planner.md
@@ -1,0 +1,154 @@
+# Turn on the live MCP planner (Honua-brings-LLM)
+
+By default the `honua_plan_analysis` MCP tool runs in **fixture (demo) mode**: it replays a
+fixed set of canned plans for a handful of demo intents and returns a structured `rejected`
+turn for anything else. Every fixture response is flagged with `engine: "fixture"`, and the
+tool description says so, so a client (or a cold client LLM) never mistakes a demo template for
+a plan compiled from its intent.
+
+This guide is the **supported configuration profile** that turns the planner live, so
+`honua_plan_analysis` compiles an arbitrary natural-language GIS intent into an executable
+analysis plan on the server ("Honua brings the LLM"), rather than replaying fixtures.
+
+> The planner reuses the [studio `WorkflowGeneration` provider plumbing](../run-studio-ai-on-bedrock.md).
+> Configure a provider there once; the planner selects among the same providers.
+
+## Edition / tier policy
+
+Honua ships **no model credentials for any edition** — the model is always brought by the
+operator (a local endpoint, an Anthropic key, or the AWS credential chain for Bedrock). The
+live planner is therefore activated the same way on every edition — by configuring a provider —
+but the intended posture differs by edition:
+
+| Edition | Planner posture | How |
+|---|---|---|
+| **Community** | Bring-your-own-model. Fixture (demo) mode until you configure a provider. | Set the config profile below with your own provider. |
+| **Pro / Enterprise** | Live planner is the supported default. | Apply the config profile below; the same provider that runs the studio flows drives the planner. |
+
+The planner is **not** silently defaulted on by edition. Because Honua provisions no keys, an
+edition-based auto-on would fail closed at request time (no credentials → provider error). The
+supported activation is always an explicit provider configuration — this profile — which is why
+it is documented per edition rather than flipped by a license bit. The mutating lanes
+(`honua_execute_plan`) remain governed by the edition entitlement ladder
+(`ai.spec-apply` / `ai.agent-operations` / `ai.approval-workflows`) independently of which
+planner engine is running.
+
+## Configuration profile
+
+Add the two sections below. `WorkflowGeneration` owns the provider credentials (endpoints,
+models, regions, keys); `PlanAnalysis` selects among them for the MCP plan lane.
+
+```jsonc
+// appsettings.json (or an environment-specific override)
+{
+  // Provider plumbing — shared with the studio generation flows.
+  "WorkflowGeneration": {
+    "Enabled": true,
+    "DefaultProvider": "bedrock",       // "local" | "openai" | "anthropic" | "bedrock" | "deterministic"
+    "Providers": {
+      "bedrock": {
+        "Model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "Region": "us-west-2",
+        "TimeoutSeconds": 120,
+        "MaxTokens": 4096
+      }
+    }
+  },
+
+  // MCP plan lane — the dedicated planner gate (optional; see precedence below).
+  "PlanAnalysis": {
+    "Enabled": true,                    // force the live planner on for honua_plan_analysis
+    "Provider": "bedrock"               // optional: override which WorkflowGeneration provider the plan lane uses
+  }
+}
+```
+
+### Precedence (how the engine is selected)
+
+The planner picks live vs. fixture as follows (see `ShouldUseLivePlanner`):
+
+1. **`PlanAnalysis:Enabled`** is authoritative when present — `true` forces the live planner on
+   for the MCP plan lane, `false` pins it to fixtures even when the studio flows are live.
+2. When `PlanAnalysis:Enabled` is unset, the planner **inherits `WorkflowGeneration:Enabled`**
+   (back-compat: the planner rode entirely on the studio gate before the dedicated seam).
+3. The **effective provider** must be a *live* provider — `PlanAnalysis:Provider` when set, else
+   `WorkflowGeneration:DefaultProvider`. If the effective provider is `deterministic`, the
+   deterministic fixture replay is selected regardless of the gate.
+
+So the minimal "planner on" profile is either:
+
+- `PlanAnalysis:Enabled=true` + `PlanAnalysis:Provider=<live provider>`, **or**
+- `WorkflowGeneration:Enabled=true` + `WorkflowGeneration:DefaultProvider=<live provider>`
+  (and leave `PlanAnalysis` unset).
+
+`PlanAnalysis:Provider` must reference a provider id registered under
+`WorkflowGeneration:Providers` (`local`, `openai`, `anthropic`, `bedrock`, or `deterministic`);
+an unknown id fails startup validation. `PlanAnalysis` carries no connection block of its own —
+endpoints, models, regions, and keys stay owned by `WorkflowGeneration:Providers`.
+
+### Credentials
+
+Provider credentials are configured exactly as for the studio flows — see
+[Run the AI studio flows on AWS Bedrock](../run-studio-ai-on-bedrock.md) for the Bedrock/IAM
+setup, or set an `ApiKey` on an `anthropic`/`openai` provider block. The IAM principal for
+Bedrock needs `bedrock:InvokeModel` on the chosen model / inference profile.
+
+## Verify
+
+With the profile applied and credentials present, call the tool with a novel intent that is not
+in the fixture set:
+
+```bash
+BASE=http://localhost:8080
+curl -s -X POST "$BASE/mcp" -H "Content-Type: application/json" -H "X-API-Key: $HONUA_API_KEY" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
+        "name":"honua_plan_analysis",
+        "arguments":{"intent":"Buffer the Maui flood-hazard layer by 500 m and select intersecting parcels."}}}'
+```
+
+- **Live planner on:** the result's `structuredContent.engine` is `"live"` and `status` is
+  `planned` (or `clarification_required` with real reasoning), compiled from your intent.
+- **Still in fixture mode:** `engine` is `"fixture"` and an unmatched novel intent returns
+  `status: "rejected"` whose `reason` explains fixture mode. Re-check the precedence rules above
+  (most often the effective provider resolved to `deterministic`, or the gate is off).
+
+A `planned` turn feeds straight into `honua_validate_plan`, `honua_dry_run_plan`, and
+`honua_execute_plan` unchanged — the live planner emits the same canonical plan shape the
+fixture path does.
+
+## Testing the live lane
+
+The live plan lane is covered on two levels:
+
+- **Deterministic (runs in CI, no credentials).** The live planner path is exercised with a
+  fake provider so the live code path is proven without any AI call, including that the live
+  planner's compiled plan flows **beyond `plan_analysis`** — it converts to a domain plan and
+  passes through the same validator the `honua_validate_plan` lane uses —
+  `tests/dotnet/Honua.Ai.Tests/Source/LivePlanAnalysisServiceTests.cs`.
+- **Real model transport (gated).** The Bedrock/Converse seam the planner reuses is driven
+  end-to-end against **real** AWS Bedrock by a gated live test that never runs in CI without
+  credentials — `tests/dotnet/Honua.Ai.Tests/Source/BedrockStudioLiveTests.cs`:
+
+  ```bash
+  HONUA_AI_LIVE_BEDROCK=1 \
+  HONUA_AI_BEDROCK_MODEL="us.anthropic.claude-sonnet-4-5-20250929-v1:0" \
+  HONUA_AI_BEDROCK_REGION="us-west-2" \
+  AWS_REGION="us-west-2" \
+  dotnet test tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj \
+    --filter "FullyQualifiedName~BedrockStudioLiveTests"
+  ```
+
+  To run the gated lane in CI, provide the same provider credentials as a CI secret (the Bedrock
+  IAM role or an `anthropic` API key) and set `HONUA_AI_LIVE_BEDROCK=1` (or the matching
+  `HONUA_AI_LIVE_*` flag for your provider).
+
+The downstream lanes (`honua_validate_plan`, `honua_dry_run_plan`, `honua_execute_plan`) are
+protocol-shared and deterministic: they consume the live planner's plan object unchanged, so no
+separate "live" engine is needed for them — the live lane is the planner, and the rest of the
+pipeline is the same code path the fixture plans already flow through.
+
+## Next steps
+
+- [Connect AI agents to Honua over MCP](ai-agents-mcp.md)
+- [Run the AI studio flows on AWS Bedrock](../run-studio-ai-on-bedrock.md)
+- [Editions and licensing](../../concepts/editions-and-licensing.md)

--- a/src/Honua.Ai/Features/AiBuilder/Planning/FixturePlanAnalysisService.cs
+++ b/src/Honua.Ai/Features/AiBuilder/Planning/FixturePlanAnalysisService.cs
@@ -57,7 +57,20 @@ internal sealed class FixturePlanAnalysisService : IPlanAnalysisService
             return Task.FromResult(new McpPlanAnalysisOutput
             {
                 Status = "rejected",
-                Reason = "No AI-builder fixture matches the supplied intent.",
+
+                // #2485: explicitly disclose fixture (demo) mode on the miss path.
+                // The engine:"fixture" discriminator already flags every fixture
+                // response, but the miss reason must also say — in plain language —
+                // that this server replays canned demo plans and how to turn the
+                // live planner on, so a caller (or a cold client LLM) does not read
+                // "rejected" as "your intent is unsupported".
+                Reason = "The plan analyzer is running in fixture (demo) mode: it replays canned "
+                    + "plans for a fixed set of demo intents and found no fixture matching the "
+                    + "supplied intent — it did not attempt to compile the intent. To compile "
+                    + "arbitrary intents into executable plans, configure a live model provider "
+                    + "(PlanAnalysis:Enabled=true with PlanAnalysis:Provider, or "
+                    + "WorkflowGeneration:Enabled=true with a live DefaultProvider). See "
+                    + "docs/guides/connect/mcp-live-planner.md.",
                 Context = context
             });
         }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpOperatorSurface.cs
@@ -40,6 +40,7 @@ internal sealed class McpOperatorSurface
     public static string LatestProtocolVersion => SupportedProtocolVersions[0];
 
     private readonly IReadOnlyDictionary<string, IMcpTool> _tools;
+    private readonly List<IMcpToolSource> _toolSources;
     private readonly IReadOnlyList<IMcpResource> _resources;
     private readonly McpSurfaceLimits _limits;
     private readonly ILogger<McpOperatorSurface> _logger;
@@ -48,9 +49,13 @@ internal sealed class McpOperatorSurface
         IEnumerable<IMcpTool> tools,
         IEnumerable<IMcpResource> resources,
         ILogger<McpOperatorSurface> logger,
-        McpSurfaceLimits? limits = null)
+        McpSurfaceLimits? limits = null,
+        IEnumerable<IMcpToolSource>? toolSources = null)
     {
         _tools = tools.ToDictionary(t => t.Name, StringComparer.Ordinal);
+        // Dynamic, runtime-published tools (#2483). None composed by default, so the
+        // surface behaves exactly as before unless a host opts a source in.
+        _toolSources = toolSources?.ToList() ?? [];
         _resources = resources.ToList();
         _limits = limits ?? McpSurfaceLimits.Default;
         _logger = logger;
@@ -156,7 +161,7 @@ internal sealed class McpOperatorSurface
             return request.Method switch
             {
                 "initialize" => HandleInitialize(request),
-                "tools/list" => ListTools(request),
+                "tools/list" => await ListToolsAsync(request, cancellationToken).ConfigureAwait(false),
                 "tools/call" => await CallToolAsync(httpContext, request, cancellationToken).ConfigureAwait(false),
                 "resources/list" => ListResources(request),
                 "resources/templates/list" => ListResourceTemplates(request),
@@ -238,15 +243,26 @@ internal sealed class McpOperatorSurface
         return LatestProtocolVersion;
     }
 
-    private McpJsonRpcResponse ListTools(McpJsonRpcRequest request)
+    private async Task<McpJsonRpcResponse> ListToolsAsync(
+        McpJsonRpcRequest request,
+        CancellationToken cancellationToken)
     {
         if (!TryReadCursor(request, out var cursor, out var error))
         {
             return error;
         }
 
-        var ordered = _tools.Values
-            .Select(t => t.Describe())
+        // Merge the static, registry-bound catalog with any runtime-published tools
+        // (#2483). Static tools always win on a name collision, and the dynamic set is
+        // empty unless a host composed a tool source, so default hosts are unchanged.
+        var describes = _tools.Values.Select(t => t.Describe());
+        var dynamicTools = await ResolveDynamicToolsAsync(cancellationToken).ConfigureAwait(false);
+        if (dynamicTools.Count > 0)
+        {
+            describes = describes.Concat(dynamicTools.Select(t => t.Describe()));
+        }
+
+        var ordered = describes
             .OrderBy(d => d.Name, StringComparer.Ordinal)
             .ToList();
 
@@ -262,6 +278,44 @@ internal sealed class McpOperatorSurface
         {
             return ErrorResponse(request.Id, McpErrorMapper.InvalidArgument(ex.Message));
         }
+    }
+
+    /// <summary>
+    /// Resolves the runtime-published dynamic tools (#2483) from every registered
+    /// <see cref="IMcpToolSource"/>, excluding any name that collides with a static
+    /// tool (static wins) or a name already yielded by an earlier source (first
+    /// wins). Returns an empty list when no source is composed — the default host.
+    /// </summary>
+    private async Task<IReadOnlyList<IMcpTool>> ResolveDynamicToolsAsync(CancellationToken cancellationToken)
+    {
+        if (_toolSources.Count == 0)
+        {
+            return [];
+        }
+
+        var merged = new List<IMcpTool>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var source in _toolSources)
+        {
+            var tools = await source.GetToolsAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var tool in tools)
+            {
+                if (_tools.ContainsKey(tool.Name) || !seen.Add(tool.Name))
+                {
+                    continue;
+                }
+
+                merged.Add(tool);
+            }
+        }
+
+        return merged;
+    }
+
+    private async Task<IMcpTool?> ResolveDynamicToolAsync(string name, CancellationToken cancellationToken)
+    {
+        var dynamicTools = await ResolveDynamicToolsAsync(cancellationToken).ConfigureAwait(false);
+        return dynamicTools.FirstOrDefault(t => string.Equals(t.Name, name, StringComparison.Ordinal));
     }
 
     private McpJsonRpcResponse ListPrompts(McpJsonRpcRequest request)
@@ -365,11 +419,18 @@ internal sealed class McpOperatorSurface
 
         if (!_tools.TryGetValue(parameters.Name, out var tool))
         {
-            // MCP 2025-03-26 maps unknown tool names to -32602 invalid params; the
-            // tool name is part of the tools/call `params` payload.
-            return ErrorResponse(
-                request.Id,
-                McpErrorMapper.InvalidArgument($"Unknown MCP tool '{parameters.Name}'."));
+            // Fall back to the runtime-published dynamic tools (#2483) before
+            // declaring the name unknown, so a published operation tool advertised in
+            // tools/list is callable. Static tools were checked first, so they win.
+            tool = await ResolveDynamicToolAsync(parameters.Name, cancellationToken).ConfigureAwait(false);
+            if (tool is null)
+            {
+                // MCP 2025-03-26 maps unknown tool names to -32602 invalid params; the
+                // tool name is part of the tools/call `params` payload.
+                return ErrorResponse(
+                    request.Id,
+                    McpErrorMapper.InvalidArgument($"Unknown MCP tool '{parameters.Name}'."));
+            }
         }
 
         McpToolsCallResult result;

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpPublishedOperationOptions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpPublishedOperationOptions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// Options controlling whether — and how — validated operations-toolset descriptors
+/// are published as first-class MCP tools (#2483, ADR-0056 Increment 4). Bound from
+/// the <c>Mcp:PublishOperations</c> configuration section.
+/// </summary>
+/// <remarks>
+/// This is off by default so no host changes its advertised <c>tools/list</c> until
+/// an operator explicitly opts in. When enabled, each descriptor in the operations
+/// catalog (except those already exposed by a hand-authored tool) is projected into
+/// a typed, cacheable, policy-governed MCP tool named <c>honua_op_{operationId}</c>.
+/// </remarks>
+public sealed class McpPublishedOperationOptions
+{
+    /// <summary>The configuration section name.</summary>
+    public const string SectionName = "Mcp:PublishOperations";
+
+    /// <summary>
+    /// Whether validated operation descriptors are published as MCP tools. Default
+    /// <see langword="false"/>: the operations catalog is not projected onto
+    /// <c>tools/list</c> until an operator turns this on.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// "Deterministic mode": when <see langword="true"/>, only descriptors whose
+    /// policy declares deterministic (AI-free) execution are published — the
+    /// audit/inspect toolset with AI off. When <see langword="false"/> (default),
+    /// AI-assisted descriptors are published too. Determinism is always surfaced on
+    /// each published tool's output regardless of this flag.
+    /// </summary>
+    public bool DeterministicOnly { get; set; }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -260,6 +260,35 @@ internal static class McpServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Publishes validated operations-toolset descriptors as first-class MCP tools
+    /// (#2483, ADR-0056 Increment 4). Off unless <c>Mcp:PublishOperations:Enabled</c>
+    /// is set, so the advertised catalog is unchanged by default. Must be called
+    /// AFTER the operations toolset is composed (<c>AddOperationsToolset</c>), because
+    /// the tool source resolves the canonical <see cref="Honua.Core.Features.Operations.Abstractions.IOperationCatalog"/>
+    /// — call it from a host that has the operations toolset wired, not from a bare
+    /// <see cref="AddMcpOperatorSurface"/> composition.
+    /// </summary>
+    public static IServiceCollection AddMcpPublishedOperationTools(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<McpPublishedOperationOptions>()
+            .Bind(configuration.GetSection(McpPublishedOperationOptions.SectionName));
+
+        // Param-keyed deterministic result cache (shared across every published tool)
+        // and the catalog-backed tool source the operator surface merges into
+        // tools/list / tools/call.
+        services.TryAddSingleton<Tools.IPublishedOperationCache, Tools.PublishedOperationCache>();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<Tools.IMcpToolSource, Tools.PublishedOperationToolSource>());
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers the hosted-promotion MCP resource handlers (published services,
     /// deployments, map/app packages, and the promotion list index). Callers
     /// must register canonical <see cref="Honua.Core.Features.Publishing.Abstractions.IPublishedServiceStore"/>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
@@ -62,6 +62,7 @@ namespace Honua.Ai.Protocols.Mcp.Models;
 [JsonSerializable(typeof(McpPublishServiceOutput))]
 [JsonSerializable(typeof(McpPublishResultArgument))]
 [JsonSerializable(typeof(McpPublishResultOutput))]
+[JsonSerializable(typeof(McpOperationToolOutput))]
 [JsonSerializable(typeof(McpIngestDatasetArgument))]
 [JsonSerializable(typeof(McpIngestDatasetOutput))]
 [JsonSerializable(typeof(McpIngestRowError))]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
@@ -173,6 +173,73 @@ internal sealed class McpPublishServiceOutput
 }
 
 /// <summary>
+/// Structured result of invoking a published operations-toolset operation projected
+/// as a first-class MCP tool (#2483, ADR-0056 Increment 4). Projects the canonical
+/// <c>OperationHandle</c> returned by the operations dispatcher, plus the
+/// determinism/cache provenance the published-tool contract adds: <c>deterministic</c>
+/// reports whether the backing descriptor is AI-free, and <c>cacheHit</c> /
+/// <c>cacheKey</c> report the param-keyed cache decision for a deterministic,
+/// read-only invocation.
+/// </summary>
+internal sealed class McpOperationToolOutput
+{
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("requiresApproval")]
+    public bool RequiresApproval { get; set; }
+
+    /// <summary>
+    /// Whether the backing operation descriptor is deterministic (AI-free). A
+    /// deterministic tool is what "deterministic mode" (a toolset with AI off)
+    /// publishes; only deterministic, read-only invocations are param-keyed cached.
+    /// </summary>
+    [JsonPropertyName("deterministic")]
+    public bool Deterministic { get; set; }
+
+    /// <summary>
+    /// True when this result was served from the param-keyed deterministic cache
+    /// rather than re-executed. Always false for non-deterministic or side-effecting
+    /// operations, which are never cached.
+    /// </summary>
+    [JsonPropertyName("cacheHit")]
+    public bool CacheHit { get; set; }
+
+    /// <summary>
+    /// The param-keyed cache key for a deterministic, read-only invocation
+    /// (operation id + catalog version + normalized parameters). Null when the
+    /// operation is not cacheable.
+    /// </summary>
+    [JsonPropertyName("cacheKey")]
+    public string? CacheKey { get; set; }
+
+    [JsonPropertyName("operationId")]
+    public string OperationId { get; set; } = string.Empty;
+
+    [JsonPropertyName("handleId")]
+    public string HandleId { get; set; } = string.Empty;
+
+    [JsonPropertyName("jobId")]
+    public string? JobId { get; set; }
+
+    [JsonPropertyName("approvalLane")]
+    public string? ApprovalLane { get; set; }
+
+    [JsonPropertyName("metadataRevision")]
+    public long? MetadataRevision { get; set; }
+
+    [JsonPropertyName("summary")]
+    public string? Summary { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    [JsonPropertyName("details")]
+    public IReadOnlyDictionary<string, string> Details { get; set; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>
 /// Arguments for <c>honua_publish_result</c> (geospatial-mcp <c>publish_result</c>,
 /// #2482): promote a completed analysis job's materialized feature/table artifact
 /// into a hosted service + layer. Per the standard schema only <c>sourceId</c>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpToolSource.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpToolSource.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// A source of dynamic, runtime-published MCP tools that the
+/// <see cref="McpOperatorSurface"/> merges into <c>tools/list</c> and
+/// <c>tools/call</c> in addition to the statically-registered
+/// <see cref="IMcpTool"/> set (#2483, ADR-0056 Increment 4).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The statically-registered tools are the built-in, capability-registry-bound
+/// catalog (every one has an <c>ICapabilityRegistry</c> descriptor, enforced at
+/// startup). A tool source instead projects tools that are <em>published at
+/// runtime</em> — for example a validated operations-toolset descriptor becoming a
+/// first-class tool — so it can change without a redeploy. Dynamic tools are kept
+/// out of the static catalog on purpose: they are not part of the registry-bound
+/// built-in contract, and a statically-registered tool of the same name always
+/// wins.
+/// </para>
+/// <para>
+/// A host with no tool source composed behaves exactly as before: the surface
+/// merges an empty dynamic set.
+/// </para>
+/// </remarks>
+internal interface IMcpToolSource
+{
+    /// <summary>
+    /// Returns the currently-published dynamic tools. Called on each
+    /// <c>tools/list</c> and on a <c>tools/call</c> that misses the static catalog,
+    /// so implementations must be cheap (return quickly when disabled, and lean on a
+    /// cached snapshot for the underlying catalog).
+    /// </summary>
+    ValueTask<IReadOnlyList<IMcpTool>> GetToolsAsync(CancellationToken cancellationToken);
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -636,6 +636,60 @@ internal static class McpToolOutputSchemas
         }
         """);
 
+    /// <summary>
+    /// Schema for <see cref="Models.McpOperationToolOutput"/> — the structured
+    /// result of a published operations-toolset operation projected as a
+    /// first-class MCP tool (#2483). Projects the canonical <c>OperationHandle</c>
+    /// plus the determinism/cache provenance the published-tool contract adds.
+    /// </summary>
+    public static readonly JsonElement OperationToolOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["status", "requiresApproval", "deterministic", "cacheHit", "operationId", "handleId"],
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Operation handle status: Completed, Queued, Running, RequiresApproval, DryRunRequired, Denied, or Failed."
+            },
+            "requiresApproval": { "type": "boolean" },
+            "deterministic": {
+              "type": "boolean",
+              "description": "Whether the backing operation descriptor is deterministic (AI-free)."
+            },
+            "cacheHit": {
+              "type": "boolean",
+              "description": "True when served from the param-keyed deterministic cache instead of re-executed."
+            },
+            "cacheKey": {
+              "type": ["string", "null"],
+              "description": "Param-keyed cache key (operation id + catalog version + normalized parameters) for a deterministic, read-only invocation; null when not cacheable."
+            },
+            "operationId": { "type": "string" },
+            "handleId": { "type": "string" },
+            "jobId": {
+              "type": ["string", "null"],
+              "description": "Durable job id when the operation was queued."
+            },
+            "approvalLane": {
+              "type": ["string", "null"],
+              "description": "Approval lane to wait on when the operation requires human approval."
+            },
+            "metadataRevision": {
+              "type": ["integer", "null"],
+              "description": "Metadata v2 graph revision produced by the operation, when it mutated the graph."
+            },
+            "summary": { "type": ["string", "null"] },
+            "message": { "type": ["string", "null"] },
+            "details": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "Operation-specific result detail values keyed by name."
+            }
+          }
+        }
+        """);
+
     private static string ArtifactKindEnum => JsonStringArray(Enum.GetNames<ArtifactKind>());
 
     private static string JsonStringArray(string[] values)

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationCache.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationCache.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Ai.Protocols.Mcp.Models;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// Process-wide, param-keyed result cache for deterministic, read-only published
+/// operations (#2483). Only invocations whose descriptor declares deterministic
+/// (AI-free) execution with no side effect are cached: identical inputs then return
+/// an identical result without re-executing the operation.
+/// </summary>
+/// <remarks>
+/// The key is <c>{operationId}|{catalogVersion}|{normalizedParameters}</c>, so a
+/// catalog change (a republished descriptor) invalidates prior entries by producing
+/// a different key. Side-effecting or AI-assisted operations are never cached — a
+/// cache would either skip a side effect or return a stale AI turn — so this cache
+/// is deliberately only consulted from the deterministic, read-only path.
+/// </remarks>
+internal interface IPublishedOperationCache
+{
+    /// <summary>
+    /// Returns the cached output for <paramref name="key"/>, or <see langword="null"/>
+    /// on a miss. The returned instance is a fresh copy flagged <c>cacheHit=true</c>.
+    /// </summary>
+    McpOperationToolOutput? TryGet(string key);
+
+    /// <summary>Stores <paramref name="output"/> under <paramref name="key"/>.</summary>
+    void Set(string key, McpOperationToolOutput output);
+
+    /// <summary>
+    /// Builds the param-keyed cache key for a deterministic, read-only invocation.
+    /// </summary>
+    static string BuildKey(
+        string operationId,
+        string catalogVersion,
+        IReadOnlyDictionary<string, string?> parameters)
+    {
+        // Order-independent, null-safe normalization so identical inputs supplied in
+        // any order produce the same key.
+        var normalized = string.Join(
+            ";",
+            parameters
+                .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
+                .Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        return $"{operationId}|{catalogVersion}|{normalized}";
+    }
+}
+
+/// <inheritdoc />
+internal sealed class PublishedOperationCache : IPublishedOperationCache
+{
+    private readonly ConcurrentDictionary<string, McpOperationToolOutput> _entries =
+        new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public McpOperationToolOutput? TryGet(string key)
+        => _entries.TryGetValue(key, out var cached) ? Clone(cached, cacheHit: true) : null;
+
+    /// <inheritdoc />
+    public void Set(string key, McpOperationToolOutput output)
+        => _entries[key] = Clone(output, cacheHit: false);
+
+    // Cache stores an immutable snapshot; every read/write returns a fresh instance so
+    // a caller mutating its output can never corrupt a cached entry.
+    private static McpOperationToolOutput Clone(McpOperationToolOutput source, bool cacheHit) => new()
+    {
+        Status = source.Status,
+        RequiresApproval = source.RequiresApproval,
+        Deterministic = source.Deterministic,
+        CacheHit = cacheHit,
+        CacheKey = source.CacheKey,
+        OperationId = source.OperationId,
+        HandleId = source.HandleId,
+        JobId = source.JobId,
+        ApprovalLane = source.ApprovalLane,
+        MetadataRevision = source.MetadataRevision,
+        Summary = source.Summary,
+        Message = source.Message,
+        Details = new Dictionary<string, string>(source.Details, StringComparer.Ordinal),
+    };
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationCache.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationCache.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Concurrent;
+using Honua.Core.Features.Operations.Domain;
 using Honua.Ai.Protocols.Mcp.Models;
 
 namespace Honua.Ai.Protocols.Mcp.Tools;
@@ -13,11 +14,17 @@ namespace Honua.Ai.Protocols.Mcp.Tools;
 /// an identical result without re-executing the operation.
 /// </summary>
 /// <remarks>
-/// The key is <c>{operationId}|{catalogVersion}|{normalizedParameters}</c>, so a
-/// catalog change (a republished descriptor) invalidates prior entries by producing
-/// a different key. Side-effecting or AI-assisted operations are never cached — a
-/// cache would either skip a side effect or return a stale AI turn — so this cache
-/// is deliberately only consulted from the deterministic, read-only path.
+/// The key is
+/// <c>{operationId}|{catalogVersion}|{principalId}|{tier}|{sortedRoles}|{normalizedParameters}</c>.
+/// A catalog change (a republished descriptor) invalidates prior entries by producing
+/// a different key. The full policy-relevant principal context (principal id, resolved
+/// tier, sorted roles) is part of the key ON PURPOSE: the cache-hit path skips the
+/// policy decision point, so a hit may only ever serve a result back to the identical
+/// principal context that was already policy-allowed for those exact inputs — a
+/// different caller, or the same caller with changed roles/tier, always misses and
+/// takes a fresh policy round-trip. Side-effecting or AI-assisted operations are never
+/// cached — a cache would either skip a side effect or return a stale AI turn — so
+/// this cache is deliberately only consulted from the deterministic, read-only path.
 /// </remarks>
 internal interface IPublishedOperationCache
 {
@@ -32,12 +39,20 @@ internal interface IPublishedOperationCache
 
     /// <summary>
     /// Builds the param-keyed cache key for a deterministic, read-only invocation.
+    /// The key binds the result to the invoking principal context
+    /// (<see cref="OperationPolicyContext.PrincipalId"/>,
+    /// <see cref="OperationPolicyContext.Tier"/>, sorted
+    /// <see cref="OperationPolicyContext.Roles"/>) so a cached policy-allowed result
+    /// can never be served across principals, tiers, or role sets.
     /// </summary>
     static string BuildKey(
         string operationId,
         string catalogVersion,
-        IReadOnlyDictionary<string, string?> parameters)
+        IReadOnlyDictionary<string, string?> parameters,
+        OperationPolicyContext principalContext)
     {
+        ArgumentNullException.ThrowIfNull(principalContext);
+
         // Order-independent, null-safe normalization so identical inputs supplied in
         // any order produce the same key.
         var normalized = string.Join(
@@ -45,7 +60,12 @@ internal interface IPublishedOperationCache
             parameters
                 .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
                 .Select(kvp => $"{kvp.Key}={kvp.Value}"));
-        return $"{operationId}|{catalogVersion}|{normalized}";
+
+        var roles = string.Join(
+            ",",
+            principalContext.Roles.OrderBy(role => role, StringComparer.Ordinal));
+
+        return $"{operationId}|{catalogVersion}|{principalContext.PrincipalId}|{principalContext.Tier}|{roles}|{normalized}";
     }
 }
 

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationTool.cs
@@ -26,9 +26,11 @@ namespace Honua.Ai.Protocols.Mcp.Tools;
 /// <see cref="OperationRequest"/> and hands it to the dispatcher, which consults the
 /// policy decision point (allow / require-approval / dry-run-first / deny) before any
 /// executor runs. For a deterministic, read-only descriptor the result is param-keyed
-/// cached (<see cref="IPublishedOperationCache"/>): identical inputs return an
-/// identical result without re-execution. Non-deterministic or side-effecting
-/// descriptors are never cached.
+/// cached (<see cref="IPublishedOperationCache"/>): identical inputs from the
+/// identical principal context (principal id + tier + roles are part of the key)
+/// return an identical result without re-execution, so a cached policy-allowed result
+/// is never served across principals. Non-deterministic or side-effecting descriptors
+/// are never cached.
 /// </remarks>
 internal sealed class PublishedOperationTool : IMcpTool
 {
@@ -122,15 +124,27 @@ internal sealed class PublishedOperationTool : IMcpTool
 
         var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
 
+        // The policy context is resolved BEFORE the cache is consulted because it is
+        // part of the cache key: the cache-hit fast path skips the policy decision
+        // point, so a hit may only ever serve a result to the identical principal
+        // context (principal id + tier + roles) that was already policy-allowed for
+        // these exact inputs. A different caller — or the same caller with changed
+        // roles/tier — always misses and takes a fresh policy round-trip.
+        var context = new OperationPolicyContext
+        {
+            PrincipalId = principal.Identity?.Name,
+            Tier = ResolveTier(httpContext),
+            Roles = principal.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray(),
+        };
+
         var parameters = ReadParameters(arguments);
         var dryRun = ReadBool(arguments, "dryRun");
         var cacheKey = IsCacheable && !dryRun
-            ? IPublishedOperationCache.BuildKey(_descriptor.OperationId, _catalogVersion, parameters)
+            ? IPublishedOperationCache.BuildKey(_descriptor.OperationId, _catalogVersion, parameters, context)
             : null;
 
-        // Deterministic, read-only cache hit: identical inputs → identical result,
-        // no re-execution and no policy round-trip needed (a read-only deterministic
-        // op that was allowed once stays allowed for the same principal context).
+        // Deterministic, read-only cache hit: identical inputs from the identical
+        // principal context → identical result, no re-execution.
         if (cacheKey is not null)
         {
             var cache = httpContext.RequestServices.GetService<IPublishedOperationCache>();
@@ -162,13 +176,6 @@ internal sealed class PublishedOperationTool : IMcpTool
             ServiceName = ReadString(arguments, "serviceName"),
             Parameters = parameters,
             DryRun = dryRun,
-        };
-
-        var context = new OperationPolicyContext
-        {
-            PrincipalId = principal.Identity?.Name,
-            Tier = ResolveTier(httpContext),
-            Roles = principal.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray(),
         };
 
         var handle = await invoker.SubmitAsync(request, context, cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationTool.cs
@@ -1,0 +1,303 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers;
+using System.Security.Claims;
+using System.Text.Json;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Ai.Protocols.Mcp.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// A validated operations-toolset descriptor (RFC #17) projected into a first-class,
+/// typed MCP tool (#2483, ADR-0056 Increment 4). One instance wraps one
+/// <see cref="OperationDescriptor"/>: <see cref="Describe"/> projects the descriptor's
+/// input schema, an output schema, and behavior annotations, and
+/// <see cref="InvokeAsync"/> routes the call through the canonical
+/// <see cref="IOperationInvoker"/> so the operation policy decision point governs every
+/// invocation exactly as the hand-authored publish tools do.
+/// </summary>
+/// <remarks>
+/// The tool does not execute the operation itself; it adapts arguments onto an
+/// <see cref="OperationRequest"/> and hands it to the dispatcher, which consults the
+/// policy decision point (allow / require-approval / dry-run-first / deny) before any
+/// executor runs. For a deterministic, read-only descriptor the result is param-keyed
+/// cached (<see cref="IPublishedOperationCache"/>): identical inputs return an
+/// identical result without re-execution. Non-deterministic or side-effecting
+/// descriptors are never cached.
+/// </remarks>
+internal sealed class PublishedOperationTool : IMcpTool
+{
+    /// <summary>Prefix for the MCP tool name projected from an operation id.</summary>
+    public const string NamePrefix = "honua_op_";
+
+    private readonly OperationDescriptor _descriptor;
+    private readonly string _catalogVersion;
+    private readonly ILogger _logger;
+    private readonly JsonElement _inputSchema;
+
+    public PublishedOperationTool(
+        OperationDescriptor descriptor,
+        string catalogVersion,
+        ILogger logger)
+    {
+        _descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        _catalogVersion = catalogVersion ?? string.Empty;
+        _logger = logger;
+        Name = ProjectName(descriptor.OperationId);
+        _inputSchema = BuildInputSchema(descriptor.InputSchema);
+    }
+
+    public string Name { get; }
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Lifecycle;
+
+    /// <summary>Whether the backing descriptor is deterministic (AI-free).</summary>
+    public bool IsDeterministic => _descriptor.Policy.Determinism == OperationDeterminism.Deterministic;
+
+    // Deterministic AND read-only invocations are the only ones safe to cache: a
+    // cache must never skip a side effect or return a stale AI turn.
+    private bool IsCacheable =>
+        IsDeterministic && _descriptor.Policy.SideEffectClass == OperationSideEffectClass.ReadOnly;
+
+    /// <summary>
+    /// Projects an operation id (for example <c>service.publish</c>) into a valid MCP
+    /// tool name (for example <c>honua_op_service_publish</c>).
+    /// </summary>
+    public static string ProjectName(string operationId)
+    {
+        var sanitized = new char[operationId.Length];
+        for (var i = 0; i < operationId.Length; i++)
+        {
+            var c = operationId[i];
+            sanitized[i] = char.IsAsciiLetterOrDigit(c) ? char.ToLowerInvariant(c) : '_';
+        }
+
+        return NamePrefix + new string(sanitized);
+    }
+
+    public McpToolDescriptor Describe()
+    {
+        var readOnly = _descriptor.Policy.SideEffectClass == OperationSideEffectClass.ReadOnly;
+        var destructive =
+            _descriptor.Policy.SideEffectClass == OperationSideEffectClass.DestroysState
+            || _descriptor.Policy.BlastRadiusClass == OperationBlastRadiusClass.DeploymentScope;
+
+        var title = _descriptor.Title;
+        var annotations = readOnly
+            ? McpToolAnnotationSets.ReadOnly(title)
+            // Non-read-only descriptors mutate state: idempotent only when they neither
+            // destroy state nor reach deployment scope.
+            : McpToolAnnotationSets.Write(title, destructive, idempotent: !destructive);
+
+        var determinismNote = IsDeterministic
+            ? " This operation is deterministic (AI-free); identical inputs return an identical, param-keyed-cached result."
+            : " This operation is AI-assisted.";
+
+        return new McpToolDescriptor
+        {
+            Name = Name,
+            Title = title,
+            Description = _descriptor.Description
+                + " Published operations-toolset operation '" + _descriptor.OperationId
+                + "', governed by the operation policy decision point on every invocation"
+                + " (allow / require-approval / dry-run-first / deny)." + determinismNote,
+            InputSchema = _inputSchema,
+            OutputSchema = McpToolOutputSchemas.OperationToolOutputSchema,
+            Annotations = annotations,
+        };
+    }
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("PublishedOperation");
+        McpLog.ToolInvoked(_logger, Name, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+
+        var parameters = ReadParameters(arguments);
+        var dryRun = ReadBool(arguments, "dryRun");
+        var cacheKey = IsCacheable && !dryRun
+            ? IPublishedOperationCache.BuildKey(_descriptor.OperationId, _catalogVersion, parameters)
+            : null;
+
+        // Deterministic, read-only cache hit: identical inputs → identical result,
+        // no re-execution and no policy round-trip needed (a read-only deterministic
+        // op that was allowed once stays allowed for the same principal context).
+        if (cacheKey is not null)
+        {
+            var cache = httpContext.RequestServices.GetService<IPublishedOperationCache>();
+            var hit = cache?.TryGet(cacheKey);
+            if (hit is not null)
+            {
+                return McpToolHelpers.SuccessResult(hit, McpJsonContext.Default.McpOperationToolOutput);
+            }
+        }
+
+        var invoker = httpContext.RequestServices.GetService<IOperationInvoker>();
+        if (invoker is null)
+        {
+            return McpToolHelpers.SuccessResult(
+                new McpOperationToolOutput
+                {
+                    Status = OperationHandleStatus.Failed.ToString(),
+                    OperationId = _descriptor.OperationId,
+                    Deterministic = IsDeterministic,
+                    Message = "The operations toolset is unavailable (no IOperationInvoker is registered in this composition).",
+                },
+                McpJsonContext.Default.McpOperationToolOutput);
+        }
+
+        var request = new OperationRequest
+        {
+            OperationId = _descriptor.OperationId,
+            ConnectionId = ReadString(arguments, "connectionId"),
+            ServiceName = ReadString(arguments, "serviceName"),
+            Parameters = parameters,
+            DryRun = dryRun,
+        };
+
+        var context = new OperationPolicyContext
+        {
+            PrincipalId = principal.Identity?.Name,
+            Tier = ResolveTier(httpContext),
+            Roles = principal.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray(),
+        };
+
+        var handle = await invoker.SubmitAsync(request, context, cancellationToken).ConfigureAwait(false);
+        var output = Project(handle, cacheKey);
+
+        // Cache only a completed, deterministic, read-only result — never a
+        // requires-approval / denied / failed outcome, and never a side effect.
+        if (cacheKey is not null && handle.Status == OperationHandleStatus.Completed)
+        {
+            httpContext.RequestServices.GetService<IPublishedOperationCache>()?.Set(cacheKey, output);
+        }
+
+        return McpToolHelpers.SuccessResult(output, McpJsonContext.Default.McpOperationToolOutput);
+    }
+
+    private McpOperationToolOutput Project(OperationHandle handle, string? cacheKey) => new()
+    {
+        Status = handle.Status.ToString(),
+        RequiresApproval = handle.Status == OperationHandleStatus.RequiresApproval,
+        Deterministic = IsDeterministic,
+        CacheHit = false,
+        CacheKey = cacheKey,
+        OperationId = handle.OperationId,
+        HandleId = handle.HandleId,
+        JobId = handle.JobId,
+        ApprovalLane = handle.ApprovalLane,
+        MetadataRevision = handle.MetadataRevision,
+        Summary = handle.Result?.Summary,
+        Message = handle.Reason,
+        Details = handle.Result?.Details ?? new Dictionary<string, string>(StringComparer.Ordinal),
+    };
+
+    private static string? ResolveTier(HttpContext httpContext)
+    {
+        // Tier is resolved from the running edition so the policy decision point can
+        // apply tier-aware rules. Resolved leniently: a host without licensing wired
+        // (a lightweight test host) leaves the tier null, i.e. Community pass-through.
+        var licensing = httpContext.RequestServices.GetService<ILicenseEntitlementService>();
+        return licensing?.GetSnapshot().Edition.ToString().ToLowerInvariant();
+    }
+
+    private Dictionary<string, string?> ReadParameters(JsonElement? arguments)
+    {
+        var parameters = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (var parameter in _descriptor.InputSchema)
+        {
+            parameters[parameter.Name] = ReadString(arguments, parameter.Name);
+        }
+
+        return parameters;
+    }
+
+    private static string? ReadString(JsonElement? arguments, string name)
+    {
+        if (arguments is not { ValueKind: JsonValueKind.Object } args
+            || !args.TryGetProperty(name, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.String => property.GetString(),
+            JsonValueKind.Number => property.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            JsonValueKind.Null => null,
+            _ => property.GetRawText(),
+        };
+    }
+
+    private static bool ReadBool(JsonElement? arguments, string name)
+    {
+        if (arguments is not { ValueKind: JsonValueKind.Object } args
+            || !args.TryGetProperty(name, out var property))
+        {
+            return false;
+        }
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String => bool.TryParse(property.GetString(), out var parsed) && parsed,
+            _ => false,
+        };
+    }
+
+    // Builds a JSON Schema object for the operation's parameters using a
+    // Utf8JsonWriter (reflection-free, AOT-safe). Operation parameters are
+    // string-valued on the wire (OperationRequest keeps them as strings), so each
+    // property is typed string with the descriptor's title as its description.
+    private static JsonElement BuildInputSchema(IReadOnlyList<OperationParameterDescriptor> parameters)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "object");
+
+            writer.WriteStartObject("properties");
+            foreach (var parameter in parameters)
+            {
+                writer.WriteStartObject(parameter.Name);
+                writer.WriteString("type", "string");
+                if (!string.IsNullOrWhiteSpace(parameter.Title))
+                {
+                    writer.WriteString("description", parameter.Title);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndObject();
+
+            writer.WriteStartArray("required");
+            foreach (var parameter in parameters)
+            {
+                if (parameter.Required)
+                {
+                    writer.WriteStringValue(parameter.Name);
+                }
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        using var document = JsonDocument.Parse(buffer.WrittenMemory);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationToolSource.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationToolSource.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// Projects validated operations-toolset descriptors from the <see cref="IOperationCatalog"/>
+/// into first-class, typed, policy-governed MCP tools (#2483, ADR-0056 Increment 4).
+/// A descriptor present in the catalog is "published"; this source turns each one into a
+/// <see cref="PublishedOperationTool"/> that the <see cref="McpOperatorSurface"/> merges into
+/// <c>tools/list</c> and <c>tools/call</c>.
+/// </summary>
+/// <remarks>
+/// Off unless <c>Mcp:PublishOperations:Enabled</c> is set, so no host changes its advertised
+/// catalog by default. In "deterministic mode" (<c>DeterministicOnly</c>) only AI-free
+/// descriptors are published — the audit/inspect toolset. Descriptors already exposed by a
+/// hand-authored tool are skipped so the same operation is not advertised twice.
+/// </remarks>
+internal sealed class PublishedOperationToolSource : IMcpToolSource
+{
+    /// <summary>
+    /// Operation ids already surfaced by a hand-authored MCP tool, so they are not
+    /// double-published here. <c>service.publish</c> is <c>honua_publish_service</c> /
+    /// <c>honua_publish_result</c>.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedOperationIds =
+        new(StringComparer.Ordinal) { PublishServiceTool.PublishOperationId };
+
+    private static readonly IReadOnlyList<IMcpTool> Empty = [];
+
+    private readonly IOperationCatalog _catalog;
+    private readonly IOptions<McpPublishedOperationOptions> _options;
+    private readonly ILogger<PublishedOperationToolSource> _logger;
+
+    public PublishedOperationToolSource(
+        IOperationCatalog catalog,
+        IOptions<McpPublishedOperationOptions> options,
+        ILogger<PublishedOperationToolSource> logger)
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<IMcpTool>> GetToolsAsync(CancellationToken cancellationToken)
+    {
+        var options = _options.Value;
+        if (!options.Enabled)
+        {
+            return Empty;
+        }
+
+        var snapshot = await _catalog.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+
+        var tools = new List<IMcpTool>(snapshot.Operations.Count);
+        foreach (var descriptor in snapshot.Operations)
+        {
+            if (ExcludedOperationIds.Contains(descriptor.OperationId))
+            {
+                continue;
+            }
+
+            // Deterministic mode: only publish AI-free descriptors.
+            if (options.DeterministicOnly
+                && descriptor.Policy.Determinism != OperationDeterminism.Deterministic)
+            {
+                continue;
+            }
+
+            tools.Add(new PublishedOperationTool(descriptor, snapshot.CatalogVersion, _logger));
+        }
+
+        return tools;
+    }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -703,6 +703,11 @@ builder.Services.AddServerFeatures(builder.Configuration);
 builder.Services.AddOperateObservabilityFixtures(builder.Configuration, builder.Environment);
 builder.Services.AddWorkflowPackages();
 builder.Services.AddOperationsToolset(builder.Configuration);
+// #2483 (ADR-0056 Increment 4): publish validated operations-toolset descriptors as
+// first-class MCP tools. Off unless Mcp:PublishOperations:Enabled=true; wired after the
+// operations toolset so the tool source can resolve the canonical IOperationCatalog.
+Honua.Ai.Protocols.Mcp.McpServiceCollectionExtensions.AddMcpPublishedOperationTools(
+    builder.Services, builder.Configuration);
 builder.Services.AddAdminRealtime();
 if (!isTestEnvironment)
 {

--- a/tests/dotnet/Honua.Ai.Tests/Source/LivePlanAnalysisServiceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/LivePlanAnalysisServiceTests.cs
@@ -15,6 +15,7 @@ using Honua.Ai.AiBuilder.Planning;
 using Honua.Ai.Protocols.Mcp.Models;
 using Honua.Ai.Protocols.Mcp.Tools;
 using Honua.Ai.WorkflowGeneration;
+using Honua.Geoprocessing;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Configuration;
@@ -61,6 +62,32 @@ public sealed class LivePlanAnalysisServiceTests
         domainPlan.Steps[0].ProcessId.Should().Be("geometry.buffer");
         domainPlan.Steps[1].Kind.Should().Be(AnalysisPlanStepKind.QueryFeatures);
         domainPlan.Steps[1].DependsOn.Should().Contain("buffer-flood");
+    }
+
+    [UnitTest]
+    public async Task PlanAsync_LivePlan_FlowsThroughValidateLaneBeyondPlanAnalysis()
+    {
+        // #2485 checklist ("live lanes beyond plan_analysis"): the live planner's
+        // compiled plan is not a dead end at plan_analysis — it must feed the same
+        // validate/dry-run lane the fixture plans flow through. Convert the live
+        // output to a domain plan and run it through the exact validator the
+        // honua_validate_plan tool uses (ProcessPlanValidator over the built-in
+        // process catalog), proving the live lane extends past plan_analysis.
+        var service = CreateLiveService(FakeProvider.Generated(CannedGraph()));
+
+        var output = await service.PlanAsync(BufferIntent, context: null, CancellationToken.None);
+        output.Status.Should().Be("planned");
+
+        var domainPlan = ToDomainPlan(output.Plan!);
+        var (violations, _) = ProcessPlanValidator.Validate(domainPlan, new BuiltInProcessCatalog());
+
+        // The validator ran over the live plan and produced a structured result
+        // (the lane is wired), and the buffer step resolves to the canonical
+        // geometry.buffer process — i.e. the live lane's plan is validate-ready,
+        // not a plan-analysis-only artifact.
+        violations.Should().NotBeNull();
+        domainPlan.Steps.Should().HaveCount(2);
+        domainPlan.Steps[0].ProcessId.Should().Be("geometry.buffer");
     }
 
     [UnitTest]
@@ -369,6 +396,40 @@ public sealed class LivePlanAnalysisServiceTests
         using var provider = services.BuildServiceProvider();
         provider.GetRequiredService<IPlanAnalysisService>()
             .Should().BeOfType<LivePlanAnalysisService>();
+    }
+
+    [UnitTest]
+    public void AddAiBuilderPlanAnalysis_DocumentedLivePlannerProfile_ResolvesLivePlanner()
+    {
+        // #2485 AC1: the supported "live-planner-on" configuration profile documented
+        // in docs/guides/connect/mcp-live-planner.md must actually select the live
+        // planner. This pins that profile verbatim (WorkflowGeneration enabled with a
+        // bedrock provider + the dedicated PlanAnalysis gate/provider) so the doc and
+        // the composition can never drift apart silently.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IWorkflowGenerationService>());
+        services.AddSingleton(Substitute.For<IWorkflowNodeRegistry>());
+
+        var profile = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["WorkflowGeneration:Enabled"] = "true",
+                ["WorkflowGeneration:DefaultProvider"] = "bedrock",
+                ["WorkflowGeneration:Providers:bedrock:Model"] =
+                    "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                ["WorkflowGeneration:Providers:bedrock:Region"] = "us-west-2",
+                ["PlanAnalysis:Enabled"] = "true",
+                ["PlanAnalysis:Provider"] = "bedrock",
+            })
+            .Build();
+
+        services.AddAiBuilderPlanAnalysis(profile);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IPlanAnalysisService>()
+            .Should().BeOfType<LivePlanAnalysisService>();
+        AiBuilderServiceCollectionExtensions.ShouldUseLivePlanner(profile).Should().BeTrue();
     }
 
     // Builds the live service over the REAL WorkflowGenerationService so the test

--- a/tests/dotnet/Honua.Ai.Tests/Source/PlanAnalysisToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/PlanAnalysisToolTests.cs
@@ -166,8 +166,12 @@ public sealed class PlanAnalysisToolTests
 
     [UnitTest]
     [Endpoint("POST /mcp tools/call honua_plan_analysis")]
-    public async Task PlanAnalysis_UnknownPrompt_ReturnsRejectedWithReason()
+    public async Task PlanAnalysis_UnknownPrompt_ReturnsRejectedWithFixtureModeDisclosure()
     {
+        // #2485 AC2: until a live-planner-on profile ships, the fixture path must
+        // explicitly disclose that it is running in fixture (demo) mode — via the
+        // engine discriminator AND a plain-language reason on the miss — so a caller
+        // never reads "rejected" as "your intent is unsupported".
         var tool = CreateTool(_jobService);
         var arguments = McpTestFactory.ParseJson(
             """{"intent":"some completely unmatched utterance"}""");
@@ -177,7 +181,11 @@ public sealed class PlanAnalysisToolTests
 
         var body = result.StructuredContent!.Value;
         body.GetProperty("status").GetString().Should().Be("rejected");
-        body.GetProperty("reason").GetString().Should().NotBeNullOrWhiteSpace();
+        body.GetProperty("engine").GetString().Should().Be("fixture");
+        var reason = body.GetProperty("reason").GetString();
+        reason.Should().NotBeNullOrWhiteSpace();
+        reason.Should().Contain("fixture", "the miss reason must disclose fixture (demo) mode");
+        reason.Should().ContainAny("live", "provider", "PlanAnalysis", "WorkflowGeneration");
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Ai.Tests/Source/PublishedOperationToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/PublishedOperationToolTests.cs
@@ -1,0 +1,569 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Operations.Abstractions;
+using Honua.Core.Features.Operations.Domain;
+using Honua.Core.Features.Operations.Policy;
+using Honua.Core.Features.Operations.Services;
+using Honua.Core.Features.WorkflowPackages.Domain;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Coverage for #2483 (ADR-0056 Increment 4): validated operations-toolset descriptors
+/// projected as first-class MCP tools. Verifies the projection (typed schema +
+/// annotations), governance through the policy decision point, deterministic
+/// param-keyed caching, deterministic mode, and the surface merge into
+/// <c>tools/list</c> / <c>tools/call</c>.
+/// </summary>
+[Protocol(TestProtocols.Mcp)]
+public sealed class PublishedOperationToolTests
+{
+    private const string DeterministicReadOnlyOpId = "geo.summary";
+    private const string MutatingOpId = "geo.export";
+
+    // ---- Descriptor projection -------------------------------------------------
+
+    [UnitTest]
+    public void Describe_ReadOnlyDeterministicDescriptor_ProjectsTypedToolWithSchemaAndAnnotations()
+    {
+        var tool = new PublishedOperationTool(
+            DeterministicReadOnlyDescriptor(), "cat-v1", NullLogger.Instance);
+
+        var descriptor = tool.Describe();
+
+        descriptor.Name.Should().Be("honua_op_geo_summary");
+        descriptor.Title.Should().NotBeNullOrWhiteSpace();
+        descriptor.Description.Should().Contain("policy decision point");
+        descriptor.Description.Should().Contain("deterministic");
+
+        // Typed input schema projected from the descriptor's parameters.
+        descriptor.InputSchema.GetProperty("type").GetString().Should().Be("object");
+        descriptor.InputSchema.GetProperty("properties").TryGetProperty("layerId", out _).Should().BeTrue();
+        descriptor.InputSchema.GetProperty("required").EnumerateArray()
+            .Select(e => e.GetString()).Should().Contain("layerId");
+
+        // Output schema + read-only annotation for a read-only descriptor.
+        descriptor.OutputSchema.Should().NotBeNull();
+        descriptor.OutputSchema!.Value.GetProperty("properties").TryGetProperty("deterministic", out _)
+            .Should().BeTrue();
+        descriptor.Annotations!.ReadOnlyHint.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Describe_MutatingDescriptor_ProjectsWriteAnnotations()
+    {
+        var tool = new PublishedOperationTool(MutatingDescriptor(), "cat-v1", NullLogger.Instance);
+
+        var descriptor = tool.Describe();
+
+        descriptor.Name.Should().Be("honua_op_geo_export");
+        descriptor.Annotations!.ReadOnlyHint.Should().BeFalse("a data-mutating operation is not read-only");
+    }
+
+    [UnitTest]
+    public void ProjectName_SanitizesOperationIdIntoToolName()
+    {
+        PublishedOperationTool.ProjectName("service.publish").Should().Be("honua_op_service_publish");
+        PublishedOperationTool.ProjectName("Geo.Buffer-2").Should().Be("honua_op_geo_buffer_2");
+    }
+
+    // ---- Governance through the policy decision point --------------------------
+
+    [UnitTest]
+    [Endpoint("POST /mcp tools/call honua_op_geo_export")]
+    public async Task Invoke_PolicyDenies_ReturnsDeniedWithoutExecuting()
+    {
+        var executor = new RecordingExecutor(MutatingOpId);
+        var invoker = Dispatcher(
+            MutatingDescriptor(),
+            executor,
+            new OperationPolicyOptions
+            {
+                Enabled = true,
+                DefaultDecision = PolicyDecisionKind.Deny,
+                DefaultReason = "Denied by policy on this tier.",
+            });
+
+        var tool = new PublishedOperationTool(MutatingDescriptor(), "cat-v1", NullLogger.Instance);
+        var result = await tool.InvokeAsync(Context(invoker), Args("""{"layerId":"7"}"""), CancellationToken.None);
+
+        var body = result.StructuredContent!.Value;
+        body.GetProperty("status").GetString().Should().Be("Denied");
+        body.GetProperty("requiresApproval").GetBoolean().Should().BeFalse();
+        executor.SubmitCount.Should().Be(0, "a denied operation must never reach the executor");
+    }
+
+    [UnitTest]
+    [Endpoint("POST /mcp tools/call honua_op_geo_export")]
+    public async Task Invoke_PolicyRequiresApproval_SurfacesApprovalLane()
+    {
+        var invoker = Dispatcher(
+            MutatingDescriptor(),
+            new RecordingExecutor(MutatingOpId),
+            new OperationPolicyOptions
+            {
+                Enabled = true,
+                DefaultDecision = PolicyDecisionKind.RequireApproval,
+                DefaultApprovalLane = "operator-gate",
+                DefaultReason = "Requires operator approval.",
+            });
+
+        var tool = new PublishedOperationTool(MutatingDescriptor(), "cat-v1", NullLogger.Instance);
+        var result = await tool.InvokeAsync(Context(invoker), Args("""{"layerId":"7"}"""), CancellationToken.None);
+
+        var body = result.StructuredContent!.Value;
+        body.GetProperty("status").GetString().Should().Be("RequiresApproval");
+        body.GetProperty("requiresApproval").GetBoolean().Should().BeTrue();
+        body.GetProperty("approvalLane").GetString().Should().Be("operator-gate");
+    }
+
+    [UnitTest]
+    public async Task Invoke_PopulatesTierAndRolesOnPolicyContext()
+    {
+        OperationPolicyContext? captured = null;
+        var invoker = new CapturingInvoker((_, ctx) =>
+        {
+            captured = ctx;
+            return CompletedHandle(MutatingOpId);
+        });
+
+        var tool = new PublishedOperationTool(MutatingDescriptor(), "cat-v1", NullLogger.Instance);
+        var context = Context(invoker, license: ProEdition(), roles: ["operator", "publisher"]);
+
+        await tool.InvokeAsync(context, Args("""{"layerId":"7"}"""), CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Tier.Should().Be("pro", "tier is resolved from the running edition for tier-aware policy");
+        captured.Roles.Should().BeEquivalentTo("operator", "publisher");
+        captured.PrincipalId.Should().Be("agent-x");
+    }
+
+    // ---- Deterministic, param-keyed caching ------------------------------------
+
+    [UnitTest]
+    public async Task Invoke_DeterministicReadOnly_CachesOnParams()
+    {
+        var invoker = new CountingInvoker(_ => CompletedHandle(DeterministicReadOnlyOpId));
+        var cache = new PublishedOperationCache();
+        var tool = new PublishedOperationTool(DeterministicReadOnlyDescriptor(), "cat-v1", NullLogger.Instance);
+
+        var first = await tool.InvokeAsync(
+            Context(invoker, cache), Args("""{"layerId":"7"}"""), CancellationToken.None);
+        var second = await tool.InvokeAsync(
+            Context(invoker, cache), Args("""{"layerId":"7"}"""), CancellationToken.None);
+
+        invoker.SubmitCount.Should().Be(1, "identical inputs must be served from the param-keyed cache");
+        first.StructuredContent!.Value.GetProperty("cacheHit").GetBoolean().Should().BeFalse();
+        second.StructuredContent!.Value.GetProperty("cacheHit").GetBoolean().Should().BeTrue();
+        second.StructuredContent!.Value.GetProperty("deterministic").GetBoolean().Should().BeTrue();
+
+        // A different parameter is a cache miss → re-executes.
+        await tool.InvokeAsync(Context(invoker, cache), Args("""{"layerId":"9"}"""), CancellationToken.None);
+        invoker.SubmitCount.Should().Be(2, "a different parameter set is a distinct cache key");
+    }
+
+    [UnitTest]
+    public async Task Invoke_MutatingOperation_IsNeverCached()
+    {
+        var invoker = new CountingInvoker(_ => CompletedHandle(MutatingOpId));
+        var cache = new PublishedOperationCache();
+        var tool = new PublishedOperationTool(MutatingDescriptor(), "cat-v1", NullLogger.Instance);
+
+        await tool.InvokeAsync(Context(invoker, cache), Args("""{"layerId":"7"}"""), CancellationToken.None);
+        var second = await tool.InvokeAsync(
+            Context(invoker, cache), Args("""{"layerId":"7"}"""), CancellationToken.None);
+
+        invoker.SubmitCount.Should().Be(2, "a side-effecting operation must re-execute every time");
+        second.StructuredContent!.Value.GetProperty("cacheHit").GetBoolean().Should().BeFalse();
+        second.StructuredContent!.Value.TryGetProperty("cacheKey", out _)
+            .Should().BeFalse("a non-cacheable operation carries no cache key");
+    }
+
+    [UnitTest]
+    public async Task Invoke_WhenInvokerUnavailable_ReturnsFailedWithoutThrowing()
+    {
+        var tool = new PublishedOperationTool(DeterministicReadOnlyDescriptor(), "cat-v1", NullLogger.Instance);
+
+        var result = await tool.InvokeAsync(
+            Context(invoker: null), Args("""{"layerId":"7"}"""), CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        result.StructuredContent!.Value.GetProperty("status").GetString().Should().Be("Failed");
+        result.StructuredContent!.Value.GetProperty("message").GetString()
+            .Should().Contain("operations toolset is unavailable");
+    }
+
+    // ---- Tool source: publish / deterministic mode -----------------------------
+
+    [UnitTest]
+    public async Task Source_Disabled_PublishesNothing()
+    {
+        var source = new PublishedOperationToolSource(
+            Catalog(DeterministicReadOnlyDescriptor(), MutatingDescriptor()),
+            Options.Create(new McpPublishedOperationOptions { Enabled = false }),
+            NullLogger<PublishedOperationToolSource>.Instance);
+
+        (await source.GetToolsAsync(CancellationToken.None)).Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public async Task Source_Enabled_PublishesDescriptorsAndExcludesHandAuthoredOps()
+    {
+        var source = new PublishedOperationToolSource(
+            Catalog(DeterministicReadOnlyDescriptor(), MutatingDescriptor(), ServicePublishDescriptor()),
+            Options.Create(new McpPublishedOperationOptions { Enabled = true }),
+            NullLogger<PublishedOperationToolSource>.Instance);
+
+        var names = (await source.GetToolsAsync(CancellationToken.None)).Select(t => t.Name).ToArray();
+
+        names.Should().Contain(["honua_op_geo_summary", "honua_op_geo_export"]);
+        names.Should().NotContain("honua_op_service_publish",
+            "service.publish is already exposed by honua_publish_service");
+    }
+
+    [UnitTest]
+    public async Task Source_DeterministicMode_PublishesOnlyDeterministicDescriptors()
+    {
+        var source = new PublishedOperationToolSource(
+            Catalog(DeterministicReadOnlyDescriptor(), MutatingDescriptor()),
+            Options.Create(new McpPublishedOperationOptions { Enabled = true, DeterministicOnly = true }),
+            NullLogger<PublishedOperationToolSource>.Instance);
+
+        var names = (await source.GetToolsAsync(CancellationToken.None)).Select(t => t.Name).ToArray();
+
+        names.Should().Contain("honua_op_geo_summary");
+        names.Should().NotContain("honua_op_geo_export",
+            "the mutating operation is AI-assisted and excluded from deterministic mode");
+    }
+
+    // ---- Surface merge: published tools appear in tools/list and are callable ---
+
+    [UnitTest]
+    [Endpoint("POST /mcp tools/list")]
+    public async Task Surface_MergesPublishedTool_IntoToolsListAndToolsCall()
+    {
+        var invoker = new CountingInvoker(_ => CompletedHandle(DeterministicReadOnlyOpId));
+        var source = new PublishedOperationToolSource(
+            Catalog(DeterministicReadOnlyDescriptor()),
+            Options.Create(new McpPublishedOperationOptions { Enabled = true }),
+            NullLogger<PublishedOperationToolSource>.Instance);
+
+        var surface = new McpOperatorSurface(
+            [],
+            [],
+            NullLogger<McpOperatorSurface>.Instance,
+            limits: null,
+            toolSources: [source]);
+
+        // tools/list advertises the runtime-published tool.
+        var listResponse = await surface.DispatchAsync(
+            AuthenticatedContext(new ServiceCollection().BuildServiceProvider()),
+            Rpc("l1", "tools/list", null),
+            CancellationToken.None);
+
+        listResponse!.Result!.Value.GetProperty("tools").EnumerateArray()
+            .Select(t => t.GetProperty("name").GetString())
+            .Should().Contain("honua_op_geo_summary");
+
+        // tools/call routes to the published tool.
+        var services = new ServiceCollection().AddSingleton<IOperationInvoker>(invoker)
+            .AddSingleton<IPublishedOperationCache>(new PublishedOperationCache())
+            .BuildServiceProvider();
+        var callResponse = await surface.DispatchAsync(
+            AuthenticatedContext(services),
+            Rpc("c1", "tools/call", """{"name":"honua_op_geo_summary","arguments":{"layerId":"7"}}"""),
+            CancellationToken.None);
+
+        callResponse!.Error.Should().BeNull();
+        callResponse.Result!.Value.GetProperty("isError").GetBoolean().Should().BeFalse();
+        callResponse.Result!.Value.GetProperty("structuredContent").GetProperty("status").GetString()
+            .Should().Be("Completed");
+        invoker.SubmitCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task Surface_StaticToolWins_OverDynamicNameCollision()
+    {
+        // A dynamic source yielding a tool whose name collides with a static tool
+        // must not shadow it: the static tool is listed exactly once.
+        var staticTool = new StubNamedTool("honua_op_geo_summary");
+        var source = new PublishedOperationToolSource(
+            Catalog(DeterministicReadOnlyDescriptor()),
+            Options.Create(new McpPublishedOperationOptions { Enabled = true }),
+            NullLogger<PublishedOperationToolSource>.Instance);
+
+        var surface = new McpOperatorSurface(
+            [staticTool], [], NullLogger<McpOperatorSurface>.Instance, limits: null, toolSources: [source]);
+
+        var response = await surface.DispatchAsync(
+            AuthenticatedContext(new ServiceCollection().BuildServiceProvider()),
+            Rpc("l2", "tools/list", null),
+            CancellationToken.None);
+
+        response!.Result!.Value.GetProperty("tools").EnumerateArray()
+            .Count(t => t.GetProperty("name").GetString() == "honua_op_geo_summary")
+            .Should().Be(1, "the static tool wins a name collision and is listed once");
+    }
+
+    // ---- Helpers ---------------------------------------------------------------
+
+    private static OperationDispatcher Dispatcher(
+        OperationDescriptor descriptor,
+        IOperationExecutor executor,
+        OperationPolicyOptions policyOptions)
+        => new(
+            Catalog(descriptor),
+            [executor],
+            new ConfigurableOperationPolicyDecisionPoint(Options.Create(policyOptions)),
+            TimeProvider.System);
+
+    private static IOperationCatalog Catalog(params OperationDescriptor[] descriptors)
+    {
+        var catalog = Substitute.For<IOperationCatalog>();
+        catalog.GetSnapshotAsync(Arg.Any<CancellationToken>()).Returns(new OperationCatalogSnapshot
+        {
+            CatalogVersion = "cat-v1",
+            GeneratedAt = DateTimeOffset.UnixEpoch,
+            ProviderIds = ["test"],
+            Operations = descriptors,
+        });
+        foreach (var descriptor in descriptors)
+        {
+            catalog.GetDescriptorAsync(descriptor.OperationId, Arg.Any<CancellationToken>())
+                .Returns(descriptor);
+        }
+
+        return catalog;
+    }
+
+    private static DefaultHttpContext Context(
+        IOperationInvoker? invoker,
+        IPublishedOperationCache? cache = null,
+        ILicenseEntitlementService? license = null,
+        string[]? roles = null)
+    {
+        var services = new ServiceCollection();
+        if (invoker is not null)
+        {
+            services.AddSingleton(invoker);
+        }
+
+        services.AddSingleton<IPublishedOperationCache>(cache ?? new PublishedOperationCache());
+        if (license is not null)
+        {
+            services.AddSingleton(license);
+        }
+
+        var claims = new List<Claim> { new(ClaimTypes.Name, "agent-x") };
+        claims.AddRange((roles ?? []).Select(r => new Claim(ClaimTypes.Role, r)));
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test")),
+        };
+    }
+
+    private static DefaultHttpContext AuthenticatedContext(IServiceProvider services)
+    {
+        var context = McpTestFactory.AuthenticatedHttpContext();
+        context.RequestServices = services;
+        return context;
+    }
+
+    private static ILicenseEntitlementService ProEdition()
+    {
+        var license = Substitute.For<ILicenseEntitlementService>();
+        license.GetSnapshot().Returns(new LicenseSnapshot(
+            HonuaEdition.Pro,
+            true,
+            LicenseValidationState.Valid,
+            null,
+            null,
+            null,
+            null,
+            [],
+            new HashSet<string>(),
+            1,
+            null));
+        return license;
+    }
+
+    private static OperationHandle CompletedHandle(string operationId) => new()
+    {
+        OperationId = operationId,
+        HandleId = "op-done",
+        Status = OperationHandleStatus.Completed,
+        Result = new OperationResultSummary
+        {
+            Summary = "ok",
+            Details = new Dictionary<string, string>(StringComparer.Ordinal) { ["rows"] = "3" },
+        },
+    };
+
+    private static OperationDescriptor DeterministicReadOnlyDescriptor() => new()
+    {
+        OperationId = DeterministicReadOnlyOpId,
+        ProviderId = "test",
+        Title = "Summarize layer",
+        Description = "Compute a deterministic summary for a layer.",
+        Category = "analysis",
+        InputSchema = [Param("layerId", required: true), Param("fields", required: false)],
+        OutputSchema = [],
+        ExecutionKind = OperationExecutionKind.Synchronous,
+        ApprovalModel = OperationApprovalModel.None,
+        Policy = new OperationPolicyMetadata
+        {
+            BlastRadiusClass = OperationBlastRadiusClass.None,
+            SideEffectClass = OperationSideEffectClass.ReadOnly,
+            Determinism = OperationDeterminism.Deterministic,
+            SupportsDryRun = false,
+        },
+    };
+
+    private static OperationDescriptor MutatingDescriptor() => new()
+    {
+        OperationId = MutatingOpId,
+        ProviderId = "test",
+        Title = "Export layer",
+        Description = "Export a layer, mutating data.",
+        Category = "lifecycle",
+        InputSchema = [Param("layerId", required: true)],
+        OutputSchema = [],
+        ExecutionKind = OperationExecutionKind.Job,
+        ApprovalModel = OperationApprovalModel.OperatorGate,
+        Policy = new OperationPolicyMetadata
+        {
+            BlastRadiusClass = OperationBlastRadiusClass.ServiceScope,
+            SideEffectClass = OperationSideEffectClass.MutatesData,
+            Determinism = OperationDeterminism.AiAssisted,
+            SupportsDryRun = true,
+        },
+    };
+
+    private static OperationDescriptor ServicePublishDescriptor() => DeterministicReadOnlyDescriptor() with
+    {
+        OperationId = PublishServiceTool.PublishOperationId,
+        Title = "Publish service",
+    };
+
+    private static OperationParameterDescriptor Param(string name, bool required) => new()
+    {
+        Name = name,
+        Title = name + " title",
+        Required = required,
+        Schema = new WorkflowSchemaDefinition { Type = WorkflowSchemaValueType.Text },
+    };
+
+    private static JsonElement Args(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static McpJsonRpcRequest Rpc(string id, string method, string? paramsJson) => new()
+    {
+        JsonRpc = "2.0",
+        Id = Args(JsonSerializer.Serialize(id)),
+        Method = method,
+        Params = paramsJson is null ? null : Args(paramsJson),
+    };
+
+    private sealed class CapturingInvoker(Func<OperationRequest, OperationPolicyContext, OperationHandle> handler)
+        : IOperationInvoker
+    {
+        public Task<OperationValidation> ValidateAsync(OperationRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new OperationValidation { IsValid = true, Status = "valid" });
+
+        public Task<OperationHandle> SubmitAsync(
+            OperationRequest request, OperationPolicyContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(handler(request, context));
+    }
+
+    private sealed class CountingInvoker(Func<OperationRequest, OperationHandle> handler) : IOperationInvoker
+    {
+        public int SubmitCount { get; private set; }
+
+        public Task<OperationValidation> ValidateAsync(OperationRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new OperationValidation { IsValid = true, Status = "valid" });
+
+        public Task<OperationHandle> SubmitAsync(
+            OperationRequest request, OperationPolicyContext context, CancellationToken cancellationToken = default)
+        {
+            SubmitCount++;
+            return Task.FromResult(handler(request));
+        }
+    }
+
+    private sealed class RecordingExecutor(string operationId) : IOperationExecutor
+    {
+        public int SubmitCount { get; private set; }
+
+        public string OperationId => operationId;
+
+        public Task<OperationValidation> ValidateAsync(OperationRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new OperationValidation { IsValid = true, Status = "valid" });
+
+        public Task<OperationHandle> SubmitAsync(
+            OperationRequest request, OperationPolicyContext context, CancellationToken cancellationToken = default)
+        {
+            SubmitCount++;
+            return Task.FromResult(new OperationHandle
+            {
+                OperationId = operationId,
+                HandleId = "op-run",
+                Status = OperationHandleStatus.Completed,
+            });
+        }
+
+        public Task<OperationStatus> GetStatusAsync(OperationHandle handle, CancellationToken cancellationToken = default)
+            => Task.FromResult(new OperationStatus
+            {
+                OperationId = operationId,
+                HandleId = handle.HandleId,
+                Status = handle.Status,
+            });
+    }
+
+    private sealed class StubNamedTool(string name) : IMcpTool
+    {
+        public string Name => name;
+
+        public string WorkflowFamily => McpTelemetry.WorkflowFamily.Lifecycle;
+
+        public McpToolDescriptor Describe() => new()
+        {
+            Name = name,
+            Description = "static",
+            InputSchema = EmptySchema,
+        };
+
+        public Task<McpToolsCallResult> InvokeAsync(
+            HttpContext httpContext, JsonElement? arguments, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        private static readonly JsonElement EmptySchema = ParseEmpty();
+
+        private static JsonElement ParseEmpty()
+        {
+            using var document = JsonDocument.Parse("""{"type":"object"}""");
+            return document.RootElement.Clone();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/PublishedOperationToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/PublishedOperationToolTests.cs
@@ -179,6 +179,81 @@ public sealed class PublishedOperationToolTests
     }
 
     [UnitTest]
+    public async Task Invoke_SameParams_DifferentPrincipal_MissesCacheAndTakesFreshPolicyRoundTrip()
+    {
+        // Security regression (PR #2584 review): the cache key includes the full
+        // policy-relevant principal context, and a cache hit skips the policy
+        // decision point — so a result cached under a policy-ALLOWED privileged
+        // caller must NEVER be served to a different caller with the same params.
+        // Policy here: role "admin" → Allow, everyone else → Deny. Caller A (admin)
+        // executes and is cached; caller B (no roles), same params, must MISS the
+        // cache, take a fresh policy round-trip, and be DENIED — not receive A's
+        // cached result.
+        var executor = new RecordingExecutor(DeterministicReadOnlyOpId);
+        var invoker = Dispatcher(
+            DeterministicReadOnlyDescriptor(),
+            executor,
+            new OperationPolicyOptions
+            {
+                Enabled = true,
+                DefaultDecision = PolicyDecisionKind.Deny,
+                DefaultReason = "Denied for non-admin callers.",
+                Rules =
+                {
+                    new OperationPolicyRule { OperationId = "*", Role = "admin", Decision = PolicyDecisionKind.Allow },
+                },
+            });
+        var cache = new PublishedOperationCache();
+        var tool = new PublishedOperationTool(DeterministicReadOnlyDescriptor(), "cat-v1", NullLogger.Instance);
+
+        // Privileged caller A: allowed, executed, cached.
+        var first = await tool.InvokeAsync(
+            Context(invoker, cache, roles: ["admin"], principalName: "agent-a"),
+            Args("""{"layerId":"7"}"""),
+            CancellationToken.None);
+        first.StructuredContent!.Value.GetProperty("status").GetString().Should().Be("Completed");
+        executor.SubmitCount.Should().Be(1);
+
+        // Low-privilege caller B, identical params: fresh policy round-trip → Denied.
+        var second = await tool.InvokeAsync(
+            Context(invoker, cache, roles: null, principalName: "agent-b"),
+            Args("""{"layerId":"7"}"""),
+            CancellationToken.None);
+
+        var body = second.StructuredContent!.Value;
+        body.GetProperty("status").GetString().Should().Be("Denied",
+            "the policy decision point must be consulted for B instead of serving A's cached allow");
+        body.GetProperty("cacheHit").GetBoolean().Should().BeFalse();
+        executor.SubmitCount.Should().Be(1, "the denied caller never reaches the executor");
+
+        // And A's own cache entry is unaffected: A re-invoking with the same params
+        // is a hit with no re-execution.
+        var third = await tool.InvokeAsync(
+            Context(invoker, cache, roles: ["admin"], principalName: "agent-a"),
+            Args("""{"layerId":"7"}"""),
+            CancellationToken.None);
+        third.StructuredContent!.Value.GetProperty("cacheHit").GetBoolean().Should().BeTrue();
+        executor.SubmitCount.Should().Be(1);
+    }
+
+    [UnitTest]
+    public async Task Invoke_SameParams_SamePrincipalDifferentRoles_MissesCache()
+    {
+        // Roles are part of the cache key: the same principal whose role set changed
+        // (e.g. a revoked grant) must not ride a result cached under the old roles.
+        var invoker = new CountingInvoker(_ => CompletedHandle(DeterministicReadOnlyOpId));
+        var cache = new PublishedOperationCache();
+        var tool = new PublishedOperationTool(DeterministicReadOnlyDescriptor(), "cat-v1", NullLogger.Instance);
+
+        await tool.InvokeAsync(
+            Context(invoker, cache, roles: ["admin"]), Args("""{"layerId":"7"}"""), CancellationToken.None);
+        await tool.InvokeAsync(
+            Context(invoker, cache, roles: ["viewer"]), Args("""{"layerId":"7"}"""), CancellationToken.None);
+
+        invoker.SubmitCount.Should().Be(2, "a changed role set is a distinct principal context and misses the cache");
+    }
+
+    [UnitTest]
     public async Task Invoke_MutatingOperation_IsNeverCached()
     {
         var invoker = new CountingInvoker(_ => CompletedHandle(MutatingOpId));
@@ -356,7 +431,8 @@ public sealed class PublishedOperationToolTests
         IOperationInvoker? invoker,
         IPublishedOperationCache? cache = null,
         ILicenseEntitlementService? license = null,
-        string[]? roles = null)
+        string[]? roles = null,
+        string principalName = "agent-x")
     {
         var services = new ServiceCollection();
         if (invoker is not null)
@@ -370,7 +446,7 @@ public sealed class PublishedOperationToolTests
             services.AddSingleton(license);
         }
 
-        var claims = new List<Claim> { new(ClaimTypes.Name, "agent-x") };
+        var claims = new List<Claim> { new(ClaimTypes.Name, principalName) };
         claims.AddRange((roles ?? []).Select(r => new Claim(ClaimTypes.Role, r)));
 
         return new DefaultHttpContext


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2485
Fixes #2483

## Summary
Closes the two coupled MCP-program tails in one PR.

**#2485 (planner rollout tail from #1955):** the dedicated `PlanAnalysis:Enabled`/`PlanAnalysis:Provider` seam and the `engine` disclosure already landed on trunk (#1955 follow-up, #2499); this PR resolves the three remaining checklist items. A documented, supported live-planner-on configuration profile now exists (`docs/guides/connect/mcp-live-planner.md`), pinned verbatim by a test so the doc and `ShouldUseLivePlanner` can never drift. The tier/edition default-on policy is resolved as an explicit documented policy rather than a license-bit auto-flip: Honua ships no model credentials on any edition, so an edition-based silent default-on would fail closed at request time — activation is always the documented provider profile, with Pro/Enterprise treating it as the supported default and Community as BYO-model (rationale in the guide). Until the profile is applied, the fixture planner's miss path now explicitly discloses fixture (demo) mode and how to turn the live planner on. Live-lane coverage now extends beyond `plan_analysis`: the live planner's compiled plan is proven to flow through the same validate lane (`ProcessPlanValidator`) the `honua_validate_plan` tool uses.

**#2483 (workflow-as-first-class-MCP-tool, ADR-0056 Increment 4):** a validated operations-toolset descriptor (RFC #17) can now be published as a first-class, typed MCP tool. `PublishedOperationToolSource` projects every descriptor in the canonical `IOperationCatalog` into a `PublishedOperationTool` (`honua_op_{operationId}`) with a typed input schema built from the descriptor's parameters, an output schema, and behavior annotations derived from its side-effect class. Every invocation routes through `IOperationInvoker`, so the existing `IOperationPolicyDecisionPoint` governs it (allow / require-approval / dry-run-first / deny) with tier (from the running edition) and roles (from the principal) populated on the policy context; `RequiresApproval` surfaces as a structured outcome with the approval lane. Deterministic, read-only invocations are param-keyed cached — the key includes the full policy-relevant principal context (PrincipalId + resolved tier + sorted roles), so a cached policy-allowed result can only ever be served back to the identical principal context and every other caller takes a fresh policy round-trip; deterministic mode (`Mcp:PublishOperations:DeterministicOnly`) publishes only AI-free descriptors. The whole surface is opt-in (`Mcp:PublishOperations:Enabled`, default off), merged into `tools/list`/`tools/call` via a new `IMcpToolSource` seam on `McpOperatorSurface` where static registry-bound tools always win — default hosts advertise a byte-identical catalog, keeping the ADR-0058 registry-binding startup check green.

## Changes Made
- `FixturePlanAnalysisService`: fixture-miss rejection reason now discloses fixture (demo) mode and points at the live-planner profile (#2485 AC2)
- New guide `docs/guides/connect/mcp-live-planner.md` (supported live-planner-on profile, edition/tier policy, precedence rules, verification, live-lane testing); nav wiring in `docs/SUMMARY.md`, `docs/guides/README.md`, cross-links in `docs/guides/connect/ai-agents-mcp.md`
- `LivePlanAnalysisServiceTests`: pins the documented profile to `LivePlanAnalysisService` resolution; proves the live plan flows through the validate lane beyond `plan_analysis`
- `PlanAnalysisToolTests`: asserts the fixture-mode disclosure (engine + reason) on the miss path
- New `PublishedOperationTool`: descriptor → typed MCP tool projection (schema, annotations, policy-governed invoke, deterministic param-keyed caching scoped to the principal context — PrincipalId + tier + sorted roles are part of the cache key so hits never cross principals/roles/tiers and every other caller re-runs the policy decision point, per PR review)
- New `PublishedOperationToolSource` + `IMcpToolSource` seam + `McpPublishedOperationOptions` (+ `PublishedOperationCache`): opt-in runtime publication of catalog descriptors, deterministic-only mode, hand-authored-op exclusion
- `McpOperatorSurface`: merges dynamic tool sources into `tools/list`/`tools/call`; static tools win name collisions; no behavior change when no source is composed
- `McpToolModels`/`McpJsonContext`/`McpToolOutputSchemas`: `McpOperationToolOutput` DTO (AOT source-gen registered) + `OperationToolOutputSchema`
- `McpServiceCollectionExtensions.AddMcpPublishedOperationTools` registrar; wired in `Program.cs` after `AddOperationsToolset`
- New `PublishedOperationToolTests` (16 tests): projection, policy deny/approval short-circuit, tier/roles context, param-keyed cache hit/miss, cache-isolation security regressions (same params + different principal → miss + fresh PDP evaluation → Denied while the original caller still hits with cacheHit=true; same principal + changed roles → miss), never-cache-side-effects, deterministic mode, tools/list + tools/call merge, static-wins collision

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Full `Honua.Ai.Tests` suite: 494/494 passed (Release). `Honua.Architecture.Tests`: 122/122 passed. Live provider lanes (`BedrockStudioLiveTests`, `AzureOpenAiStudioLiveTests`) self-skip without credentials on this host; they require `HONUA_AI_LIVE_BEDROCK=1` + AWS credentials (or the Azure equivalents) as CI secrets to run for real — the live planner code path itself is covered deterministically with fake providers.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed — ran its equivalents on this Windows host (the script itself fails here on known CLAUDE.md-symlink/MSYS-path issues): full `dotnet build Honua.sln -c Release` with warnings-as-errors (0 warnings, 0 errors), `dotnet format Honua.sln --verify-no-changes` (clean), affected test suites (Honua.Ai.Tests 494/494, Honua.Architecture.Tests 122/122), `git diff --check` (clean, no CRLF/BOM introduced)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
