### PR TITLE
feat(control-plane): gateway executor completeness — MetadataRelease executor, Seed descoped, supportedKinds truthful

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
@@ -79,6 +79,16 @@ internal sealed class McpProposeOperationOutput
     [JsonPropertyName("executionOperationId")]
     public string? ExecutionOperationId { get; set; }
 
+    /// <summary>
+    /// Operation classes that have a genuinely registered executor and are therefore routable
+    /// through the gateway (#2563). Reported on every response, including rejections, so an
+    /// agent proposing an unsupported kind (Seed today) learns the real supported set instead of
+    /// discovering it only after a dead-end <c>NotSupported</c> outcome. Null when the executor
+    /// catalog is unavailable.
+    /// </summary>
+    [JsonPropertyName("supportedKinds")]
+    public string[]? SupportedKinds { get; set; }
+
     [JsonPropertyName("message")]
     public string? Message { get; set; }
 }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -114,6 +114,11 @@ internal static class McpToolOutputSchemas
               "description": "honua://proposals/{proposalId} resource URI to poll when human approval is required."
             },
             "executionOperationId": { "type": ["string", "null"] },
+            "supportedKinds": {
+              "type": ["array", "null"],
+              "items": { "type": "string" },
+              "description": "Operation classes with a genuinely registered executor (routable through the gateway); reported on every response, including rejections, so proposing an unsupported kind is never a silent dead end (#2563)."
+            },
             "message": { "type": ["string", "null"] }
           }
         }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ProposeOperationTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/ProposeOperationTool.cs
@@ -59,6 +59,15 @@ internal sealed class ProposeOperationTool : IMcpTool
         var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
         var argument = McpToolHelpers.ParseArguments(arguments, McpJsonContext.Default.McpProposeOperationArgument);
 
+        // Executor-discovery surface (#2563): report which kinds are genuinely routable on every
+        // response, including rejections, so an agent proposing an unsupported kind (Seed today)
+        // learns the real supported set instead of hitting a silent dead end.
+        var catalog = httpContext.RequestServices.GetService<IOperationExecutorCatalog>();
+        var supportedKinds = catalog?.SupportedKinds
+            .Select(supportedKind => supportedKind.ToString())
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
         if (string.IsNullOrWhiteSpace(argument.Kind) ||
             !Enum.TryParse<OperationClass>(argument.Kind, ignoreCase: true, out var kind) ||
             !Enum.IsDefined(kind))
@@ -68,6 +77,7 @@ internal sealed class ProposeOperationTool : IMcpTool
                 {
                     Outcome = "rejected",
                     RequiresApproval = false,
+                    SupportedKinds = supportedKinds,
                     Message = "Unknown or missing operation 'kind'. Expected one of: AdminConfigChange, Deploy, MetadataRelease, Seed."
                 },
                 McpJsonContext.Default.McpProposeOperationOutput);
@@ -81,6 +91,7 @@ internal sealed class ProposeOperationTool : IMcpTool
                 {
                     Outcome = "unavailable",
                     RequiresApproval = false,
+                    SupportedKinds = supportedKinds,
                     Message = "The operation gateway is unavailable (durable storage is not configured)."
                 },
                 McpJsonContext.Default.McpProposeOperationOutput);
@@ -106,6 +117,7 @@ internal sealed class ProposeOperationTool : IMcpTool
             ProposalId = result.ProposalId,
             ResourceUri = result.ProposalId == null ? null : McpResourceUris.ProposalUri(result.ProposalId),
             ExecutionOperationId = result.ExecutionOperationId,
+            SupportedKinds = supportedKinds,
             Message = result.Message,
         };
 

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IOperationExecutorCatalog.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IOperationExecutorCatalog.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Guardrails.Domain;
+
+namespace Honua.Core.Features.ControlPlane.Abstractions;
+
+/// <summary>
+/// Small capability surface over the registered <see cref="IOperationExecutor"/> set, kept
+/// separate from <see cref="IOperationGateway"/> so discovery surfaces (for example the MCP
+/// <c>honua_propose_operation</c> tool's <c>supportedKinds</c> reporting) can ask which
+/// <see cref="OperationClass"/> kinds are genuinely routable without widening the gateway's own
+/// routing contract (#2563). A kind absent from <see cref="SupportedKinds"/> always resolves to
+/// <see cref="OperationGatewayOutcome.NotSupported"/> when routed through
+/// <see cref="IOperationGateway.RouteAsync"/> — this surface exists so callers can discover that
+/// truth up front instead of hitting a dead end after proposing.
+/// </summary>
+public interface IOperationExecutorCatalog
+{
+    /// <summary>
+    /// Operation classes that have a registered <see cref="IOperationExecutor"/> and are
+    /// therefore genuinely routable through the gateway. Reflects the actual DI registration, not
+    /// a static/declared list, so it can never drift from what the gateway will do.
+    /// </summary>
+    IReadOnlyCollection<OperationClass> SupportedKinds { get; }
+}

--- a/src/Honua.Server/Features/ControlPlane/Executors/MetadataReleaseOperationExecutor.cs
+++ b/src/Honua.Server/Features/ControlPlane/Executors/MetadataReleaseOperationExecutor.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Domain;
+
+namespace Honua.ControlPlane.Executors;
+
+/// <summary>
+/// Gateway executor for metadata-release proposals. Adapts
+/// <see cref="MetadataReleaseControlService.CreateAsync"/> ONLY (#2563) — the same additive
+/// create path <see cref="Honua.Server.Features.Admin.MetadataReleaseControlEndpoints"/> builds
+/// inline today. The execution payload therefore carries an explicit <c>action</c> discriminator
+/// with <see cref="CreateAction"/> as the ONLY supported value.
+/// </summary>
+/// <remarks>
+/// Two related surfaces are deliberately NOT adapted here, by design:
+/// <list type="bullet">
+/// <item>
+/// Metadata-release rollback is an action on an EXISTING release operation id (advance an
+/// already-submitted lifecycle backward), not a new proposal this create-only payload shape can
+/// express. It stays endpoint/cockpit-driven.
+/// </item>
+/// <item>
+/// <see cref="CoordinatedReleaseControlService"/> has its own
+/// approval-gate model (an operator-facing coordinated-release request lane); routing it through
+/// this gateway would stack a second human-approval layer on top of gateway proposals. It stays
+/// endpoint-driven.
+/// </item>
+/// </list>
+/// </remarks>
+internal sealed class MetadataReleaseOperationExecutor(MetadataReleaseControlService controlService) : IOperationExecutor
+{
+    /// <summary>The only execution-payload action this executor supports.</summary>
+    public const string CreateAction = "create";
+
+    public OperationClass OperationClass => OperationClass.MetadataRelease;
+
+    public Task<OperationProposalPlan?> PlanAsync(
+        OperationGatewayRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var (payload, error) = MetadataReleaseExecutionPayload.ParseAndValidate(request.ExecutionPayload);
+        if (payload == null)
+        {
+            return Task.FromResult<OperationProposalPlan?>(new OperationProposalPlan
+            {
+                Summary = "Metadata release operation",
+                BlockingReasons = [error ?? "Metadata release execution payload is missing or malformed."],
+                RiskLevel = ProposalRiskLevel.High,
+            });
+        }
+
+        var diff = new List<string>
+        {
+            $"package: {payload.PackageId}",
+            $"environment: {payload.TargetEnvironment}",
+            $"resource: {payload.ResourceSemanticId}",
+            payload.NewFieldType is null
+                ? $"field: {payload.NewFieldName}"
+                : $"field: {payload.NewFieldName} ({payload.NewFieldType})",
+        };
+
+        return Task.FromResult<OperationProposalPlan?>(new OperationProposalPlan
+        {
+            Summary = $"Create metadata release for {payload.PackageId} ({payload.ResourceSemanticId}.{payload.NewFieldName})",
+            Diff = diff,
+            RiskLevel = ProposalRiskLevel.Medium,
+            ExecutionPayload = request.ExecutionPayload,
+        });
+    }
+
+    public async Task<string?> ExecuteAsync(
+        OperationGatewayRequest request,
+        string? executionPayload,
+        CancellationToken cancellationToken = default)
+    {
+        var (payload, error) = MetadataReleaseExecutionPayload.ParseAndValidate(executionPayload);
+        if (payload == null)
+        {
+            throw new InvalidOperationException(error ?? "Metadata release execution payload is missing or malformed.");
+        }
+
+        var operation = await controlService.CreateAsync(
+                payload.ToExecutionPlan(),
+                request.RequestedBy,
+                request.Reason,
+                request.IdempotencyKey,
+                request.CorrelationId,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return operation.OperationId;
+    }
+}
+
+/// <summary>
+/// Class-specific execution payload for metadata-release operations carried through the gateway.
+/// Mirrors <see cref="Honua.Server.Features.Admin.Models.CreateMetadataReleaseOperationRequest"/>
+/// plus the explicit <see cref="Action"/> discriminator (#2563).
+/// </summary>
+internal sealed record MetadataReleaseExecutionPayload
+{
+    /// <summary>
+    /// Action discriminator. Only <see cref="MetadataReleaseOperationExecutor.CreateAction"/> is
+    /// supported; any other value (including a future rollback action) is rejected rather than
+    /// silently ignored, since rollback stays endpoint/cockpit-driven (#2563).
+    /// </summary>
+    public string Action { get; init; } = MetadataReleaseOperationExecutor.CreateAction;
+
+    /// <summary>Release package identifier the lifecycle advances.</summary>
+    public required string PackageId { get; init; }
+
+    /// <summary>Target environment whose current graph snapshot is the rollback target.</summary>
+    public required string TargetEnvironment { get; init; }
+
+    /// <summary>Semantic identifier of the resource/layer being evolved and smoke-checked.</summary>
+    public required string ResourceSemanticId { get; init; }
+
+    /// <summary>Name of the newly added field the smoke stage asserts is present.</summary>
+    public required string NewFieldName { get; init; }
+
+    /// <summary>Canonical type of the new field (for example <c>String</c> or <c>Integer</c>).</summary>
+    public string? NewFieldType { get; init; }
+
+    /// <summary>Optional ETL/data-populate workload identifier dispatched after the schema change.</summary>
+    public string? DataPopulateWorkloadId { get; init; }
+
+    /// <summary>Stable script identifier for the additive change.</summary>
+    public string? ScriptId { get; init; }
+
+    /// <summary>Parses and validates a serialized payload, returning a descriptive error on failure.</summary>
+    public static (MetadataReleaseExecutionPayload? Payload, string? Error) ParseAndValidate(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return (null, "Metadata release execution payload is required.");
+        }
+
+        MetadataReleaseExecutionPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize(json, MetadataReleaseExecutionPayloadJsonContext.Default.MetadataReleaseExecutionPayload);
+        }
+        catch (JsonException)
+        {
+            return (null, "Metadata release execution payload is not valid JSON.");
+        }
+
+        if (payload == null)
+        {
+            return (null, "Metadata release execution payload is missing or malformed.");
+        }
+
+        if (!string.Equals(payload.Action, MetadataReleaseOperationExecutor.CreateAction, StringComparison.OrdinalIgnoreCase))
+        {
+            return (null, $"Unsupported metadata release action '{payload.Action}'. Only " +
+                $"'{MetadataReleaseOperationExecutor.CreateAction}' is supported through the gateway; rollback and " +
+                "coordinated-release actions stay endpoint/cockpit-driven.");
+        }
+
+        if (string.IsNullOrWhiteSpace(payload.PackageId) ||
+            string.IsNullOrWhiteSpace(payload.TargetEnvironment) ||
+            string.IsNullOrWhiteSpace(payload.ResourceSemanticId) ||
+            string.IsNullOrWhiteSpace(payload.NewFieldName))
+        {
+            return (null, "packageId, targetEnvironment, resourceSemanticId, and newFieldName are required.");
+        }
+
+        return (payload, null);
+    }
+
+    /// <summary>Builds the executable additive script plan the control service consumes.</summary>
+    public MetadataReleaseExecutionPlan ToExecutionPlan()
+    {
+        var scriptId = string.IsNullOrWhiteSpace(ScriptId) ? $"add-{NewFieldName}" : ScriptId!;
+        return new MetadataReleaseExecutionPlan
+        {
+            PackageId = PackageId,
+            TargetEnvironment = TargetEnvironment,
+            ResourceSemanticId = ResourceSemanticId,
+            NewFieldName = NewFieldName,
+            DataPopulateWorkloadId = DataPopulateWorkloadId,
+            Script = new MetadataReleaseScript
+            {
+                ScriptId = scriptId,
+                Reversible = true,
+                ForwardOperations =
+                [
+                    new MetadataReleaseScriptOperation
+                    {
+                        Kind = MetadataReleaseScriptOperationKind.AddColumn,
+                        ResourceSemanticId = ResourceSemanticId,
+                        FieldName = NewFieldName,
+                        FieldType = NewFieldType,
+                        Nullable = true,
+                    }
+                ]
+            }
+        };
+    }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(MetadataReleaseExecutionPayload))]
+internal sealed partial class MetadataReleaseExecutionPayloadJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Server/Features/ControlPlane/OperationExecutorCatalog.cs
+++ b/src/Honua.Server/Features/ControlPlane/OperationExecutorCatalog.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.Guardrails.Domain;
+
+namespace Honua.ControlPlane;
+
+/// <summary>
+/// Default <see cref="IOperationExecutorCatalog"/> that derives the supported-kinds set directly
+/// from the same <see cref="IOperationExecutor"/> registrations the gateway itself resolves
+/// (#2563). Registered alongside <see cref="OperationGateway"/> and its executors so the two can
+/// never drift apart.
+/// </summary>
+internal sealed class OperationExecutorCatalog : IOperationExecutorCatalog
+{
+    public OperationExecutorCatalog(IEnumerable<IOperationExecutor> executors)
+    {
+        ArgumentNullException.ThrowIfNull(executors);
+        SupportedKinds = executors
+            .Select(executor => executor.OperationClass)
+            .Distinct()
+            .ToArray();
+    }
+
+    public IReadOnlyCollection<OperationClass> SupportedKinds { get; }
+}

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -508,6 +508,16 @@ if (connectedRedis != null)
         Honua.ControlPlane.Executors.DeployOperationExecutor>();
     builder.Services.AddSingleton<Honua.Core.Features.ControlPlane.Abstractions.IOperationExecutor,
         Honua.ControlPlane.Executors.AdminConfigOperationExecutor>();
+    // MetadataRelease executor is create-only BY DESIGN (#2563): rollback and the coordinated-release
+    // approval-gate model stay endpoint/cockpit-driven — see MetadataReleaseOperationExecutor remarks.
+    // Seed has NO executor here — it is enum-only on trunk with no runner to adapt (#2563); the gateway
+    // continues to return NotSupported for it, and IOperationExecutorCatalog reports that truthfully.
+    builder.Services.AddSingleton<Honua.Core.Features.ControlPlane.Abstractions.IOperationExecutor,
+        Honua.ControlPlane.Executors.MetadataReleaseOperationExecutor>();
+    // Executor-discovery capability surface (#2563): reflects the exact executors registered above so
+    // discovery consumers (honua_propose_operation's supportedKinds) can never drift from routing reality.
+    builder.Services.AddSingleton<Honua.Core.Features.ControlPlane.Abstractions.IOperationExecutorCatalog,
+        Honua.ControlPlane.OperationExecutorCatalog>();
 }
 
 // Pending-approval notification channel (#1695): emitted from the gateway/store

--- a/tests/dotnet/Honua.Ai.Tests/Source/ProposeOperationToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/ProposeOperationToolTests.cs
@@ -24,10 +24,15 @@ namespace Honua.Server.Tests.Features.Protocols.Mcp;
 [Protocol(TestProtocols.Mcp)]
 public sealed class ProposeOperationToolTests
 {
-    private static DefaultHttpContext ContextWithGateway(IOperationGateway gateway)
+    private static DefaultHttpContext ContextWithGateway(IOperationGateway gateway, IOperationExecutorCatalog? catalog = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton(gateway);
+        if (catalog != null)
+        {
+            services.AddSingleton(catalog);
+        }
+
         return new DefaultHttpContext
         {
             RequestServices = services.BuildServiceProvider(),
@@ -106,6 +111,42 @@ public sealed class ProposeOperationToolTests
         var result = await tool.InvokeAsync(ContextWithGateway(gateway), arguments, CancellationToken.None);
 
         result.StructuredContent!.Value.GetProperty("outcome").GetString().Should().Be("rejected");
+    }
+
+    [UnitTest]
+    [Operation(Operations.ApprovalManagement)]
+    [Endpoint("POST /mcp tools/call honua_propose_operation")]
+    public async Task ProposeOperation_ReportsSupportedKindsFromCatalog_OnEveryOutcome()
+    {
+        // #2563: supportedKinds must reflect genuinely registered executors (MetadataRelease
+        // appears, Seed does not) so an agent never hits a silent dead end.
+        var gateway = new FakeGateway(new OperationGatewayResult
+        {
+            Outcome = OperationGatewayOutcome.NotSupported,
+            Decision = new GuardrailDecision(GuardrailTier.DirectExecute, OperationClass.Seed, default, "test"),
+            Message = "No executor is registered for operation kind 'Seed'; the operation was not performed."
+        });
+        var catalog = new FakeExecutorCatalog([OperationClass.AdminConfigChange, OperationClass.Deploy, OperationClass.MetadataRelease]);
+
+        var tool = new ProposeOperationTool(NullLogger<ProposeOperationTool>.Instance);
+        var arguments = McpTestFactory.ToArguments(
+            new McpProposeOperationArgument { Kind = "Seed" },
+            McpJsonContext.Default.McpProposeOperationArgument);
+
+        var result = await tool.InvokeAsync(ContextWithGateway(gateway, catalog), arguments, CancellationToken.None);
+
+        var content = result.StructuredContent!.Value;
+        content.GetProperty("outcome").GetString().Should().Be("NotSupported");
+        var supportedKinds = content.GetProperty("supportedKinds").EnumerateArray()
+            .Select(element => element.GetString())
+            .ToArray();
+        supportedKinds.Should().BeEquivalentTo(["AdminConfigChange", "Deploy", "MetadataRelease"]);
+        supportedKinds.Should().NotContain("Seed", "Seed has no registered executor and must never be advertised as supported");
+    }
+
+    private sealed class FakeExecutorCatalog(IReadOnlyCollection<OperationClass> supportedKinds) : IOperationExecutorCatalog
+    {
+        public IReadOnlyCollection<OperationClass> SupportedKinds { get; } = supportedKinds;
     }
 
     private sealed class FakeGateway(OperationGatewayResult result) : IOperationGateway

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/GatewayExecutorCompletenessTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/GatewayExecutorCompletenessTests.cs
@@ -1,0 +1,427 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Honua.ControlPlane;
+using Honua.ControlPlane.Executors;
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Abstractions;
+using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
+
+/// <summary>
+/// Coverage for honua-server#2563 (gateway executor completeness): the
+/// <see cref="MetadataReleaseOperationExecutor"/> adapts
+/// <see cref="MetadataReleaseControlService.CreateAsync"/> ONLY, Seed stays genuinely
+/// unregistered (NotSupported, not a fake success), and <see cref="IOperationExecutorCatalog"/>
+/// truthfully reports the registered set so discovery consumers never hit a dead end.
+/// </summary>
+public sealed class GatewayExecutorCompletenessTests
+{
+    // ── MetadataReleaseOperationExecutor: payload validation ───────────────────
+
+    [UnitTest]
+    public async Task PlanAsync_WithValidCreatePayload_ReturnsPlanWithDiff()
+    {
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([new InMemoryWorkflowOperationStore()]));
+        var request = new OperationGatewayRequest
+        {
+            Kind = OperationClass.MetadataRelease,
+            ExecutionPayload = CreatePayloadJson(packageId: "pkg-1", resourceSemanticId: "parcels", newFieldName: "owner_email"),
+        };
+
+        var plan = await executor.PlanAsync(request);
+
+        plan.Should().NotBeNull();
+        plan!.BlockingReasons.Should().BeEmpty();
+        plan.Diff.Should().Contain(line => line.Contains("parcels"));
+        plan.Diff.Should().Contain(line => line.Contains("owner_email"));
+    }
+
+    [UnitTest]
+    public async Task PlanAsync_WithNonCreateAction_ReturnsBlockingPlan()
+    {
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([new InMemoryWorkflowOperationStore()]));
+        var request = new OperationGatewayRequest
+        {
+            Kind = OperationClass.MetadataRelease,
+            ExecutionPayload = CreatePayloadJson(action: "rollback"),
+        };
+
+        var plan = await executor.PlanAsync(request);
+
+        plan.Should().NotBeNull();
+        plan!.BlockingReasons.Should().ContainMatch("*Unsupported metadata release action*",
+            "rollback must be rejected — it stays endpoint/cockpit-driven, not routed through the gateway (#2563)");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_WithNonCreateAction_Throws()
+    {
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([new InMemoryWorkflowOperationStore()]));
+
+        var act = async () => await executor.ExecuteAsync(
+            new OperationGatewayRequest { Kind = OperationClass.MetadataRelease },
+            CreatePayloadJson(action: "rollback"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Unsupported metadata release action*");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_WithMissingJsonKeys_ThrowsMalformedPayload()
+    {
+        // Required members absent entirely trips System.Text.Json's own required-member
+        // enforcement during deserialization (caught and reported as malformed payload).
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([new InMemoryWorkflowOperationStore()]));
+
+        var act = async () => await executor.ExecuteAsync(
+            new OperationGatewayRequest { Kind = OperationClass.MetadataRelease },
+            executionPayload: """{"action":"create","packageId":"pkg-1"}""");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not valid JSON*");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_WithBlankRequiredFields_ThrowsRequiredFieldsMessage()
+    {
+        // Keys present but blank pass System.Text.Json's required-member check, so this
+        // exercises the executor's own field-level validation message.
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([new InMemoryWorkflowOperationStore()]));
+
+        var act = async () => await executor.ExecuteAsync(
+            new OperationGatewayRequest { Kind = OperationClass.MetadataRelease },
+            executionPayload: """{"action":"create","packageId":"","targetEnvironment":"","resourceSemanticId":"","newFieldName":""}""");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*required*");
+    }
+
+    [UnitTest]
+    public async Task ExecuteAsync_WithValidCreatePayload_CreatesReleaseOperation()
+    {
+        var store = new InMemoryWorkflowOperationStore();
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([store]));
+        var request = new OperationGatewayRequest
+        {
+            Kind = OperationClass.MetadataRelease,
+            RequestedBy = "agent:tester",
+            Reason = "additive evolution",
+            ExecutionPayload = CreatePayloadJson(packageId: "pkg-2", resourceSemanticId: "parcels", newFieldName: "owner_phone", newFieldType: "String"),
+        };
+
+        var operationId = await executor.ExecuteAsync(request, request.ExecutionPayload);
+
+        operationId.Should().NotBeNullOrEmpty();
+        var stored = await store.GetAsync(operationId!);
+        stored.Should().NotBeNull();
+        stored!.Kind.Should().Be(WorkflowOperationKind.MetadataRelease);
+        stored.Status.Should().Be(WorkflowOperationStatus.Submitted);
+        stored.MetadataRelease!.ExecutionPlan!.NewFieldName.Should().Be("owner_phone");
+        stored.MetadataRelease.ExecutionPlan.ResourceSemanticId.Should().Be("parcels");
+        stored.Audit.RequestedBy.Should().Be("agent:tester");
+    }
+
+    // ── End-to-end through the real OperationGateway ───────────────────────────
+
+    [UnitTest]
+    public async Task Gateway_DirectExecuteTier_RoutesMetadataReleaseCreate_EndToEnd()
+    {
+        var workflowStore = new InMemoryWorkflowOperationStore();
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([workflowStore]));
+        var ladder = Substitute.For<IGuardrailLadder>();
+        ladder.Resolve(OperationClass.MetadataRelease).Returns(
+            new GuardrailDecision(GuardrailTier.DirectExecute, OperationClass.MetadataRelease, HonuaEdition.Pro, "test"));
+
+        var gateway = BuildGateway(new InMemoryProposalStore(), executor, ladder);
+
+        var result = await gateway.RouteAsync(new OperationGatewayRequest
+        {
+            Kind = OperationClass.MetadataRelease,
+            RequestedBy = "agent:tester",
+            ExecutionPayload = CreatePayloadJson(packageId: "pkg-e2e-direct", resourceSemanticId: "parcels", newFieldName: "owner_email"),
+        });
+
+        result.Outcome.Should().Be(OperationGatewayOutcome.Executed);
+        result.ExecutionOperationId.Should().NotBeNullOrEmpty();
+        var stored = await workflowStore.GetAsync(result.ExecutionOperationId!);
+        stored.Should().NotBeNull("a release operation must actually have been created, not just claimed as Executed");
+        stored!.MetadataRelease!.PackageId.Should().Be("pkg-e2e-direct");
+    }
+
+    [UnitTest]
+    public async Task Gateway_RequiresApprovalTier_ProposeThenApprove_CreatesReleaseOperation()
+    {
+        var workflowStore = new InMemoryWorkflowOperationStore();
+        var executor = new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([workflowStore]));
+        var ladder = Substitute.For<IGuardrailLadder>();
+        ladder.Resolve(OperationClass.MetadataRelease).Returns(
+            new GuardrailDecision(GuardrailTier.RequiresApproval, OperationClass.MetadataRelease, HonuaEdition.Enterprise, "test"));
+
+        var proposalStore = new InMemoryProposalStore();
+        var gateway = BuildGateway(proposalStore, executor, ladder);
+
+        var payload = CreatePayloadJson(packageId: "pkg-e2e-approve", resourceSemanticId: "parcels", newFieldName: "owner_email");
+        var proposeResult = await gateway.RouteAsync(new OperationGatewayRequest
+        {
+            Kind = OperationClass.MetadataRelease,
+            RequestedBy = "agent:proposer",
+            ExecutionPayload = payload,
+        });
+
+        proposeResult.Outcome.Should().Be(OperationGatewayOutcome.ProposalCreated);
+        proposeResult.ProposalId.Should().NotBeNullOrEmpty();
+
+        var approved = await gateway.ApplyApprovedProposalAsync(proposeResult.ProposalId!, "admin");
+
+        approved.Should().NotBeNull();
+        approved!.Status.Should().Be(OperationProposalStatus.Submitted);
+        approved.ExecutionOperationId.Should().NotBeNullOrEmpty();
+
+        var stored = await workflowStore.GetAsync(approved.ExecutionOperationId!);
+        stored.Should().NotBeNull("approving the proposal must create the underlying metadata-release operation");
+        stored!.MetadataRelease!.PackageId.Should().Be("pkg-e2e-approve");
+    }
+
+    [UnitTest]
+    public async Task Gateway_SeedKind_ReturnsNotSupported_NoExecutorRegistered()
+    {
+        // Production-shaped executor set: MetadataRelease (real), plus stand-ins for
+        // AdminConfigChange/Deploy. Seed has none — the gateway must return NotSupported,
+        // never claim Executed with no work performed (BH6-032).
+        var executors = new IOperationExecutor[]
+        {
+            new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([new InMemoryWorkflowOperationStore()])),
+            new StubExecutor(OperationClass.AdminConfigChange),
+            new StubExecutor(OperationClass.Deploy),
+        };
+
+        var ladder = Substitute.For<IGuardrailLadder>();
+        ladder.Resolve(OperationClass.Seed).Returns(
+            new GuardrailDecision(GuardrailTier.DirectExecute, OperationClass.Seed, HonuaEdition.Community, "test"));
+
+        var gateway = BuildGateway(new InMemoryProposalStore(), executors, ladder);
+
+        var result = await gateway.RouteAsync(new OperationGatewayRequest { Kind = OperationClass.Seed });
+
+        result.Outcome.Should().Be(OperationGatewayOutcome.NotSupported);
+        result.ExecutionOperationId.Should().BeNull();
+    }
+
+    // ── IOperationExecutorCatalog: truthful supportedKinds ─────────────────────
+
+    [UnitTest]
+    public void OperationExecutorCatalog_ReflectsRegisteredExecutors_MetadataReleaseInSeedOut()
+    {
+        var executors = new IOperationExecutor[]
+        {
+            new MetadataReleaseOperationExecutor(new MetadataReleaseControlService([new InMemoryWorkflowOperationStore()])),
+            new StubExecutor(OperationClass.AdminConfigChange),
+            new StubExecutor(OperationClass.Deploy),
+        };
+
+        var catalog = new OperationExecutorCatalog(executors);
+
+        catalog.SupportedKinds.Should().BeEquivalentTo(new[]
+        {
+            OperationClass.AdminConfigChange,
+            OperationClass.Deploy,
+            OperationClass.MetadataRelease,
+        });
+        catalog.SupportedKinds.Should().NotContain(OperationClass.Seed,
+            "Seed has no runner on trunk (descoped by design, #2563) and must never be advertised as routable");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static string CreatePayloadJson(
+        string action = "create",
+        string packageId = "pkg-1",
+        string targetEnvironment = "production",
+        string resourceSemanticId = "parcels",
+        string newFieldName = "owner_email",
+        string? newFieldType = "String")
+        => $$"""
+        {
+          "action": "{{action}}",
+          "packageId": "{{packageId}}",
+          "targetEnvironment": "{{targetEnvironment}}",
+          "resourceSemanticId": "{{resourceSemanticId}}",
+          "newFieldName": "{{newFieldName}}",
+          "newFieldType": {{(newFieldType is null ? "null" : $"\"{newFieldType}\"")}}
+        }
+        """;
+
+    private static OperationGateway BuildGateway(
+        IOperationProposalStore proposalStore,
+        IOperationExecutor executor,
+        IGuardrailLadder ladder)
+        => BuildGateway(proposalStore, new[] { executor }, ladder);
+
+    private static OperationGateway BuildGateway(
+        IOperationProposalStore proposalStore,
+        IEnumerable<IOperationExecutor> executors,
+        IGuardrailLadder ladder)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IAuditLog>(_ => NullAuditLog.Instance);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+        var notifier = Substitute.For<IProposalNotifier>();
+
+        return new OperationGateway(
+            ladder,
+            proposalStore,
+            executors,
+            scopeFactory,
+            notifier,
+            NullLogger<OperationGateway>.Instance);
+    }
+
+    /// <summary>Executor stand-in for classes not under test here (AdminConfigChange/Deploy).</summary>
+    private sealed class StubExecutor(OperationClass operationClass) : IOperationExecutor
+    {
+        public OperationClass OperationClass => operationClass;
+
+        public Task<OperationProposalPlan?> PlanAsync(OperationGatewayRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult<OperationProposalPlan?>(null);
+
+        public Task<string?> ExecuteAsync(OperationGatewayRequest request, string? executionPayload, CancellationToken cancellationToken = default)
+            => Task.FromResult<string?>("stub-op-id");
+    }
+
+    /// <summary>Thread-safe in-memory workflow-operation store (mirrors the fixture used elsewhere in this folder).</summary>
+    private sealed class InMemoryWorkflowOperationStore : IWorkflowOperationStore
+    {
+        private readonly ConcurrentDictionary<string, WorkflowOperationRecord> _operations = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, string> _metadataPackageIndex = new(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, string> _leases = new(StringComparer.Ordinal);
+
+        public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(_leases.TryAdd(operationId, ownerId));
+
+        public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(_leases.TryGetValue(operationId, out var currentOwner) && currentOwner == ownerId);
+
+        public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+        {
+            _leases.TryRemove(new KeyValuePair<string, string>(operationId, ownerId));
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> TryCreateAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            var created = _operations.TryAdd(operation.OperationId, operation);
+            if (created)
+            {
+                Index(operation);
+            }
+
+            return Task.FromResult(created);
+        }
+
+        public Task<WorkflowOperationRecord?> GetAsync(string operationId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_operations.TryGetValue(operationId, out var operation) ? operation : null);
+
+        public Task<WorkflowOperationRecord?> GetByMetadataPackageIdAsync(string packageId, CancellationToken cancellationToken = default)
+            => Task.FromResult(
+                _metadataPackageIndex.TryGetValue(packageId, out var operationId) &&
+                _operations.TryGetValue(operationId, out var operation)
+                    ? operation
+                    : null);
+
+        public Task SetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            Index(operation);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(WorkflowOperationRecord operation, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            Index(operation);
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(WorkflowOperationKind? kind = null, CancellationToken cancellationToken = default)
+        {
+            var operations = _operations.Values
+                .Where(operation => !kind.HasValue || operation.Kind == kind.Value)
+                .ToArray();
+            return Task.FromResult<IReadOnlyList<WorkflowOperationRecord>>(operations);
+        }
+
+        private void Index(WorkflowOperationRecord operation)
+        {
+            if (operation.Kind == WorkflowOperationKind.MetadataRelease &&
+                !string.IsNullOrWhiteSpace(operation.MetadataRelease?.PackageId))
+            {
+                _metadataPackageIndex[operation.MetadataRelease.PackageId] = operation.OperationId;
+            }
+        }
+    }
+
+    /// <summary>Thread-safe in-memory proposal store with CAS semantics (mirrors the state-machine tests fixture).</summary>
+    private sealed class InMemoryProposalStore : IOperationProposalStore
+    {
+        private readonly ConcurrentDictionary<string, OperationProposal> _proposals = new(StringComparer.Ordinal);
+
+        public Task<OperationProposal?> GetAsync(string proposalId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_proposals.TryGetValue(proposalId, out var proposal) ? proposal : null);
+
+        public Task<bool> TrySetAsync(OperationProposal proposal, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            if (_proposals.TryGetValue(proposal.ProposalId, out var existing) && existing.Version != proposal.Version)
+            {
+                return Task.FromResult(false);
+            }
+
+            _proposals[proposal.ProposalId] = proposal with { Version = proposal.Version + 1 };
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> TryCreateAsync(OperationProposal proposal, TimeSpan? ttl = null, CancellationToken cancellationToken = default)
+        {
+            if (_proposals.ContainsKey(proposal.ProposalId))
+            {
+                return Task.FromResult(false);
+            }
+
+            _proposals[proposal.ProposalId] = proposal with { Version = 1 };
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<OperationProposal>> ListActiveAsync(OperationClass? kind = null, CancellationToken cancellationToken = default)
+        {
+            var active = _proposals.Values
+                .Where(proposal => !kind.HasValue || proposal.Kind == kind.Value)
+                .Where(proposal => proposal.Status is not (OperationProposalStatus.Succeeded
+                    or OperationProposalStatus.Failed
+                    or OperationProposalStatus.Rejected
+                    or OperationProposalStatus.RolledBack))
+                .ToArray();
+
+            return Task.FromResult<IReadOnlyList<OperationProposal>>(active);
+        }
+
+        public Task<bool> TryAcquireLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(string operationId, string ownerId, TimeSpan leaseDuration, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(string operationId, string ownerId, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2563

## Summary
Closes the gateway executor completeness gap: `MetadataRelease` proposals routed through `IOperationGateway` now execute for real (adapting `MetadataReleaseControlService.CreateAsync` only), `Seed` stays genuinely unregistered (no runner exists on trunk), and a new `IOperationExecutorCatalog` capability surface lets discovery consumers (the `honua_propose_operation` MCP tool) report truthfully which kinds are routable — so proposing an unsupported kind is a documented `NotSupported` outcome plus a `supportedKinds` list, never a silent dead end.

## Changes Made
- Add `MetadataReleaseOperationExecutor` (`src/Honua.Server/Features/ControlPlane/Executors/MetadataReleaseOperationExecutor.cs`), registered for `OperationClass.MetadataRelease`. It adapts `MetadataReleaseControlService.CreateAsync` only, mirroring the plan `MetadataReleaseControlEndpoints.cs` already builds inline. The execution payload carries an explicit `action` discriminator; `create` is the ONLY supported value — any other action (including a future rollback action) is rejected with a descriptive error, by design (rollback is an action on an *existing* operation id and stays endpoint/cockpit-driven; `CoordinatedReleaseControlService` has its own approval-gate model and also stays endpoint-driven).
- `Seed` remains deliberately unregistered — there is no seed runner on trunk (enum-only), so the gateway continues to return `NotSupported` for it. No seed pipeline was built (out of scope per the issue's non-goals).
- Add `IOperationExecutorCatalog` (`src/Honua.Core/Features/ControlPlane/Abstractions/IOperationExecutorCatalog.cs`) — a small capability surface over the registered `IOperationExecutor` set, kept separate from `IOperationGateway` so it doesn't widen that interface's contract. Default implementation `OperationExecutorCatalog` derives `SupportedKinds` directly from DI registrations so it can never drift from what the gateway will actually route.
- Register the new executor and catalog in `Program.cs` alongside the existing Deploy/AdminConfigChange executors (same Redis-gated block, `#2579`-adjacent).
- Wire `honua_propose_operation` (`ProposeOperationTool.cs`) to report `supportedKinds` on every response — including rejections and `NotSupported` outcomes — via the new catalog. Added the field to `McpProposeOperationOutput` and its JSON output schema (input schema, which is vendored/pinned to the geospatial-mcp spec, is untouched — the standard's own `supportedKinds` discovery lands separately per gsm#58).
- Tests: new `GatewayExecutorCompletenessTests.cs` covering the executor's payload validation (create-only enforcement, required-field validation), end-to-end gateway routing for MetadataRelease at both DirectExecute and RequiresApproval tiers (propose → [approve →] release operation actually created in the durable store), Seed returning `NotSupported` with a production-shaped executor set, and `OperationExecutorCatalog` correctly including MetadataRelease/excluding Seed. Extended `ProposeOperationToolTests.cs` with a `supportedKinds` coverage test.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact (MCP tool output schema gained an optional field; no HTTP/OpenAPI routes changed)

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (script itself fails on this Windows host per known symlink/MSYS issue; ran its equivalents instead — see below)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

### pre-pr-check.sh equivalents run locally
- `dotnet build Honua.sln --no-restore --configuration Release -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors.
- `dotnet format Honua.sln --verify-no-changes` → clean, no changes required.
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~GatewayExecutorCompletenessTests"` → 10/10 passed.
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~ControlPlane.OperationGateway|FullyQualifiedName~ProposalEndpointsTests|FullyQualifiedName~MetadataReleaseControlEndpointsTests"` → 27/27 passed (regression check, Testcontainers).
- `dotnet test tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj --filter "FullyQualifiedName~ProposeOperationToolTests|FullyQualifiedName~McpTaxonomyAlignmentTests|FullyQualifiedName~McpGeospatialMcpSchemaConformanceTests"` → 45/45 passed.
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj` → 122/122 passed.
