### PR TITLE
feat(observability): realtime ops push — admin SignalR hub groups + Redis backplane

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,8 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.Client.Web" Version="2.76.0" />
     <PackageVersion Include="Mapsui" Version="5.0.2" />
-    <!-- Transitive of NBomber.Contracts; pinned directly to clear GHSA-hv8m-jj95-wg3x (NU1903). -->
+    <!-- Transitive of NBomber.Contracts (tests) and Microsoft.AspNetCore.SignalR.StackExchangeRedis (server
+         admin realtime backplane, #2554); pinned directly to clear GHSA-hv8m-jj95-wg3x (NU1903). -->
     <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.6" />
@@ -64,6 +65,8 @@
          first patched release and stays API-compatible within the 2.x line. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.2" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.6" />

--- a/src/Honua.Server/Features/Admin/AdminRealtimeBroadcaster.cs
+++ b/src/Honua.Server/Features/Admin/AdminRealtimeBroadcaster.cs
@@ -1,0 +1,220 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Threading.Channels;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Infrastructure.Monitoring;
+using Honua.Server.Features.Admin.Models;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Fans ops-health snapshots (from the #2553 flush signal) and deploy/workflow-operation transitions (from
+/// the #2562 transition seam, forwarded by <see cref="RealtimeOperationTransitionListener"/>) out to the
+/// admin hub groups over the Redis backplane (#2554).
+/// </summary>
+/// <remarks>
+/// Isolation guarantees:
+/// <list type="bullet">
+/// <item>The flush-signal handler and the transition enqueue are non-blocking <c>TryWrite</c>s into bounded
+/// channels — they never block the sampler loop or the store-write path, and never throw back into them.</item>
+/// <item>The channels are bounded with <see cref="BoundedChannelFullMode.DropOldest"/> so a slow/backed-up
+/// broadcast can never grow memory without bound. Dropped items are acceptable: the durable ops-health
+/// history and the deploy-operations list API are the authoritative sources a client re-syncs from.</item>
+/// <item>Every hub send is wrapped so a backplane/transport fault degrades to a logged miss instead of
+/// faulting the loop — serving and the producers are unaffected (fail-open).</item>
+/// </list>
+/// </remarks>
+internal sealed partial class AdminRealtimeBroadcaster : BackgroundService
+{
+    // Latest-wins: only the freshest ops-health snapshot matters, so a capacity of one that drops the older
+    // pending snapshot coalesces bursts without buffering.
+    private readonly Channel<OpsHealthSnapshotResponse> _opsHealth =
+        Channel.CreateBounded<OpsHealthSnapshotResponse>(new BoundedChannelOptions(1)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+    // Each transition is an independent event; bound the buffer and drop the oldest under sustained
+    // backpressure (clients reconcile via the deploy-operations list / operate-events APIs).
+    private readonly Channel<WorkflowOperationTransition> _transitions =
+        Channel.CreateBounded<WorkflowOperationTransition>(new BoundedChannelOptions(256)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+    private readonly IHubContext<AdminHub> _hubContext;
+    private readonly OpsHealthFlushSignal _flushSignal;
+    private readonly AdminRealtimeCapabilities _capabilities;
+    private readonly ILogger<AdminRealtimeBroadcaster> _logger;
+
+    public AdminRealtimeBroadcaster(
+        IHubContext<AdminHub> hubContext,
+        OpsHealthFlushSignal flushSignal,
+        AdminRealtimeCapabilities capabilities,
+        ILogger<AdminRealtimeBroadcaster> logger)
+    {
+        _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
+        _flushSignal = flushSignal ?? throw new ArgumentNullException(nameof(flushSignal));
+        _capabilities = capabilities ?? throw new ArgumentNullException(nameof(capabilities));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // Subscribe unconditionally; the handler short-circuits when the backplane is absent. Subscribing in
+        // the constructor guarantees the seam is wired before the sampler produces its first flush.
+        _flushSignal.Flushed += OnFlushed;
+    }
+
+    /// <summary>
+    /// Forwards a workflow-operation transition to the deploy-operations / operate-events groups. Non-blocking
+    /// and exception-isolated so the store-write path that raised the transition is never slowed or faulted.
+    /// </summary>
+    /// <param name="transition">The observed transition.</param>
+    public void EnqueueTransition(WorkflowOperationTransition transition)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+
+        if (!_capabilities.BackplaneEnabled)
+        {
+            return;
+        }
+
+        _transitions.Writer.TryWrite(transition);
+    }
+
+    private void OnFlushed(object? sender, OpsHealthFlushedEventArgs args)
+    {
+        if (!_capabilities.BackplaneEnabled)
+        {
+            return;
+        }
+
+        try
+        {
+            // Non-blocking latest-wins write; the sampler is never awaited or blocked here.
+            _opsHealth.Writer.TryWrite(args.Snapshot);
+        }
+        catch (Exception ex)
+        {
+            // A broadcast-enqueue fault must never propagate into the sampler.
+            FlushEnqueueFailed(_logger, ex);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_capabilities.BackplaneEnabled)
+        {
+            return;
+        }
+
+        await Task.WhenAll(
+            DrainOpsHealthAsync(stoppingToken),
+            DrainTransitionsAsync(stoppingToken)).ConfigureAwait(false);
+    }
+
+    private async Task DrainOpsHealthAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await foreach (var snapshot in _opsHealth.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    await _hubContext.Clients
+                        .Group(AdminRealtimeContract.OpsHealthGroup)
+                        .SendAsync(AdminRealtimeContract.OpsHealthSnapshotEventName, snapshot, stoppingToken)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // Fail-open: a backplane/transport fault drops this push; clients re-sync via history.
+                    OpsHealthBroadcastFailed(_logger, ex);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    private async Task DrainTransitionsAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await foreach (var transition in _transitions.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    var deployEvent = MapDeployEvent(transition);
+                    await _hubContext.Clients
+                        .Group(AdminRealtimeContract.DeployOperationsGroup)
+                        .SendAsync(AdminRealtimeContract.DeployOperationEventName, deployEvent, stoppingToken)
+                        .ConfigureAwait(false);
+
+                    // The operate-events group receives the same wire shape as GET observability/events.
+                    var operateEvent = OperateEventResponseMapper.Map(ReleaseTimelineEventFactory.Create(transition));
+                    await _hubContext.Clients
+                        .Group(AdminRealtimeContract.OperateEventsGroup)
+                        .SendAsync(AdminRealtimeContract.OperateEventEventName, operateEvent, stoppingToken)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // Fail-open: clients reconcile via the deploy-operations list / operate-events APIs.
+                    TransitionBroadcastFailed(_logger, ex);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    private static DeployOperationRealtimeEvent MapDeployEvent(WorkflowOperationTransition transition)
+    {
+        var occurredTicks = transition.OccurredAt.UtcTicks.ToString(CultureInfo.InvariantCulture);
+        return new DeployOperationRealtimeEvent(
+            EventId: $"deploy:{transition.OperationId}:{transition.Kind}:{occurredTicks}",
+            OperationId: transition.OperationId,
+            TransitionKind: transition.Kind.ToString(),
+            Status: transition.Operation.Status.ToString(),
+            Phase: transition.Operation.CurrentPhase,
+            TargetId: transition.TargetId,
+            ReleaseId: transition.ReleaseId,
+            CorrelationId: transition.CorrelationId,
+            OccurredAt: transition.OccurredAt);
+    }
+
+    public override void Dispose()
+    {
+        _flushSignal.Flushed -= OnFlushed;
+        _opsHealth.Writer.TryComplete();
+        _transitions.Writer.TryComplete();
+        base.Dispose();
+    }
+
+    [LoggerMessage(EventId = 9310, Level = LogLevel.Warning, Message = "Ops-health realtime enqueue threw.")]
+    private static partial void FlushEnqueueFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9311, Level = LogLevel.Warning, Message = "Ops-health realtime broadcast failed; dropping this push (clients re-sync via history).")]
+    private static partial void OpsHealthBroadcastFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 9312, Level = LogLevel.Warning, Message = "Deploy/operate realtime broadcast failed; dropping this push (clients re-sync via list API).")]
+    private static partial void TransitionBroadcastFailed(ILogger logger, Exception exception);
+}

--- a/src/Honua.Server/Features/Admin/AdminRealtimeHub.cs
+++ b/src/Honua.Server/Features/Admin/AdminRealtimeHub.cs
@@ -4,22 +4,82 @@
 using System.Text.Json.Serialization;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Monitoring;
+using Honua.Server.Features.Admin.Models;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Honua.Server.Features.Admin;
 
 internal static class AdminRealtimeHubExtensions
 {
-    public static IServiceCollection AddAdminRealtime(this IServiceCollection services)
+    /// <summary>
+    /// Registers the admin realtime hub, its background broadcaster, and — when a Redis connection is
+    /// configured — the SignalR Redis backplane so leased-replica producers (the deploy reconciler, the
+    /// ops-health sampler) reach clients connected to any replica (#2554).
+    /// </summary>
+    /// <remarks>
+    /// Backplane feature-detect contract: when no Redis connection string is configured the hub runs
+    /// single-replica only, so the realtime groups are NOT advertised (see
+    /// <see cref="AdminRealtimeStatus.RealtimeGroups"/> / <see cref="AdminRealtimeStatus.BackplaneEnabled"/>)
+    /// and the console falls back to polling the ops-health / history / list APIs. When Redis is present the
+    /// groups are advertised and pushed. A Redis outage at runtime never blocks serving: the backplane
+    /// connection is created with <c>AbortOnConnectFail=false</c>, sends run on an isolated background loop,
+    /// and clients re-sync via the history/list APIs (there is no Last-Event-ID replay).
+    /// </remarks>
+    public static IServiceCollection AddAdminRealtime(this IServiceCollection services, IConfiguration configuration)
     {
-        services
-            .AddSignalR()
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var redisConnectionString = configuration.GetConnectionString("redis")
+            ?? configuration["Aspire:StackExchange:Redis:ConnectionString"];
+        var backplaneEnabled = !string.IsNullOrWhiteSpace(redisConnectionString);
+
+        services.AddSingleton(new AdminRealtimeCapabilities(backplaneEnabled));
+
+        var signalR = services
+            .AddSignalR(options =>
+            {
+                // Bounded per-connection behavior: a client that stops reading past the transport buffer is
+                // disconnected rather than buffered unboundedly, and a stalled client is timed out. These are
+                // the framework's protective defaults, pinned explicitly so the realtime groups cannot become
+                // an unbounded per-connection memory sink under a slow consumer.
+                options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+                options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+                options.MaximumParallelInvocationsPerClient = 1;
+            })
             .AddJsonProtocol(options =>
             {
                 options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(
                     0,
+                    AdminRealtimeGroupsJsonContext.Default);
+                options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(
+                    0,
                     AdminRealtimeJsonContext.Default);
             });
+
+        if (backplaneEnabled)
+        {
+            // Dedicated backplane connection. AbortOnConnectFail=false so a Redis outage degrades to
+            // single-replica delivery (fail-open) instead of faulting hub startup or serving.
+            signalR.AddStackExchangeRedis(redisConnectionString!, options =>
+            {
+                options.Configuration.AbortOnConnectFail = false;
+                options.Configuration.ChannelPrefix =
+                    StackExchange.Redis.RedisChannel.Literal("honua:signalr:admin");
+            });
+        }
+
+        // Background broadcaster: subscribes to the ops-health flush signal and receives forwarded workflow
+        // transitions, fanning both out to the hub groups on an isolated loop that never blocks the sampler
+        // or the store-write path.
+        services.AddSingleton<AdminRealtimeBroadcaster>();
+        services.AddHostedService(sp => sp.GetRequiredService<AdminRealtimeBroadcaster>());
+
+        // Second, independent consumer of the #2562 workflow-transition seam that forwards transitions to the
+        // deploy-operations / operate-events groups. Registered as an additional listener so the transition
+        // store decorator fans transitions to it alongside the operate-timeline producer.
+        services.AddSingleton<Honua.Core.Features.ControlPlane.Abstractions.IWorkflowOperationTransitionListener,
+            RealtimeOperationTransitionListener>();
 
         return services;
     }
@@ -44,11 +104,60 @@ internal static class AdminRealtimeContract
 
     /// <summary>Event raised when a proposal is resolved (approved/rejected/terminal).</summary>
     internal const string ProposalResolvedEventName = "ProposalResolved";
+
+    /// <summary>
+    /// Group carrying cluster-aggregated ops-health snapshots (#2554). Pushed the SAME DTO as
+    /// <c>GET ops-health</c> on every sampler flush; a client backfills a reconnect gap by re-fetching the
+    /// history API (no Last-Event-ID replay).
+    /// </summary>
+    internal const string OpsHealthGroup = "ops-health";
+
+    /// <summary>Event name for an ops-health snapshot push.</summary>
+    internal const string OpsHealthSnapshotEventName = "OpsHealthSnapshot";
+
+    /// <summary>Group carrying new Operate-timeline events (currently deploy/release transitions, #2562).</summary>
+    internal const string OperateEventsGroup = "operate-events";
+
+    /// <summary>Event name for an operate-timeline event push.</summary>
+    internal const string OperateEventEventName = "OperateEvent";
+
+    /// <summary>Group carrying deploy/workflow-operation transitions for the deploy cockpit (#2554).</summary>
+    internal const string DeployOperationsGroup = "deploy-operations";
+
+    /// <summary>
+    /// Event name for a deploy-operation transition push. Delivery is at-least-once (the #2562 seam classifies
+    /// absolute status, not deltas), so the payload carries a stable <c>eventId</c> plus
+    /// <c>operationId</c>+<c>transitionKind</c> for client-side dedup.
+    /// </summary>
+    internal const string DeployOperationEventName = "DeployOperationTransition";
+}
+
+/// <summary>
+/// Process-wide realtime capabilities resolved at startup. Drives what the hub advertises and which group
+/// subscriptions are accepted: without a Redis backplane, cross-replica fan-out cannot be guaranteed, so the
+/// ops-health / operate-events / deploy-operations groups are neither advertised nor joinable and the console
+/// polls instead.
+/// </summary>
+internal sealed class AdminRealtimeCapabilities(bool backplaneEnabled)
+{
+    /// <summary>Gets a value indicating whether the Redis backplane is active (multi-replica fan-out).</summary>
+    public bool BackplaneEnabled { get; } = backplaneEnabled;
+
+    /// <summary>The realtime groups advertised to clients; empty when the backplane is absent.</summary>
+    public IReadOnlyList<string> AdvertisedGroups { get; } = backplaneEnabled
+        ?
+        [
+            AdminRealtimeContract.OpsHealthGroup,
+            AdminRealtimeContract.OperateEventsGroup,
+            AdminRealtimeContract.DeployOperationsGroup
+        ]
+        : Array.Empty<string>();
 }
 
 internal sealed class AdminHub(
     IHostEnvironment environment,
-    MigrationState migrationState) : Hub
+    MigrationState migrationState,
+    AdminRealtimeCapabilities capabilities) : Hub
 {
     public override async Task OnConnectedAsync()
     {
@@ -71,6 +180,45 @@ internal sealed class AdminHub(
     public Task UnsubscribeFromProposals()
         => Groups.RemoveFromGroupAsync(Context.ConnectionId, AdminRealtimeContract.ProposalsGroup);
 
+    /// <summary>Joins the ops-health group so the caller receives cluster-aggregated snapshot pushes.</summary>
+    public Task SubscribeToOpsHealth()
+        => JoinRealtimeGroupAsync(AdminRealtimeContract.OpsHealthGroup);
+
+    /// <summary>Leaves the ops-health group.</summary>
+    public Task UnsubscribeFromOpsHealth()
+        => Groups.RemoveFromGroupAsync(Context.ConnectionId, AdminRealtimeContract.OpsHealthGroup);
+
+    /// <summary>Joins the operate-events group so the caller receives new Operate-timeline events.</summary>
+    public Task SubscribeToOperateEvents()
+        => JoinRealtimeGroupAsync(AdminRealtimeContract.OperateEventsGroup);
+
+    /// <summary>Leaves the operate-events group.</summary>
+    public Task UnsubscribeFromOperateEvents()
+        => Groups.RemoveFromGroupAsync(Context.ConnectionId, AdminRealtimeContract.OperateEventsGroup);
+
+    /// <summary>Joins the deploy-operations group so the caller receives workflow-operation transitions.</summary>
+    public Task SubscribeToDeployOperations()
+        => JoinRealtimeGroupAsync(AdminRealtimeContract.DeployOperationsGroup);
+
+    /// <summary>Leaves the deploy-operations group.</summary>
+    public Task UnsubscribeFromDeployOperations()
+        => Groups.RemoveFromGroupAsync(Context.ConnectionId, AdminRealtimeContract.DeployOperationsGroup);
+
+    private Task JoinRealtimeGroupAsync(string group)
+    {
+        // Feature-detect contract: refuse subscriptions to groups that are not advertised (no backplane) so a
+        // client cannot silently join a group that will never deliver cross-replica — it must fall back to
+        // polling instead.
+        if (!capabilities.BackplaneEnabled)
+        {
+            throw new HubException(
+                $"Realtime group '{group}' is unavailable because the Redis backplane is not configured. " +
+                "Poll the ops-health / history / deploy-operations APIs instead.");
+        }
+
+        return Groups.AddToGroupAsync(Context.ConnectionId, group);
+    }
+
     private AdminRealtimeStatus CreateStatus()
         => new(
             Status: migrationState.IsFailed ? "degraded" : "online",
@@ -78,7 +226,9 @@ internal sealed class AdminHub(
             EnvironmentName: environment.EnvironmentName,
             MigrationStatus: GetMigrationStatusLabel(migrationState.Status),
             MigrationReady: migrationState.IsReady,
-            GeneratedAt: DateTimeOffset.UtcNow);
+            GeneratedAt: DateTimeOffset.UtcNow,
+            BackplaneEnabled: capabilities.BackplaneEnabled,
+            RealtimeGroups: capabilities.AdvertisedGroups);
 
     private static string GetMigrationStatusLabel(MigrationLifecycleStatus status)
         => status switch
@@ -97,7 +247,9 @@ internal sealed record AdminRealtimeStatus(
     string EnvironmentName,
     string MigrationStatus,
     bool MigrationReady,
-    DateTimeOffset GeneratedAt);
+    DateTimeOffset GeneratedAt,
+    bool BackplaneEnabled,
+    IReadOnlyList<string> RealtimeGroups);
 
 /// <summary>
 /// Lightweight proposal event payload pushed to the proposals group. Carries only
@@ -112,6 +264,37 @@ internal sealed record ProposalRealtimeEvent(
     string RiskLevel,
     DateTimeOffset GeneratedAt);
 
+/// <summary>
+/// Lightweight deploy/workflow-operation transition pushed to the <c>deploy-operations</c> group. Carries
+/// only identifiers and lifecycle classification — never the full operation record or provider payload.
+/// Delivery is at-least-once; <see cref="EventId"/> (and the <see cref="OperationId"/>+<see cref="TransitionKind"/>
+/// pair) are the client dedup keys.
+/// </summary>
+internal sealed record DeployOperationRealtimeEvent(
+    string EventId,
+    string OperationId,
+    string TransitionKind,
+    string Status,
+    string? Phase,
+    string? TargetId,
+    string? ReleaseId,
+    string? CorrelationId,
+    DateTimeOffset OccurredAt);
+
 [JsonSerializable(typeof(AdminRealtimeStatus))]
 [JsonSerializable(typeof(ProposalRealtimeEvent))]
 internal sealed partial class AdminRealtimeJsonContext : JsonSerializerContext;
+
+/// <summary>
+/// Camel-cased, null-omitting source-generated context for the realtime group payloads. Kept separate from
+/// <see cref="AdminRealtimeJsonContext"/> so the ops-health snapshot and operate-event pushes serialize
+/// byte-identically to their REST counterparts (same casing + <c>WhenWritingNull</c> omission) without
+/// changing the existing status/proposal wire shapes.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OpsHealthSnapshotResponse))]
+[JsonSerializable(typeof(OperateEventResponse))]
+[JsonSerializable(typeof(DeployOperationRealtimeEvent))]
+internal sealed partial class AdminRealtimeGroupsJsonContext : JsonSerializerContext;

--- a/src/Honua.Server/Features/Admin/Models/OperateEventResponseMapper.cs
+++ b/src/Honua.Server/Features/Admin/Models/OperateEventResponseMapper.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Server.Features.Admin.Models;
+
+/// <summary>
+/// Maps a normalized <see cref="OperateEvent"/> onto its wire shape (<see cref="OperateEventResponse"/>).
+/// Shared by the REST Operate timeline (<c>GET /api/v1/admin/observability/events</c>) and the realtime
+/// <c>operate-events</c> hub group (#2554) so a live-pushed event is byte-identical to the same event read
+/// back from the timeline API — the reconnect gap-fill contract relies on that identity.
+/// </summary>
+internal static class OperateEventResponseMapper
+{
+    /// <summary>Projects the domain event onto the camel-cased, kind/severity-lowercased wire shape.</summary>
+    /// <param name="value">The normalized operate event.</param>
+    /// <returns>The wire response.</returns>
+    public static OperateEventResponse Map(OperateEvent value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        return new OperateEventResponse
+        {
+            EventId = value.EventId,
+            Kind = ToCamel(value.Kind.ToString()),
+            Severity = value.Severity.ToString().ToLowerInvariant(),
+            OccurredAt = value.OccurredAt,
+            Title = value.Title,
+            Summary = value.Summary,
+            ServiceId = value.ServiceId,
+            LayerId = value.LayerId,
+            ObjectId = value.ObjectId,
+            Actor = value.Actor,
+            CorrelationId = value.CorrelationId,
+            TraceId = value.TraceId,
+            RequestId = value.RequestId,
+            OperationId = value.OperationId,
+            ReleaseId = value.ReleaseId,
+            ReplicaId = value.ReplicaId,
+            ChangeSetId = value.ChangeSetId,
+            ResourceRef = value.ResourceRef,
+            ProviderLinks = value.ProviderLinks?.Select(link => new OperateProviderLinkResponse
+            {
+                Provider = link.Provider,
+                Label = link.Label,
+                Url = link.Url
+            }).ToArray(),
+            DetailsJson = value.DetailsJson
+        };
+    }
+
+    private static string ToCamel(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        return char.ToLowerInvariant(value[0]) + value[1..];
+    }
+}

--- a/src/Honua.Server/Features/Admin/ObservabilityEventEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ObservabilityEventEndpoints.cs
@@ -47,7 +47,7 @@ internal static class ObservabilityEventEndpoints
         var page = await feed.ListAsync(filter, cancellationToken).ConfigureAwait(false);
         var response = new OperateEventPageResponse
         {
-            Items = page.Items.Select(MapEvent).ToArray(),
+            Items = page.Items.Select(OperateEventResponseMapper.Map).ToArray(),
             PartialResult = page.PartialResult,
             SourceErrors = page.SourceErrors?.ToDictionary(
                 pair => pair.Key.ToString().ToLowerInvariant(),
@@ -134,45 +134,4 @@ internal static class ObservabilityEventEndpoints
         return true;
     }
 
-    private static OperateEventResponse MapEvent(OperateEvent value)
-    {
-        return new OperateEventResponse
-        {
-            EventId = value.EventId,
-            Kind = ToCamel(value.Kind.ToString()),
-            Severity = value.Severity.ToString().ToLowerInvariant(),
-            OccurredAt = value.OccurredAt,
-            Title = value.Title,
-            Summary = value.Summary,
-            ServiceId = value.ServiceId,
-            LayerId = value.LayerId,
-            ObjectId = value.ObjectId,
-            Actor = value.Actor,
-            CorrelationId = value.CorrelationId,
-            TraceId = value.TraceId,
-            RequestId = value.RequestId,
-            OperationId = value.OperationId,
-            ReleaseId = value.ReleaseId,
-            ReplicaId = value.ReplicaId,
-            ChangeSetId = value.ChangeSetId,
-            ResourceRef = value.ResourceRef,
-            ProviderLinks = value.ProviderLinks?.Select(link => new OperateProviderLinkResponse
-            {
-                Provider = link.Provider,
-                Label = link.Label,
-                Url = link.Url
-            }).ToArray(),
-            DetailsJson = value.DetailsJson
-        };
-    }
-
-    private static string ToCamel(string value)
-    {
-        if (string.IsNullOrEmpty(value))
-        {
-            return value;
-        }
-
-        return char.ToLowerInvariant(value[0]) + value[1..];
-    }
 }

--- a/src/Honua.Server/Features/Admin/RealtimeOperationTransitionListener.cs
+++ b/src/Honua.Server/Features/Admin/RealtimeOperationTransitionListener.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Server.Features.Admin;
+
+/// <summary>
+/// Second, independent consumer of the #2562 workflow-transition seam. Forwards every observed transition to
+/// the <see cref="AdminRealtimeBroadcaster"/>, which pushes it to the <c>deploy-operations</c> and
+/// <c>operate-events</c> hub groups over the Redis backplane (#2554). It does NOT build a producer of its own
+/// — it rides the same seam the operate-timeline listener uses, so a transition fans to both consumers.
+/// </summary>
+/// <remarks>
+/// The forward is a non-blocking enqueue and is exception-isolated inside the broadcaster, so this listener
+/// never slows or faults the authoritative store-write path (matching the seam's listener-isolation contract).
+/// </remarks>
+internal sealed class RealtimeOperationTransitionListener(AdminRealtimeBroadcaster broadcaster)
+    : IWorkflowOperationTransitionListener
+{
+    private readonly AdminRealtimeBroadcaster _broadcaster =
+        broadcaster ?? throw new ArgumentNullException(nameof(broadcaster));
+
+    public Task OnTransitionAsync(WorkflowOperationTransition transition, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+
+        _broadcaster.EnqueueTransition(transition);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineEventFactory.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineEventFactory.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Observability.Domain;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Maps an observed workflow-operation transition onto the normalized <see cref="OperateEventKind.Release"/>
+/// timeline event. Shared by the in-process <see cref="ReleaseTimelineTransitionListener"/> (which appends
+/// to the <see cref="ReleaseTimelineBuffer"/> so releases show on the Operate timeline) and the realtime
+/// broadcaster (#2554, which pushes the same event to the <c>operate-events</c> hub group). Keeping one
+/// mapping guarantees a live-pushed release event is identical to the one read back from the timeline API.
+/// </summary>
+internal static class ReleaseTimelineEventFactory
+{
+    /// <summary>Builds the release timeline event for a transition.</summary>
+    /// <param name="transition">The observed workflow-operation transition.</param>
+    /// <returns>The normalized release event.</returns>
+    public static OperateEvent Create(WorkflowOperationTransition transition)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+
+        var operation = transition.Operation;
+        var occurredTicks = transition.OccurredAt.UtcTicks.ToString(CultureInfo.InvariantCulture);
+
+        return new OperateEvent
+        {
+            EventId = $"release:{operation.OperationId}:{transition.Kind}:{occurredTicks}",
+            Kind = OperateEventKind.Release,
+            Severity = MapSeverity(transition.Kind),
+            OccurredAt = transition.OccurredAt,
+            Title = BuildTitle(transition),
+            Summary = operation.CurrentPhase,
+            Actor = operation.Audit.RequestedBy,
+            CorrelationId = transition.CorrelationId,
+            OperationId = transition.OperationId,
+            ReleaseId = transition.ReleaseId,
+            ResourceRef = "release/" + operation.OperationId
+        };
+    }
+
+    private static string BuildTitle(WorkflowOperationTransition transition)
+    {
+        var subject = transition.TargetId
+            ?? transition.Operation.MetadataRelease?.PackageId
+            ?? transition.OperationId;
+        var action = transition.Kind switch
+        {
+            WorkflowOperationTransitionKind.Created => "Deploy operation created",
+            WorkflowOperationTransitionKind.Submitted => "Deploy submitted",
+            WorkflowOperationTransitionKind.Promoted => "Deploy promoted",
+            WorkflowOperationTransitionKind.RolledBack => "Deploy rolled back",
+            WorkflowOperationTransitionKind.ManualInterventionRequired => "Deploy needs manual intervention",
+            _ => "Deploy transition"
+        };
+
+        return $"{action}: {subject}";
+    }
+
+    private static OperateEventSeverity MapSeverity(WorkflowOperationTransitionKind kind) => kind switch
+    {
+        WorkflowOperationTransitionKind.Created => OperateEventSeverity.Info,
+        WorkflowOperationTransitionKind.Submitted => OperateEventSeverity.Info,
+        WorkflowOperationTransitionKind.Promoted => OperateEventSeverity.Notice,
+        WorkflowOperationTransitionKind.RolledBack => OperateEventSeverity.Warning,
+        WorkflowOperationTransitionKind.ManualInterventionRequired => OperateEventSeverity.Error,
+        _ => OperateEventSeverity.Info
+    };
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineTransitionListener.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ReleaseTimelineTransitionListener.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Globalization;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Observability.Domain;
@@ -27,56 +26,7 @@ internal sealed class ReleaseTimelineTransitionListener : IWorkflowOperationTran
     {
         ArgumentNullException.ThrowIfNull(transition);
 
-        _buffer.Append(MapEvent(transition));
+        _buffer.Append(ReleaseTimelineEventFactory.Create(transition));
         return Task.CompletedTask;
     }
-
-    private static OperateEvent MapEvent(WorkflowOperationTransition transition)
-    {
-        var operation = transition.Operation;
-        var occurredTicks = transition.OccurredAt.UtcTicks.ToString(CultureInfo.InvariantCulture);
-
-        return new OperateEvent
-        {
-            EventId = $"release:{operation.OperationId}:{transition.Kind}:{occurredTicks}",
-            Kind = OperateEventKind.Release,
-            Severity = MapSeverity(transition.Kind),
-            OccurredAt = transition.OccurredAt,
-            Title = BuildTitle(transition),
-            Summary = operation.CurrentPhase,
-            Actor = operation.Audit.RequestedBy,
-            CorrelationId = transition.CorrelationId,
-            OperationId = transition.OperationId,
-            ReleaseId = transition.ReleaseId,
-            ResourceRef = "release/" + operation.OperationId
-        };
-    }
-
-    private static string BuildTitle(WorkflowOperationTransition transition)
-    {
-        var subject = transition.TargetId
-            ?? transition.Operation.MetadataRelease?.PackageId
-            ?? transition.OperationId;
-        var action = transition.Kind switch
-        {
-            WorkflowOperationTransitionKind.Created => "Deploy operation created",
-            WorkflowOperationTransitionKind.Submitted => "Deploy submitted",
-            WorkflowOperationTransitionKind.Promoted => "Deploy promoted",
-            WorkflowOperationTransitionKind.RolledBack => "Deploy rolled back",
-            WorkflowOperationTransitionKind.ManualInterventionRequired => "Deploy needs manual intervention",
-            _ => "Deploy transition"
-        };
-
-        return $"{action}: {subject}";
-    }
-
-    private static OperateEventSeverity MapSeverity(WorkflowOperationTransitionKind kind) => kind switch
-    {
-        WorkflowOperationTransitionKind.Created => OperateEventSeverity.Info,
-        WorkflowOperationTransitionKind.Submitted => OperateEventSeverity.Info,
-        WorkflowOperationTransitionKind.Promoted => OperateEventSeverity.Notice,
-        WorkflowOperationTransitionKind.RolledBack => OperateEventSeverity.Warning,
-        WorkflowOperationTransitionKind.ManualInterventionRequired => OperateEventSeverity.Error,
-        _ => OperateEventSeverity.Info
-    };
 }

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -118,6 +118,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <PackageReference Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" />
+    <!-- Force the audited-safe MessagePack (2.5.301) over the vulnerable 2.5.187 that the SignalR Redis
+         backplane pulls transitively (transitive pinning is not enabled repo-wide). See #2554. -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -714,7 +714,7 @@ builder.Services.AddOperationsToolset(builder.Configuration);
 // operations toolset so the tool source can resolve the canonical IOperationCatalog.
 Honua.Ai.Protocols.Mcp.McpServiceCollectionExtensions.AddMcpPublishedOperationTools(
     builder.Services, builder.Configuration);
-builder.Services.AddAdminRealtime();
+builder.Services.AddAdminRealtime(builder.Configuration);
 if (!isTestEnvironment)
 {
     builder.Services.AddOrchestrationBackgroundServices(builder.Configuration);

--- a/tests/dotnet/Honua.Server.Tests/Admin/AdminRealtimeGroupsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Admin/AdminRealtimeGroupsTests.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Infrastructure.Monitoring;
+using Honua.Server.Features.Admin;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Honua.Server.Tests.Admin;
+
+/// <summary>
+/// Realtime ops-push coverage for #2554: the ops-health / operate-events / deploy-operations hub groups,
+/// their admin authorization, the backplane feature-detect fallback, and real cross-replica fan-out over a
+/// Testcontainers Redis backplane.
+/// </summary>
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.Streaming)]
+public sealed class AdminRealtimeGroupsTests : IClassFixture<RedisFixture>
+{
+    private const string AdminPassword = "admin-realtime-groups-password";
+    private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(20);
+
+    private static readonly JsonSerializerOptions CaseInsensitive = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly RedisFixture _redis;
+
+    public AdminRealtimeGroupsTests(RedisFixture redis)
+    {
+        _redis = redis;
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /hubs/admin/negotiate")]
+    public async Task NonAdminConnection_CannotConnect_SoCannotSubscribe()
+    {
+        using var factory = CreateFactory(redisConnectionString: null);
+        await using var connection = BuildConnection(factory, apiKey: null);
+
+        // Hub-level admin authorization gates the whole connection: a non-admin cannot negotiate, therefore
+        // cannot reach any Subscribe method.
+        var connect = async () => await connection.StartAsync();
+        await connect.Should().ThrowAsync<Exception>();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /hubs/admin/negotiate")]
+    public async Task WithoutBackplane_GroupsNotAdvertised_AndSubscribeRejected()
+    {
+        using var factory = CreateFactory(redisConnectionString: null);
+        await using var connection = BuildConnection(factory, AdminPassword);
+        await connection.StartAsync();
+
+        var status = await connection.InvokeAsync<JsonElement>("GetStatus");
+        var probe = Deserialize<StatusProbe>(status);
+        probe.BackplaneEnabled.Should().BeFalse();
+        probe.RealtimeGroups.Should().BeEmpty();
+
+        // Feature-detect contract: with no backplane the group is not joinable — the client must poll.
+        var subscribe = async () => await connection.InvokeAsync("SubscribeToOpsHealth");
+        await subscribe.Should().ThrowAsync<HubException>();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /hubs/admin/negotiate")]
+    public async Task WithBackplane_OpsHealthFlush_PushesSnapshotToSubscriber()
+    {
+        using var factory = CreateFactory(_redis.ConnectionString);
+        await using var connection = BuildConnection(factory, AdminPassword);
+
+        var received = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.On<JsonElement>(
+            AdminRealtimeContract.OpsHealthSnapshotEventName,
+            snapshot => received.TrySetResult(snapshot));
+
+        await connection.StartAsync();
+
+        var status = Deserialize<StatusProbe>(await connection.InvokeAsync<JsonElement>("GetStatus"));
+        status.BackplaneEnabled.Should().BeTrue();
+        status.RealtimeGroups.Should().Contain(AdminRealtimeContract.OpsHealthGroup);
+
+        await connection.InvokeAsync("SubscribeToOpsHealth");
+
+        var flushSignal = factory.Services.GetRequiredService<OpsHealthFlushSignal>();
+        flushSignal.Raise(BuildSnapshot("Degraded"));
+
+        var payload = await received.Task.WaitAsync(ReceiveTimeout);
+        payload.GetProperty("overallStatus").GetString().Should().Be("Degraded");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /hubs/admin/negotiate")]
+    public async Task WithBackplane_Transition_PushesDeployAndOperateEvents()
+    {
+        using var factory = CreateFactory(_redis.ConnectionString);
+        await using var connection = BuildConnection(factory, AdminPassword);
+
+        var deploy = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var operate = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.On<JsonElement>(AdminRealtimeContract.DeployOperationEventName, e => deploy.TrySetResult(e));
+        connection.On<JsonElement>(AdminRealtimeContract.OperateEventEventName, e => operate.TrySetResult(e));
+
+        await connection.StartAsync();
+        await connection.InvokeAsync("SubscribeToDeployOperations");
+        await connection.InvokeAsync("SubscribeToOperateEvents");
+
+        var operationId = $"op-{Guid.NewGuid():N}";
+        var listener = factory.Services.GetServices<IWorkflowOperationTransitionListener>()
+            .OfType<RealtimeOperationTransitionListener>()
+            .Single();
+        await listener.OnTransitionAsync(
+            BuildTransition(operationId, WorkflowOperationTransitionKind.Submitted));
+
+        var deployPayload = await deploy.Task.WaitAsync(ReceiveTimeout);
+        deployPayload.GetProperty("operationId").GetString().Should().Be(operationId);
+        deployPayload.GetProperty("transitionKind").GetString().Should().Be("Submitted");
+        deployPayload.GetProperty("eventId").GetString().Should().NotBeNullOrWhiteSpace();
+
+        var operatePayload = await operate.Task.WaitAsync(ReceiveTimeout);
+        operatePayload.GetProperty("kind").GetString().Should().Be("release");
+        operatePayload.GetProperty("operationId").GetString().Should().Be(operationId);
+        operatePayload.GetProperty("title").GetString().Should().StartWith("Deploy submitted");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /hubs/admin/negotiate")]
+    public async Task WithBackplane_FansOutAcrossReplicas()
+    {
+        // Two independent server hosts sharing ONE Redis backplane: a client connected to host B must receive
+        // an ops-health snapshot produced on host A. This is the multi-replica fan-out the ticket exists for.
+        using var hostA = CreateFactory(_redis.ConnectionString);
+        using var hostB = CreateFactory(_redis.ConnectionString);
+        await using var connectionB = BuildConnection(hostB, AdminPassword);
+
+        var marker = $"FanOut-{Guid.NewGuid():N}";
+        var received = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        connectionB.On<JsonElement>(AdminRealtimeContract.OpsHealthSnapshotEventName, snapshot =>
+        {
+            if (snapshot.GetProperty("overallStatus").GetString() == marker)
+            {
+                received.TrySetResult(snapshot);
+            }
+        });
+
+        await connectionB.StartAsync();
+        await connectionB.InvokeAsync("SubscribeToOpsHealth");
+
+        // Produce on host A; host B's connected client should receive it via the shared backplane.
+        var flushOnA = hostA.Services.GetRequiredService<OpsHealthFlushSignal>();
+        flushOnA.Raise(BuildSnapshot(marker));
+
+        var payload = await received.Task.WaitAsync(ReceiveTimeout);
+        payload.GetProperty("overallStatus").GetString().Should().Be(marker);
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(string? redisConnectionString)
+        => new TestWebApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseSetting("HONUA_ADMIN_PASSWORD", AdminPassword);
+                // Set the Redis connection via UseSetting (not ConfigureAppConfiguration) so it is visible in
+                // builder.Configuration when AddAdminRealtime reads it during service registration — app
+                // configuration sources are only merged at build time, which is too late for the backplane gate.
+                if (!string.IsNullOrWhiteSpace(redisConnectionString))
+                {
+                    builder.UseSetting("ConnectionStrings:redis", redisConnectionString);
+                }
+
+                builder.ConfigureAppConfiguration((_, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["HONUA_ADMIN_PASSWORD"] = AdminPassword,
+                    });
+                });
+            });
+
+    private static HubConnection BuildConnection(WebApplicationFactory<Program> factory, string? apiKey)
+    {
+        var server = factory.Server;
+        var builder = new HubConnectionBuilder()
+            .WithUrl(new Uri(server.BaseAddress, AdminRealtimeContract.HubPath.TrimStart('/')), options =>
+            {
+                options.HttpMessageHandlerFactory = _ => server.CreateHandler();
+                options.Transports = HttpTransportType.LongPolling;
+                if (apiKey is not null)
+                {
+                    options.Headers["X-API-Key"] = apiKey;
+                }
+            });
+
+        return builder.Build();
+    }
+
+    private static T Deserialize<T>(JsonElement element)
+        => element.Deserialize<T>(CaseInsensitive)!;
+
+    private static WorkflowOperationTransition BuildTransition(string operationId, WorkflowOperationTransitionKind kind)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var record = new WorkflowOperationRecord
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.Deploy,
+            Status = WorkflowOperationStatus.Submitted,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CurrentPhase = "Submitting",
+        };
+
+        return new WorkflowOperationTransition
+        {
+            Operation = record,
+            Kind = kind,
+            OccurredAt = now,
+        };
+    }
+
+    private static OpsHealthSnapshotResponse BuildSnapshot(string overallStatus)
+        => new()
+        {
+            GeneratedAt = DateTimeOffset.UtcNow,
+            OverallStatus = overallStatus,
+            Health = new OpsHealthChecksView
+            {
+                Status = overallStatus,
+                TotalDurationMs = 0,
+                Entries = Array.Empty<OpsHealthCheckEntryView>(),
+            },
+            ServingLatency = new OpsServingLatencyView
+            {
+                WindowSeconds = 60,
+                Protocols = Array.Empty<OpsServingLatencyProtocolView>(),
+            },
+            Geoprocessing = new OpsGpQueueView
+            {
+                TotalActive = 0,
+                Available = true,
+                Buckets = Array.Empty<OpsGpQueueBucketView>(),
+            },
+            AlertDispatch = new OpsAlertDispatchView
+            {
+                DispatcherRunning = false,
+                DispatcherEnabled = false,
+                StoragePollFailing = false,
+            },
+            Deploy = new OpsDeployReadinessView
+            {
+                Status = "ready",
+                ReadyForCoordinatedDeploy = true,
+                PendingMigrationsCount = 0,
+                PendingContractScriptsCount = 0,
+                PlatformRelease = new OpsPlatformReleaseView
+                {
+                    ReleaseDeclared = false,
+                    IsCoVersioned = true,
+                    SkewedIds = Array.Empty<string>(),
+                },
+            },
+            Database = new OpsDatabaseView
+            {
+                HasConnectionPoolData = false,
+                ActiveConnections = 0,
+                ConnectionAcquisitionTimeouts = 0,
+                ConnectionAcquisitionFailures = 0,
+                CacheHitRatio = 0,
+                ErrorRate = 0,
+            },
+        };
+
+    private sealed record StatusProbe(
+        [property: JsonPropertyName("backplaneEnabled")] bool BackplaneEnabled,
+        [property: JsonPropertyName("realtimeGroups")] IReadOnlyList<string> RealtimeGroups);
+}

--- a/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Net.Client.Web" />
     <PackageReference Include="Mapsui" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.OData.Client" />
     <PackageReference Include="Moq" />


### PR DESCRIPTION
## Issue Link
Fixes #2554

## Summary
Every observability surface is poll-only today and `AdminRealtimeHub` has no backplane, so
deploy transitions produced by the leased reconciler on one replica are invisible to clients on
other replicas. This adds three admin hub groups — `ops-health`, `operate-events`,
`deploy-operations` — plus a SignalR Redis backplane so leased-replica producers fan out to
clients on any replica. Producers consume the existing in-process seams (#2553 flush signal,
#2562 transition seam); no second producer is built.

## Changes Made
- **`ops-health` group** — a background broadcaster subscribes to `OpsHealthFlushSignal` (#2553)
  and pushes the SAME cluster-aggregated `OpsHealthSnapshotResponse` as `GET ops-health` on each
  sampler flush. The flush handler is a non-blocking, latest-wins `TryWrite` into a bounded
  (capacity-1, DropOldest) channel, so it never blocks or throws back into the sampler.
- **`deploy-operations` + `operate-events` groups** — a second, independent
  `IWorkflowOperationTransitionListener` (`RealtimeOperationTransitionListener`) rides the #2562
  seam and forwards each transition. Delivery is at-least-once, so the deploy payload carries a
  stable `eventId` plus `operationId`+`transitionKind` for client dedup; `operate-events` reuses
  the `GET observability/events` wire shape via a shared mapper so a pushed event is
  byte-identical to the timeline read.
- **Redis backplane** — `AddStackExchangeRedis` on a dedicated connection
  (`AbortOnConnectFail=false`, channel prefix `honua:signalr:admin`), packaged via
  `Directory.Packages.props`. Gated on a configured Redis connection string.
- **Feature-detect + fallback** — with no Redis the groups are not advertised
  (`AdminRealtimeStatus.BackplaneEnabled` / `RealtimeGroups` are surfaced on connect and via
  `GetStatus`) and `Subscribe*` is rejected with a `HubException`, so the console falls back to
  polling. A runtime Redis outage degrades to single-replica delivery and never blocks serving;
  reconnect gap-fill is the history/list API (no Last-Event-ID).
- **Bounded per-connection behavior** — broadcaster channels are bounded (DropOldest, so no
  unbounded buffering) and the hub pins `ClientTimeoutInterval`/`KeepAliveInterval` so a slow
  consumer is disconnected rather than buffered.
- **Auth** — hub-level admin authorization is unchanged (`RequireAdminAuthorization` on the hub
  endpoint gates connect + every invocation); a non-admin cannot connect, therefore cannot
  subscribe.
- **Refactors** — extracted the release-transition→`OperateEvent` mapping
  (`ReleaseTimelineEventFactory`) and the `OperateEvent`→wire mapping (`OperateEventResponseMapper`)
  into shared helpers reused by the timeline listener and the REST endpoint (no behavior change).
- **MessagePack pin** — pinned MessagePack to the audited-safe `2.5.301`; the SignalR Redis
  backplane pulls the vulnerable `2.5.187` transitively (transitive pinning is not enabled
  repo-wide, so this is a direct reference, matching the existing NBomber pin pattern).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

`AdminRealtimeGroupsTests` — real Testcontainers (Redis + Postgres), all passing locally:
- non-admin cannot connect (so cannot subscribe);
- without a backplane, groups are not advertised and `Subscribe` is rejected;
- ops-health flush pushes the snapshot to a subscriber;
- a transition pushes both the deploy-operations and operate-events payloads (dedup key +
  `release` wire shape asserted);
- **two independent hosts sharing one Redis backplane**: a flush on host A reaches a client
  connected to host B (multi-replica fan-out).

Also re-ran `DeployReleaseTimelineTests` + observability endpoint tests (28 passed) to confirm the
extracted mappers are behavior-preserving. Full `Honua.Server` Release build is warnings-as-errors
clean; `dotnet format --verify-no-changes` clean on both touched projects.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [ ] None — no docs or contract impact

New realtime wire DTOs consumed by console #288/#290: the ops-health push reuses the existing
`GET ops-health` DTO; `operate-events` reuses the `GET observability/events` wire shape;
`deploy-operations` is a new lightweight `DeployOperationRealtimeEvent`. The backplane feature-detect
contract (advertised groups + `BackplaneEnabled`) and the "reconnect = history/list API, no
Last-Event-ID" contract are documented on the hub. No new HTTP routes (SignalR hub methods only), so
no OpenAPI / feature-catalog change.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

Redis is already required for the control plane; no new infra. When absent, the hub degrades to
single-replica + poll.

## Breaking Changes
None. `AdminRealtimeStatus` gains two additive fields; existing proposals/status wire shapes are
unchanged (the new group payloads use a separate camel-cased serializer context).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Note on pre-PR check: `scripts/ci/pre-pr-check.sh` does not run on this Windows host (known
CLAUDE.md symlink / MSYS path issue per the agent protocol). Ran the equivalents instead: full
`Honua.Server` Release build (warnings-as-errors, 0 warnings), `dotnet format --verify-no-changes`
on both touched projects (clean), and the affected integration tests (green).
