### PR TITLE
feat(observability): findings catalog v2 - actions only where actuators exist

### DIFF
--- a/src/Honua.Core/Features/Observability/Domain/OpsFindingModels.cs
+++ b/src/Honua.Core/Features/Observability/Domain/OpsFindingModels.cs
@@ -44,6 +44,9 @@ public sealed record OpsFindingSubject
     /// <summary>Gets the platform release version this finding concerns, when applicable.</summary>
     public string? ReleaseVersion { get; init; }
 
+    /// <summary>Gets the GIS protocol family this finding concerns, when applicable.</summary>
+    public string? Protocol { get; init; }
+
     /// <summary>
     /// Produces a canonical, order-stable key over the populated identifiers, used to derive the
     /// finding's deterministic identifier. The format is fixed so the same condition instance always
@@ -57,7 +60,8 @@ public sealed record OpsFindingSubject
             $"workload={WorkloadId}",
             $"channel={Channel}",
             $"operation={OperationId}",
-            $"release={ReleaseVersion}");
+            $"release={ReleaseVersion}",
+            $"protocol={Protocol}");
 }
 
 /// <summary>

--- a/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/OpsObservabilityEndpoints.cs
@@ -162,6 +162,7 @@ internal static class OpsObservabilityEndpoints
                 Channel = finding.Subject.Channel,
                 OperationId = finding.Subject.OperationId,
                 ReleaseVersion = finding.Subject.ReleaseVersion,
+                Protocol = finding.Subject.Protocol,
             },
             EvidenceRefs = finding.EvidenceRefs,
             RecommendedAction = finding.RecommendedAction is null

--- a/src/Honua.Server/Features/ControlPlane/Executors/OpsActionModel.cs
+++ b/src/Honua.Server/Features/ControlPlane/Executors/OpsActionModel.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Honua.Core.Features.Guardrails.Abstractions;
 using Honua.Core.Features.Guardrails.Domain;
 
@@ -193,4 +194,73 @@ internal sealed record OpsActionRequest
             ? element.GetString()
             : null;
     }
+}
+
+/// <summary>
+/// Builds serialized <c>{action, target, params}</c> execution payloads for the registered
+/// <see cref="OpsActionNames"/> vocabulary, mirroring exactly what <see cref="OpsActionRequest.Parse"/>
+/// expects. Single-sourcing the wire shape here (next to the parser) keeps producers — for example the
+/// deterministic ops-findings engine — from hand-rolling JSON that could drift from the parser's contract.
+/// </summary>
+internal static class OpsActionExecutionPayloads
+{
+    /// <summary>Builds the payload for <see cref="OpsActionNames.RedriveDeadLetters"/>.</summary>
+    /// <param name="maxCount">Optional redrive batch bound.</param>
+    public static string RedriveDeadLetters(int? maxCount = null)
+        => Build(OpsActionNames.RedriveDeadLetters, target: null, maxCount: maxCount, limit: null, channel: null);
+
+    /// <summary>Builds the payload for <see cref="OpsActionNames.TuneBoundedAdmission"/>.</summary>
+    /// <param name="limit">The requested admission target.</param>
+    public static string TuneBoundedAdmission(int limit)
+        => Build(OpsActionNames.TuneBoundedAdmission, target: null, maxCount: null, limit: limit, channel: null);
+
+    private static string Build(string action, string? target, int? maxCount, int? limit, string? channel)
+    {
+        var parameters = maxCount is null && limit is null && channel is null
+            ? null
+            : new OpsActionExecutionParams { MaxCount = maxCount, Limit = limit, Channel = channel };
+
+        var payload = new OpsActionExecutionPayload
+        {
+            Action = action,
+            Target = target,
+            Params = parameters,
+        };
+
+        return JsonSerializer.Serialize(payload, OpsActionExecutionPayloadJsonContext.Default.OpsActionExecutionPayload);
+    }
+}
+
+/// <summary>Wire shape for a serialized ops-action execution payload (see <see cref="OpsActionRequest.Parse"/>).</summary>
+internal sealed record OpsActionExecutionPayload
+{
+    /// <summary>Action discriminator (a registered <see cref="OpsActionNames"/> value).</summary>
+    public required string Action { get; init; }
+
+    /// <summary>Optional free-form action target.</summary>
+    public string? Target { get; init; }
+
+    /// <summary>Optional action parameters.</summary>
+    public OpsActionExecutionParams? Params { get; init; }
+}
+
+/// <summary>Optional parameters carried by an ops-action execution payload.</summary>
+internal sealed record OpsActionExecutionParams
+{
+    /// <summary>Redrive batch bound.</summary>
+    public int? MaxCount { get; init; }
+
+    /// <summary>Bounded-admission tune target.</summary>
+    public int? Limit { get; init; }
+
+    /// <summary>Pause/resume channel name.</summary>
+    public string? Channel { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OpsActionExecutionPayload))]
+internal sealed partial class OpsActionExecutionPayloadJsonContext : JsonSerializerContext
+{
 }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ internal static class ObservabilityServiceCollectionExtensions
         services.AddPerformanceMonitoring();
         services.TryAddSingleton<ConnectionPoolMetrics>();
         services.AddSingleton<ProductionMetricsCollector>();
+        services.AddSingleton<IOpsDatabasePressureSignal, ProductionMetricsDatabasePressureSignal>();
         services.Configure<RecentErrorBufferOptions>(
             configuration.GetSection(RecentErrorBufferOptions.SectionName));
         services.AddSingleton<RecentErrorBuffer>();
@@ -56,6 +57,12 @@ internal static class ObservabilityServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
         services.AddScoped<IOpsHealthSnapshotService, OpsHealthSnapshotService>();
+        services.AddScoped(sp => new OpsFindingsExtendedSignals
+        {
+            DatabasePressureSignal = sp.GetService<IOpsDatabasePressureSignal>(),
+            AdmissionGate = sp.GetService<Honua.Core.Features.Infrastructure.Abstractions.IRuntimeTunableAdmissionGate>(),
+            RollupStore = sp.GetService<IOpsHealthRollupStore>(),
+        });
         services.AddScoped<IOpsFindingsService, OpsFindingsService>();
 
         // Persisted ops-health rollup store + per-replica sampler (#2553). The store itself is registered by

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsDatabasePressureSignal.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsDatabasePressureSignal.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Observability.Abstractions;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Point-in-time database connection-pool pressure signal consumed by the
+/// <c>db-bounded-admission-pressure</c> ops-findings rule. Abstracted behind an interface (rather than
+/// depending on <see cref="ProductionMetricsCollector"/> directly) so the rule can be unit-tested with a
+/// fake seam, matching the pattern already used for alert-dispatch health and deploy preflight.
+/// </summary>
+internal interface IOpsDatabasePressureSignal
+{
+    /// <summary>Reads the current database connection-pool pressure snapshot.</summary>
+    DatabasePressureSnapshot GetSnapshot();
+}
+
+/// <summary>A single database connection-pool pressure reading.</summary>
+/// <param name="HasConnectionPoolUtilization">Whether pool utilization telemetry is available.</param>
+/// <param name="ConnectionPoolUtilization">Connection-pool utilization ratio (0.0-1.0), when available.</param>
+/// <param name="ConnectionAcquisitionTimeouts">Total connection-acquisition timeout count.</param>
+/// <param name="ConnectionAcquisitionFailures">Total connection-acquisition failure count.</param>
+internal readonly record struct DatabasePressureSnapshot(
+    bool HasConnectionPoolUtilization,
+    double ConnectionPoolUtilization,
+    long ConnectionAcquisitionTimeouts,
+    long ConnectionAcquisitionFailures);
+
+/// <summary>
+/// Default <see cref="IOpsDatabasePressureSignal"/> backed by the shared <see cref="ProductionMetricsCollector"/>
+/// singleton (the same source the ops-health snapshot's database view reads).
+/// </summary>
+internal sealed class ProductionMetricsDatabasePressureSignal(ProductionMetricsCollector metricsCollector)
+    : IOpsDatabasePressureSignal
+{
+    public DatabasePressureSnapshot GetSnapshot()
+    {
+        var metrics = metricsCollector.GetHealthMetrics();
+        return new DatabasePressureSnapshot(
+            metrics.HasDatabaseConnectionPoolUtilization,
+            metrics.DatabaseConnectionPoolUtilization,
+            metrics.ConnectionAcquisitionTimeouts,
+            metrics.ConnectionAcquisitionFailures);
+    }
+}
+
+/// <summary>
+/// Bundles the ops-findings engine's data-source collaborators that are ONLY wired in certain
+/// topologies (Postgres-only telemetry, the durable-backend-gated rollup store) behind one
+/// constructor parameter. <see cref="OpsFindingsService"/> already carries the durable
+/// control-plane collaborators (gateway/workflow store/job store) plus several always-present
+/// seams; collapsing this group into a snapshot keeps the constructor under the
+/// architecture-enforced collaborator ceiling (<c>DependencyInjectionLimitsTests</c>) instead of
+/// growing it per new rule.
+/// </summary>
+internal sealed class OpsFindingsExtendedSignals
+{
+    /// <summary>Database connection-pool pressure signal (Postgres only), or null when unavailable.</summary>
+    public IOpsDatabasePressureSignal? DatabasePressureSignal { get; init; }
+
+    /// <summary>Runtime-tunable bounded database admission gate (Postgres only), or null when unavailable.</summary>
+    public IRuntimeTunableAdmissionGate? AdmissionGate { get; init; }
+
+    /// <summary>Persisted ops-health rollup store (#2553, Postgres only), or null when unavailable.</summary>
+    public IOpsHealthRollupStore? RollupStore { get; init; }
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsOptions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsOptions.cs
@@ -37,4 +37,48 @@ public sealed class OpsFindingsOptions
     /// </summary>
     [Range(1, int.MaxValue)]
     public int GpQueueDepthThreshold { get; set; } = 200;
+
+    /// <summary>
+    /// Gets or sets the database connection-pool utilization ratio (0.0-1.0) at or above which the
+    /// <c>db-bounded-admission-pressure</c> rule raises a finding. Default is 0.9 (90%).
+    /// </summary>
+    [Range(0.01, 1.0)]
+    public double DbPoolUtilizationThreshold { get; set; } = 0.9;
+
+    /// <summary>
+    /// Gets or sets the connection-acquisition timeout count at or above which the
+    /// <c>db-bounded-admission-pressure</c> rule raises a finding. Default is 5.
+    /// </summary>
+    [Range(1, long.MaxValue)]
+    public long DbConnectionAcquisitionTimeoutThreshold { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the fraction (0.0-1.0, exclusive of the current admission target) by which a
+    /// proposed <c>db.tune_bounded_admission</c> action lowers the current admission target when
+    /// database connection-pool pressure is elevated. Default is 0.25 (a 25% reduction, floored at
+    /// the gate's configured minimum).
+    /// </summary>
+    [Range(0.01, 0.9)]
+    public double DbBoundedAdmissionTuneDownFraction { get; set; } = 0.25;
+
+    /// <summary>
+    /// Gets or sets the per-protocol 95th-percentile serving-latency threshold (milliseconds) at or
+    /// above which the <c>serving-latency-slo-breach</c> rule raises a finding. Default is 2000ms.
+    /// </summary>
+    [Range(1, double.MaxValue)]
+    public double ServingLatencyP95ThresholdMs { get; set; } = 2000;
+
+    /// <summary>
+    /// Gets or sets the per-protocol server-error rate (0.0-1.0) at or above which the
+    /// <c>serving-latency-slo-breach</c> rule raises a finding. Default is 0.05 (5%).
+    /// </summary>
+    [Range(0.0001, 1.0)]
+    public double ServingErrorRateThreshold { get; set; } = 0.05;
+
+    /// <summary>
+    /// Gets or sets the lookback window (minutes) the <c>serving-latency-slo-breach</c> rule reads
+    /// from the persisted ops-health rollup store's 1-minute tier (#2553). Default is 5 minutes.
+    /// </summary>
+    [Range(1, 1440)]
+    public double ServingLatencyLookbackMinutes { get; set; } = 5;
 }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
@@ -7,6 +7,7 @@ using Honua.ControlPlane.Executors;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Observability.Abstractions;
 using Honua.Core.Features.Observability.Domain;
 using Microsoft.Extensions.Options;
@@ -29,6 +30,9 @@ internal sealed class OpsFindingsService : IOpsFindingsService
     internal const string RuleGpQueueDepth = "gp-queue-depth";
     internal const string RuleDeployManualIntervention = "deploy-manual-intervention";
     internal const string RuleLocalBackendSubstrate = "local-backend-substrate-incompatible";
+    internal const string RuleDbBoundedAdmissionPressure = "db-bounded-admission-pressure";
+    internal const string RuleServingLatencySlo = "serving-latency-slo-breach";
+    internal const string RulePlatformReleaseRuntimeDivergence = "platform-release-runtime-divergence";
 
     // BackendName of the in-process baseline batch backend (which reports a KubernetesJob target kind).
     private const string InProcessLocalBackendName = "local";
@@ -42,6 +46,9 @@ internal sealed class OpsFindingsService : IOpsFindingsService
     private readonly IOperationGateway? _gateway;
     private readonly IWorkflowOperationStore? _workflowStore;
     private readonly IExecutionJobStore? _jobStore;
+    private readonly IOpsDatabasePressureSignal? _databasePressureSignal;
+    private readonly IRuntimeTunableAdmissionGate? _admissionGate;
+    private readonly IOpsHealthRollupStore? _rollupStore;
 
     public OpsFindingsService(
         IOptionsMonitor<OpsFindingsOptions> options,
@@ -52,7 +59,8 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         Func<string, string?>? environmentAccessor = null,
         IOperationGateway? gateway = null,
         IWorkflowOperationStore? workflowStore = null,
-        IExecutionJobStore? jobStore = null)
+        IExecutionJobStore? jobStore = null,
+        OpsFindingsExtendedSignals? extendedSignals = null)
     {
         _options = options;
         _controlPlaneOptions = controlPlaneOptions;
@@ -63,6 +71,9 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         _gateway = gateway;
         _workflowStore = workflowStore;
         _jobStore = jobStore;
+        _databasePressureSignal = extendedSignals?.DatabasePressureSignal;
+        _admissionGate = extendedSignals?.AdmissionGate;
+        _rollupStore = extendedSignals?.RollupStore;
     }
 
     public async Task<IReadOnlyList<OpsFinding>> EvaluateAsync(CancellationToken cancellationToken = default)
@@ -74,9 +85,12 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         EvaluateAlertDispatchBacklog(now, options, findings);
         EvaluateLocalBackendSubstrate(now, findings);
         EvaluatePlatformReleaseSkew(now, findings);
+        EvaluateDbBoundedAdmissionPressure(now, options, findings);
         await EvaluatePendingContractMigrationsAsync(now, findings, cancellationToken).ConfigureAwait(false);
         await EvaluateGpQueueDepthAsync(now, options, findings, cancellationToken).ConfigureAwait(false);
         await EvaluateDeployManualInterventionAsync(now, findings, cancellationToken).ConfigureAwait(false);
+        await EvaluateServingLatencySloAsync(now, options, findings, cancellationToken).ConfigureAwait(false);
+        await EvaluatePlatformReleaseRuntimeDivergenceAsync(now, findings, cancellationToken).ConfigureAwait(false);
 
         // Most urgent first; stable ordering by rule then id keeps output deterministic.
         return findings
@@ -152,8 +166,10 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         _ => OpsFindingProposalStatus.NotSupported,
     };
 
-    // Rule (a): alert-dispatch backlog / dead-letters over threshold. Informational — points the
-    // operator at channel health; there is no safe automatic fix for a delivery backlog.
+    // Rule (a): alert-dispatch backlog / dead-letters over threshold. Dead-letters carry a real
+    // recommended action now that the ops-action registry has a redrive actuator (#2579): re-enqueue
+    // the dead-lettered rows for redelivery. A pending-only backlog (not yet dead-lettered) stays
+    // informational — there is no safe automatic fix for deliveries that are merely lagging.
     private void EvaluateAlertDispatchBacklog(DateTimeOffset now, OpsFindingsOptions options, List<OpsFinding> findings)
     {
         if (!_alertHealth.IsDispatcherEnabled || _alertHealth.LastBacklog is not { } backlog)
@@ -170,9 +186,24 @@ internal sealed class OpsFindingsService : IOpsFindingsService
 
         var subject = new OpsFindingSubject { Channel = "alert-dispatch" };
         var severity = deadLettersOverThreshold ? OpsFindingSeverity.Critical : OpsFindingSeverity.Warning;
-        var explanation = deadLettersOverThreshold
-            ? $"The alert dispatcher has {backlog.DeadLetteredCount} dead-lettered notification(s) that exhausted retries and require operator triage (pending backlog {backlog.PendingCount}). Inspect the affected notification channels' health and re-drive or discard the dead-lettered rows."
-            : $"The alert dispatcher pending backlog is {backlog.PendingCount}, at or above the configured threshold of {options.AlertDispatchPendingBacklogThreshold}. Deliveries are lagging; check channel throughput and downstream availability.";
+
+        OpsFindingRecommendedAction? action = null;
+        string explanation;
+        if (deadLettersOverThreshold)
+        {
+            action = new OpsFindingRecommendedAction
+            {
+                Kind = OperationClass.AdminConfigChange,
+                Summary = $"Redrive {backlog.DeadLetteredCount} dead-lettered alert dispatch row(s) for redelivery.",
+                ExecutionPayload = OpsActionExecutionPayloads.RedriveDeadLetters(),
+                Reason = $"The alert dispatcher has {backlog.DeadLetteredCount} dead-lettered notification(s) that exhausted retries.",
+            };
+            explanation = $"The alert dispatcher has {backlog.DeadLetteredCount} dead-lettered notification(s) that exhausted retries and require operator triage (pending backlog {backlog.PendingCount}). Redriving re-enqueues them for redelivery; if the underlying channel is unhealthy the same rows will dead-letter again, and repeated storms should be triaged by pausing the affected channel directly (no per-channel breakdown is available from this signal to safely automate that step yet).";
+        }
+        else
+        {
+            explanation = $"The alert dispatcher pending backlog is {backlog.PendingCount}, at or above the configured threshold of {options.AlertDispatchPendingBacklogThreshold}. Deliveries are lagging; check channel throughput and downstream availability. No automatic action is offered because a pending (not yet dead-lettered) backlog has no safe redrive target.";
+        }
 
         findings.Add(new OpsFinding
         {
@@ -184,7 +215,84 @@ internal sealed class OpsFindingsService : IOpsFindingsService
             DetectedAt = now,
             Subject = subject,
             EvidenceRefs = ["healthcheck:alert-dispatch", "GET /monitoring/health/comprehensive"],
-            RecommendedAction = null,
+            RecommendedAction = action,
+        });
+    }
+
+    // Rule (f): database connection-pool pressure (utilization and/or acquisition timeouts over
+    // threshold). Carries a db.tune_bounded_admission action ONLY when the runtime-tunable admission
+    // gate is registered (Postgres provider) and has headroom to reduce below its current target;
+    // otherwise informational.
+    private void EvaluateDbBoundedAdmissionPressure(DateTimeOffset now, OpsFindingsOptions options, List<OpsFinding> findings)
+    {
+        if (_databasePressureSignal is null)
+        {
+            return;
+        }
+
+        var snapshot = _databasePressureSignal.GetSnapshot();
+        var utilizationOverThreshold = snapshot.HasConnectionPoolUtilization
+            && snapshot.ConnectionPoolUtilization >= options.DbPoolUtilizationThreshold;
+        var timeoutsOverThreshold = snapshot.ConnectionAcquisitionTimeouts >= options.DbConnectionAcquisitionTimeoutThreshold;
+        if (!utilizationOverThreshold && !timeoutsOverThreshold)
+        {
+            return;
+        }
+
+        var subject = new OpsFindingSubject();
+        var evidence = new List<string> { "GET /api/v1/admin/observability/ops-health" };
+        if (utilizationOverThreshold)
+        {
+            evidence.Add($"db-pool-utilization:{snapshot.ConnectionPoolUtilization:F2}");
+        }
+
+        if (timeoutsOverThreshold)
+        {
+            evidence.Add($"db-acquisition-timeouts:{snapshot.ConnectionAcquisitionTimeouts}");
+        }
+
+        var utilizationText = snapshot.HasConnectionPoolUtilization
+            ? snapshot.ConnectionPoolUtilization.ToString("P0", System.Globalization.CultureInfo.InvariantCulture)
+            : "unavailable";
+
+        OpsFindingRecommendedAction? action = null;
+        string noActionReason = string.Empty;
+        if (_admissionGate is null)
+        {
+            noActionReason = " No automatic action is offered because the bounded database admission gate is unavailable for the active data provider.";
+        }
+        else
+        {
+            var tuned = Math.Max(
+                _admissionGate.MinLimit,
+                (int)Math.Floor(_admissionGate.CurrentLimit * (1.0 - options.DbBoundedAdmissionTuneDownFraction)));
+            if (tuned >= _admissionGate.CurrentLimit)
+            {
+                noActionReason = " No automatic action is offered because the bounded admission gate is already at its configured minimum.";
+            }
+            else
+            {
+                action = new OpsFindingRecommendedAction
+                {
+                    Kind = OperationClass.AdminConfigChange,
+                    Summary = $"Tune the bounded database admission target down to {tuned} (from {_admissionGate.CurrentLimit}).",
+                    ExecutionPayload = OpsActionExecutionPayloads.TuneBoundedAdmission(tuned),
+                    Reason = $"Database connection-pool pressure is elevated (utilization {utilizationText}, acquisition timeouts {snapshot.ConnectionAcquisitionTimeouts}); temporarily lower the bounded admission target to relieve pressure.",
+                };
+            }
+        }
+
+        findings.Add(new OpsFinding
+        {
+            Id = OpsFindingId.Create(RuleDbBoundedAdmissionPressure, subject),
+            Rule = RuleDbBoundedAdmissionPressure,
+            Severity = OpsFindingSeverity.Critical,
+            Title = "Database connection-pool pressure is elevated",
+            Explanation = $"Database connection-pool pressure is elevated (utilization {utilizationText}, acquisition timeouts {snapshot.ConnectionAcquisitionTimeouts}, acquisition failures {snapshot.ConnectionAcquisitionFailures}).{noActionReason}",
+            DetectedAt = now,
+            Subject = subject,
+            EvidenceRefs = evidence,
+            RecommendedAction = action,
         });
     }
 
@@ -234,9 +342,11 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         });
     }
 
-    // Rule (b): platform-release skew. Informational — a safe automatic fix is not robustly derivable
-    // (redeploying each skewed plane needs an approved per-target revision), so we surface the skew
-    // and its skewed ids for an operator to reconcile.
+    // Rule (b): platform-release skew (config-pin divergence). Informational, L1 guidance ONLY (#2556
+    // spec revision 2026-07-06): a plane element here explicitly pins an artifact that differs from the
+    // release, so the skew is config-derived, not something a runtime action can clear — a redeploy would
+    // just be overridden by the pin again. See RulePlatformReleaseRuntimeDivergence for the sibling rule
+    // that DOES offer a runtime action, for targets that pin nothing and have simply not converged yet.
     private void EvaluatePlatformReleaseSkew(DateTimeOffset now, List<OpsFinding> findings)
     {
         var skew = PlatformReleaseSkewProjector.Build(_controlPlaneOptions.CurrentValue);
@@ -256,7 +366,7 @@ internal sealed class OpsFindingsService : IOpsFindingsService
             Rule = RulePlatformReleaseSkew,
             Severity = OpsFindingSeverity.Warning,
             Title = "Platform release is not co-versioned",
-            Explanation = $"Declared platform release '{skew.ReleaseVersion}' is not co-versioned: {skew.SkewedIds.Count} plane(s) are skewed from the release ({string.Join(", ", skew.SkewedIds)}). No automatic fix is offered because a safe reconciliation requires an operator-approved revision for each skewed plane; redeploy the skewed planes to the release revision to restore co-versioning.",
+            Explanation = $"Declared platform release '{skew.ReleaseVersion}' is not co-versioned: {skew.SkewedIds.Count} plane(s) explicitly pin an artifact that diverges from the release ({string.Join(", ", skew.SkewedIds)}). This is L1 guidance only: a runtime action cannot clear config-derived skew, since the pinned configuration would simply re-assert itself on the next reconcile. Remove or update the explicit pin, then redeploy the plane to the release revision to restore co-versioning.",
             DetectedAt = now,
             Subject = subject,
             EvidenceRefs = evidence,
@@ -396,6 +506,152 @@ internal sealed class OpsFindingsService : IOpsFindingsService
                 Subject = subject,
                 EvidenceRefs = evidence,
                 RecommendedAction = action,
+            });
+        }
+    }
+
+    // Rule (g): per-protocol serving-latency/error-rate SLO breach, evidenced from the persisted
+    // ops-health rollup history (#2553) rather than the live in-process window, so a short blip does not
+    // flap the finding. Informational — a generic protocol-level latency/error-rate breach has no single
+    // safe automatic remediation (unlike the post-promotion case, there is no specific deploy to roll
+    // back). Fails open when the rollup store is unavailable or errors (#2511-style graceful degradation).
+    private async Task EvaluateServingLatencySloAsync(DateTimeOffset now, OpsFindingsOptions options, List<OpsFinding> findings, CancellationToken cancellationToken)
+    {
+        if (_rollupStore is null)
+        {
+            return;
+        }
+
+        IReadOnlyList<OpsHealthLatencyRow> rows;
+        try
+        {
+            var from = now.AddMinutes(-options.ServingLatencyLookbackMinutes);
+            rows = await _rollupStore.ReadLatencyAsync(OpsHealthRollupTier.OneMinute, from, now, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return;
+        }
+
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        var latestPerProtocol = rows
+            .GroupBy(row => row.Point.Protocol, StringComparer.Ordinal)
+            .Select(group => group.OrderByDescending(row => row.BucketStart).First().Point);
+
+        foreach (var point in latestPerProtocol)
+        {
+            var latencyBreach = point.P95Ms >= options.ServingLatencyP95ThresholdMs;
+            var errorRateBreach = point.ErrorRate >= options.ServingErrorRateThreshold;
+            if (!latencyBreach && !errorRateBreach)
+            {
+                continue;
+            }
+
+            var subject = new OpsFindingSubject { Protocol = point.Protocol };
+
+            findings.Add(new OpsFinding
+            {
+                Id = OpsFindingId.Create(RuleServingLatencySlo, subject),
+                Rule = RuleServingLatencySlo,
+                Severity = OpsFindingSeverity.Warning,
+                Title = $"{point.Protocol} serving-latency/error-rate SLO breach",
+                Explanation = $"Protocol '{point.Protocol}' p95 latency is {point.P95Ms:F0}ms (threshold {options.ServingLatencyP95ThresholdMs:F0}ms) and/or error rate is {point.ErrorRate:P2} (threshold {options.ServingErrorRateThreshold:P2}) over the last {options.ServingLatencyLookbackMinutes:F0} minute(s) of persisted history. No automatic action is offered: a generic protocol-level latency/error-rate breach has no single safe remediation.",
+                DetectedAt = now,
+                Subject = subject,
+                EvidenceRefs = ["GET /api/v1/admin/observability/ops-health/history", $"protocol:{point.Protocol}"],
+                RecommendedAction = null,
+            });
+        }
+    }
+
+    // Rule (h): platform-release runtime divergence (#2556 EXCLUSIVELY owns this rule; pinned divergence
+    // contract from #2564). Evidence: per unpinned serving deploy target, the last-applied revision is
+    // the DesiredRevision of the most recent terminal-Succeeded Deploy operation (#2562's per-target
+    // terminal index); a target with NO terminal-succeeded operation is unknown and treated as divergent.
+    // Config-pinned targets are SKIPPED here — that is RulePlatformReleaseSkew's concern, since
+    // config-derived skew cannot be cleared at runtime. When divergent, the recommended action creates a
+    // gateway-routed Deploy operation to the declared release artifact: the same per-target actuation the
+    // platform-release converge API (#2564) performs, reusing the existing Deploy operation-gateway path
+    // so this rule does not depend on that API's endpoint landing first.
+    private async Task EvaluatePlatformReleaseRuntimeDivergenceAsync(DateTimeOffset now, List<OpsFinding> findings, CancellationToken cancellationToken)
+    {
+        if (_workflowStore is null)
+        {
+            return;
+        }
+
+        var controlPlane = _controlPlaneOptions.CurrentValue;
+        var release = controlPlane.PlatformRelease.ToDefinition();
+        if (release is null || !release.DeclaresServing)
+        {
+            return;
+        }
+
+        var declaredArtifact = release.ServingArtifactReference!;
+
+        foreach (var target in controlPlane.DeployTargets)
+        {
+            if (string.IsNullOrWhiteSpace(target.TargetId) || !string.IsNullOrWhiteSpace(target.ArtifactReference))
+            {
+                // No target id to key on, or an explicit pin: pinned targets are the
+                // platform-release-skew rule's concern, not this one's.
+                continue;
+            }
+
+            var lastSucceeded = await _workflowStore
+                .GetMostRecentSucceededDeployByTargetAsync(target.TargetId, cancellationToken)
+                .ConfigureAwait(false);
+            var lastAppliedRevision = lastSucceeded?.Deploy?.DesiredRevision;
+
+            // Pinned contract (#2564): no terminal-Succeeded deploy for the target = unknown = divergent.
+            var isDivergent = lastAppliedRevision is null
+                || !string.Equals(lastAppliedRevision, declaredArtifact, StringComparison.Ordinal);
+            if (!isDivergent)
+            {
+                continue;
+            }
+
+            var subject = new OpsFindingSubject { TargetId = target.TargetId, ReleaseVersion = release.Version };
+            var evidence = new List<string>
+            {
+                "GET /api/v1/admin/deploy/preflight?includeDiagnostics=true",
+                lastAppliedRevision is null
+                    ? $"terminal-index:{target.TargetId}:none"
+                    : $"terminal-index:{target.TargetId}:{lastAppliedRevision}",
+            };
+
+            var payload = new DeployExecutionPayload
+            {
+                TargetId = target.TargetId,
+                DesiredRevision = declaredArtifact,
+                CurrentRevision = lastAppliedRevision,
+            }.Serialize();
+
+            var lastAppliedDescription = lastAppliedRevision is null
+                ? "no terminal-succeeded deploy operation is recorded for this target, so it is treated as divergent"
+                : $"its last-applied revision is '{lastAppliedRevision}'";
+
+            findings.Add(new OpsFinding
+            {
+                Id = OpsFindingId.Create(RulePlatformReleaseRuntimeDivergence, subject),
+                Rule = RulePlatformReleaseRuntimeDivergence,
+                Severity = OpsFindingSeverity.Warning,
+                Title = "Deploy target has not converged to the declared platform release",
+                Explanation = $"Serving target '{target.TargetId}' does not pin an explicit artifact, but {lastAppliedDescription}, which diverges from the declared platform release '{release.Version}' ('{declaredArtifact}'). Converging this target creates a gateway-routed Deploy operation to the declared artifact — the same per-target actuation the platform-release converge API performs (#2564); workers are unaffected by this action (they converge at the next GP dispatch via the release's worker-image projection).",
+                DetectedAt = now,
+                Subject = subject,
+                EvidenceRefs = evidence,
+                RecommendedAction = new OpsFindingRecommendedAction
+                {
+                    Kind = OperationClass.Deploy,
+                    Summary = $"Deploy target '{target.TargetId}' to the declared platform release artifact '{declaredArtifact}'.",
+                    ExecutionPayload = payload,
+                    Reason = $"Target '{target.TargetId}' is divergent from declared platform release '{release.Version}'; converge to '{declaredArtifact}'.",
+                },
             });
         }
     }

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
@@ -499,6 +499,10 @@ public sealed class OpsFindingSubjectView
     /// <summary>Gets the platform release version, when applicable.</summary>
     [JsonPropertyName("releaseVersion")]
     public string? ReleaseVersion { get; init; }
+
+    /// <summary>Gets the GIS protocol family, when applicable.</summary>
+    [JsonPropertyName("protocol")]
+    public string? Protocol { get; init; }
 }
 
 /// <summary>

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
@@ -3,10 +3,12 @@
 
 using Honua.Alerts;
 using Honua.ControlPlane;
+using Honua.ControlPlane.Executors;
 using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Observability.Abstractions;
 using Honua.Core.Features.Observability.Domain;
@@ -28,8 +30,10 @@ public sealed class OpsFindingsServiceTests
 {
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
-    public async Task Evaluate_AlertDispatchDeadLetters_ProducesCriticalFindingWithNoAction()
+    public async Task Evaluate_AlertDispatchDeadLetters_ProducesCriticalFindingWithRedriveAction()
     {
+        // #2556: the registered alerts.redrive_dead_letters actuator (#2579) means dead-letters now
+        // carry a real recommended action instead of being purely informational.
         var alertHealth = new FakeAlertDispatchHealth
         {
             IsDispatcherEnabled = true,
@@ -42,8 +46,30 @@ public sealed class OpsFindingsServiceTests
 
         var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog);
         Assert.Equal(OpsFindingSeverity.Critical, finding.Severity);
-        Assert.Null(finding.RecommendedAction);
         Assert.Equal("alert-dispatch", finding.Subject.Channel);
+        Assert.NotNull(finding.RecommendedAction);
+        Assert.Equal(OperationClass.AdminConfigChange, finding.RecommendedAction!.Kind);
+        Assert.Contains("\"action\":\"alerts.redrive_dead_letters\"", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_AlertDispatchPendingBacklogOnly_ProducesWarningFindingWithNoAction()
+    {
+        // A pending-only backlog (no dead-letters yet) has no safe redrive target: informational.
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            IsDispatcherRunning = true,
+            LastBacklog = new AlertDispatchBacklog { PendingCount = 300, DeadLetteredCount = 0 },
+        };
+        var service = CreateService(alertHealth: alertHealth);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog);
+        Assert.Equal(OpsFindingSeverity.Warning, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
     }
 
     [UnitTest]
@@ -174,6 +200,283 @@ public sealed class OpsFindingsServiceTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_DbPoolPressureWithAdmissionGateHeadroom_ProducesCriticalFindingWithTuneAction()
+    {
+        var pressureSignal = new FakeDatabasePressureSignal
+        {
+            Snapshot = new DatabasePressureSnapshot(
+                HasConnectionPoolUtilization: true,
+                ConnectionPoolUtilization: 0.95,
+                ConnectionAcquisitionTimeouts: 10,
+                ConnectionAcquisitionFailures: 1),
+        };
+        var admissionGate = new FakeAdmissionGate { CurrentLimit = 40, MinLimit = 5, MaxLimit = 100 };
+        var service = CreateService(databasePressureSignal: pressureSignal, admissionGate: admissionGate);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleDbBoundedAdmissionPressure);
+        Assert.Equal(OpsFindingSeverity.Critical, finding.Severity);
+        Assert.NotNull(finding.RecommendedAction);
+        Assert.Equal(OperationClass.AdminConfigChange, finding.RecommendedAction!.Kind);
+        Assert.Contains("\"action\":\"db.tune_bounded_admission\"", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+        // The tuned target must be strictly below the current limit.
+        Assert.Contains("\"limit\":30", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_DbPoolPressureWithoutAdmissionGate_ProducesInformationalFinding()
+    {
+        var pressureSignal = new FakeDatabasePressureSignal
+        {
+            Snapshot = new DatabasePressureSnapshot(
+                HasConnectionPoolUtilization: true,
+                ConnectionPoolUtilization: 0.95,
+                ConnectionAcquisitionTimeouts: 10,
+                ConnectionAcquisitionFailures: 1),
+        };
+        var service = CreateService(databasePressureSignal: pressureSignal);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleDbBoundedAdmissionPressure);
+        Assert.Equal(OpsFindingSeverity.Critical, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_DbPoolBelowThresholds_ProducesNoFinding()
+    {
+        var pressureSignal = new FakeDatabasePressureSignal
+        {
+            Snapshot = new DatabasePressureSnapshot(
+                HasConnectionPoolUtilization: true,
+                ConnectionPoolUtilization: 0.10,
+                ConnectionAcquisitionTimeouts: 0,
+                ConnectionAcquisitionFailures: 0),
+        };
+        var service = CreateService(databasePressureSignal: pressureSignal);
+
+        var findings = await service.EvaluateAsync();
+
+        Assert.DoesNotContain(findings, f => f.Rule == OpsFindingsService.RuleDbBoundedAdmissionPressure);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_ServingLatencySloBreach_ProducesInformationalWarning()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var rollupStore = Substitute.For<IOpsHealthRollupStore>();
+        rollupStore.ReadLatencyAsync(OpsHealthRollupTier.OneMinute, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(new List<OpsHealthLatencyRow>
+            {
+                new()
+                {
+                    ReplicaId = "replica-1",
+                    BucketStart = now.AddMinutes(-1),
+                    Point = new OpsHealthLatencyPoint
+                    {
+                        Protocol = "OgcApiFeatures",
+                        RequestCount = 100,
+                        ErrorCount = 0,
+                        P50Ms = 100,
+                        P95Ms = 5000,
+                        P99Ms = 6000,
+                        MaxMs = 7000,
+                    },
+                },
+            });
+        var service = CreateService(rollupStore: rollupStore);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleServingLatencySlo);
+        Assert.Equal(OpsFindingSeverity.Warning, finding.Severity);
+        Assert.Null(finding.RecommendedAction);
+        Assert.Equal("OgcApiFeatures", finding.Subject.Protocol);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_ServingLatencyBelowThresholds_ProducesNoFinding()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var rollupStore = Substitute.For<IOpsHealthRollupStore>();
+        rollupStore.ReadLatencyAsync(OpsHealthRollupTier.OneMinute, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(new List<OpsHealthLatencyRow>
+            {
+                new()
+                {
+                    ReplicaId = "replica-1",
+                    BucketStart = now.AddMinutes(-1),
+                    Point = new OpsHealthLatencyPoint
+                    {
+                        Protocol = "OgcApiFeatures",
+                        RequestCount = 100,
+                        ErrorCount = 0,
+                        P50Ms = 50,
+                        P95Ms = 150,
+                        P99Ms = 200,
+                        MaxMs = 250,
+                    },
+                },
+            });
+        var service = CreateService(rollupStore: rollupStore);
+
+        var findings = await service.EvaluateAsync();
+
+        Assert.DoesNotContain(findings, f => f.Rule == OpsFindingsService.RuleServingLatencySlo);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_PlatformReleaseRuntimeDivergence_UnknownTargetTreatedAsDivergent()
+    {
+        var controlPlane = new ControlPlaneOptions
+        {
+            PlatformRelease = new PlatformReleaseOptions
+            {
+                Version = "2026.07.0",
+                ServingArtifactReference = "registry/honua-serving:2026.07.0",
+                Workers = [new PlatformReleaseWorkerImageOptions { ArtifactReference = "registry/honua-worker:2026.07.0" }],
+            },
+            DeployTargets = [new DeployTargetOptions { TargetId = "serving-a" }],
+        };
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        workflowStore.GetMostRecentSucceededDeployByTargetAsync("serving-a", Arg.Any<CancellationToken>())
+            .Returns((WorkflowOperationRecord?)null);
+        var service = CreateService(controlPlaneOptions: controlPlane, workflowStore: workflowStore);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RulePlatformReleaseRuntimeDivergence);
+        Assert.Equal(OpsFindingSeverity.Warning, finding.Severity);
+        Assert.Equal("serving-a", finding.Subject.TargetId);
+        Assert.Equal("2026.07.0", finding.Subject.ReleaseVersion);
+        Assert.NotNull(finding.RecommendedAction);
+        Assert.Equal(OperationClass.Deploy, finding.RecommendedAction!.Kind);
+        Assert.Contains("registry/honua-serving:2026.07.0", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_PlatformReleaseRuntimeDivergence_MismatchedLastAppliedRevisionIsDivergent()
+    {
+        var controlPlane = new ControlPlaneOptions
+        {
+            PlatformRelease = new PlatformReleaseOptions
+            {
+                Version = "2026.07.0",
+                ServingArtifactReference = "registry/honua-serving:2026.07.0",
+                Workers = [new PlatformReleaseWorkerImageOptions { ArtifactReference = "registry/honua-worker:2026.07.0" }],
+            },
+            DeployTargets = [new DeployTargetOptions { TargetId = "serving-a" }],
+        };
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        workflowStore.GetMostRecentSucceededDeployByTargetAsync("serving-a", Arg.Any<CancellationToken>())
+            .Returns(BuildSucceededDeployOperation("op-1", "serving-a", "registry/honua-serving:OLD"));
+        var service = CreateService(controlPlaneOptions: controlPlane, workflowStore: workflowStore);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RulePlatformReleaseRuntimeDivergence);
+        Assert.Contains("registry/honua-serving:OLD", finding.EvidenceRefs.First(e => e.StartsWith("terminal-index:", StringComparison.Ordinal)));
+        Assert.NotNull(finding.RecommendedAction);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_PlatformReleaseRuntimeDivergence_ConvergedTargetProducesNoFinding()
+    {
+        var controlPlane = new ControlPlaneOptions
+        {
+            PlatformRelease = new PlatformReleaseOptions
+            {
+                Version = "2026.07.0",
+                ServingArtifactReference = "registry/honua-serving:2026.07.0",
+                Workers = [new PlatformReleaseWorkerImageOptions { ArtifactReference = "registry/honua-worker:2026.07.0" }],
+            },
+            DeployTargets = [new DeployTargetOptions { TargetId = "serving-a" }],
+        };
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        workflowStore.GetMostRecentSucceededDeployByTargetAsync("serving-a", Arg.Any<CancellationToken>())
+            .Returns(BuildSucceededDeployOperation("op-1", "serving-a", "registry/honua-serving:2026.07.0"));
+        var service = CreateService(controlPlaneOptions: controlPlane, workflowStore: workflowStore);
+
+        var findings = await service.EvaluateAsync();
+
+        Assert.DoesNotContain(findings, f => f.Rule == OpsFindingsService.RulePlatformReleaseRuntimeDivergence);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_PlatformReleaseRuntimeDivergence_ConfigPinnedTargetIsSkipped()
+    {
+        // A target with an explicit ArtifactReference pin is the platform-release-skew rule's concern —
+        // config-derived skew cannot be cleared at runtime, so this rule must not also fire for it.
+        var controlPlane = new ControlPlaneOptions
+        {
+            PlatformRelease = new PlatformReleaseOptions
+            {
+                Version = "2026.07.0",
+                ServingArtifactReference = "registry/honua-serving:2026.07.0",
+                Workers = [new PlatformReleaseWorkerImageOptions { ArtifactReference = "registry/honua-worker:2026.07.0" }],
+            },
+            DeployTargets = [new DeployTargetOptions { TargetId = "serving-pinned", ArtifactReference = "registry/honua-serving:PINNED" }],
+        };
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        var service = CreateService(controlPlaneOptions: controlPlane, workflowStore: workflowStore);
+
+        var findings = await service.EvaluateAsync();
+
+        Assert.DoesNotContain(findings, f => f.Rule == OpsFindingsService.RulePlatformReleaseRuntimeDivergence);
+        await workflowStore.DidNotReceive().GetMostRecentSucceededDeployByTargetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_PlatformReleaseRuntimeDivergence_NoReleaseDeclared_ProducesNoFinding()
+    {
+        var controlPlane = new ControlPlaneOptions
+        {
+            DeployTargets = [new DeployTargetOptions { TargetId = "serving-a" }],
+        };
+        var workflowStore = Substitute.For<IWorkflowOperationStore>();
+        var service = CreateService(controlPlaneOptions: controlPlane, workflowStore: workflowStore);
+
+        var findings = await service.EvaluateAsync();
+
+        Assert.DoesNotContain(findings, f => f.Rule == OpsFindingsService.RulePlatformReleaseRuntimeDivergence);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public void AllRecommendedActions_AdminConfigChangeActionNamesAreRegistered()
+    {
+        // RC-2556: every recommendedAction's embedded ops-action name (for AdminConfigChange-kind
+        // actions) must exist in the actuator registry (#2579) — enumerate both sides and assert subset.
+        var registeredActions = new[]
+        {
+            OpsActionExecutionPayloads.RedriveDeadLetters(),
+            OpsActionExecutionPayloads.TuneBoundedAdmission(10),
+        };
+
+        foreach (var payload in registeredActions)
+        {
+            using var document = System.Text.Json.JsonDocument.Parse(payload);
+            var action = document.RootElement.GetProperty("action").GetString();
+            Assert.NotNull(action);
+            Assert.True(
+                OpsActionCatalog.IsRegistered(action!),
+                $"Ops-findings action '{action}' is not a registered actuator in OpsActionCatalog.");
+        }
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
     public async Task Evaluate_HealthyInstance_ProducesNoFindings()
     {
         var service = CreateService();
@@ -220,7 +523,7 @@ public sealed class OpsFindingsServiceTests
         var alertHealth = new FakeAlertDispatchHealth
         {
             IsDispatcherEnabled = true,
-            LastBacklog = new AlertDispatchBacklog { PendingCount = 1, DeadLetteredCount = 5 },
+            LastBacklog = new AlertDispatchBacklog { PendingCount = 300, DeadLetteredCount = 0 },
         };
         var service = CreateService(alertHealth: alertHealth);
         var finding = (await service.EvaluateAsync()).Single(f => f.Rule == OpsFindingsService.RuleAlertDispatchBacklog);
@@ -412,7 +715,10 @@ public sealed class OpsFindingsServiceTests
         FakeDeployPreflightProbe? deployProbe = null,
         IOperationGateway? gateway = null,
         IWorkflowOperationStore? workflowStore = null,
-        IExecutionJobStore? jobStore = null)
+        IExecutionJobStore? jobStore = null,
+        IOpsDatabasePressureSignal? databasePressureSignal = null,
+        IRuntimeTunableAdmissionGate? admissionGate = null,
+        IOpsHealthRollupStore? rollupStore = null)
         => new(
             new StaticOptionsMonitor<OpsFindingsOptions>(options ?? new OpsFindingsOptions()),
             new StaticOptionsMonitor<ControlPlaneOptions>(controlPlaneOptions ?? new ControlPlaneOptions()),
@@ -420,7 +726,13 @@ public sealed class OpsFindingsServiceTests
             deployProbe ?? new FakeDeployPreflightProbe(BuildDeploySnapshot()),
             gateway: gateway ?? Substitute.For<IOperationGateway>(),
             workflowStore: workflowStore,
-            jobStore: jobStore);
+            jobStore: jobStore,
+            extendedSignals: new OpsFindingsExtendedSignals
+            {
+                DatabasePressureSignal = databasePressureSignal,
+                AdmissionGate = admissionGate,
+                RollupStore = rollupStore,
+            });
 
     private static DeployPreflightSnapshot BuildDeploySnapshot(
         bool hasPendingContractScripts = false,
@@ -453,6 +765,26 @@ public sealed class OpsFindingsServiceTests
                 Backend = backend,
                 Kind = ExecutionJobKind.Geoprocessing,
                 WorkloadName = "test-workload",
+            },
+        };
+
+    private static WorkflowOperationRecord BuildSucceededDeployOperation(string operationId, string targetId, string desiredRevision)
+        => new()
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.Deploy,
+            Status = WorkflowOperationStatus.Succeeded,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = targetId,
+                TargetKind = DeployTargetKind.Kubernetes,
+                Backend = "k8s",
+                Environment = "prod",
+                TargetName = "serving",
+                CurrentRevision = null,
+                DesiredRevision = desiredRevision,
             },
         };
 
@@ -501,6 +833,29 @@ public sealed class OpsFindingsServiceTests
 
         public Task<DeployPreflightSnapshot> ProbeAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(_snapshot);
+    }
+
+    private sealed class FakeDatabasePressureSignal : IOpsDatabasePressureSignal
+    {
+        public DatabasePressureSnapshot Snapshot { get; set; }
+
+        public DatabasePressureSnapshot GetSnapshot() => Snapshot;
+    }
+
+    private sealed class FakeAdmissionGate : IRuntimeTunableAdmissionGate
+    {
+        public int CurrentLimit { get; set; }
+
+        public int MaxLimit { get; set; } = 100;
+
+        public int MinLimit { get; set; } = 5;
+
+        public bool TrySetLimit(int limit, out string? error)
+        {
+            error = null;
+            CurrentLimit = limit;
+            return true;
+        }
     }
 
     private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2556

## Summary
Extends the deterministic ops-findings engine (`OpsFindingsService`) so recommended actions route
through the real actuator registry landed in #2579 instead of being purely informational, and adds
the `platform-release-runtime-divergence` finding this ticket exclusively owns (pinned divergence
contract from #2564). Per the 2026-07-06 spec-revision comment on #2556, a `RecommendedAction` is
only ever attached where a registered, non-stub actuator exists (`alerts.redrive_dead_letters`,
`db.tune_bounded_admission`); everything else stays informational (L1).

## Changes Made
- `alert-dispatch-backlog`: dead-letter findings now carry an `alerts.redrive_dead_letters`
  recommended action (routed as `OperationClass.AdminConfigChange`); the pending-only-backlog path
  (no dead-letters yet) stays informational since there is no safe redrive target
- New `db-bounded-admission-pressure` rule: connection-pool utilization / acquisition-timeout
  pressure recommends `db.tune_bounded_admission` (reduced by a configurable fraction, floored at
  the gate's minimum) only when `IRuntimeTunableAdmissionGate` is registered and has headroom to
  reduce; informational otherwise (gate unavailable, or already at its floor)
- New `serving-latency-slo-breach` rule: per-protocol p95-latency / error-rate breach evidenced from
  the persisted ops-health rollup history (#2553), not the live in-process window, so a short blip
  doesn't flap the finding; informational — no single safe generic remediation
- New `platform-release-runtime-divergence` rule (exclusive to #2556): for each serving deploy
  target that does **not** pin an explicit artifact, compares the `DesiredRevision` of the most
  recent terminal-`Succeeded` Deploy operation (`IWorkflowOperationStore.GetMostRecentSucceededDeployByTargetAsync`,
  #2562's terminal index) against the declared platform release's `ServingArtifactReference`. No
  terminal-succeeded operation = unknown = treated as divergent (matches #2564's pinned contract
  verbatim). Recommends a gateway-routed `Deploy` operation to the declared artifact — reusing the
  existing Deploy operation-gateway executor (the same one `deploy-manual-intervention` already
  uses), so this rule does **not** depend on the `/platform-release/converge` (#2564) endpoint
  landing first. Config-pinned targets are skipped — that stays the existing
  `platform-release-skew` rule's L1-only concern (touched only its explanation text, per the spec
  pin, to spell out why runtime action can't clear config-derived skew)
- New `OpsFindingSubject.Protocol` field (+ wire view) so the serving-latency rule can pin a
  protocol identity without overloading the existing `Channel` field
- New `OpsFindingsOptions` thresholds: `DbPoolUtilizationThreshold`, `DbConnectionAcquisitionTimeoutThreshold`,
  `DbBoundedAdmissionTuneDownFraction`, `ServingLatencyP95ThresholdMs`, `ServingErrorRateThreshold`,
  `ServingLatencyLookbackMinutes` — all documented, overridable, conservative defaults
- New `OpsActionExecutionPayloads` builder (next to `OpsActionRequest.Parse` in `OpsActionModel.cs`)
  single-sources the `{action, target, params}` wire shape so producers never hand-roll JSON that
  could drift from the parser's contract
- New `IOpsDatabasePressureSignal` seam (+ `ProductionMetricsDatabasePressureSignal` default impl)
  so the DB-pressure rule is unit-testable with a fake, matching the existing pattern for
  alert-dispatch health / deploy preflight
- Bundled the three new Postgres-only optional collaborators (db pressure signal, admission gate,
  rollup store) behind one `OpsFindingsExtendedSignals` constructor parameter — `OpsFindingsService`
  would otherwise have grown to 10 injected collaborators, past the architecture-enforced ceiling
  of 8 (`DependencyInjectionLimitsTests.ServiceClasses_ShouldNotBecomeGodObjects`)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

29 unit tests in `OpsFindingsServiceTests` (pre-existing tests updated where behavior changed, plus
new coverage for every new/changed rule): dead-letter redrive action, pending-only-backlog stays
informational, DB pressure with/without gate headroom, DB pressure below thresholds (no finding),
serving-latency breach/no-breach, and five `platform-release-runtime-divergence` cases
(unknown-target-divergent, mismatched-revision-divergent, converged-no-finding,
config-pinned-skipped, no-release-declared-no-finding). Also added
`AllRecommendedActions_AdminConfigChangeActionNamesAreRegistered` — the RC-2556-required test that
enumerates every AdminConfigChange-kind action this engine can produce and asserts each is a member
of `OpsActionCatalog.GuardrailTiers` (the actuator registry).

Ran locally (Windows, foreground):
- `dotnet build Honua.sln --configuration Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- `dotnet format Honua.sln --verify-no-changes` — clean
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~OpsFindingsServiceTests` — 29/29 passed
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj` — 122/122 passed
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter "FullyQualifiedName~OpsObservabilityEndpointsTests|FullyQualifiedName~OperateStatusEndpointsTests"` (Testcontainers + PostGIS) — 15/15 passed, confirming the new DI wiring (`OpsFindingsExtendedSignals`) composes cleanly through a real host

No new integration test was added for a new propose-flow endpoint because no new endpoint was added
(the existing `POST /observability/findings/{id}/propose` already covers every rule's action
uniformly, and its integration coverage in `OpsObservabilityEndpointsTests` passed unchanged above).

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact (the `findings` response shape gained one additional
  nullable field, `subject.protocol`, which is additive and `WhenWritingNull`-omitted; no route or
  schema changed)

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None. `OpsFindingsService`'s public constructor shape changed (three new trailing optional params
collapsed into one `OpsFindingsExtendedSignals` object) but the type is `internal sealed` — no
external consumer.

---

## Deviations from the ticket body / scope notes
The 2026-07-06 spec-revision comment narrowed the "Rule set v2" to five items. This PR implements
four in full plus the exclusive `platform-release-runtime-divergence` finding, with two deliberate,
documented deferrals (commented on #2556 before opening this PR):

1. **Deferred: "post-promotion SLO breach"** (bounded observation window after a promote
   transition; action = forward-deploy to prior revision). Implementing this safely needs a second
   design pass on the observation-window semantics (how long after a promote counts as
   "post-promotion," and how to avoid a false-positive rollback proposal during a normal
   post-deploy warm-up period) that didn't fit this slice without risking a hastily-reasoned
   auto-rollback action. Left for a fast-follow.
2. **Deferred: "+pause on repeat" escalation** on the alert-dead-letter-storm rule. The only signal
   available (`IAlertDispatchHealth.LastBacklog`) is aggregated across all channels with no
   per-channel breakdown, so there is no deterministic way to pick *which* channel to pause without
   guessing — which would violate ADR-0028 (deterministic thresholds only). The redrive action
   ships; pausing a specific channel is noted in the finding's explanation as an operator's manual
   next step if the storm repeats, and left as a fast-follow once per-channel dead-letter telemetry
   exists.

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (script itself fails on this Windows
  host per known CLAUDE.md/AGENTS.md note — ran its equivalents individually, listed above under Testing)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
