### PR TITLE
feat(mcp): add platform ops tools

### DIFF
--- a/scripts/ci/check-instructions-sync.sh
+++ b/scripts/ci/check-instructions-sync.sh
@@ -18,6 +18,15 @@ for stale_file in CLAUDE.md CODEX.md; do
     fi
     continue
   fi
+  # Windows checkouts with core.symlinks=false materialize an indexed symlink
+  # as a regular file containing the symlink target. Treat that exact Git
+  # placeholder as equivalent to the sanctioned symlink so local gates can run
+  # on Windows without weakening the duplicate-file guard.
+  if [[ -f "$stale_file" ]] &&
+     git ls-files -s -- "$stale_file" | grep -q '^120000 ' &&
+     [[ "$(cat "$stale_file")" == "AGENTS.md" ]]; then
+    continue
+  fi
   if [[ -f "$stale_file" ]]; then
     echo "::error::Stale duplicate instruction file found: $stale_file. Use AGENTS.md as the canonical source (a symlink to AGENTS.md is allowed)."
     exit 1

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -184,9 +184,9 @@ else
     SHARD_REASON="$(jq -r '.reason // "unknown"' <<< "${TARGETED}")"
     echo "   Honua.Server.Tests shards (router: ${SHARD_REASON})..."
     if [[ "${RUN_ALL_SHARDS}" == "true" ]]; then
-        SELECTED_SHARDS="$(jq -r '.shards[].shard_name' .github/ci-shards.json)"
+        SELECTED_SHARDS="$(jq -r '.shards[].shard_name' .github/ci-shards.json | tr -d '\r')"
     else
-        SELECTED_SHARDS="$(jq -r '.shards[]?' <<< "${TARGETED}")"
+        SELECTED_SHARDS="$(jq -r '.shards[]?' <<< "${TARGETED}" | tr -d '\r')"
     fi
     if [[ -z "${SELECTED_SHARDS//[[:space:]]/}" ]]; then
         echo "   (no server-test shards selected for this diff)"
@@ -197,6 +197,7 @@ else
 
         run_one_shard() {
             local shard_name="$1"
+            shard_name="${shard_name%$'\r'}"
             local safe="${shard_name//[^A-Za-z0-9_]/_}"
             local shard_json log_name filter max_cpu_count test_timeout_minutes csproj
             shard_json="$(jq -c --arg n "${shard_name}" '.shards[] | select(.shard_name==$n)' .github/ci-shards.json)"

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -112,6 +112,16 @@ internal static class McpServiceCollectionExtensions
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, OperateEventsTool>());
         }
 
+        // Platform-ops tools (#2566) are thin MCP adapters over the deploy
+        // control-plane read/proposal seams. Tool advertisement is gated on the
+        // host providing the server-side reader, so minimal compositions stay truthful.
+        if (services.Any(d => d.ServiceType == typeof(IMcpPlatformOpsReader)))
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, PlatformReleaseStatusTool>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, DeployOperationsTool>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ProposeRollbackTool>());
+        }
+
         // honua_list_capabilities (#1949): a self-describing manifest of the live
         // tool/resource surface for a cold client LLM. Registered unconditionally
         // because it only reflects whatever catalog the composition wired — it has

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
@@ -61,6 +61,8 @@ namespace Honua.Ai.Protocols.Mcp.Models;
 [JsonSerializable(typeof(McpOpsFindingsArgument))]
 [JsonSerializable(typeof(McpAlertEventsArgument))]
 [JsonSerializable(typeof(McpOperateEventsArgument))]
+[JsonSerializable(typeof(McpDeployOperationsArgument))]
+[JsonSerializable(typeof(McpProposeRollbackArgument))]
 [JsonSerializable(typeof(McpPublishServiceArgument))]
 [JsonSerializable(typeof(McpPublishServiceOutput))]
 [JsonSerializable(typeof(McpPublishResultArgument))]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
@@ -134,6 +134,47 @@ internal sealed class McpOperateEventsArgument
 }
 
 /// <summary>
+/// Arguments for <c>honua_deploy_operations</c>: list deploy operations or
+/// fetch one deploy operation by stable operation id.
+/// </summary>
+internal sealed class McpDeployOperationsArgument
+{
+    [JsonPropertyName("operationId")]
+    public string? OperationId { get; set; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("page")]
+    public int? Page { get; set; }
+
+    [JsonPropertyName("pageSize")]
+    public int? PageSize { get; set; }
+}
+
+/// <summary>
+/// Arguments for <c>honua_propose_rollback</c>: propose rolling a deploy
+/// target forward to a prior revision through the shared operation gateway.
+/// </summary>
+internal sealed class McpProposeRollbackArgument
+{
+    [JsonPropertyName("targetId")]
+    public string? TargetId { get; set; }
+
+    [JsonPropertyName("toRevision")]
+    public string? ToRevision { get; set; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+
+    [JsonPropertyName("idempotencyKey")]
+    public string? IdempotencyKey { get; set; }
+}
+
+/// <summary>
 /// Output for <c>honua_propose_operation</c>. On <c>requiresApproval</c> the
 /// agent polls the <c>resourceUri</c> until the proposal resolves (#1696).
 /// </summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpPlatformOpsReader.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpPlatformOpsReader.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text.Json;
+using Honua.Ai.Protocols.Mcp.Models;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// Server-implemented adapter for admin-gated platform-release and deploy-operation
+/// projections exposed through MCP platform-ops tools.
+/// </summary>
+internal interface IMcpPlatformOpsReader
+{
+    /// <summary>Gets the declared platform-release status projection.</summary>
+    Task<JsonElement> GetPlatformReleaseStatusAsync(
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+
+    /// <summary>Lists deploy operations or fetches one deploy operation by id.</summary>
+    Task<JsonElement> GetDeployOperationsAsync(
+        ClaimsPrincipal principal,
+        McpDeployOperationsArgument argument,
+        CancellationToken cancellationToken);
+
+    /// <summary>Proposes a forward deploy to a prior revision as a rollback.</summary>
+    Task<McpProposeOperationOutput> ProposeRollbackAsync(
+        ClaimsPrincipal principal,
+        McpProposeRollbackArgument argument,
+        CancellationToken cancellationToken);
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpPlatformOpsSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpPlatformOpsSchemas.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// JSON schemas for platform-release and deploy-operation MCP tools.
+/// </summary>
+internal static class McpPlatformOpsSchemas
+{
+    public static readonly JsonElement PlatformReleaseStatusInputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+        """);
+
+    public static readonly JsonElement DeployOperationsInputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "properties": {
+            "operationId": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Deploy-operation identifier to fetch a single operation. When omitted, the tool lists deploy operations."
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "Planned",
+                "AwaitingApproval",
+                "Submitted",
+                "Reconciling",
+                "Succeeded",
+                "Failed",
+                "RollbackRequested",
+                "RolledBack",
+                "ManualInterventionRequired"
+              ]
+            },
+            "kind": {
+              "type": "string",
+              "enum": ["Deploy", "Rollback", "Migration", "MetadataRelease", "CoordinatedRelease"]
+            },
+            "page": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "pageSize": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            }
+          },
+          "additionalProperties": false
+        }
+        """);
+
+    public static readonly JsonElement ProposeRollbackInputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "required": ["targetId"],
+          "properties": {
+            "targetId": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Deploy target to roll back."
+            },
+            "toRevision": {
+              "type": "string",
+              "description": "Optional prior revision to roll forward to. When omitted, the server selects the target's most recent prior succeeded Deploy revision."
+            },
+            "reason": {
+              "type": "string",
+              "description": "Operator-facing reason recorded on the proposal."
+            },
+            "idempotencyKey": {
+              "type": "string",
+              "description": "Stable idempotency key for the underlying forward Deploy operation."
+            }
+          },
+          "additionalProperties": false
+        }
+        """);
+
+    public static readonly JsonElement PlatformReleaseStatusOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["releaseDeclared", "isCoVersioned", "serving", "execution", "skewedIds"],
+          "properties": {
+            "releaseVersion": { "type": ["string", "null"] },
+            "releaseDeclared": { "type": "boolean" },
+            "isCoVersioned": { "type": "boolean" },
+            "serving": {
+              "type": "array",
+              "items": { "type": "object", "additionalProperties": true }
+            },
+            "execution": {
+              "type": "array",
+              "items": { "type": "object", "additionalProperties": true }
+            },
+            "skewedIds": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+        """);
+
+    public static readonly JsonElement DeployOperationsOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["items", "page", "pageSize", "totalCount", "hasMore"],
+          "properties": {
+            "items": {
+              "type": "array",
+              "items": { "type": "object", "additionalProperties": true }
+            },
+            "page": { "type": "integer" },
+            "pageSize": { "type": "integer" },
+            "totalCount": { "type": "integer" },
+            "hasMore": { "type": "boolean" }
+          }
+        }
+        """);
+
+    private static JsonElement Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PlatformOpsTools.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PlatformOpsTools.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Ai.Protocols.Mcp.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Ai.Protocols.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that returns the declared platform-release co-versioning snapshot.
+/// </summary>
+internal sealed class PlatformReleaseStatusTool(ILogger<PlatformReleaseStatusTool> logger) : IMcpTool
+{
+    public const string ToolName = "honua_platform_release_status";
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "Platform release status",
+        Description =
+            "Read-only deterministic platform_release / server_upgrade status. Mirrors the admin "
+            + "platformRelease preflight projection and is distinct from hosted-content deployments.",
+        InputSchema = McpPlatformOpsSchemas.PlatformReleaseStatusInputSchema,
+        OutputSchema = McpPlatformOpsSchemas.PlatformReleaseStatusOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Platform release status")
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("GetPlatformReleaseStatus");
+        McpLog.ToolInvoked(logger, ToolName, WorkflowFamily);
+        McpToolHelpers.EnsureNoArguments(arguments);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        var payload = await ResolveReader(httpContext)
+            .GetPlatformReleaseStatusAsync(principal, cancellationToken)
+            .ConfigureAwait(false);
+
+        return McpToolHelpers.SuccessJsonElement(
+            payload,
+            static _ => "Platform-release status returned in structuredContent.");
+    }
+
+    private static IMcpPlatformOpsReader ResolveReader(HttpContext httpContext) =>
+        httpContext.RequestServices.GetRequiredService<IMcpPlatformOpsReader>();
+}
+
+/// <summary>
+/// MCP tool that lists deploy operations or fetches one deploy operation by id.
+/// </summary>
+internal sealed class DeployOperationsTool(ILogger<DeployOperationsTool> logger) : IMcpTool
+{
+    public const string ToolName = "honua_deploy_operations";
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "Deploy operations",
+        Description =
+            "Read-only deterministic platform_release / server_upgrade deploy-operation read. "
+            + "Omit operationId to list newest-first operations; provide operationId to fetch one.",
+        InputSchema = McpPlatformOpsSchemas.DeployOperationsInputSchema,
+        OutputSchema = McpPlatformOpsSchemas.DeployOperationsOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Deploy operations")
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("GetDeployOperations");
+        McpLog.ToolInvoked(logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        var argument = McpToolHelpers.ParseOptionalArguments(
+            arguments,
+            McpJsonContext.Default.McpDeployOperationsArgument);
+        var payload = await ResolveReader(httpContext)
+            .GetDeployOperationsAsync(principal, argument, cancellationToken)
+            .ConfigureAwait(false);
+
+        return McpToolHelpers.SuccessJsonElement(
+            payload,
+            static _ => "Deploy operations returned in structuredContent.");
+    }
+
+    private static IMcpPlatformOpsReader ResolveReader(HttpContext httpContext) =>
+        httpContext.RequestServices.GetRequiredService<IMcpPlatformOpsReader>();
+}
+
+/// <summary>
+/// MCP tool that proposes a rollback as a new forward Deploy operation to a prior revision.
+/// </summary>
+internal sealed class ProposeRollbackTool(ILogger<ProposeRollbackTool> logger) : IMcpTool
+{
+    public const string ToolName = "honua_propose_rollback";
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Lifecycle;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "Propose rollback",
+        Description =
+            "Propose a platform rollback by routing OperationClass.Deploy through the operation gateway "
+            + "with a new forward deploy to a prior revision. This is not an in-flight deploy abort/undo, "
+            + "and no approve, submit, promote, or reject action is exposed to agents.",
+        InputSchema = McpPlatformOpsSchemas.ProposeRollbackInputSchema,
+        OutputSchema = McpToolOutputSchemas.ProposeOperationOutputSchema,
+        Annotations = McpToolAnnotationSets.Write("Propose rollback", destructive: false, idempotent: true)
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("ProposeRollback");
+        McpLog.ToolInvoked(logger, ToolName, WorkflowFamily);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        var argument = McpToolHelpers.ParseArguments(
+            arguments,
+            McpJsonContext.Default.McpProposeRollbackArgument);
+        var output = await ResolveReader(httpContext)
+            .ProposeRollbackAsync(principal, argument, cancellationToken)
+            .ConfigureAwait(false);
+
+        return McpToolHelpers.SuccessResult(output, McpJsonContext.Default.McpProposeOperationOutput);
+    }
+
+    private static IMcpPlatformOpsReader ResolveReader(HttpContext httpContext) =>
+        httpContext.RequestServices.GetRequiredService<IMcpPlatformOpsReader>();
+}

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -110,6 +110,9 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
             ("honua_ops_findings", "ops_findings", "results"),
             ("honua_alert_events", "alert_events", "results"),
             ("honua_operate_events", "operate_events", "results"),
+            ("honua_platform_release_status", "platform_release_status", "results"),
+            ("honua_deploy_operations", "deploy_operations", "results"),
+            ("honua_propose_rollback", "propose_rollback", "lifecycle"),
             ("honua_list_layers", "list_layers", "results"),
             ("honua_query_features", "query_features", "results"),
             // No honua_edit_features: Honua does not expose an AI/MCP feature-mutation

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/McpPlatformOpsReader.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/McpPlatformOpsReader.cs
@@ -1,0 +1,311 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.ControlPlane;
+using Honua.ControlPlane.Executors;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Domain;
+using Honua.Geoprocessing;
+using Honua.Infrastructure.Authentication;
+using Honua.Server.Features.Admin;
+using Honua.Server.Features.Admin.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Infrastructure.Monitoring;
+
+/// <summary>
+/// Server adapter that backs the platform-release and deploy-operation MCP
+/// tools with the same admin DTOs and control-plane gateway used by REST.
+/// </summary>
+internal sealed class McpPlatformOpsReader(
+    IOptionsMonitor<ControlPlaneOptions> controlPlaneOptions,
+    DeployWorkflowService deployWorkflowService,
+    IAuthorizationService authorization,
+    IServiceProvider services) : IMcpPlatformOpsReader
+{
+    private const int DefaultPageSize = 50;
+    private const int MaxPageSize = 200;
+    private const string AgentActorPrefix = "agent:";
+
+    private readonly IOptionsMonitor<ControlPlaneOptions> _controlPlaneOptions = controlPlaneOptions;
+    private readonly DeployWorkflowService _deployWorkflowService = deployWorkflowService;
+    private readonly IAuthorizationService _authorization = authorization;
+    private readonly IServiceProvider _services = services;
+
+    public async Task<JsonElement> GetPlatformReleaseStatusAsync(
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        await EnsureOpsReadAsync(principal, cancellationToken).ConfigureAwait(false);
+
+        var skew = PlatformReleaseSkewProjector.Build(_controlPlaneOptions.CurrentValue);
+        var response = new DeployPreflightPlatformRelease
+        {
+            ReleaseVersion = skew.ReleaseVersion,
+            ReleaseDeclared = skew.ReleaseDeclared,
+            IsCoVersioned = skew.IsCoVersioned,
+            Serving = skew.Serving.Select(MapPlaneProjection).ToArray(),
+            Execution = skew.Execution.Select(MapPlaneProjection).ToArray(),
+            SkewedIds = skew.SkewedIds
+        };
+
+        return Serialize(response, DeployControlJsonContext.Default.DeployPreflightPlatformRelease);
+    }
+
+    public async Task<JsonElement> GetDeployOperationsAsync(
+        ClaimsPrincipal principal,
+        McpDeployOperationsArgument argument,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(argument);
+        await EnsureOpsReadAsync(principal, cancellationToken).ConfigureAwait(false);
+
+        var operationId = Clean(argument.OperationId);
+        if (operationId is not null)
+        {
+            var operation = await _deployWorkflowService.GetAsync(operationId, cancellationToken).ConfigureAwait(false)
+                ?? throw new GeoprocessingNotFoundException($"Deploy operation '{operationId}' was not found.");
+
+            var response = new DeployOperationListResponse
+            {
+                Items = [DeployControlEndpoints.MapOperationResponse(operation)],
+                Page = 1,
+                PageSize = 1,
+                TotalCount = 1,
+                HasMore = false
+            };
+
+            return Serialize(response, DeployControlJsonContext.Default.DeployOperationListResponse);
+        }
+
+        var status = ParseOptionalEnum<WorkflowOperationStatus>(argument.Status, "status");
+        var kind = ParseOptionalEnum<WorkflowOperationKind>(argument.Kind, "kind");
+        var page = Math.Max(1, argument.Page ?? 1);
+        var pageSize = ClampPageSize(argument.PageSize);
+
+        var result = await _deployWorkflowService
+            .ListDeployOperationsAsync(status, kind, page, pageSize, cancellationToken)
+            .ConfigureAwait(false);
+
+        var list = new DeployOperationListResponse
+        {
+            Items = result.Items.Select(DeployControlEndpoints.MapOperationResponse).ToArray(),
+            Page = result.Page,
+            PageSize = result.PageSize,
+            TotalCount = result.TotalCount,
+            HasMore = result.HasMore
+        };
+
+        return Serialize(list, DeployControlJsonContext.Default.DeployOperationListResponse);
+    }
+
+    public async Task<McpProposeOperationOutput> ProposeRollbackAsync(
+        ClaimsPrincipal principal,
+        McpProposeRollbackArgument argument,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(argument);
+
+        var gateway = _services.GetService<IOperationGateway>();
+        var supportedKinds = ResolveSupportedKinds();
+        if (gateway is null)
+        {
+            return new McpProposeOperationOutput
+            {
+                Outcome = "unavailable",
+                RequiresApproval = false,
+                SupportedKinds = supportedKinds,
+                Message = "The operation gateway is unavailable (durable storage is not configured)."
+            };
+        }
+
+        var targetId = Clean(argument.TargetId);
+        if (targetId is null)
+        {
+            throw new GeoprocessingValidationException("'targetId' is required.");
+        }
+
+        var selection = await ResolveRollbackRevisionAsync(
+                targetId,
+                Clean(argument.ToRevision),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var payload = new DeployExecutionPayload
+        {
+            TargetId = targetId,
+            DesiredRevision = selection.DesiredRevision,
+            CurrentRevision = selection.CurrentRevision,
+        }.Serialize();
+
+        var actor = principal.Identity?.Name;
+        var result = await gateway.RouteAsync(
+                new OperationGatewayRequest
+                {
+                    Kind = OperationClass.Deploy,
+                    RequestedByAgent = string.IsNullOrWhiteSpace(actor) ? $"{AgentActorPrefix}mcp" : $"{AgentActorPrefix}{actor}",
+                    RequestedBy = actor,
+                    Reason = string.IsNullOrWhiteSpace(argument.Reason)
+                        ? $"Propose rollback of deploy target '{targetId}' to prior revision '{selection.DesiredRevision}'."
+                        : argument.Reason,
+                    IdempotencyKey = Clean(argument.IdempotencyKey)
+                        ?? $"rollback:{targetId}:{selection.DesiredRevision}",
+                    ExecutionPayload = payload,
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return new McpProposeOperationOutput
+        {
+            Outcome = result.Outcome.ToString(),
+            RequiresApproval = result.Outcome == OperationGatewayOutcome.ProposalCreated,
+            ProposalId = result.ProposalId,
+            ResourceUri = result.ProposalId == null ? null : McpResourceUris.ProposalUri(result.ProposalId),
+            ExecutionOperationId = result.ExecutionOperationId,
+            SupportedKinds = supportedKinds,
+            Message = result.Message,
+        };
+    }
+
+    private async Task<RollbackRevisionSelection> ResolveRollbackRevisionAsync(
+        string targetId,
+        string? explicitRevision,
+        CancellationToken cancellationToken)
+    {
+        var targetDeploys = await ListRecentSucceededDeploysForTargetAsync(
+                targetId,
+                explicitRevision is null ? 2 : 1,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (explicitRevision is not null)
+        {
+            return new RollbackRevisionSelection(
+                explicitRevision,
+                targetDeploys.Count == 0 ? null : targetDeploys[0].Deploy?.DesiredRevision);
+        }
+
+        if (targetDeploys.Count < 2)
+        {
+            throw new GeoprocessingPreconditionFailedException(
+                $"Deploy target '{targetId}' does not have a prior succeeded deploy revision to roll back to.");
+        }
+
+        return new RollbackRevisionSelection(
+            targetDeploys[1].Deploy!.DesiredRevision,
+            targetDeploys[0].Deploy?.DesiredRevision);
+    }
+
+    private async Task<IReadOnlyList<WorkflowOperationRecord>> ListRecentSucceededDeploysForTargetAsync(
+        string targetId,
+        int requiredCount,
+        CancellationToken cancellationToken)
+    {
+        var matches = new List<WorkflowOperationRecord>(Math.Max(1, requiredCount));
+
+        for (var page = 1; matches.Count < requiredCount; page++)
+        {
+            var result = await _deployWorkflowService
+                .ListDeployOperationsAsync(
+                    WorkflowOperationStatus.Succeeded,
+                    WorkflowOperationKind.Deploy,
+                    page,
+                    MaxPageSize,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            matches.AddRange(result.Items.Where(operation =>
+                operation.Deploy is not null &&
+                string.Equals(operation.Deploy.TargetId, targetId, StringComparison.Ordinal) &&
+                !string.IsNullOrWhiteSpace(operation.Deploy.DesiredRevision)));
+
+            if (!result.HasMore || result.Items.Count == 0)
+            {
+                break;
+            }
+        }
+
+        return matches;
+    }
+
+    private async Task EnsureOpsReadAsync(ClaimsPrincipal principal, CancellationToken cancellationToken)
+    {
+        var resource = new DefaultHttpContext
+        {
+            User = principal,
+            RequestAborted = cancellationToken
+        };
+        resource.Request.Method = HttpMethods.Get;
+
+        var result = await _authorization
+            .AuthorizeAsync(principal, resource, AuthenticationExtensions.OpsReadPolicy)
+            .ConfigureAwait(false);
+
+        if (!result.Succeeded)
+        {
+            throw new GeoprocessingAuthorizationException(
+                requiresAuthentication: false,
+                message: "Caller is not authorized to read platform operations.");
+        }
+    }
+
+    private string[]? ResolveSupportedKinds()
+    {
+        var catalog = _services.GetService<IOperationExecutorCatalog>();
+        return catalog?.SupportedKinds
+            .Select(kind => kind.ToString())
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static DeployPreflightPlaneProjection MapPlaneProjection(PlatformReleasePlaneProjection projection)
+        => new()
+        {
+            Id = projection.Id,
+            RuntimeProfile = projection.RuntimeProfile,
+            EffectiveArtifactReference = projection.EffectiveArtifactReference,
+            ProjectedFromRelease = projection.ProjectedFromRelease,
+            Skewed = projection.Skewed
+        };
+
+    private static TEnum? ParseOptionalEnum<TEnum>(string? value, string fieldName)
+        where TEnum : struct, Enum
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed) &&
+            Enum.IsDefined(parsed))
+        {
+            return parsed;
+        }
+
+        throw new GeoprocessingValidationException(
+            $"'{fieldName}' contains unsupported value '{value}'.");
+    }
+
+    private static int ClampPageSize(int? pageSize) =>
+        Math.Min(MaxPageSize, Math.Max(1, pageSize ?? DefaultPageSize));
+
+    private static string? Clean(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static JsonElement Serialize<T>(T value, JsonTypeInfo<T> typeInfo)
+    {
+        var json = JsonSerializer.Serialize(value, typeInfo);
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private sealed record RollbackRevisionSelection(string DesiredRevision, string? CurrentRevision);
+}

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/ObservabilityServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ internal static class ObservabilityServiceCollectionExtensions
         });
         services.AddScoped<IOpsFindingsService, OpsFindingsService>();
         services.AddScoped<IMcpOpsObservabilityReader, McpOpsObservabilityReader>();
+        services.AddScoped<IMcpPlatformOpsReader, McpPlatformOpsReader>();
 
         // Persisted ops-health rollup store + per-replica sampler (#2553). The store itself is registered by
         // the Postgres provider; the sampler and history service resolve it as optional so non-Postgres

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/deploy_operations/deploy_operations_get.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/deploy_operations/deploy_operations_get.json
@@ -1,0 +1,10 @@
+{
+  "id": "deploy_operations.get_by_id",
+  "schemaRef": "tools/deploy_operations.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "operationId": "op_5f31c2"
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["DeployOperationResponse"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/deploy_operations/deploy_operations_list.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/deploy_operations/deploy_operations_list.json
@@ -1,0 +1,13 @@
+{
+  "id": "deploy_operations.list_filtered",
+  "schemaRef": "tools/deploy_operations.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "status": "Submitted",
+    "kind": "Deploy",
+    "page": 1,
+    "pageSize": 50
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["DeployOperationResponse"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/deploy_operations/deploy_operations_result.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/deploy_operations/deploy_operations_result.json
@@ -1,0 +1,72 @@
+{
+  "id": "deploy_operations.result_paged_envelope",
+  "schemaRef": "tools/deploy_operations.result.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "items": [
+      {
+        "operationId": "op_5f31c2",
+        "kind": "Deploy",
+        "status": "Submitted",
+        "priority": "Normal",
+        "target": {
+          "targetId": "serving-us-west",
+          "targetKind": "Serving",
+          "backend": "ecs",
+          "environment": "prod",
+          "targetName": "Serving (us-west)",
+          "currentRevision": "rev_2026_06_30",
+          "desiredRevision": "rev_2026_07_01",
+          "parameters": { "region": "us-west-2" }
+        },
+        "warnings": [],
+        "blockingReasons": [],
+        "requestedBy": "mike@honua.io",
+        "reason": "Ship 2026.07.01 platform release.",
+        "correlationId": "corr-9f2a",
+        "createdAt": "2026-07-07T09:00:00+00:00",
+        "updatedAt": "2026-07-07T09:05:00+00:00"
+      },
+      {
+        "operationId": "op_4a10bd",
+        "kind": "MetadataRelease",
+        "status": "Succeeded",
+        "priority": "Normal",
+        "metadataRelease": {
+          "packageId": "pkg_maui_nui",
+          "prUrl": "https://github.com/honua-io/honua-content/pull/42",
+          "commitSha": "abc1234",
+          "desiredRevision": "2026.07.01",
+          "targetEnvironment": "prod",
+          "deployOperationId": "op_5f31c2",
+          "jobIds": ["job_1", "job_2"],
+          "evidenceRefs": [
+            { "kind": "ci-run", "refId": "run-8891", "uri": "https://ci.honua.io/runs/8891", "at": "2026-07-07T08:50:00+00:00" }
+          ],
+          "currentStage": "Applied",
+          "rollbackPlan": {
+            "class": "MetadataOnly",
+            "isDataAffecting": false,
+            "requiresExplicitApproval": false,
+            "steps": ["revert PR", "re-release prior metadata snapshot"],
+            "evidenceRequired": ["ci-run"]
+          },
+          "blockers": [],
+          "warnings": []
+        },
+        "warnings": [],
+        "blockingReasons": [],
+        "createdAt": "2026-07-07T08:40:00+00:00",
+        "updatedAt": "2026-07-07T08:55:00+00:00",
+        "completedAt": "2026-07-07T08:55:00+00:00"
+      }
+    ],
+    "page": 1,
+    "pageSize": 50,
+    "totalCount": 2,
+    "hasMore": false
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["DeployOperationResponse"],
+  "notes": "Response envelope copied verbatim from the honua-server#2562 / PR #2577 pinned wire contract; nulls are omitted (missing key == null)."
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/platform_release_status/platform_release_status.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/platform_release_status/platform_release_status.json
@@ -1,0 +1,8 @@
+{
+  "id": "platform_release_status.snapshot",
+  "schemaRef": "tools/platform_release_status.schema.json",
+  "validates": "inputs",
+  "inputs": {},
+  "expected": "tool_result",
+  "canonicalRefs": ["DeployPreflightPlatformRelease"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/platform_release_status/platform_release_status_result.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/platform_release_status/platform_release_status_result.json
@@ -1,0 +1,38 @@
+{
+  "id": "platform_release_status.result_snapshot",
+  "schemaRef": "tools/platform_release_status.result.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "releaseVersion": "2026.07.01",
+    "releaseDeclared": true,
+    "isCoVersioned": false,
+    "serving": [
+      {
+        "id": "serving-us-west",
+        "runtimeProfile": "linux_x64_aot",
+        "effectiveArtifactReference": "ghcr.io/honua-io/server:2026.07.01",
+        "projectedFromRelease": true,
+        "skewed": false
+      },
+      {
+        "id": "serving-us-east",
+        "runtimeProfile": "linux_x64_aot",
+        "effectiveArtifactReference": "ghcr.io/honua-io/server:2026.06.30",
+        "projectedFromRelease": false,
+        "skewed": true
+      }
+    ],
+    "execution": [
+      {
+        "id": "gp-batch",
+        "runtimeProfile": "linux_x64",
+        "effectiveArtifactReference": "ghcr.io/honua-io/gp:2026.07.01",
+        "projectedFromRelease": true,
+        "skewed": false
+      }
+    ],
+    "skewedIds": ["serving-us-east"]
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["DeployPreflightPlatformRelease"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/propose_rollback/propose_rollback.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/propose_rollback/propose_rollback.json
@@ -1,0 +1,13 @@
+{
+  "id": "propose_rollback.prior_revision",
+  "schemaRef": "tools/propose_rollback.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "targetId": "serving-us-west",
+    "toRevision": "rev_2026_06_30",
+    "reason": "p99 regression after 2026.07.01; roll forward to the prior good revision.",
+    "idempotencyKey": "rb-serving-us-west-2026-07-07"
+  },
+  "expected": "tool_result",
+  "canonicalRefs": []
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
@@ -108,38 +108,6 @@
       "notes": "honua_publish_result (honua-server#2482) promotes a completed analysis job's materialized FeatureLayer/Table artifact (sourceId = the job id) into a hosted published service + layer, routing through the same canonical service.publish promotion as honua_publish_service. The standard schema requires only sourceId; the reference tool adds honua extension selectors (artifactId / serviceName / layerName) under additionalProperties. Analyze / Publish Data (published_service) is implemented; Build App (deployment) promotion is deferred (honua-server#730/#732)."
     },
     {
-      "standardName": "ops_health",
-      "referenceToolName": "honua_ops_health",
-      "family": "Platform operations (reference shape)",
-      "schema": "tools/ops_health.schema.json",
-      "implementationStatus": "implemented",
-      "notes": "Read-only platform-ops health snapshot; mirror of honua-server GET /api/v1/admin/observability/ops-health. Response payload is the honua://ops/health resource."
-    },
-    {
-      "standardName": "ops_findings",
-      "referenceToolName": "honua_ops_findings",
-      "family": "Platform operations (reference shape)",
-      "schema": "tools/ops_findings.schema.json",
-      "implementationStatus": "implemented",
-      "notes": "Read-only deterministic ops findings list/get; mirror of honua-server GET /api/v1/admin/observability/findings. Response payload is the honua://ops/findings resource."
-    },
-    {
-      "standardName": "alert_events",
-      "referenceToolName": "honua_alert_events",
-      "family": "Platform operations (reference shape)",
-      "schema": "tools/alert_events.schema.json",
-      "implementationStatus": "implemented",
-      "notes": "Read-only, cursor-paged alert-event query over source/severity/rule/lifecycle/time filters."
-    },
-    {
-      "standardName": "operate_events",
-      "referenceToolName": "honua_operate_events",
-      "family": "Platform operations (reference shape)",
-      "schema": "tools/operate_events.schema.json",
-      "implementationStatus": "implemented",
-      "notes": "Read-only, paged fused Operate timeline query over kind/correlation/operation/release/time filters."
-    },
-    {
       "standardName": "list_layers",
       "referenceToolName": "honua_list_layers",
       "family": "Discovery and query (reference shape)",
@@ -257,7 +225,64 @@
       "referenceToolName": "honua_propose_operation",
       "family": "Control-plane proposal (reference shape)",
       "schema": "tools/propose_operation.schema.json",
-      "implementationStatus": "implemented"
+      "implementationStatus": "implemented",
+      "notes": "Amended with x-honua-supported-kinds runtime capability discovery (geospatial-mcp#57): the kind enum stays the full wire-compatible OperationClass set, but the routable subset is discoverable at runtime (Seed is currently not routable in the reference)."
+    },
+    {
+      "standardName": "ops_health",
+      "referenceToolName": "honua_ops_health",
+      "family": "Platform operations (reference shape)",
+      "schema": "tools/ops_health.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Read-only platform-ops health snapshot; mirror of honua-server GET /api/v1/admin/observability/ops-health (OpsHealthSnapshotResponse, incl. the additive clusterReplicaCount from honua-server#2576). Response payload is the honua://ops/health resource (resources/ops-health.schema.json). Reference surface lands via honua-server#2555 (read-tools impl) under epic #2552 and is kept in sync with the vendored schema copy per honua-server#2496."
+    },
+    {
+      "standardName": "ops_findings",
+      "referenceToolName": "honua_ops_findings",
+      "family": "Platform operations (reference shape)",
+      "schema": "tools/ops_findings.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Read-only deterministic ops findings (list/get via optional findingId); mirror of honua-server GET /api/v1/admin/observability/findings. Each finding carries recommendedAction {kind, summary, reason} + evidenceRefs; the action is proposed (never executed) by finding id (honua-server ADR-0028 posture). Response payload is the honua://ops/findings resource (resources/ops-findings.schema.json). Reference surface lands via honua-server#2555 under epic #2552; vendored copy synced per honua-server#2496."
+    },
+    {
+      "standardName": "alert_events",
+      "referenceToolName": "honua_alert_events",
+      "family": "Platform operations (reference shape)",
+      "schema": "tools/alert_events.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Read-only, cursor-paged alert-event query (filters: source gis|ops, severity, rule, lifecycle state, time range). Mirror of the honua-server Console Operate alert-event API. Response envelope in tools/alert_events.result.schema.json. Reference surface lands via honua-server#2555 under epic #2552; vendored copy synced per honua-server#2496."
+    },
+    {
+      "standardName": "operate_events",
+      "referenceToolName": "honua_operate_events",
+      "family": "Platform operations (reference shape)",
+      "schema": "tools/operate_events.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Read-only, paged fused Operate timeline (filters: kind, correlationId, operationId, releaseId, time range). Mirror of honua-server GET /api/v1/admin/observability/events; the ReleaseId filter is fed by the Release events added in honua-server#2577. Response envelope in tools/operate_events.result.schema.json. Reference surface lands via honua-server#2555 under epic #2552; vendored copy synced per honua-server#2496."
+    },
+    {
+      "standardName": "platform_release_status",
+      "referenceToolName": "honua_platform_release_status",
+      "family": "Platform operations (reference shape)",
+      "schema": "tools/platform_release_status.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Read-only platform_release / server_upgrade co-versioning + skew snapshot (declared release, co-versioning, per-plane serving/execution projections, skewed plane ids). Mirror of the honua-server platformRelease projection (DeployPreflightPlatformRelease). Distinct from the hosted-content Deployment resource. Response in tools/platform_release_status.result.schema.json. Reference surface lands via honua-server#2555 under epic #2552; vendored copy synced per honua-server#2496."
+    },
+    {
+      "standardName": "deploy_operations",
+      "referenceToolName": "honua_deploy_operations",
+      "family": "Platform operations (reference shape)",
+      "schema": "tools/deploy_operations.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Read-only platform_release / server_upgrade operation surface (list/get via optional operationId; list filters status, kind, page, pageSize). Paged response envelope {items, page, pageSize, totalCount, hasMore} copied VERBATIM from the wire contract pinned in honua-server#2562 / PR #2577 (tools/deploy_operations.result.schema.json). Distinct from the hosted-content Deployment resource. Reference surface lands via honua-server#2577 under epic #2552; vendored copy synced per honua-server#2496."
+    },
+    {
+      "standardName": "propose_rollback",
+      "referenceToolName": "honua_propose_rollback",
+      "family": "Control-plane proposal (reference shape)",
+      "schema": "tools/propose_rollback.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Action tool: proposes a platform rollback as a NEW FORWARD Deploy operation to the target's prior revision (not an in-flight-operation abort); returns a proposal id / honua://proposals/{id} like propose_operation, approval-gated behind the human console inbox (honua-server ADR-0028 posture). Reference surface lands under epic #2552 (backed by the prior-succeeded-deploy lookup added in honua-server#2577); vendored copy synced per honua-server#2496."
     },
     {
       "standardName": "ingest_dataset",
@@ -341,20 +366,6 @@
       "implementationStatus": "implemented"
     },
     {
-      "family": "Ops health",
-      "uriForm": "honua://ops/health",
-      "schema": "resources/ops-health.schema.json",
-      "shapeFidelity": "concrete-reference",
-      "implementationStatus": "implemented"
-    },
-    {
-      "family": "Ops findings",
-      "uriForm": "honua://ops/findings",
-      "schema": "resources/ops-findings.schema.json",
-      "shapeFidelity": "concrete-reference",
-      "implementationStatus": "implemented"
-    },
-    {
       "family": "Workspace artifact",
       "uriForm": "honua://workspaces/{workspace_id}/artifacts/{artifact_id}",
       "schema": "resources/artifact.schema.json",
@@ -417,6 +428,22 @@
       "schema": "resources/deployment.schema.json",
       "shapeFidelity": "responsibility-level",
       "implementationStatus": "implemented"
+    },
+    {
+      "family": "Ops health",
+      "uriForm": "honua://ops/health",
+      "schema": "resources/ops-health.schema.json",
+      "shapeFidelity": "concrete-reference",
+      "implementationStatus": "implemented",
+      "notes": "Read-only, admin-gated consolidated operational-health snapshot; mirror of honua-server OpsHealthSnapshotResponse (incl. the additive clusterReplicaCount from honua-server#2576). Same gated pattern as the promotion-surface resources. Response of the ops_health tool. Reference surface lands via honua-server#2555 under epic #2552; vendored copy synced per honua-server#2496."
+    },
+    {
+      "family": "Ops findings",
+      "uriForm": "honua://ops/findings",
+      "schema": "resources/ops-findings.schema.json",
+      "shapeFidelity": "concrete-reference",
+      "implementationStatus": "implemented",
+      "notes": "Read-only, admin-gated deterministic ops findings (recommendedAction {kind, summary, reason} + evidence refs); mirror of honua-server OpsFindingsListResponse. Same gated pattern as the promotion-surface resources. Response of the ops_findings tool. Reference surface lands via honua-server#2555 under epic #2552; vendored copy synced per honua-server#2496."
     }
   ],
   "common": [

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/deploy_operations.result.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/deploy_operations.result.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/deploy_operations.result.schema.json",
+  "title": "deploy_operations result payload",
+  "description": "Response payload for the deploy_operations tool: the paged deploy-operations envelope copied VERBATIM from the wire contract pinned in honua-server#2562 / PR #2577 (GET /api/v1/admin/deploy/operations). camelCase; null-valued properties are OMITTED (DefaultIgnoreCondition = WhenWritingNull), so a missing key means null. items is DeployOperationResponse[], newest-first by createdAt. warnings / blockingReasons / target.parameters / metadataRelease.jobIds|evidenceRefs|blockers|warnings are always present (possibly empty). x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["items", "page", "pageSize", "totalCount", "hasMore"],
+  "properties": {
+    "items": {
+      "type": "array",
+      "description": "DeployOperationResponse[], newest-first by createdAt.",
+      "items": { "$ref": "#/$defs/deployOperation" }
+    },
+    "page": { "type": "integer", "description": "Effective 1-based page." },
+    "pageSize": { "type": "integer", "description": "Effective (clamped) page size." },
+    "totalCount": { "type": "integer", "description": "Match count within the materialized window." },
+    "hasMore": { "type": "boolean", "description": "At least one more page exists." }
+  },
+  "$defs": {
+    "deployOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operationId", "kind", "status", "priority", "warnings", "blockingReasons", "createdAt", "updatedAt"],
+      "properties": {
+        "operationId": { "type": "string" },
+        "kind": { "type": "string", "description": "WorkflowOperationKind enum name, e.g. \"Deploy\"." },
+        "status": { "type": "string", "description": "WorkflowOperationStatus enum name, e.g. \"Submitted\"." },
+        "priority": { "type": "string", "description": "Priority enum name, e.g. \"Normal\"." },
+        "target": { "$ref": "#/$defs/target" },
+        "metadataRelease": { "$ref": "#/$defs/metadataRelease" },
+        "providerOperationId": { "type": "string" },
+        "currentPhase": { "type": "string" },
+        "observedState": { "type": "string" },
+        "errorMessage": { "type": "string" },
+        "warnings": { "type": "array", "items": { "type": "string" } },
+        "blockingReasons": { "type": "array", "items": { "type": "string" } },
+        "requestedBy": { "type": "string" },
+        "reason": { "type": "string" },
+        "correlationId": { "type": "string" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" },
+        "completedAt": { "type": "string", "format": "date-time" }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targetId", "targetKind", "backend", "environment", "targetName", "desiredRevision", "parameters"],
+      "properties": {
+        "targetId": { "type": "string" },
+        "targetKind": { "type": "string", "description": "Enum name." },
+        "backend": { "type": "string" },
+        "environment": { "type": "string" },
+        "targetName": { "type": "string" },
+        "artifactReference": { "type": "string" },
+        "runtimeProfile": { "type": "string" },
+        "currentRevision": { "type": "string" },
+        "desiredRevision": { "type": "string" },
+        "parameters": { "type": "object", "additionalProperties": { "type": "string" } }
+      }
+    },
+    "metadataRelease": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["packageId", "desiredRevision", "targetEnvironment", "jobIds", "evidenceRefs", "currentStage", "blockers", "warnings"],
+      "properties": {
+        "packageId": { "type": "string" },
+        "gitOperationId": { "type": "string" },
+        "prUrl": { "type": "string" },
+        "commitSha": { "type": "string" },
+        "desiredRevision": { "type": "string" },
+        "targetEnvironment": { "type": "string" },
+        "deployOperationId": { "type": "string" },
+        "jobIds": { "type": "array", "items": { "type": "string" } },
+        "evidenceRefs": { "type": "array", "items": { "$ref": "#/$defs/evidenceRef" } },
+        "currentStage": { "type": "string", "description": "Enum name." },
+        "rollbackPlan": { "$ref": "#/$defs/rollbackPlan" },
+        "blockers": { "type": "array", "items": { "type": "string" } },
+        "warnings": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "refId", "at"],
+      "properties": {
+        "kind": { "type": "string" },
+        "refId": { "type": "string" },
+        "uri": { "type": "string" },
+        "at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "rollbackPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["class", "isDataAffecting", "requiresExplicitApproval", "steps", "evidenceRequired"],
+      "properties": {
+        "class": { "type": "string", "description": "Enum name." },
+        "isDataAffecting": { "type": "boolean" },
+        "requiresExplicitApproval": { "type": "boolean" },
+        "steps": { "type": "array", "items": { "type": "string" } },
+        "evidenceRequired": { "type": "array", "items": { "type": "string" } },
+        "approvalPolicyRef": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/deploy_operations.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/deploy_operations.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/deploy_operations.schema.json",
+  "title": "deploy_operations inputSchema",
+  "description": "Argument shape for the deploy-operations tool (advertised name honua_deploy_operations). Read-only over the platform_release / server_upgrade operation workflow (mirror of GET /api/v1/admin/deploy/operations, whose wire contract is pinned by honua-server#2562 / PR #2577). Two modes: omit operationId to LIST deploy operations (newest-first by createdAt, paged) filtered by status and kind; provide operationId to GET a single operation. Uses platform_release / server_upgrade vocabulary — this is the platform-upgrade operation surface, distinct from the hosted-content honua://deployments/{deployment_id} resource. The response is a paged envelope of DeployOperationResponse items copied verbatim from the pinned contract; see deploy_operations.result.schema.json. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {
+    "operationId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Deploy-operation identifier to fetch a single operation (get mode). When omitted, the tool lists deploy operations (list mode)."
+    },
+    "status": {
+      "type": "string",
+      "description": "List-mode filter: WorkflowOperationStatus name (case-insensitive).",
+      "enum": [
+        "Planned",
+        "AwaitingApproval",
+        "Submitted",
+        "Reconciling",
+        "Succeeded",
+        "Failed",
+        "RollbackRequested",
+        "RolledBack",
+        "ManualInterventionRequired"
+      ]
+    },
+    "kind": {
+      "type": "string",
+      "description": "List-mode filter: WorkflowOperationKind name (case-insensitive).",
+      "enum": ["Deploy", "Rollback", "Migration", "MetadataRelease", "CoordinatedRelease"]
+    },
+    "page": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "List-mode 1-based page number (default 1, must be >= 1)."
+    },
+    "pageSize": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 200,
+      "default": 50,
+      "description": "List-mode page size (default 50, clamped server-side to 1..200)."
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/platform_release_status.result.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/platform_release_status.result.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/platform_release_status.result.schema.json",
+  "title": "platform_release_status result payload",
+  "description": "Response payload for the platform_release_status tool: the declared platform_release / server_upgrade co-versioning + skew snapshot, mirroring the honua-server platformRelease projection (DeployPreflightPlatformRelease). Reports the declared release version, whether all planes are co-versioned, the per-plane serving/execution projections, and the identifiers of planes skewed from the declared release. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["releaseDeclared", "isCoVersioned", "serving", "execution", "skewedIds"],
+  "properties": {
+    "releaseVersion": {
+      "type": "string",
+      "description": "Declared platform release version, or absent/null when no release is configured."
+    },
+    "releaseDeclared": {
+      "type": "boolean",
+      "description": "Whether a platform release is declared."
+    },
+    "isCoVersioned": {
+      "type": "boolean",
+      "description": "Whether all planes are co-versioned with the declared release."
+    },
+    "serving": {
+      "type": "array",
+      "description": "Per-plane serving projections.",
+      "items": { "$ref": "#/$defs/plane" }
+    },
+    "execution": {
+      "type": "array",
+      "description": "Per-plane execution projections.",
+      "items": { "$ref": "#/$defs/plane" }
+    },
+    "skewedIds": {
+      "type": "array",
+      "description": "Identifiers of planes skewed from the declared release.",
+      "items": { "type": "string" }
+    }
+  },
+  "$defs": {
+    "plane": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "projectedFromRelease", "skewed"],
+      "properties": {
+        "id": { "type": "string" },
+        "runtimeProfile": { "type": "string" },
+        "effectiveArtifactReference": { "type": "string" },
+        "projectedFromRelease": { "type": "boolean" },
+        "skewed": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/platform_release_status.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/platform_release_status.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/platform_release_status.schema.json",
+  "title": "platform_release_status inputSchema",
+  "description": "Argument shape for the platform-release status tool (advertised name honua_platform_release_status). Read-only: returns the declared platform_release / server_upgrade co-versioning snapshot (mirror of the platformRelease projection on the honua-server coordinated-deploy preflight) — the declared release version, whether all planes are co-versioned with it, the per-plane serving/execution projections, and the identifiers of any planes skewed from the declared release. Takes no arguments. Uses platform_release / server_upgrade vocabulary; this is distinct from the hosted-content honua://deployments/{deployment_id} resource. The response is the release-status snapshot; see platform_release_status.result.schema.json. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/propose_operation.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/propose_operation.schema.json
@@ -2,14 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/propose_operation.schema.json",
   "title": "propose_operation inputSchema",
-  "description": "Argument shape for the control-plane proposal tool (advertised name honua_propose_operation). Proposes an in-scope mutating control-plane operation for human approval (never autonomously executed), consistent with the ADR-0028 no-direct-AI-mutation boundary in taxonomy.md §Non-Goals. x-honua-reference-shape: tracks the reference implementation.",
+  "description": "Argument shape for the control-plane proposal tool (advertised name honua_propose_operation). Proposes an in-scope mutating control-plane operation for human approval on a deterministic server; the proposal is NEVER autonomously executed — execution stays approval-gated behind the human console inbox — consistent with the ADR-0028 posture (deterministic server, approval-gated mutation, no autonomous AI data edits) in taxonomy.md §Non-Goals. x-honua-reference-shape: tracks the reference implementation.",
   "x-honua-reference-shape": true,
+  "x-honua-supported-kinds": {
+    "description": "Capability discovery: the kind enum is the full, wire-compatible OperationClass vocabulary, but not every member is routable by a given server at runtime. Clients learn which kinds are actually routable from the reference self-describing capability surface (list_capabilities) rather than assuming the full enum. In the reference implementation, Seed is currently NOT routable through the operation gateway; AdminConfigChange, Deploy, and MetadataRelease are. Advertising a non-routable kind yields a NotSupported outcome; the enum is retained unchanged so the wire contract stays stable as kinds become routable.",
+    "routable": ["AdminConfigChange", "Deploy", "MetadataRelease"],
+    "notRoutable": ["Seed"]
+  },
   "type": "object",
   "required": ["kind"],
   "properties": {
     "kind": {
       "type": "string",
-      "description": "In-scope mutating control-plane operation class to propose.",
+      "description": "In-scope mutating control-plane operation class to propose. Wire-compatible OperationClass enum; the routable subset is discoverable at runtime (see x-honua-supported-kinds). Seed is currently not routable in the reference.",
       "enum": ["AdminConfigChange", "Deploy", "MetadataRelease", "Seed"]
     },
     "reason": {

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/propose_rollback.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/propose_rollback.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/propose_rollback.schema.json",
+  "title": "propose_rollback inputSchema",
+  "description": "Argument shape for the platform-rollback proposal tool (advertised name honua_propose_rollback). Proposes rolling a deploy target back to its prior revision by requesting a NEW FORWARD Deploy operation to that prior revision — it is NOT an in-flight-operation abort/undo and does not reverse an operation already running; it converges the target forward onto the previous known-good revision. Like propose_operation, this proposes an in-scope mutating control-plane operation for human approval and is NEVER autonomously executed: a deterministic server records the proposal and returns a proposal id / honua://proposals/{id}; execution stays approval-gated behind the human console inbox. Consistent with the honua-server ADR-0028 posture reconciled by the standard's ADR-0028 (deterministic server, approval-gated mutation, no autonomous AI data edits). Uses platform_release / server_upgrade vocabulary; distinct from the hosted-content honua://deployments/{deployment_id} resource. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "required": ["targetId"],
+  "properties": {
+    "targetId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Deploy target to roll back (from deploy_operations[].target.targetId or ops findings/health subject.targetId)."
+    },
+    "toRevision": {
+      "type": "string",
+      "description": "Optional prior revision to roll forward to. When omitted, the server selects the target's most recent prior succeeded Deploy revision (a rolled-back latest deploy is demoted; the prior succeeded deploy is chosen)."
+    },
+    "reason": {
+      "type": "string",
+      "description": "Operator-facing reason recorded on the proposal."
+    },
+    "idempotencyKey": {
+      "type": "string",
+      "description": "Stable idempotency key for the underlying forward Deploy operation."
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
@@ -291,6 +291,9 @@ public sealed class CapabilityRegistryConformanceTests
             new OpsFindingsTool(NullLogger<OpsFindingsTool>.Instance),
             new AlertEventsTool(NullLogger<AlertEventsTool>.Instance),
             new OperateEventsTool(NullLogger<OperateEventsTool>.Instance),
+            new PlatformReleaseStatusTool(NullLogger<PlatformReleaseStatusTool>.Instance),
+            new DeployOperationsTool(NullLogger<DeployOperationsTool>.Instance),
+            new ProposeRollbackTool(NullLogger<ProposeRollbackTool>.Instance),
             new ValidatePackageTool(reviewService, jobService, NullLogger<ValidatePackageTool>.Instance),
             new PreviewPackageTool(reviewService, jobService, NullLogger<PreviewPackageTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool(

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -80,6 +80,9 @@ public sealed partial class McpTaxonomyAlignmentTests
             ["honua_ops_findings"] = "ops_findings",
             ["honua_alert_events"] = "alert_events",
             ["honua_operate_events"] = "operate_events",
+            ["honua_platform_release_status"] = "platform_release_status",
+            ["honua_deploy_operations"] = "deploy_operations",
+            ["honua_propose_rollback"] = "propose_rollback",
             // Honua extensions over the bare taxonomy (#1949): the standard models
             // entity resolution and capability discovery as CapabilityCatalog reads;
             // the reference implementation exposes them as discrete tools and ships

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpPlatformOpsToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpPlatformOpsToolTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Unit coverage for MCP platform-ops tools (#2566).
+/// </summary>
+public sealed class McpPlatformOpsToolTests
+{
+    [UnitTest]
+    public async Task PlatformReleaseStatusTool_Invoke_ReturnsReaderPayload()
+    {
+        var reader = new FakePlatformOpsReader();
+        var context = BuildContext(reader);
+        var tool = new PlatformReleaseStatusTool(NullLogger<PlatformReleaseStatusTool>.Instance);
+
+        var result = await tool.InvokeAsync(context, Json("{}"), CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        result.StructuredContent!.Value.GetProperty("releaseDeclared").GetBoolean().Should().BeTrue();
+        reader.PlatformReleaseStatusCalls.Should().Be(1);
+        reader.LastPrincipal.Should().BeSameAs(context.User);
+    }
+
+    [UnitTest]
+    public async Task DeployOperationsTool_Invoke_PassesFiltersToReader()
+    {
+        var reader = new FakePlatformOpsReader();
+        var context = BuildContext(reader);
+        var tool = new DeployOperationsTool(NullLogger<DeployOperationsTool>.Instance);
+        var arguments = Json(
+            """
+            {
+              "operationId": "op-1",
+              "status": "Submitted",
+              "kind": "Deploy",
+              "page": 2,
+              "pageSize": 25
+            }
+            """);
+
+        var result = await tool.InvokeAsync(context, arguments, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        reader.DeployOperationsArgument.Should().NotBeNull();
+        reader.DeployOperationsArgument!.OperationId.Should().Be("op-1");
+        reader.DeployOperationsArgument.Status.Should().Be("Submitted");
+        reader.DeployOperationsArgument.Kind.Should().Be("Deploy");
+        reader.DeployOperationsArgument.Page.Should().Be(2);
+        reader.DeployOperationsArgument.PageSize.Should().Be(25);
+    }
+
+    [UnitTest]
+    public async Task ProposeRollbackTool_Invoke_PassesArgumentsAndReturnsProposal()
+    {
+        var reader = new FakePlatformOpsReader();
+        var context = BuildContext(reader);
+        var tool = new ProposeRollbackTool(NullLogger<ProposeRollbackTool>.Instance);
+        var arguments = Json(
+            """
+            {
+              "targetId": "serving-us-west",
+              "toRevision": "rev-9",
+              "reason": "SLO regression",
+              "idempotencyKey": "rb-1"
+            }
+            """);
+
+        var result = await tool.InvokeAsync(context, arguments, CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        result.StructuredContent!.Value.GetProperty("proposalId").GetString().Should().Be("proposal-1");
+        reader.RollbackArgument.Should().NotBeNull();
+        reader.RollbackArgument!.TargetId.Should().Be("serving-us-west");
+        reader.RollbackArgument.ToRevision.Should().Be("rev-9");
+        reader.RollbackArgument.Reason.Should().Be("SLO regression");
+        reader.RollbackArgument.IdempotencyKey.Should().Be("rb-1");
+    }
+
+    private static DefaultHttpContext BuildContext(IMcpPlatformOpsReader reader)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(reader);
+        var provider = services.BuildServiceProvider();
+
+        return new DefaultHttpContext
+        {
+            RequestServices = provider,
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, "mcp-test")],
+                "Test"))
+        };
+    }
+
+    private static JsonElement Json(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private sealed class FakePlatformOpsReader : IMcpPlatformOpsReader
+    {
+        public int PlatformReleaseStatusCalls { get; private set; }
+
+        public ClaimsPrincipal? LastPrincipal { get; private set; }
+
+        public McpDeployOperationsArgument? DeployOperationsArgument { get; private set; }
+
+        public McpProposeRollbackArgument? RollbackArgument { get; private set; }
+
+        public Task<JsonElement> GetPlatformReleaseStatusAsync(
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken)
+        {
+            LastPrincipal = principal;
+            PlatformReleaseStatusCalls++;
+            return Task.FromResult(Json("""{"releaseDeclared":true,"isCoVersioned":true,"serving":[],"execution":[],"skewedIds":[]}"""));
+        }
+
+        public Task<JsonElement> GetDeployOperationsAsync(
+            ClaimsPrincipal principal,
+            McpDeployOperationsArgument argument,
+            CancellationToken cancellationToken)
+        {
+            LastPrincipal = principal;
+            DeployOperationsArgument = argument;
+            return Task.FromResult(Json("""{"items":[],"page":1,"pageSize":50,"totalCount":0,"hasMore":false}"""));
+        }
+
+        public Task<McpProposeOperationOutput> ProposeRollbackAsync(
+            ClaimsPrincipal principal,
+            McpProposeRollbackArgument argument,
+            CancellationToken cancellationToken)
+        {
+            LastPrincipal = principal;
+            RollbackArgument = argument;
+            return Task.FromResult(new McpProposeOperationOutput
+            {
+                Outcome = "ProposalCreated",
+                RequiresApproval = true,
+                ProposalId = "proposal-1",
+                ResourceUri = "honua://proposals/proposal-1",
+            });
+        }
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
@@ -150,6 +150,39 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
+    public void AddMcpOperatorSurface_WithoutPlatformOpsReader_DoesNotRegisterPlatformOpsTools()
+    {
+        var services = BuildBaseServices();
+
+        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+
+        RegisteredToolHandlers(services)
+            .Should().NotContain(new[]
+            {
+                typeof(PlatformReleaseStatusTool),
+                typeof(DeployOperationsTool),
+                typeof(ProposeRollbackTool)
+            }, "platform-ops tools must only be advertised when the server reader is wired");
+    }
+
+    [UnitTest]
+    public void AddMcpOperatorSurface_WithPlatformOpsReader_RegistersPlatformOpsTools()
+    {
+        var services = BuildBaseServices();
+        services.AddScoped(_ => Substitute.For<IMcpPlatformOpsReader>());
+
+        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+
+        RegisteredToolHandlers(services)
+            .Should().Contain(new[]
+            {
+                typeof(PlatformReleaseStatusTool),
+                typeof(DeployOperationsTool),
+                typeof(ProposeRollbackTool)
+            }, "the full server composition registers the MCP platform-ops reader before the operator surface");
+    }
+
+    [UnitTest]
     public void AddMcpPromotionSurface_RegistersPromotionResourceHandlersOnly()
     {
         var services = BuildBaseServices();

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -49,6 +49,9 @@ public sealed partial class McpTaxonomyAlignmentTests
         "honua_ops_findings",
         "honua_alert_events",
         "honua_operate_events",
+        "honua_platform_release_status",
+        "honua_deploy_operations",
+        "honua_propose_rollback",
         "honua_list_layers",
         "honua_query_features",
         // No honua_edit_features: Honua exposes no AI/MCP feature-mutation tool
@@ -233,6 +236,8 @@ public sealed partial class McpTaxonomyAlignmentTests
         "honua_ops_findings",
         "honua_alert_events",
         "honua_operate_events",
+        "honua_platform_release_status",
+        "honua_deploy_operations",
         "honua_list_layers",
         "honua_query_features",
         "honua_render_map",
@@ -250,6 +255,7 @@ public sealed partial class McpTaxonomyAlignmentTests
             ["honua_execute_plan"] = (Destructive: false, Idempotent: true),
             ["honua_cancel_job"] = (Destructive: true, Idempotent: true),
             ["honua_propose_operation"] = (Destructive: false, Idempotent: true),
+            ["honua_propose_rollback"] = (Destructive: false, Idempotent: true),
             ["honua_ingest_dataset"] = (Destructive: false, Idempotent: false),
             ["honua_publish_service"] = (Destructive: false, Idempotent: false),
             ["honua_publish_result"] = (Destructive: false, Idempotent: false),
@@ -601,6 +607,9 @@ public sealed partial class McpTaxonomyAlignmentTests
             new OpsFindingsTool(NullLogger<OpsFindingsTool>.Instance),
             new AlertEventsTool(NullLogger<AlertEventsTool>.Instance),
             new OperateEventsTool(NullLogger<OperateEventsTool>.Instance),
+            new PlatformReleaseStatusTool(NullLogger<PlatformReleaseStatusTool>.Instance),
+            new DeployOperationsTool(NullLogger<DeployOperationsTool>.Instance),
+            new ProposeRollbackTool(NullLogger<ProposeRollbackTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool(
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.QueryFeaturesTool(

--- a/tests/dotnet/Honua.Core.Tests/Features/Import/InMemoryImportJobServiceCleanupTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Import/InMemoryImportJobServiceCleanupTests.cs
@@ -133,15 +133,11 @@ public sealed class InMemoryImportJobServiceCleanupTests
     private static async Task TriggerCleanupAsync(InMemoryImportJobService jobService)
     {
         var type = typeof(InMemoryImportJobService);
-        var intervalField = type.GetField("_cleanupInterval", BindingFlags.NonPublic | BindingFlags.Static);
-        intervalField.Should().NotBeNull();
-        var interval = (TimeSpan)(intervalField?.GetValue(null) ?? TimeSpan.Zero);
+        var cleanupMethod = type.GetMethod("CleanupCompletedJobs", BindingFlags.NonPublic | BindingFlags.Instance);
+        cleanupMethod.Should().NotBeNull();
 
-        var lastCleanupField = type.GetField("_lastCleanupTick", BindingFlags.NonPublic | BindingFlags.Instance);
-        lastCleanupField.Should().NotBeNull();
-        lastCleanupField?.SetValue(jobService, Environment.TickCount64 - (long)interval.TotalMilliseconds - 1);
-
-        _ = await jobService.GetProgressAsync("force-cleanup");
+        cleanupMethod?.Invoke(jobService, [DateTimeOffset.UtcNow]);
+        await Task.CompletedTask;
     }
 
     private sealed class FakeFileImportService : IFileImportService

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoPackagePreviewTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoPackagePreviewTests.cs
@@ -39,10 +39,7 @@ public sealed class GeoPackagePreviewTests
         }
         finally
         {
-            if (File.Exists(filePath))
-            {
-                File.Delete(filePath);
-            }
+            await DeleteGeoPackageAsync(filePath);
         }
     }
 
@@ -66,10 +63,7 @@ public sealed class GeoPackagePreviewTests
         }
         finally
         {
-            if (File.Exists(filePath))
-            {
-                File.Delete(filePath);
-            }
+            await DeleteGeoPackageAsync(filePath);
         }
     }
 
@@ -99,16 +93,13 @@ public sealed class GeoPackagePreviewTests
         }
         finally
         {
-            if (File.Exists(filePath))
-            {
-                File.Delete(filePath);
-            }
+            await DeleteGeoPackageAsync(filePath);
         }
     }
 
     private static void CreateGeoPackage(string filePath, bool includeSecondLayer = false)
     {
-        using var connection = new SqliteConnection($"Data Source={filePath}");
+        using var connection = new SqliteConnection($"Data Source={filePath};Pooling=False");
         connection.Open();
 
         ExecuteNonQuery(connection, """
@@ -230,4 +221,25 @@ public sealed class GeoPackagePreviewTests
     private static IFileImportService CreateService() =>
         PreviewImportServiceFactory.Create();
 
+    private static async Task DeleteGeoPackageAsync(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return;
+        }
+
+        for (var attempt = 1; attempt <= 5; attempt++)
+        {
+            SqliteConnection.ClearAllPools();
+            try
+            {
+                File.Delete(filePath);
+                return;
+            }
+            catch (IOException) when (attempt < 5)
+            {
+                await Task.Delay(100).ConfigureAwait(false);
+            }
+        }
+    }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerInventoryBaselineTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerInventoryBaselineTests.cs
@@ -142,6 +142,7 @@ public sealed class GeoServerInventoryBaselineTests
 
     private static void AssertMatchesBaseline(string scenario, string actualJson)
     {
+        var normalizedActualJson = NormalizeLineEndings(actualJson);
         var baselineFile = $"{scenario}-expected.json";
         var outputBaselinePath = Path.Combine(
             AppContext.BaseDirectory,
@@ -168,20 +169,23 @@ public sealed class GeoServerInventoryBaselineTests
         if (regenRequested)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(sourceBaselinePath)!);
-            File.WriteAllText(sourceBaselinePath, actualJson);
+            File.WriteAllText(sourceBaselinePath, normalizedActualJson);
             Directory.CreateDirectory(Path.GetDirectoryName(outputBaselinePath)!);
-            File.WriteAllText(outputBaselinePath, actualJson);
+            File.WriteAllText(outputBaselinePath, normalizedActualJson);
             return;
         }
 
         File.Exists(sourceBaselinePath).Should().BeTrue(
             $"baseline {baselineFile} must exist at {sourceBaselinePath}. Re-run with UPDATE_GEOSERVER_INVENTORY_BASELINES=1 to regenerate it and commit the result.");
 
-        var expectedJson = File.ReadAllText(sourceBaselinePath);
-        actualJson.Should().Be(
+        var expectedJson = NormalizeLineEndings(File.ReadAllText(sourceBaselinePath));
+        normalizedActualJson.Should().Be(
             expectedJson,
             $"baseline {baselineFile} should match scanner output. Re-run with UPDATE_GEOSERVER_INVENTORY_BASELINES=1 to refresh after intentional model changes.");
     }
+
+    private static string NormalizeLineEndings(string value) =>
+        value.Replace("\r\n", "\n", StringComparison.Ordinal);
 
     private static GeoServerImportService CreateService(HttpMessageHandler handler)
     {

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisInventoryBaselineTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoservicesArcGisInventoryBaselineTests.cs
@@ -367,6 +367,7 @@ public sealed class GeoservicesArcGisInventoryBaselineTests
 
     private static void AssertMatchesBaseline(string scenario, string actualJson)
     {
+        var normalizedActualJson = NormalizeLineEndings(actualJson);
         var baselineFile = $"{scenario}-expected.json";
         var outputBaselinePath = Path.Combine(
             AppContext.BaseDirectory,
@@ -393,20 +394,23 @@ public sealed class GeoservicesArcGisInventoryBaselineTests
         if (regenRequested)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(sourceBaselinePath)!);
-            File.WriteAllText(sourceBaselinePath, actualJson);
+            File.WriteAllText(sourceBaselinePath, normalizedActualJson);
             Directory.CreateDirectory(Path.GetDirectoryName(outputBaselinePath)!);
-            File.WriteAllText(outputBaselinePath, actualJson);
+            File.WriteAllText(outputBaselinePath, normalizedActualJson);
             return;
         }
 
         File.Exists(sourceBaselinePath).Should().BeTrue(
             $"baseline {baselineFile} must exist at {sourceBaselinePath}. Re-run with UPDATE_ARCGIS_INVENTORY_BASELINES=1 to regenerate it and commit the result.");
 
-        var expectedJson = File.ReadAllText(sourceBaselinePath);
-        actualJson.Should().Be(
+        var expectedJson = NormalizeLineEndings(File.ReadAllText(sourceBaselinePath));
+        normalizedActualJson.Should().Be(
             expectedJson,
             $"baseline {baselineFile} should match scanner output. Re-run with UPDATE_ARCGIS_INVENTORY_BASELINES=1 to refresh after intentional model changes.");
     }
+
+    private static string NormalizeLineEndings(string value) =>
+        value.Replace("\r\n", "\n", StringComparison.Ordinal);
 
     private static GeoservicesImportService CreateService(HttpMessageHandler handler)
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/McpPlatformOpsReaderTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/McpPlatformOpsReaderTests.cs
@@ -1,0 +1,545 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.ControlPlane;
+using Honua.ControlPlane.Executors;
+using Honua.Core.Features.Authorization.Abstractions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Guardrails.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Infrastructure.Authentication;
+using Honua.Infrastructure.Monitoring;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Monitoring;
+
+/// <summary>
+/// Unit coverage for the server-side MCP platform-ops adapter (#2566).
+/// </summary>
+[Protocol(TestProtocols.TestQuality)]
+public sealed class McpPlatformOpsReaderTests
+{
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task GetPlatformReleaseStatus_Authorized_UsesOpsReadPolicyAndReturnsProjection()
+    {
+        var principal = CreatePrincipal();
+        var authorization = CreateAuthorization(AuthorizationResult.Success());
+
+        using var services = CreateServices();
+        var reader = CreateReader(authorization: authorization, services: services);
+
+        var result = await reader.GetPlatformReleaseStatusAsync(principal, CancellationToken.None);
+
+        result.GetProperty("releaseDeclared").GetBoolean().Should().BeTrue();
+        result.GetProperty("releaseVersion").GetString().Should().Be("2026.07.01");
+        result.GetProperty("skewedIds")
+            .EnumerateArray()
+            .Select(element => element.GetString())
+            .Should()
+            .Contain("serving-pinned");
+        result.GetProperty("serving")
+            .EnumerateArray()
+            .Select(element => element.GetProperty("id").GetString())
+            .Should()
+            .Contain("serving-us-west");
+        result.GetProperty("execution")
+            .EnumerateArray()
+            .Select(element => element.GetProperty("id").GetString())
+            .Should()
+            .Contain("gp-gdal");
+
+        await authorization.Received(1).AuthorizeAsync(
+            principal,
+            Arg.Is<object>(resource => IsOpsReadResource(resource, principal)),
+            AuthenticationExtensions.OpsReadPolicy);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task GetDeployOperations_List_TranslatesFiltersAndClampsPageSize()
+    {
+        var store = new RecordingWorkflowOperationStore(
+            BuildDeployOperation(
+                "op-1",
+                targetId: "serving-us-west",
+                desiredRevision: "rev-2",
+                currentRevision: "rev-1",
+                status: WorkflowOperationStatus.Submitted));
+        using var services = CreateServices();
+        var reader = CreateReader(store: store, services: services);
+
+        var result = await reader.GetDeployOperationsAsync(
+            CreatePrincipal(),
+            new McpDeployOperationsArgument
+            {
+                Status = "Submitted",
+                Kind = "Deploy",
+                Page = 0,
+                PageSize = 999,
+            },
+            CancellationToken.None);
+
+        store.LastQuery.Should().NotBeNull();
+        store.LastQuery!.Status.Should().Be(WorkflowOperationStatus.Submitted);
+        store.LastQuery.Kind.Should().Be(WorkflowOperationKind.Deploy);
+        store.LastQuery.Page.Should().Be(1);
+        store.LastQuery.PageSize.Should().Be(200);
+        result.GetProperty("page").GetInt32().Should().Be(1);
+        result.GetProperty("pageSize").GetInt32().Should().Be(200);
+        result.GetProperty("items")
+            .EnumerateArray()
+            .Should()
+            .ContainSingle()
+            .Which
+            .GetProperty("operationId")
+            .GetString()
+            .Should()
+            .Be("op-1");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task GetDeployOperations_ById_ReturnsSingleItemEnvelope()
+    {
+        var store = new RecordingWorkflowOperationStore(
+            BuildDeployOperation(
+                "op-7",
+                targetId: "serving-us-west",
+                desiredRevision: "rev-7",
+                currentRevision: "rev-6",
+                status: WorkflowOperationStatus.Succeeded));
+        using var services = CreateServices();
+        var reader = CreateReader(store: store, services: services);
+
+        var result = await reader.GetDeployOperationsAsync(
+            CreatePrincipal(),
+            new McpDeployOperationsArgument { OperationId = " op-7 " },
+            CancellationToken.None);
+
+        result.GetProperty("page").GetInt32().Should().Be(1);
+        result.GetProperty("pageSize").GetInt32().Should().Be(1);
+        result.GetProperty("totalCount").GetInt32().Should().Be(1);
+        result.GetProperty("items")
+            .EnumerateArray()
+            .Should()
+            .ContainSingle()
+            .Which
+            .GetProperty("target")
+            .GetProperty("desiredRevision")
+            .GetString()
+            .Should()
+            .Be("rev-7");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task ProposeRollback_ExplicitRevision_RoutesForwardDeployPayload()
+    {
+        var store = new RecordingWorkflowOperationStore(
+            BuildDeployOperation(
+                "op-latest",
+                targetId: "serving-us-west",
+                desiredRevision: "rev-10",
+                currentRevision: "rev-9",
+                status: WorkflowOperationStatus.Succeeded));
+        var gateway = new RecordingGateway(new OperationGatewayResult
+        {
+            Outcome = OperationGatewayOutcome.ProposalCreated,
+            Decision = new GuardrailDecision(
+                GuardrailTier.RequiresApproval,
+                OperationClass.Deploy,
+                HonuaEdition.Pro,
+                "test"),
+            ProposalId = "proposal-1",
+            Message = "queued for approval",
+        });
+
+        using var services = CreateServices(
+            gateway,
+            new StaticExecutorCatalog([OperationClass.MetadataRelease, OperationClass.Deploy]));
+        var reader = CreateReader(store: store, services: services);
+
+        var output = await reader.ProposeRollbackAsync(
+            CreatePrincipal(),
+            new McpProposeRollbackArgument
+            {
+                TargetId = " serving-us-west ",
+                ToRevision = " rev-9 ",
+                Reason = "rollback bad release",
+                IdempotencyKey = "rollback-key",
+            },
+            CancellationToken.None);
+
+        output.Outcome.Should().Be(nameof(OperationGatewayOutcome.ProposalCreated));
+        output.RequiresApproval.Should().BeTrue();
+        output.ProposalId.Should().Be("proposal-1");
+        output.ResourceUri.Should().NotBeNullOrWhiteSpace();
+        output.SupportedKinds.Should().Equal("Deploy", "MetadataRelease");
+        gateway.LastRequest.Should().NotBeNull();
+        gateway.LastRequest!.Kind.Should().Be(OperationClass.Deploy);
+        gateway.LastRequest.RequestedBy.Should().Be("ops-agent");
+        gateway.LastRequest.RequestedByAgent.Should().Be("agent:ops-agent");
+        gateway.LastRequest.Reason.Should().Be("rollback bad release");
+        gateway.LastRequest.IdempotencyKey.Should().Be("rollback-key");
+
+        var payload = DeployExecutionPayload.Parse(gateway.LastRequest.ExecutionPayload);
+        payload.Should().NotBeNull();
+        payload!.TargetId.Should().Be("serving-us-west");
+        payload.DesiredRevision.Should().Be("rev-9");
+        payload.CurrentRevision.Should().Be("rev-10");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task ProposeRollback_WithoutRevision_UsesSecondNewestSucceededDeploy()
+    {
+        var store = new RecordingWorkflowOperationStore(
+            BuildDeployOperation(
+                "op-new",
+                targetId: "serving-us-west",
+                desiredRevision: "rev-10",
+                currentRevision: "rev-9",
+                status: WorkflowOperationStatus.Succeeded,
+                createdAt: DateTimeOffset.UtcNow),
+            BuildDeployOperation(
+                "op-prior",
+                targetId: "serving-us-west",
+                desiredRevision: "rev-9",
+                currentRevision: "rev-8",
+                status: WorkflowOperationStatus.Succeeded,
+                createdAt: DateTimeOffset.UtcNow.AddMinutes(-10)));
+        var gateway = new RecordingGateway(new OperationGatewayResult
+        {
+            Outcome = OperationGatewayOutcome.Executed,
+            Decision = new GuardrailDecision(
+                GuardrailTier.DirectExecute,
+                OperationClass.Deploy,
+                HonuaEdition.Pro,
+                "test"),
+            ExecutionOperationId = "op-rollback",
+            Message = "submitted",
+        });
+
+        using var services = CreateServices(gateway);
+        var reader = CreateReader(store: store, services: services);
+
+        var output = await reader.ProposeRollbackAsync(
+            CreatePrincipal(),
+            new McpProposeRollbackArgument { TargetId = "serving-us-west" },
+            CancellationToken.None);
+
+        output.Outcome.Should().Be(nameof(OperationGatewayOutcome.Executed));
+        output.ExecutionOperationId.Should().Be("op-rollback");
+        gateway.LastRequest.Should().NotBeNull();
+        gateway.LastRequest!.IdempotencyKey.Should().Be("rollback:serving-us-west:rev-9");
+
+        var payload = DeployExecutionPayload.Parse(gateway.LastRequest.ExecutionPayload);
+        payload.Should().NotBeNull();
+        payload!.DesiredRevision.Should().Be("rev-9");
+        payload.CurrentRevision.Should().Be("rev-10");
+    }
+
+    private static McpPlatformOpsReader CreateReader(
+        ControlPlaneOptions? options = null,
+        IWorkflowOperationStore? store = null,
+        IAuthorizationService? authorization = null,
+        IServiceProvider? services = null)
+        => new(
+            new StaticOptionsMonitor<ControlPlaneOptions>(options ?? CreateOptions()),
+            CreateDeployService(store ?? new RecordingWorkflowOperationStore()),
+            authorization ?? CreateAuthorization(AuthorizationResult.Success()),
+            services ?? CreateServices());
+
+    private static DeployWorkflowService CreateDeployService(IWorkflowOperationStore store)
+        => new(
+            Substitute.For<IDeployTargetRegistry>(),
+            [store],
+            Array.Empty<IDeployBackend>(),
+            Substitute.For<IOperatorApprovalEvaluator>(),
+            NullLogger<DeployWorkflowService>.Instance);
+
+    private static IAuthorizationService CreateAuthorization(AuthorizationResult result)
+    {
+        var authorization = Substitute.For<IAuthorizationService>();
+        authorization.AuthorizeAsync(
+                Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<object>(),
+                AuthenticationExtensions.OpsReadPolicy)
+            .Returns(result);
+        return authorization;
+    }
+
+    private static ServiceProvider CreateServices(
+        IOperationGateway? gateway = null,
+        IOperationExecutorCatalog? catalog = null)
+    {
+        var services = new ServiceCollection();
+        if (gateway is not null)
+        {
+            services.AddSingleton(gateway);
+        }
+
+        if (catalog is not null)
+        {
+            services.AddSingleton(catalog);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ClaimsPrincipal CreatePrincipal()
+        => new(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Name, "ops-agent"),
+                new Claim(ClaimTypes.NameIdentifier, "ops-agent"),
+            ],
+            "test"));
+
+    private static bool IsOpsReadResource(object resource, ClaimsPrincipal principal)
+        => resource is DefaultHttpContext context &&
+            ReferenceEquals(context.User, principal) &&
+            string.Equals(context.Request.Method, HttpMethods.Get, StringComparison.Ordinal);
+
+    private static ControlPlaneOptions CreateOptions()
+        => new()
+        {
+            PlatformRelease = new PlatformReleaseOptions
+            {
+                Version = "2026.07.01",
+                ServingArtifactReference = "ghcr.io/honua/server:2026.07.01",
+                Workers =
+                [
+                    new PlatformReleaseWorkerImageOptions
+                    {
+                        RuntimeProfile = "gdal",
+                        ArtifactReference = "ghcr.io/honua/worker-gdal:2026.07.01",
+                    },
+                ],
+            },
+            DeployTargets =
+            [
+                new DeployTargetOptions
+                {
+                    TargetId = "serving-us-west",
+                    TargetKind = DeployTargetKind.SelfHostedRolling,
+                    Backend = "self-hosted",
+                    Environment = "prod",
+                    TargetName = "Serving west",
+                },
+                new DeployTargetOptions
+                {
+                    TargetId = "serving-pinned",
+                    TargetKind = DeployTargetKind.SelfHostedRolling,
+                    Backend = "self-hosted",
+                    Environment = "prod",
+                    TargetName = "Pinned",
+                    ArtifactReference = "ghcr.io/honua/server:old",
+                },
+            ],
+            ExecutionWorkloads =
+            [
+                new ExecutionWorkloadOptions
+                {
+                    WorkloadId = "gp-gdal",
+                    TargetKind = BatchComputeTargetKind.LocalProcess,
+                    Backend = "local-process",
+                    WorkloadName = "GDAL workers",
+                    RuntimeProfile = "gdal",
+                },
+            ],
+        };
+
+    private static WorkflowOperationRecord BuildDeployOperation(
+        string operationId,
+        string targetId,
+        string desiredRevision,
+        string? currentRevision,
+        WorkflowOperationStatus status,
+        DateTimeOffset? createdAt = null)
+    {
+        var created = createdAt ?? DateTimeOffset.UtcNow;
+        return new WorkflowOperationRecord
+        {
+            OperationId = operationId,
+            Kind = WorkflowOperationKind.Deploy,
+            Status = status,
+            CreatedAt = created,
+            UpdatedAt = created,
+            Deploy = new DeployOperationSpec
+            {
+                TargetId = targetId,
+                TargetKind = DeployTargetKind.SelfHostedRolling,
+                Backend = "self-hosted",
+                Environment = "prod",
+                TargetName = "Honua serving",
+                CurrentRevision = currentRevision,
+                DesiredRevision = desiredRevision,
+            },
+        };
+    }
+
+    private sealed class RecordingWorkflowOperationStore(params WorkflowOperationRecord[] operations) : IWorkflowOperationStore
+    {
+        private readonly Dictionary<string, WorkflowOperationRecord> _operations =
+            operations.ToDictionary(operation => operation.OperationId, StringComparer.Ordinal);
+
+        public WorkflowOperationQuery? LastQuery { get; private set; }
+
+        public Task<bool> TryAcquireLeaseAsync(
+            string operationId,
+            string ownerId,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task<bool> RenewLeaseAsync(
+            string operationId,
+            string ownerId,
+            TimeSpan leaseDuration,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+
+        public Task ReleaseLeaseAsync(
+            string operationId,
+            string ownerId,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task<bool> TryCreateAsync(
+            WorkflowOperationRecord operation,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+        {
+            var created = !_operations.ContainsKey(operation.OperationId);
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(created);
+        }
+
+        public Task<WorkflowOperationRecord?> GetAsync(
+            string operationId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_operations.GetValueOrDefault(operationId));
+
+        public Task<WorkflowOperationRecord?> GetByMetadataPackageIdAsync(
+            string packageId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_operations.Values.FirstOrDefault(
+                operation => string.Equals(operation.MetadataRelease?.PackageId, packageId, StringComparison.Ordinal)));
+
+        public Task SetAsync(
+            WorkflowOperationRecord operation,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetAsync(
+            WorkflowOperationRecord operation,
+            TimeSpan? ttl = null,
+            CancellationToken cancellationToken = default)
+        {
+            _operations[operation.OperationId] = operation;
+            return Task.FromResult(true);
+        }
+
+        public Task<IReadOnlyList<WorkflowOperationRecord>> ListActiveAsync(
+            WorkflowOperationKind? kind = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<WorkflowOperationRecord>>(
+                _operations.Values
+                    .Where(operation => !kind.HasValue || operation.Kind == kind.Value)
+                    .ToArray());
+
+        public Task<WorkflowOperationPage> QueryAsync(
+            WorkflowOperationQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            LastQuery = query;
+            var filtered = _operations.Values
+                .Where(operation => !query.Kind.HasValue || operation.Kind == query.Kind.Value)
+                .Where(operation => !query.Status.HasValue || operation.Status == query.Status.Value)
+                .OrderByDescending(operation => operation.CreatedAt)
+                .ToArray();
+            var items = filtered
+                .Skip((query.Page - 1) * query.PageSize)
+                .Take(query.PageSize)
+                .ToArray();
+
+            return Task.FromResult(new WorkflowOperationPage
+            {
+                Items = items,
+                Page = query.Page,
+                PageSize = query.PageSize,
+                TotalCount = filtered.Length,
+                HasMore = query.Page * query.PageSize < filtered.Length,
+            });
+        }
+
+        public Task<WorkflowOperationRecord?> GetMostRecentSucceededDeployByTargetAsync(
+            string targetId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(_operations.Values
+                .Where(operation =>
+                    operation.Kind == WorkflowOperationKind.Deploy &&
+                    operation.Status == WorkflowOperationStatus.Succeeded &&
+                    string.Equals(operation.Deploy?.TargetId, targetId, StringComparison.Ordinal))
+                .OrderByDescending(operation => operation.CreatedAt)
+                .FirstOrDefault());
+    }
+
+    private sealed class RecordingGateway(OperationGatewayResult result) : IOperationGateway
+    {
+        public OperationGatewayRequest? LastRequest { get; private set; }
+
+        public Task<OperationGatewayResult> RouteAsync(
+            OperationGatewayRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(result);
+        }
+
+        public Task<OperationProposal?> ApplyApprovedProposalAsync(
+            string proposalId,
+            string approvedBy,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<OperationProposal?>(null);
+
+        public Task<OperationProposal?> RejectProposalAsync(
+            string proposalId,
+            string rejectedBy,
+            string reason,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<OperationProposal?>(null);
+    }
+
+    private sealed class StaticExecutorCatalog(IReadOnlyCollection<OperationClass> supportedKinds) : IOperationExecutorCatalog
+    {
+        public IReadOnlyCollection<OperationClass> SupportedKinds { get; } = supportedKinds;
+    }
+
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+        where T : class
+    {
+        public T CurrentValue { get; } = value;
+
+        public T Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2566
Related to #2552
Related to #2457
Related to #1948
Related to honua-io/geospatial-mcp#57

## Summary
Adds the MCP platform-ops tool surface for release status, deploy operation inspection, and rollback proposal support needed by the self-operating platform epic. This implements the merged geospatial-mcp schema names for #2566: `honua_platform_release_status`, `honua_deploy_operations`, and `honua_propose_rollback`.

## Changes Made
- Added MCP platform-ops schemas, tool handlers, registration, JSON context coverage, capability registry entries, and taxonomy/schema conformance coverage.
- Added the server-side `IMcpPlatformOpsReader` adapter over platform-release and deploy-operation projections, with auth-preserving read checks and bounded pagination.
- Added rollback proposal support through the existing operation gateway without adding approve/reject/submit/promote tools.
- Synced the vendored geospatial-mcp schemas and fixtures for platform release status, deploy operations, propose rollback, and supported deploy operation kinds.
- Hardened local Windows validation issues in instruction-sync handling, import baseline newline comparison, SQLite GeoPackage cleanup, import cleanup retention testing, and pre-PR shard-name routing.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Validation notes:
- `dotnet build Honua.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true` passed via `scripts/ci/pre-pr-check.sh`.
- `dotnet format Honua.sln --verify-no-changes --verbosity diagnostic` passed via `scripts/ci/pre-pr-check.sh`.
- `dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --no-build --no-restore --configuration Release --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1` passed: 3475 passed, 2 skipped.
- `Honua.Core.Security.Tests`, `Honua.LoadTests`, and `Honua.Postgres.Tests` passed via `scripts/ci/pre-pr-check.sh`; Postgres tests passed 843/843.
- Focused MCP/platform ops, reader, AI schema/taxonomy, and architecture test runs passed locally before opening this draft.
- Local Git Bash verification confirms the pushed pre-PR shard-name normalization selects all 52 configured shards and resolves a representative shard lookup.
- Full local `scripts/ci/pre-pr-check.sh` has not been rerun through every server shard after the Windows shard-router fix; previous full server-misc shard execution hit two unrelated streaming timing failures that both passed an immediate isolated rerun.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None - no docs or contract impact
- [x] MCP/geospatial-mcp tool schema copy updated

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review