### PR TITLE
test(architecture): add seat parity contract (#2567)

### DIFF
--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/ops-parity-map.yaml
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/ops-parity-map.yaml
@@ -1,0 +1,52 @@
+# Geospatial MCP operations parity map.
+#
+# Format:
+# routes:
+#   "METHOD /api/v1/example/{id}":
+#     tool: honua_tool_name
+#     # or:
+#     resource: honua://resource/{id}
+#     # or:
+#     human-only: "Required justification for an operator-only action."
+#
+# Each route in the architecture-test enforced operate/admin-observability/deploy/proposals
+# partition must appear exactly once with exactly one of `tool`, `resource`, or `human-only`.
+# `human-only` is reserved for actions that must remain human controls, such as approval,
+# rejection, staged submit, and promotion.
+routes:
+  "GET /api/v1/operate/status":
+    tool: honua_ops_health
+  "GET /api/v1/admin/observability/ops-health":
+    tool: honua_ops_health
+  "GET /api/v1/admin/observability/ops-health/history":
+    resource: honua://ops/health
+  "GET /api/v1/admin/observability/findings":
+    tool: honua_ops_findings
+  "POST /api/v1/admin/observability/findings/{findingId}/propose":
+    tool: honua_propose_operation
+  "GET /api/v1/admin/deploy/preflight":
+    tool: honua_ops_health
+  "POST /api/v1/admin/deploy/plan":
+    tool: honua_propose_operation
+  "GET /api/v1/admin/deploy/operations":
+    tool: honua_operate_events
+  "POST /api/v1/admin/deploy/operations":
+    tool: honua_propose_operation
+  "GET /api/v1/admin/deploy/operations/{operationId}":
+    tool: honua_operate_events
+  "POST /api/v1/admin/deploy/operations/{operationId}/submit":
+    human-only: "Submitting a staged deploy operation is an operator control; agents propose operations and observe status instead."
+  "POST /api/v1/admin/deploy/operations/{operationId}/promote":
+    human-only: "Promoting a staged deploy operation is an operator control; agents propose operations and observe status instead."
+  "POST /api/v1/admin/deploy/operations/{operationId}/rollback":
+    tool: honua_propose_operation
+  "POST /api/v1/admin/platform-release/converge":
+    tool: honua_propose_operation
+  "GET /api/v1/admin/proposals":
+    resource: honua://proposals/{proposalId}
+  "GET /api/v1/admin/proposals/{id}":
+    resource: honua://proposals/{proposalId}
+  "POST /api/v1/admin/proposals/{id}/approve":
+    human-only: "Approving a proposal must be performed by a human operator; agents can propose and poll honua://proposals/{proposalId}."
+  "POST /api/v1/admin/proposals/{id}/reject":
+    human-only: "Rejecting a proposal must be performed by a human operator; agents can propose and poll honua://proposals/{proposalId}."

--- a/tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj
+++ b/tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj
@@ -34,6 +34,7 @@
       champions. See ConformanceSchemas/README.md.
     -->
     <Content Include="ConformanceSchemas\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="ConformanceSchemas\**\*.yaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.Architecture.Tests/SeatParityContractTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/SeatParityContractTests.cs
@@ -1,0 +1,365 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Server;
+
+namespace Honua.Architecture.Tests;
+
+/// <summary>
+/// Architecture contracts for the console/agent seat-parity promise tracked by #2567.
+/// </summary>
+public sealed class SeatParityContractTests
+{
+    private const string OpsParityMapRelativePath =
+        "tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/ops-parity-map.yaml";
+
+    private static readonly Regex RouteLineRegex = new(
+        "^\\s{2}\"(?<route>[^\"]+)\"\\s*:\\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex RoutePropertyRegex = new(
+        "^\\s{4}(?<key>tool|resource|human-only)\\s*:\\s*(?<value>.+?)\\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex OperationKindRegex = new(
+        "Kind\\s*=\\s*OperationClass\\.(?<kind>\\w+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ExecutorRegistrationRegex = new(
+        "(?:TryAddSingleton|AddSingleton)<\\s*Honua\\.Core\\.Features\\.ControlPlane\\.Abstractions\\.IOperationExecutor\\s*,\\s*(?<type>[\\w\\.]+)\\s*>\\s*\\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex AdminConfigApplierRegistrationRegex = new(
+        "(?:TryAddSingleton|AddSingleton)<\\s*Honua\\.Core\\.Features\\.ControlPlane\\.Abstractions\\.IAdminConfigChangeApplier\\s*,\\s*(?<type>[\\w\\.]+)\\s*>\\s*\\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ExecutorKindSourceRegex = new(
+        "OperationClass\\s*=>\\s*OperationClass\\.(?<kind>\\w+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex OpsActionPayloadBuilderRegex = new(
+        "OpsActionExecutionPayloads\\.(?<method>\\w+)\\s*\\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    [ArchitectureTest]
+    public void OpsParityMap_CoversOperateObservabilityDeployAndProposalRoutes()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var parityMap = LoadParityMap(repoRoot);
+        var expectedRoutes = EndpointRegistry.All
+            .Where(IsOpsParityRoute)
+            .Select(endpoint => $"{endpoint.Method.ToUpperInvariant()} {endpoint.Path}")
+            .OrderBy(route => route, StringComparer.Ordinal)
+            .ToArray();
+
+        parityMap.Keys.OrderBy(route => route, StringComparer.Ordinal)
+            .Should().BeEquivalentTo(
+                expectedRoutes,
+                "every operate/admin-observability/deploy/proposal EndpointRegistry route must be mapped for MCP parity");
+
+        var implementedMcpTools = LoadImplementedMcpTools(repoRoot);
+        foreach (var (route, entry) in parityMap)
+        {
+            var populatedFields = new[]
+                {
+                    entry.Tool,
+                    entry.Resource,
+                    entry.HumanOnly
+                }
+                .Count(value => !string.IsNullOrWhiteSpace(value));
+
+            populatedFields.Should().Be(
+                1,
+                $"{route} must choose exactly one parity target: tool, resource, or human-only");
+
+            if (!string.IsNullOrWhiteSpace(entry.Tool))
+            {
+                implementedMcpTools.Should().Contain(
+                    entry.Tool,
+                    $"{route} maps to a checked-in implemented geospatial-mcp tool");
+            }
+
+            if (!string.IsNullOrWhiteSpace(entry.Resource))
+            {
+                entry.Resource.Should().StartWith("honua://", $"{route} maps to an MCP resource URI");
+            }
+
+            if (!string.IsNullOrWhiteSpace(entry.HumanOnly))
+            {
+                entry.HumanOnly.Should().NotBeNullOrWhiteSpace(
+                    $"{route} is operator-only and must carry an explicit justification");
+            }
+        }
+    }
+
+    [ArchitectureTest]
+    public void OpsFindingRecommendedActions_RouteThroughRealGatewayExecutors()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var findingsSource = ReadRepoFile(repoRoot, "src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs");
+        var programSource = ReadRepoFile(repoRoot, "src/Honua.Server/Program.cs");
+
+        var recommendedKinds = OperationKindRegex.Matches(findingsSource)
+            .Select(match => match.Groups["kind"].Value)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(kind => kind, StringComparer.Ordinal)
+            .ToArray();
+
+        recommendedKinds.Should().NotBeEmpty(
+            "ops findings with recommended actions must be checked against the gateway executor surface");
+
+        var registeredExecutorKinds = ExtractRegisteredExecutorKinds(repoRoot, programSource);
+        recommendedKinds.Should().OnlyContain(
+            kind => registeredExecutorKinds.Contains(kind),
+            "every recommended action kind emitted by OpsFindingsService must have a registered IOperationExecutor");
+
+        var registeredAppliers = AdminConfigApplierRegistrationRegex.Matches(programSource)
+            .Select(match => match.Groups["type"].Value)
+            .ToArray();
+
+        registeredAppliers.Should().Contain(
+            "Honua.ControlPlane.Executors.OpsActionAdminConfigChangeApplier",
+            "AdminConfigChange findings must execute through the real ops-action applier");
+        registeredAppliers.Should().NotContain(
+            type => type.EndsWith(".LoggingAdminConfigChangeApplier", StringComparison.Ordinal)
+                || string.Equals(type, "LoggingAdminConfigChangeApplier", StringComparison.Ordinal),
+            "a logging/no-op admin config applier silently drops approved actions");
+
+        var loggingAppliers = ArchitectureTestHelpers.GetTypesSafely(typeof(EndpointRegistry).Assembly)
+            .Where(type => typeof(IAdminConfigChangeApplier).IsAssignableFrom(type))
+            .Where(type => type.Name.Contains("Logging", StringComparison.Ordinal))
+            .Select(type => type.FullName)
+            .ToArray();
+
+        loggingAppliers.Should().BeEmpty(
+            "production IAdminConfigChangeApplier implementations must not be logging/no-op stubs");
+    }
+
+    [ArchitectureTest]
+    public void OpsFindingAdminConfigActions_AreRegisteredInOpsActionCatalog()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var findingsSource = ReadRepoFile(repoRoot, "src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs");
+        var actionModelSource = ReadRepoFile(repoRoot, "src/Honua.Server/Features/ControlPlane/Executors/OpsActionModel.cs");
+
+        var adminConfigActionContexts = OperationKindRegex.Matches(findingsSource)
+            .Where(match => string.Equals(match.Groups["kind"].Value, "AdminConfigChange", StringComparison.Ordinal))
+            .Select(match => findingsSource.Substring(
+                match.Index,
+                Math.Min(800, findingsSource.Length - match.Index)))
+            .ToArray();
+
+        adminConfigActionContexts.Should().NotBeEmpty(
+            "registry-dispatched AdminConfigChange findings should exist and be validated");
+
+        foreach (var context in adminConfigActionContexts)
+        {
+            context.Should().Contain(
+                "ExecutionPayload = OpsActionExecutionPayloads.",
+                "AdminConfigChange findings must use the typed ops-action payload builders instead of hand-rolled payloads");
+        }
+
+        var builderMethods = adminConfigActionContexts
+            .SelectMany(context => OpsActionPayloadBuilderRegex.Matches(context)
+                .Select(match => match.Groups["method"].Value))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(method => method, StringComparer.Ordinal)
+            .ToArray();
+
+        var actionNamesByField = LoadOpsActionNameConstants();
+        var registeredActions = LoadRegisteredOpsActions();
+        var emittedActions = builderMethods
+            .Select(method => ExtractOpsActionNameFromBuilder(actionModelSource, method))
+            .Select(field => actionNamesByField[field])
+            .OrderBy(action => action, StringComparer.Ordinal)
+            .ToArray();
+
+        emittedActions.Should().OnlyContain(
+            action => registeredActions.Contains(action),
+            "every ops-action payload emitted by a finding must exist in the T4 ops-action registry");
+    }
+
+    private static bool IsOpsParityRoute(EndpointDefinition endpoint)
+        => endpoint.Path.StartsWith("/api/v1/operate/", StringComparison.Ordinal)
+            || endpoint.Path.StartsWith("/api/v1/admin/observability/ops-health", StringComparison.Ordinal)
+            || endpoint.Path.StartsWith("/api/v1/admin/observability/findings", StringComparison.Ordinal)
+            || endpoint.Path.StartsWith("/api/v1/admin/deploy/", StringComparison.Ordinal)
+            || endpoint.Path.StartsWith("/api/v1/admin/proposals", StringComparison.Ordinal)
+            || string.Equals(endpoint.Path, "/api/v1/admin/platform-release/converge", StringComparison.Ordinal);
+
+    private static Dictionary<string, ParityMapEntry> LoadParityMap(string repoRoot)
+    {
+        var path = Path.Combine(repoRoot, OpsParityMapRelativePath.Replace('/', Path.DirectorySeparatorChar));
+        File.Exists(path).Should().BeTrue($"the #2567 parity map should exist at {path}");
+
+        var entries = new Dictionary<string, ParityMapEntry>(StringComparer.Ordinal);
+        string? currentRoute = null;
+        ParityMapEntry currentEntry = default;
+
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var trimmed = rawLine.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#') || string.Equals(trimmed, "routes:", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var routeMatch = RouteLineRegex.Match(rawLine);
+            if (routeMatch.Success)
+            {
+                AddCurrentEntry(entries, currentRoute, currentEntry);
+                currentRoute = routeMatch.Groups["route"].Value;
+                entries.Should().NotContainKey(currentRoute, $"route '{currentRoute}' should appear once in the parity map");
+                currentEntry = default;
+                continue;
+            }
+
+            var propertyMatch = RoutePropertyRegex.Match(rawLine);
+            propertyMatch.Success.Should().BeTrue($"line '{rawLine}' must be a route key or route property");
+            currentRoute.Should().NotBeNull($"line '{rawLine}' must belong to a route entry");
+
+            var value = Unquote(propertyMatch.Groups["value"].Value.Trim());
+            currentEntry = propertyMatch.Groups["key"].Value switch
+            {
+                "tool" => currentEntry with { Tool = value },
+                "resource" => currentEntry with { Resource = value },
+                "human-only" => currentEntry with { HumanOnly = value },
+                _ => currentEntry
+            };
+        }
+
+        AddCurrentEntry(entries, currentRoute, currentEntry);
+        return entries;
+    }
+
+    private static void AddCurrentEntry(
+        IDictionary<string, ParityMapEntry> entries,
+        string? currentRoute,
+        ParityMapEntry currentEntry)
+    {
+        if (currentRoute is not null)
+        {
+            entries.Add(currentRoute, currentEntry);
+        }
+    }
+
+    private static HashSet<string> LoadImplementedMcpTools(string repoRoot)
+    {
+        var indexPath = Path.Combine(
+            repoRoot,
+            "tests",
+            "dotnet",
+            "Honua.Ai.Tests",
+            "ConformanceSchemas",
+            "geospatial-mcp",
+            "index.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(indexPath));
+        return document.RootElement
+            .GetProperty("tools")
+            .EnumerateArray()
+            .Where(tool => string.Equals(tool.GetProperty("implementationStatus").GetString(), "implemented", StringComparison.Ordinal))
+            .Select(tool => tool.GetProperty("referenceToolName").GetString())
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static HashSet<string> ExtractRegisteredExecutorKinds(string repoRoot, string programSource)
+    {
+        var executorTypes = ExecutorRegistrationRegex.Matches(programSource)
+            .Select(match => match.Groups["type"].Value)
+            .ToArray();
+
+        executorTypes.Should().NotBeEmpty("Program.cs must register gateway executors");
+
+        var kinds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var executorType in executorTypes)
+        {
+            var source = FindTypeSource(repoRoot, executorType);
+            var match = ExecutorKindSourceRegex.Match(source);
+            match.Success.Should().BeTrue($"{executorType} must declare a stable OperationClass");
+            kinds.Add(match.Groups["kind"].Value);
+        }
+
+        return kinds;
+    }
+
+    private static Dictionary<string, string> LoadOpsActionNameConstants()
+    {
+        var type = typeof(EndpointRegistry).Assembly.GetType("Honua.ControlPlane.Executors.OpsActionNames");
+        type.Should().NotBeNull("OpsActionNames is the stable action-id vocabulary");
+
+        return type!.GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(string))
+            .ToDictionary(
+                field => field.Name,
+                field => (string)field.GetValue(null)!,
+                StringComparer.Ordinal);
+    }
+
+    private static HashSet<string> LoadRegisteredOpsActions()
+    {
+        var type = typeof(EndpointRegistry).Assembly.GetType("Honua.ControlPlane.Executors.OpsActionCatalog");
+        type.Should().NotBeNull("OpsActionCatalog is the T4 action registry");
+
+        var field = type!.GetField("GuardrailTiers", BindingFlags.Public | BindingFlags.Static);
+        field.Should().NotBeNull("OpsActionCatalog.GuardrailTiers is the registered action-id set");
+
+        var values = (IEnumerable)field!.GetValue(null)!;
+        return values
+            .Cast<object>()
+            .Select(entry => (string)entry.GetType().GetProperty("Key")!.GetValue(entry)!)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string ExtractOpsActionNameFromBuilder(string actionModelSource, string methodName)
+    {
+        var regex = new Regex(
+            "\\bpublic\\s+static\\s+string\\s+" + Regex.Escape(methodName)
+            + "\\s*\\([^)]*\\)\\s*=>\\s*Build\\(OpsActionNames\\.(?<name>\\w+)",
+            RegexOptions.CultureInvariant | RegexOptions.Singleline);
+
+        var match = regex.Match(actionModelSource);
+        match.Success.Should().BeTrue($"OpsActionExecutionPayloads.{methodName} must delegate to a registered OpsActionNames constant");
+        return match.Groups["name"].Value;
+    }
+
+    private static string FindTypeSource(string repoRoot, string fullTypeName)
+    {
+        var typeName = fullTypeName[(fullTypeName.LastIndexOf('.') + 1)..];
+        var serverRoot = Path.Combine(repoRoot, "src", "Honua.Server");
+        foreach (var file in Directory.EnumerateFiles(serverRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            var source = File.ReadAllText(file);
+            if (source.Contains("class " + typeName, StringComparison.Ordinal)
+                || source.Contains("record " + typeName, StringComparison.Ordinal))
+            {
+                return source;
+            }
+        }
+
+        throw new FileNotFoundException($"Unable to locate source for {fullTypeName}.");
+    }
+
+    private static string ReadRepoFile(string repoRoot, string relativePath)
+        => File.ReadAllText(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+    private static string Unquote(string value)
+    {
+        if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+        {
+            return value[1..^1].Replace("\\\"", "\"", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private readonly record struct ParityMapEntry(string? Tool, string? Resource, string? HumanOnly);
+}


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Closes #2567
Related to #2552
Related to #2457

## Summary
Adds enforceable seat-parity architecture contracts for the operate/control-plane surface. The new tests verify that the admin operate, observability, deploy, and proposal routes have an explicit MCP parity mapping, and that ops findings route recommended actions through real gateway executors instead of no-op/logging paths.

## Changes Made
- Added `SeatParityContractTests` for MCP parity-map coverage and findings-action executor registration.
- Added `ops-parity-map.yaml` for the current operate/admin-observability/deploy/proposal route partition.
- Included YAML geospatial-MCP conformance fixtures in the AI test project.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Validation run locally:
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --configuration Release`
- `dotnet format Honua.sln --verify-no-changes`
- `git diff --check origin/trunk...HEAD`