### PR TITLE
fix(mcp): align workspace result URIs (#2581)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpResourceUris.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpResourceUris.cs
@@ -15,6 +15,7 @@ internal static class McpResourceUris
     public const string JobsPrefix = "honua://jobs/";
     public const string JobResultsSuffix = "/results";
     public const string JobReportSuffix = "/report";
+    public const string ResultsPrefix = "honua://results/";
     public const string WorkspacesPrefix = "honua://workspaces/";
     public const string ProposalsPrefix = "honua://proposals/";
     public const string CatalogProcesses = "honua://catalog/processes";
@@ -36,6 +37,9 @@ internal static class McpResourceUris
 
     /// <summary>Builds the <c>honua://jobs/{jobId}/results</c> URI.</summary>
     public static string JobResultsUri(string jobId) => $"{JobsPrefix}{jobId}{JobResultsSuffix}";
+
+    /// <summary>Builds the <c>honua://results/{resultPackageId}</c> URI.</summary>
+    public static string ResultPackageUri(string resultPackageId) => $"{ResultsPrefix}{resultPackageId}";
 
     /// <summary>Builds the <c>honua://jobs/{jobId}/report</c> URI.</summary>
     public static string JobReportUri(string jobId) => $"{JobsPrefix}{jobId}{JobReportSuffix}";

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpResourceModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpResourceModels.cs
@@ -265,10 +265,10 @@ internal sealed class McpWorkspaceResource
     public string WorkspaceId { get; set; } = string.Empty;
 
     [JsonPropertyName("kind")]
-    public string Kind { get; set; } = string.Empty;
+    public string? Kind { get; set; }
 
     [JsonPropertyName("label")]
-    public string Label { get; set; } = string.Empty;
+    public string? Label { get; set; }
 
     [JsonPropertyName("uri")]
     public string? Uri { get; set; }
@@ -276,8 +276,8 @@ internal sealed class McpWorkspaceResource
     [JsonPropertyName("expiresAt")]
     public DateTimeOffset? ExpiresAt { get; set; }
 
-    [JsonPropertyName("status")]
-    public string Status { get; set; } = string.Empty;
+    [JsonPropertyName("lifecycleState")]
+    public string? LifecycleState { get; set; }
 
     [JsonPropertyName("cleanupScheduledAt")]
     public DateTimeOffset? CleanupScheduledAt { get; set; }

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Resources/WorkspaceResource.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Resources/WorkspaceResource.cs
@@ -114,9 +114,6 @@ internal sealed class WorkspaceResource : IMcpResource
     private static McpWorkspaceResource CreateDegradedResource(string workspaceId) => new()
     {
         WorkspaceId = workspaceId,
-        Kind = string.Empty,
-        Label = string.Empty,
-        Status = "degraded",
         NotImplementedReason = LifecycleUnavailableReason
     };
 
@@ -127,7 +124,7 @@ internal sealed class WorkspaceResource : IMcpResource
         Label = workspace.Label,
         Uri = workspace.Uri,
         ExpiresAt = workspace.ExpiresAt,
-        Status = ToWireStatus(workspace.State),
+        LifecycleState = ToWireLifecycleState(workspace.State),
         CleanupScheduledAt = workspace.State == WorkspaceLifecycleState.Expired
             ? workspace.ExpiresAt
             : null,
@@ -144,12 +141,12 @@ internal sealed class WorkspaceResource : IMcpResource
         _ => kind.ToString()
     };
 
-    private static string ToWireStatus(WorkspaceLifecycleState state) => state switch
+    private static string ToWireLifecycleState(WorkspaceLifecycleState state) => state switch
     {
         WorkspaceLifecycleState.Active => "active",
-        WorkspaceLifecycleState.Expired => "cleanup_pending",
-        WorkspaceLifecycleState.Archived => "sealed",
-        WorkspaceLifecycleState.Deleted => "not_found",
+        WorkspaceLifecycleState.Expired => "expired",
+        WorkspaceLifecycleState.Archived => "archived",
+        WorkspaceLifecycleState.Deleted => "deleted",
         _ => state.ToString()
     };
 
@@ -157,12 +154,12 @@ internal sealed class WorkspaceResource : IMcpResource
     {
         foreach (var artifact in workspace.Artifacts)
         {
-            if (TryGetMetadataValue(artifact.Metadata, "jobId", out var jobId)
-                || TryGetMetadataValue(artifact.Metadata, "job.id", out jobId)
-                || TryGetMetadataValue(artifact.Metadata, "honua.jobId", out jobId)
-                || TryGetMetadataValue(artifact.Metadata, "sourceJobId", out jobId))
+            if (TryGetMetadataValue(artifact.Metadata, "resultPackageId", out var resultPackageId)
+                || TryGetMetadataValue(artifact.Metadata, "result.package.id", out resultPackageId)
+                || TryGetMetadataValue(artifact.Metadata, "honua.resultPackageId", out resultPackageId)
+                || TryGetMetadataValue(artifact.Metadata, "sourceResultPackageId", out resultPackageId))
             {
-                return McpResourceUris.JobResultsUri(jobId);
+                return McpResourceUris.ResultPackageUri(resultPackageId);
             }
         }
 

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -1,15 +1,21 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
+using System.Security.Claims;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Honua.Ai.Protocols.Mcp;
 using Honua.Ai.Protocols.Mcp.Discovery;
+using Honua.Ai.Protocols.Mcp.Resources;
 using Honua.Ai.Protocols.Mcp.Tools;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
 using Honua.Core.Features.PackageReview.Abstractions;
 using Honua.Geoprocessing;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
@@ -393,6 +399,126 @@ public sealed partial class McpTaxonomyAlignmentTests
     }
 
     [UnitTest]
+    public async Task LiveWorkspacePayload_ConformsToVendoredWorkspaceSchema()
+    {
+        var lifecycle = Substitute.For<IWorkspaceLifecycleService>();
+        lifecycle.GetWorkspaceAsync("ws-42", Arg.Any<CancellationToken>())
+            .Returns(new Workspace
+            {
+                WorkspaceId = "ws-42",
+                Kind = WorkspaceKind.ResultCollection,
+                Label = "Result workspace",
+                OwnerId = "test-user",
+                State = WorkspaceLifecycleState.Active,
+                Uri = "honua://workspace-storage/ws-42",
+                CreatedAt = DateTimeOffset.Parse("2026-05-18T12:00:00Z", CultureInfo.InvariantCulture),
+                ExpiresAt = DateTimeOffset.Parse("2026-05-19T12:00:00Z", CultureInfo.InvariantCulture),
+                Artifacts =
+                [
+                    new Artifact
+                    {
+                        ArtifactId = "artifact-1",
+                        Kind = ArtifactKind.FeatureLayer,
+                        Label = "Output layer",
+                        State = ArtifactLifecycleState.Available,
+                        WorkspaceId = "ws-42",
+                        CreatedAt = DateTimeOffset.Parse("2026-05-18T12:05:00Z", CultureInfo.InvariantCulture),
+                        Metadata = new Dictionary<string, string>
+                        {
+                            ["resultPackageId"] = "result_3f21"
+                        }
+                    }
+                ]
+            });
+
+        await using var services = new ServiceCollection()
+            .AddScoped(_ => lifecycle)
+            .BuildServiceProvider();
+        var resource = new WorkspaceResource(
+            Substitute.For<IGeoprocessingJobService>(),
+            services.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<WorkspaceResource>.Instance);
+
+        var result = await resource.ReadAsync(
+            McpTestFactory.AuthenticatedHttpContext(),
+            "honua://workspaces/ws-42",
+            CancellationToken.None);
+
+        var payload = JToken.Parse(result.Contents[0].Text);
+        payload["lifecycleState"]!.Value<string>().Should().Be("active");
+        payload["resultsUri"]!.Value<string>().Should().Be("honua://results/result_3f21");
+        payload["status"].Should().BeNull();
+        AssertPayloadConformsToResourceSchema(payload, "workspace.schema.json", "live workspace payload");
+    }
+
+    [UnitTest]
+    public async Task LiveResultPayload_ConformsToVendoredResultPackageSchema()
+    {
+        var jobService = Substitute.For<IGeoprocessingJobService>();
+        jobService.GetJobResultsAsync("job-xyz", Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(AnalysisResultPackage.CreateCompleted(
+                "result_3f21",
+                new ResultSummary
+                {
+                    Title = "Buffered parcels",
+                    Description = "5-meter parcel buffers"
+                },
+                [
+                    new ArtifactRef
+                    {
+                        ArtifactId = "artifact-1",
+                        Kind = ArtifactKind.FeatureLayer,
+                        Label = "Buffered output",
+                        Uri = "honua://artifacts/artifact-1",
+                        ContentType = "application/geo+json",
+                        Metadata = new Dictionary<string, string>
+                        {
+                            ["resultPackageId"] = "result_3f21"
+                        }
+                    }
+                ],
+                [
+                    new WorkspaceRef
+                    {
+                        WorkspaceId = "ws-42",
+                        Kind = WorkspaceKind.Scratch,
+                        Label = "Scratch workspace",
+                        Uri = "honua://workspace-storage/ws-42",
+                        ExpiresAt = DateTimeOffset.Parse("2026-05-19T12:00:00Z", CultureInfo.InvariantCulture)
+                    }
+                ],
+                new ProvenanceRecord
+                {
+                    Sources =
+                    [
+                        new ProvenanceSource
+                        {
+                            SourceId = "parcels",
+                            Version = "v1",
+                            Description = "County parcels"
+                        }
+                    ],
+                    ProcessDefinitions = ["geometry.buffer"],
+                    Assumptions = ["buffers use planar meters"],
+                    ClarificationsAsked = ["distance_units"],
+                    ClarificationsAnswered = ["meters"],
+                    ExecutedAt = DateTimeOffset.Parse("2026-05-18T12:05:00Z", CultureInfo.InvariantCulture),
+                    GeneratedArtifactIds = ["artifact-1"]
+                },
+                assumptions: ["output uses source CRS"]));
+
+        var resource = new JobResultsResource(jobService, NullLogger<JobResultsResource>.Instance);
+        var result = await resource.ReadAsync(
+            McpTestFactory.AuthenticatedHttpContext(),
+            "honua://jobs/job-xyz/results",
+            CancellationToken.None);
+
+        var payload = JToken.Parse(result.Contents[0].Text);
+        payload["resultPackageId"]!.Value<string>().Should().Be("result_3f21");
+        AssertPayloadConformsToResourceSchema(payload, "result-package.schema.json", "live result payload");
+    }
+
+    [UnitTest]
     public void HonuaResourceFamilies_AreCoveredByTheStandardResourceSchemas()
     {
         // Every resource family Honua advertises that the standard defines a
@@ -667,6 +793,13 @@ public sealed partial class McpTaxonomyAlignmentTests
         }
 
         return root.TryGetValue("inputs", out var inputs) ? inputs : null;
+    }
+
+    private static void AssertPayloadConformsToResourceSchema(JToken payload, string schemaFile, string reason)
+    {
+        var schema = LoadSchema(Path.Combine(SchemaRoot, "resources", schemaFile));
+        payload.IsValid(schema, out IList<string> errors);
+        errors.Should().BeEmpty($"{reason} must conform to '{schemaFile}'");
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpResourceSerializationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpResourceSerializationTests.cs
@@ -203,7 +203,8 @@ public sealed class McpResourceSerializationTests
         result.Contents.Should().HaveCount(1);
         var body = McpTestFactory.ParseJson(result.Contents[0].Text);
         body.GetProperty("workspaceId").GetString().Should().Be("ws-42");
-        body.GetProperty("status").GetString().Should().Be("degraded");
+        body.TryGetProperty("kind", out _).Should().BeFalse();
+        body.TryGetProperty("lifecycleState", out _).Should().BeFalse();
         body.GetProperty("notImplementedReason").GetString().Should().NotBeNullOrEmpty();
     }
 
@@ -235,7 +236,7 @@ public sealed class McpResourceSerializationTests
                         WorkspaceId = "ws-42",
                         Metadata = new Dictionary<string, string>
                         {
-                            ["jobId"] = "job-123"
+                            ["resultPackageId"] = "result-123"
                         }
                     }
                 ]
@@ -259,8 +260,9 @@ public sealed class McpResourceSerializationTests
         body.GetProperty("kind").GetString().Should().Be("result_collection");
         body.GetProperty("label").GetString().Should().Be("Linked dashboard results");
         body.GetProperty("uri").GetString().Should().Be("honua://workspace-storage/ws-42");
-        body.GetProperty("status").GetString().Should().Be("active");
-        body.GetProperty("resultsUri").GetString().Should().Be("honua://jobs/job-123/results");
+        body.GetProperty("lifecycleState").GetString().Should().Be("active");
+        body.TryGetProperty("status", out _).Should().BeFalse();
+        body.GetProperty("resultsUri").GetString().Should().Be("honua://results/result-123");
         body.TryGetProperty("notImplementedReason", out _).Should().BeFalse();
     }
 


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Closes #2581
Related to #2552
Related to #1948

## Summary
Aligns the live MCP workspace projection with the vendored geospatial-mcp workspace schema. Workspace resources now expose `lifecycleState` instead of the old `status` field and only emit `resultsUri` using the standard `honua://results/{resultPackageId}` shape when a result-package id is available.

## Changes Made
- Added a standard `honua://results/{resultPackageId}` URI helper for MCP resource projections.
- Updated `WorkspaceResource` to emit schema-valid lifecycle states and result-package URIs from result-package metadata.
- Updated degraded workspace serialization to omit invalid empty `kind`, `label`, and lifecycle fields.
- Added live workspace and result-package payload validation against vendored geospatial-mcp resource schemas.
- Updated MCP resource serialization expectations for `lifecycleState` and standard `resultsUri` addressing.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation run locally:
- `dotnet build tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj --no-restore --configuration Release --disable-build-servers /p:TreatWarningsAsErrors=true /p:UseSharedCompilation=false -m:1 -nr:false`
- `dotnet test tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj --no-build --no-restore --configuration Release --filter "FullyQualifiedName~McpResourceSerializationTests" --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1`
- `dotnet test tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj --no-build --no-restore --configuration Release --filter "FullyQualifiedName~McpTaxonomyAlignmentTests" --logger "console;verbosity=minimal" -- RunConfiguration.MaxCpuCount=1`
- `dotnet format Honua.sln --verify-no-changes --verbosity diagnostic`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [ ] None - no docs or contract impact
- [x] MCP/geospatial-mcp resource schema conformance updated

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
MCP workspace resource payloads replace `status` with `lifecycleState` and switch workspace `resultsUri` from job-keyed result reads to standard result-package addressing when the result package id is available.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review