### PR TITLE
feat(compose): wire quickstart console ops dashboard

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -9,8 +9,8 @@ ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=honua_dev;
 # =============================================================================
 # REDIS (connects to compose service 'redis')
 # =============================================================================
-# Redis connection is auto-configured via Aspire service defaults
-# Cache settings below control behavior
+HONUA_REDIS_URL=redis:6379
+HONUA_REDIS_MAXMEMORY=64mb
 
 # =============================================================================
 # FEATURE FLAGS
@@ -19,6 +19,16 @@ HONUA_OBSERVABILITY=true
 HONUA_OPENTELEMETRY=false
 Observability__Prometheus__Path=/metrics
 HONUA_SKIP_MIGRATIONS=false
+HONUA_CONTRACT_APPLY_POLICY=Gate
+
+# =============================================================================
+# CONSOLE OPS DASHBOARD
+# =============================================================================
+# Enable after the compatible honua-console image is published.
+# COMPOSE_PROFILES=console
+# HONUA_CONSOLE_IMAGE=ghcr.io/honua-io/honua-console:replace-with-compatible-tag
+HONUA_CONSOLE_PORT=5174
+HONUA_CONSOLE_REPLICAS=1
 
 # =============================================================================
 # SECURITY
@@ -44,7 +54,7 @@ Cache__EnableFallback=true
 # CORS (allow localhost for development)
 # =============================================================================
 HONUA_DEV_CORS_ORIGIN=http://localhost:3000
-HONUA_DEV_ADMIN_CORS_ORIGIN=http://localhost:5173
+HONUA_DEV_ADMIN_CORS_ORIGIN=http://localhost:5174
 
 # =============================================================================
 # LIMITS (relaxed for development)

--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,16 @@ Cache__EnableFallback=true
 Cache__FallbackMaxEntries=1000
 
 # =============================================================================
+# DATABASE MIGRATION SAFETY
+# =============================================================================
+# Gate requires explicit approval before pending reviewed contract-phase
+# migrations apply on an existing database. Fresh installs still provision fully.
+# Docker quickstart uses Gate by default; production can choose Auto or Gate.
+# Database__MigrationSafety__ContractApplyPolicy=Gate
+# HONUA_APPROVE_CONTRACT_MIGRATIONS=false
+# Database__MigrationSafety__BackupCommand=
+
+# =============================================================================
 # FILE STORAGE (optional S3-compatible, e.g. MinIO)
 # =============================================================================
 FileStorage__Provider=Local

--- a/.env.production.example
+++ b/.env.production.example
@@ -14,6 +14,7 @@ HONUA_OBSERVABILITY=true
 HONUA_OPENTELEMETRY=true
 Observability__Prometheus__Path=/metrics
 HONUA_SKIP_MIGRATIONS=false
+Database__MigrationSafety__ContractApplyPolicy=Gate
 
 # =============================================================================
 # SECURITY (Required for Production)
@@ -24,6 +25,7 @@ HONUA_ADMIN_PASSWORD=${ADMIN_PASSWORD}
 # =============================================================================
 # CACHE (Redis - recommended for production)
 # =============================================================================
+ConnectionStrings__Redis=redis.example.com:6379
 Cache__Enabled=true
 Cache__DefaultTtlSeconds=300
 Cache__ServiceTtlSeconds=300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ on:
         required: false
         type: boolean
         default: false
+      console_image:
+        description: 'Optional honua-console image tag for the quickstart Console compose smoke. Defaults to repository variable HONUA_CONSOLE_IMAGE when set.'
+        required: false
+        default: ''
 
 concurrency:
   # PR runs key on the PR number (re-push cancels the prior run). merge_group
@@ -2006,6 +2010,38 @@ jobs:
           docker stop honua-test || true
           docker rm honua-test || true
 
+  quickstart-console-smoke:
+    name: Quickstart Console Compose Smoke
+    if: ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') && needs.changes.outputs.full_ci == 'true' && needs.changes.outputs.integration_changes == 'true' && needs.changes.outputs.non_test_changes == 'true' }}
+    runs-on: ubuntu-latest
+    needs: [build, changes]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve Console image
+        id: console_image
+        env:
+          INPUT_CONSOLE_IMAGE: ${{ github.event.inputs.console_image || '' }}
+          VAR_CONSOLE_IMAGE: ${{ vars.HONUA_CONSOLE_IMAGE || '' }}
+        run: |
+          set -euo pipefail
+          image="${INPUT_CONSOLE_IMAGE:-${VAR_CONSOLE_IMAGE:-}}"
+          if [ -z "${image}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::HONUA_CONSOLE_IMAGE is not configured; skipping quickstart Console compose smoke until a compatible image is published."
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+
+      - name: Run quickstart Console compose smoke
+        if: steps.console_image.outputs.enabled == 'true'
+        env:
+          HONUA_CONSOLE_IMAGE: ${{ steps.console_image.outputs.image }}
+        run: bash scripts/ci/smoke-quickstart-console.sh
+
   # ===========================================================================
   # LEAN MERGE-QUEUE GATE
   # ===========================================================================
@@ -2108,7 +2144,7 @@ jobs:
     # NOT this one. Keeping CI Gate off merge_group avoids a misleading all-
     # skipped "pass" status appearing in the queue context.
     if: ${{ github.event_name != 'merge_group' && always() && !cancelled() }}
-    needs: [pr-template-check, pr-readiness, changes, targeted-shards, ci-router-validation, build, test-all, aot-build, js-integration-tests, esri-leaflet-browser-tests, maplibre-compat, mcp-certification, core-package-compatibility, postgres-compat, docker-build]
+    needs: [pr-template-check, pr-readiness, changes, targeted-shards, ci-router-validation, build, test-all, aot-build, js-integration-tests, esri-leaflet-browser-tests, maplibre-compat, mcp-certification, core-package-compatibility, postgres-compat, docker-build, quickstart-console-smoke]
     runs-on: ubuntu-latest
     steps:
       - name: Check required job results

--- a/README.md
+++ b/README.md
@@ -52,8 +52,13 @@ docker compose up -d
 curl http://localhost:8080/healthz/ready
 ```
 
-PostGIS starts automatically. Migrations run on first boot. HTTP/1 REST and gRPC-Web are at
-`http://localhost:8080`; native h2c gRPC for SDK/mobile clients is at `http://localhost:8081`.
+PostGIS, Redis, and Honua Server start automatically. Migrations run on first
+boot with the contract-migration gate enabled for existing databases. HTTP/1 REST
+and gRPC-Web are at `http://localhost:8080`; native h2c gRPC for SDK/mobile
+clients is at `http://localhost:8081`. The compose file also includes a Console
+service under the `console` profile; set `HONUA_CONSOLE_IMAGE` to a compatible
+published Console image and run `docker compose --profile console up -d` to serve
+Operate at `http://localhost:5174/operate`.
 For self-hosted pilots, run the [pilot onboarding runbook](docs/guides/deploy/pilot-onboarding-runbook.md)
 before exercising durable jobs/workflows or handing the deployment to another team.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,31 @@ services:
       retries: 5
     restart: unless-stopped
 
+  # Redis for the durable local control plane. The quickstart keeps the memory
+  # budget small and uses noeviction so approval/workflow keys are never dropped.
+  redis:
+    image: redis:7.4-alpine
+    ports:
+      - "${HONUA_BIND_ADDRESS:-127.0.0.1}:${REDIS_PORT:-6379}:6379"
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--maxmemory",
+        "${HONUA_REDIS_MAXMEMORY:-64mb}",
+        "--maxmemory-policy",
+        "noeviction"
+      ]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
   # Honua Server application
   honua:
     build:
@@ -43,7 +68,11 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ConnectionStrings__DefaultConnection: "Host=postgres;Database=honua_dev;Username=honua_user;Password=honua_password"
-      ConnectionStrings__Redis: "${HONUA_REDIS_URL:-}"
+      ConnectionStrings__Redis: "${HONUA_REDIS_URL:-redis:6379}"
+      Database__MigrationSafety__ContractApplyPolicy: "${HONUA_CONTRACT_APPLY_POLICY:-Gate}"
+      Licensing__DevGrantEdition: "${HONUA_DEV_GRANT_EDITION:-}"
+      HONUA_ENABLE_OBSERVABILITY_TEST_SEED: "${HONUA_ENABLE_OBSERVABILITY_TEST_SEED:-false}"
+      OperateObservabilityFixture__SeedOnStartup: "${HONUA_OPERATE_FIXTURE_SEED_ON_STARTUP:-false}"
       # Development-only defaults for the repo quickstart. Override these before
       # reusing this compose file outside a local developer workstation.
       HONUA_ADMIN_PASSWORD: "${HONUA_ADMIN_PASSWORD:-quickstart-admin-password}"
@@ -57,13 +86,15 @@ services:
       Security__ConnectionEncryption__MasterKey: "${HONUA_CONNECTION_ENCRYPTION_MASTER_KEY:-honua-compose-dev-master-key-0123456789}"
       Security__ConnectionEncryption__Salt: "${HONUA_CONNECTION_ENCRYPTION_SALT:-aG9udWEtY29tcG9zZS1kZXYtc2FsdC0yMDI2}"
       Cors__AllowedOrigins__0: "${HONUA_DEV_CORS_ORIGIN:-http://localhost:3000}"
-      Cors__AllowedOrigins__1: "${HONUA_DEV_ADMIN_CORS_ORIGIN:-http://localhost:5173}"
+      Cors__AllowedOrigins__1: "${HONUA_DEV_ADMIN_CORS_ORIGIN:-http://localhost:5174}"
       Kestrel__Endpoints__Http__Url: "http://+:8080"
       Kestrel__Endpoints__Http__Protocols: "Http1"
       Kestrel__Endpoints__Grpc__Url: "http://+:8081"
       Kestrel__Endpoints__Grpc__Protocols: "Http2"
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/healthz/live"]
@@ -85,22 +116,41 @@ services:
       - honua_cache:/tmp/honua-cache
       - dotnet_diagnostics:/tmp/dotnet-diagnostics
 
-  # Redis (optional)
-  redis:
-    image: redis:7-alpine
+  # Honua Console ops dashboard. Enable with:
+  #   HONUA_CONSOLE_IMAGE=<compatible-image> docker compose --profile console up -d
+  # until the public Console image is available for the default quickstart.
+  console:
+    image: "${HONUA_CONSOLE_IMAGE:-ghcr.io/honua-io/honua-console:pending}"
     profiles:
-      - redis
+      - console
     ports:
-      - "${REDIS_PORT:-6379}:6379"
-    command: redis-server --appendonly yes
-    volumes:
-      - redis_data:/data
+      - "${HONUA_BIND_ADDRESS:-127.0.0.1}:${HONUA_CONSOLE_PORT:-5174}:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: "http://+:8080"
+      HONUA_SERVER_BASE_URL: "http://honua:8080"
+      HONUA_ADMIN_API_KEY: "${HONUA_ADMIN_PASSWORD:-quickstart-admin-password}"
+      Honua__Server__BaseUrl: "http://honua:8080"
+      Honua__Server__AdminApiKey: "${HONUA_ADMIN_PASSWORD:-quickstart-admin-password}"
+    depends_on:
+      honua:
+        condition: service_healthy
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/operate"]
+      interval: 30s
+      timeout: 10s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100m
+    deploy:
+      replicas: ${HONUA_CONSOLE_REPLICAS:-1}
 
   # MinIO (optional S3-compatible storage)
   minio:

--- a/docker/monitoring/README.md
+++ b/docker/monitoring/README.md
@@ -1,7 +1,13 @@
 # Monitoring Docker Assets
 
 Reusable self-hosted monitoring assets for Docker-based environments, plus a curated
-Grafana + Prometheus bundle ("Splunk out of the box") that deploys in one command.
+Grafana + Prometheus bundle that deploys in one command.
+
+The root quickstart includes a profiled Honua Console Operate service at
+`http://localhost:5174/operate` once a compatible Console image is published.
+Use this monitoring bundle when you want
+external Prometheus storage, Grafana dashboards, or alert-rule experiments beyond
+the built-in Console view.
 
 ## Quick start (one command)
 

--- a/docker/monitoring/compose.yml
+++ b/docker/monitoring/compose.yml
@@ -1,4 +1,4 @@
-# Curated Grafana + Prometheus observability bundle for Honua Server ("Splunk out of the box").
+# Optional Grafana + Prometheus observability depth for Honua Server.
 #
 # One-command deploy (server already running, e.g. via the root `docker compose up -d`):
 #

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -12,7 +12,7 @@ You'll have Honua running in Docker with a published dataset rendered in a brows
 git clone https://github.com/honua-io/honua-server.git && cd honua-server
 ```
 
-2. Start the stack (PostGIS plus Honua, built from source — the first run takes a few minutes). The repo-root compose file includes development-only defaults for the admin password, connection-encryption key, and browser origin used below.
+2. Start the stack (PostGIS, Redis, and Honua Server, built from source - the first run takes a few minutes). The repo-root compose file includes development-only defaults for the admin password, connection-encryption key, Redis control-plane connection, Gate migration policy, and browser origin used below.
 
 ```bash
 docker compose up -d
@@ -24,7 +24,19 @@ docker compose up -d
 curl http://localhost:8080/healthz/ready
 ```
 
-4. Create a small GeoJSON file to import.
+4. Optional Console dashboard: once a compatible `honua-console` image is published, start the profiled Console service and open <http://localhost:5174/operate>. The same service also serves <http://localhost:5174/operate/health> and <http://localhost:5174/operate/copilot>. Console binds to the local server with the quickstart admin key, so admin-only Operate reads work without another deploy step.
+
+```bash
+HONUA_CONSOLE_IMAGE=ghcr.io/honua-io/honua-console:replace-with-compatible-tag docker compose --profile console up -d
+```
+
+For headless local runs after enabling the profile, leave Redis enabled and disable only the dashboard:
+
+```bash
+HONUA_CONSOLE_REPLICAS=0 docker compose up -d
+```
+
+5. Create a small GeoJSON file to import.
 
 ```bash
 cat > points.geojson <<'EOF'
@@ -35,7 +47,7 @@ cat > points.geojson <<'EOF'
 EOF
 ```
 
-5. Import it. Admin endpoints authenticate with the `X-API-Key` header carrying the admin password.
+6. Import it. Admin endpoints authenticate with the `X-API-Key` header carrying the admin password.
 
 ```bash
 curl -s -H "X-API-Key: quickstart-admin-password" \
@@ -43,7 +55,7 @@ curl -s -H "X-API-Key: quickstart-admin-password" \
   http://localhost:8080/api/v1/admin/import/upload
 ```
 
-6. Register the compose database as a connection (publishing reads tables through named connections).
+7. Register the compose database as a connection (publishing reads tables through named connections).
 
 ```bash
 curl -s -H "X-API-Key: quickstart-admin-password" -H "Content-Type: application/json" \
@@ -51,7 +63,7 @@ curl -s -H "X-API-Key: quickstart-admin-password" -H "Content-Type: application/
   http://localhost:8080/api/v1/admin/connections
 ```
 
-7. Publish the imported table as a layer (imports land in the `honua_data` schema) and note the `layerId` in the response.
+8. Publish the imported table as a layer (imports land in the `honua_data` schema) and note the `layerId` in the response.
 
 ```bash
 curl -s -H "X-API-Key: quickstart-admin-password" -H "Content-Type: application/json" \
@@ -59,7 +71,7 @@ curl -s -H "X-API-Key: quickstart-admin-password" -H "Content-Type: application/
   http://localhost:8080/api/v1/admin/connections/local/layers
 ```
 
-8. Allow anonymous reads on the `default` service so the browser can fetch tiles without a key.
+9. Allow anonymous reads on the `default` service so the browser can fetch tiles without a key.
 
 ```bash
 curl -s -X PUT -H "X-API-Key: quickstart-admin-password" -H "Content-Type: application/json" \
@@ -67,7 +79,7 @@ curl -s -X PUT -H "X-API-Key: quickstart-admin-password" -H "Content-Type: appli
   http://localhost:8080/api/v1/admin/services/default/access-policy
 ```
 
-9. Save this as `map.html` (if your `layerId` from step 7 was not `1`, change the first line of the script), then serve it and open <http://localhost:3000/map.html>.
+10. Save this as `map.html` (if your `layerId` from step 8 was not `1`, change the first line of the script), then serve it and open <http://localhost:3000/map.html>.
 
 ```bash
 cat > map.html <<'EOF'
@@ -104,8 +116,10 @@ In the browser you should see three blue circles over San Francisco.
 
 ## Troubleshoot
 
-- **Tiles return 401 in the browser** — step 8 (anonymous read) was skipped, or the publish used a different service name than `default`.
+- **Tiles return 401 in the browser** — step 9 (anonymous read) was skipped, or the publish used a different service name than `default`.
 - **Blank map and CORS errors in the browser console** — the page must be served from `http://localhost:3000`, not opened as a `file://` URL. Use `HONUA_DEV_CORS_ORIGIN` before `docker compose up -d` if you serve the page from another origin.
+- **Console is not needed after enabling the profile** - use `HONUA_CONSOLE_REPLICAS=0 docker compose up -d`; Redis still starts because durable jobs, proposals, and workflow state use it.
+- **Contract migration is gated on an existing database** - the quickstart sets `HONUA_CONTRACT_APPLY_POLICY=Gate`. Fresh installs still provision fully; for an upgrade with pending contract scripts, approve one run with `HONUA_APPROVE_CONTRACT_MIGRATIONS=true` and unset it afterward.
 - More help: [Troubleshooting](../guides/deploy/troubleshooting.md)
 
 ## Next steps

--- a/docs/guides/deploy/docker-compose.md
+++ b/docs/guides/deploy/docker-compose.md
@@ -1,6 +1,6 @@
 # Deploy with Docker Compose
 
-You'll run a production-shaped Honua stack on a single host: pinned image, secrets in an env file, persistent PostGIS volume, optional Redis, and TLS terminated by a reverse proxy. For the build-from-source dev stack, use the [quickstart](../../get-started/quickstart.md) instead.
+You'll run a production-shaped Honua stack on a single host: pinned image, secrets in an env file, persistent PostGIS and Redis volumes, optional Console, and TLS terminated by a reverse proxy. For the build-from-source dev stack with the profiled Console service, use the [quickstart](../../get-started/quickstart.md) instead.
 
 **Prerequisites:** Docker with Compose v2, a DNS name pointing at the host (for TLS), and outbound access to Docker Hub or GHCR.
 
@@ -37,9 +37,12 @@ services:
       Security__ConnectionEncryption__MasterKey: ${HONUA_MASTER_KEY}
       Cors__AllowedOrigins__0: ${HONUA_CORS_ORIGIN}
       HONUA_OBSERVABILITY: "true"
-      ConnectionStrings__Redis: ""
+      ConnectionStrings__Redis: "redis:6379"
+      Database__MigrationSafety__ContractApplyPolicy: Gate
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/healthz/live"]
@@ -74,11 +77,15 @@ services:
     restart: unless-stopped
 
   redis:
-    image: redis:7-alpine
-    profiles: [redis]
-    command: redis-server --appendonly yes
+    image: redis:7.4-alpine
+    command: redis-server --appendonly yes --maxmemory 64mb --maxmemory-policy noeviction
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     restart: unless-stopped
 
 volumes:
@@ -94,11 +101,36 @@ HONUA_HOST=honua.example.com
 printf '%s {\n  reverse_proxy 127.0.0.1:8080\n}\n' "$HONUA_HOST" | sudo tee /etc/caddy/Caddyfile && sudo systemctl reload caddy
 ```
 
-4. Start the stack. Add `--profile redis` and set `ConnectionStrings__Redis: "redis:6379"` in the compose file when you need durable jobs, queued imports, or workflows — Redis is required for those, optional otherwise.
+4. Start the stack. Redis is part of the production-shaped baseline because durable jobs, queued imports, workflows, operation proposals, and Console approval flows need it.
 
 ```bash
 docker compose up -d
 ```
+
+For headless deployments, keep Redis unless every durable control-plane feature is intentionally disabled. To add Console in production, use a published Console image tag that is compatible with the server ops-health contract and add this service:
+
+```yaml
+  console:
+    image: ghcr.io/honua-io/honua-console:replace-with-compatible-tag
+    ports:
+      - "127.0.0.1:5174:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: "http://+:8080"
+      HONUA_SERVER_BASE_URL: "http://honua:8080"
+      HONUA_ADMIN_API_KEY: ${HONUA_ADMIN_PASSWORD}
+    depends_on:
+      honua:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/operate"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+```
+
+Then start it with `docker compose up -d console`, or disable it with `docker compose up -d --scale console=0`.
 
 ## Verify
 
@@ -112,12 +144,27 @@ Expected output: `Ready`. Then confirm admin auth works:
 source .env && curl -s -H "X-API-Key: $HONUA_ADMIN_PASSWORD" http://127.0.0.1:8080/api/v1/admin/config | head -c 200
 ```
 
+If Console is enabled, confirm the ops dashboard responds:
+
+```bash
+curl -fsS http://127.0.0.1:5174/operate >/dev/null
+curl -fsS http://127.0.0.1:5174/operate/health >/dev/null
+curl -fsS http://127.0.0.1:5174/operate/copilot >/dev/null
+```
+
+CI can run the same root-compose smoke through `scripts/ci/smoke-quickstart-console.sh`.
+Set the repository variable `HONUA_CONSOLE_IMAGE` or pass the `console_image`
+workflow-dispatch input once a compatible Console image tag is published. The
+smoke starts Redis, Honua, and Console, creates a Redis-backed operation proposal
+through the platform-release converge API, and verifies the Operate routes.
+
 ## Troubleshoot
 
 - **Admin calls return 401** — `HONUA_ADMIN_PASSWORD` was not passed into the container; check your production compose file and secret source.
 - **Startup fails with "Master key must be at least 32 characters"** — lengthen `Security__ConnectionEncryption__MasterKey`.
 - **Browser requests blocked by CORS** — the permissive dev CORS policy is force-disabled inside containers; set `Cors__AllowedOrigins__0` to your app's exact origin.
-- **`503` on OGC Processes or import job routes** — those need Redis; enable the `redis` profile and set `ConnectionStrings__Redis`.
+- **`503` on OGC Processes, import job routes, or proposal flows** — those need Redis; check the `redis` container health and `ConnectionStrings__Redis`.
+- **Console shows a missing server binding** — set `HONUA_SERVER_BASE_URL` to the server origin reachable from the Console container and pass `HONUA_ADMIN_API_KEY`.
 - **Container restarts in a loop** — check `docker compose logs honua` for migration failures; the server applies database migrations at startup.
 
 ## Upgrade & Rollback
@@ -157,7 +204,7 @@ docker compose logs --tail=50 honua
 
 ### Gating contract-phase migrations (optional)
 
-By default the server applies reviewed contract-phase migrations automatically at startup. To turn a schema-narrowing upgrade into a deliberate, approved step on this existing database, set the journal-scoped gate — it applies only to an already-migrated database, so a first install still provisions fully with no extra config:
+The root quickstart uses the journal-scoped Gate policy by default. For production compose, keep `Database__MigrationSafety__ContractApplyPolicy: Gate` when you want a schema-narrowing upgrade to be a deliberate, approved step on an existing database. It applies only to an already-migrated database, so a first install still provisions fully with no extra config:
 
 ```yaml
     environment:

--- a/docs/guides/deploy/local-development.md
+++ b/docs/guides/deploy/local-development.md
@@ -31,7 +31,7 @@ dotnet build src/Honua.Server/Honua.Server.csproj
 
 ## Plain Docker Compose alternative
 
-If you don't want the .NET SDK in the loop, the repo-root `docker-compose.yml` builds the server from source and starts PostGIS (`docker compose up -d`), with optional `--profile redis` and `--profile minio`. The compose file includes development-only defaults for the admin password, connection-encryption key, and localhost browser origins used by the [quickstart](../../get-started/quickstart.md).
+If you don't want the .NET SDK in the loop, the repo-root `docker-compose.yml` builds the server from source and starts PostGIS plus Redis (`docker compose up -d`), with optional `--profile minio` and a profiled Console service once a compatible Console image is available. The compose file includes development-only defaults for the admin password, connection-encryption key, Redis control-plane connection, Gate migration policy, and localhost browser origins used by the [quickstart](../../get-started/quickstart.md).
 
 ## Verify
 

--- a/docs/guides/deploy/monitoring.md
+++ b/docs/guides/deploy/monitoring.md
@@ -1,6 +1,6 @@
 # Monitor Honua Server
 
-You'll wire up health probes, Prometheus metrics, OpenTelemetry export, and the pinned alert rules so a degraded deployment pages you before users notice. For the higher-level operate story - the loop, Console and MCP seats, autonomy ladder, rollback taxonomy, and when Grafana is optional depth - start with [Operating Honua](../operate/README.md).
+You'll wire up health probes, Prometheus metrics, OpenTelemetry export, and the pinned alert rules so a degraded deployment pages you before users notice. For the higher-level operate story - the loop, Console and MCP seats, autonomy ladder, rollback taxonomy, and when Grafana is optional depth - start with [Operating Honua](../operate/README.md). The profiled Console Operate service in the Docker quickstart is the first local ops view once a compatible Console image is published; Grafana and Prometheus are optional depth for teams that want an external metrics backend.
 
 **Prerequisites:** A running deployment and the admin password (admin endpoints authenticate with the `X-API-Key` header). A metrics backend (managed Prometheus, self-hosted Prometheus, or any OTLP-compatible stack) is needed for long-retention metrics and deep traces/logs, but the built-in operate status, ops-health, findings, and timeline surfaces do not require Grafana or Prometheus.
 
@@ -29,6 +29,8 @@ curl -s -H "X-API-Key: $HONUA_ADMIN_PASSWORD" http://localhost:8080/api/v1/opera
 ```
 
 It returns a server-computed `status` (`healthy` / `degraded` / `unhealthy`) with the machine-readable `reasons` that drove it, per-domain rollups (`deploys`, `jobs`, `alerts`, `migrations`, `findings`, `telemetryBackends`) each carrying a `source` hint you can drill down to, and a `schemaVersion` + `generatedAt` so a consumer can version its parsing. The verdict rules are fixed and documented server-side: the health-check roll-up being `Unhealthy` ⇒ `unhealthy`; a `Critical` finding, a deploy parked in manual intervention, dead-lettered alerts, an impaired dispatcher, or an exhausted SLO error budget ⇒ `degraded`; otherwise `healthy`.
+
+With the quickstart `console` profile enabled, open <http://localhost:5174/operate/health> for this status plus the Console health dashboard, and <http://localhost:5174/operate/copilot> for deterministic findings and proposal entry points. Those pages read the same server-owned APIs described here.
 
 ### Availability SLO / error budget
 
@@ -88,7 +90,7 @@ On Azure Monitor managed Prometheus, define rule-group resources (ARM/Bicep/Terr
 helm install monitoring prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace
 ```
 
-5. (One-command Docker option) For local or single-node deployments, bring up the curated Grafana + Prometheus bundle — provisioned datasource plus the Serving, GP/Jobs, and Ops/Alerts dashboards — against a running server:
+5. (Optional one-command Docker depth) For local or single-node deployments that also need Grafana and Prometheus, bring up the curated bundle - provisioned datasource plus the Serving, GP/Jobs, and Ops/Alerts dashboards - against a running server:
 
 ```bash
 docker compose -f docker/monitoring/compose.yml up -d

--- a/docs/guides/deploy/pilot-onboarding-runbook.md
+++ b/docs/guides/deploy/pilot-onboarding-runbook.md
@@ -8,7 +8,7 @@ Use this runbook before handing a self-hosted pilot to an operator or customer t
 
 ### Local or disposable pilot
 
-The repository Docker Compose stack supplies PostGIS and runs migrations. A local pilot still needs explicit runtime secrets and Redis when it exercises asynchronous work:
+The repository Docker Compose stack supplies PostGIS, Redis, and migrations. A local pilot still needs explicit runtime secrets:
 
 ```bash
 HONUA_ADMIN_PASSWORD=replace-with-admin-password
@@ -16,10 +16,10 @@ Security__ConnectionEncryption__MasterKey=replace-with-32-plus-character-secret
 HONUA_REDIS_URL=redis:6379
 ```
 
-Start Redis with the Compose profile when durable jobs, queued imports, OGC Processes, GPServer async jobs, tile-operation jobs, or workflow runs are in scope:
+Start the stack normally; Redis is part of the root Compose baseline because durable jobs, queued imports, OGC Processes, GPServer async jobs, tile-operation jobs, workflow runs, and proposal flows use it:
 
 ```bash
-HONUA_REDIS_URL=redis:6379 docker compose --profile redis up -d
+docker compose up -d
 ```
 
 The stock Compose file maps host `HONUA_REDIS_URL` into the container's `ConnectionStrings__Redis`. If you use a `docker-compose.override.yml`, setting `ConnectionStrings__Redis: redis:6379` on the `honua` service is equivalent.
@@ -28,7 +28,7 @@ For a disposable fresh-stack smoke test only, clear volumes first:
 
 ```bash
 docker compose down -v
-HONUA_REDIS_URL=redis:6379 docker compose --profile redis up -d
+docker compose up -d
 curl -fsS http://localhost:8080/healthz/ready
 ```
 

--- a/docs/internal/contributor/development/getting-started.md
+++ b/docs/internal/contributor/development/getting-started.md
@@ -26,9 +26,10 @@ The root `docker-compose.yml` provisions:
 | Service | Default port | Credentials |
 |---------|-------------|-------------|
 | PostGIS | 5432 | `honua_user` / `honua_password`, database `honua_dev` |
+| Redis | 6379 | none |
 | Honua Server | 8080 | — |
 
-Database migrations run automatically on first boot.
+Database migrations run automatically on first boot. The root compose stack also sets the journal-scoped `Gate` policy for contract-phase migrations on existing databases.
 
 ## 2. Verify it works
 
@@ -45,8 +46,9 @@ curl http://localhost:8080/rest/services?f=json
 Add these as needed — none are required for basic development:
 
 ```bash
-# Redis (distributed caching)
-HONUA_REDIS_URL=redis:6379 docker compose --profile redis up -d
+# Console ops dashboard (requires a compatible published honua-console image)
+HONUA_CONSOLE_IMAGE=ghcr.io/honua-io/honua-console:replace-with-compatible-tag \
+  docker compose --profile console up -d
 
 # MinIO (S3-compatible storage for file imports)
 HONUA_STORAGE_PROVIDER=AwsS3 HONUA_S3_BUCKET=honua-dev \

--- a/scripts/ci/smoke-quickstart-console.sh
+++ b/scripts/ci/smoke-quickstart-console.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.yml"
+PROJECT_NAME="${HONUA_QUICKSTART_SMOKE_PROJECT:-honua-quickstart-console-smoke}"
+SMOKE_OVERRIDE_FILE=""
+HONUA_HTTP_PORT="${HONUA_QUICKSTART_SMOKE_HTTP_PORT:-18080}"
+HONUA_GRPC_PORT="${HONUA_QUICKSTART_SMOKE_GRPC_PORT:-18081}"
+HONUA_CONSOLE_PORT="${HONUA_QUICKSTART_SMOKE_CONSOLE_PORT:-15174}"
+POSTGRES_PORT="${HONUA_QUICKSTART_SMOKE_POSTGRES_PORT:-15432}"
+REDIS_PORT="${HONUA_QUICKSTART_SMOKE_REDIS_PORT:-16379}"
+ADMIN_PASSWORD="${HONUA_ADMIN_PASSWORD:-quickstart-admin-password}"
+
+compose() {
+  local compose_files=(-f "${COMPOSE_FILE}")
+  if [[ -n "${SMOKE_OVERRIDE_FILE}" ]]; then
+    compose_files+=(-f "${SMOKE_OVERRIDE_FILE}")
+  fi
+
+  COMPOSE_PROJECT_NAME="${PROJECT_NAME}" \
+  HONUA_HTTP_PORT="${HONUA_HTTP_PORT}" \
+  HONUA_GRPC_PORT="${HONUA_GRPC_PORT}" \
+  HONUA_CONSOLE_PORT="${HONUA_CONSOLE_PORT}" \
+  POSTGRES_PORT="${POSTGRES_PORT}" \
+  REDIS_PORT="${REDIS_PORT}" \
+  HONUA_ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
+  HONUA_DEV_GRANT_EDITION="${HONUA_DEV_GRANT_EDITION:-Enterprise}" \
+  HONUA_ENABLE_OBSERVABILITY_TEST_SEED="${HONUA_ENABLE_OBSERVABILITY_TEST_SEED:-true}" \
+  HONUA_CONSOLE_IMAGE="${HONUA_CONSOLE_IMAGE}" \
+    docker compose --profile console "${compose_files[@]}" --project-directory "${ROOT_DIR}" "$@"
+}
+
+cleanup() {
+  local status=$?
+  if [[ "${status}" != "0" ]]; then
+    compose ps || true
+    compose logs --no-color --tail=200 || true
+  fi
+  compose_down
+  if [[ -n "${SMOKE_OVERRIDE_FILE}" ]]; then
+    rm -f "${SMOKE_OVERRIDE_FILE}" >/dev/null 2>&1 || true
+  fi
+  return "${status}"
+}
+trap cleanup EXIT
+
+compose_down() {
+  compose down --remove-orphans --volumes >/dev/null 2>&1 || true
+}
+
+wait_for_url() {
+  local url="$1"
+  local label="$2"
+  local attempts="${3:-60}"
+
+  for _ in $(seq 1 "${attempts}"); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      echo "${label}: ok"
+      return 0
+    fi
+
+    sleep 2
+  done
+
+  echo "${label}: timed out waiting for ${url}" >&2
+  return 1
+}
+
+assert_proposal_roundtrip() {
+  local base_url="http://127.0.0.1:${HONUA_HTTP_PORT}"
+  local response proposal_id proposals
+
+  response="$(
+    curl -fsS \
+      -X POST \
+      -H "X-API-Key: ${ADMIN_PASSWORD}" \
+      -H "Content-Type: application/json" \
+      -d '{"reason":"Quickstart Console smoke proposal","correlationId":"quickstart-console-smoke"}' \
+      "${base_url}/api/v1/admin/platform-release/converge"
+  )"
+
+  proposal_id="$(
+    printf '%s' "${response}" \
+      | jq -r '.targets[]? | select(.proposalId != null) | .proposalId' \
+      | head -n 1
+  )"
+
+  if [[ -z "${proposal_id}" || "${proposal_id}" == "null" ]]; then
+    echo "proposal roundtrip: converge did not return a proposalId" >&2
+    printf '%s\n' "${response}" >&2
+    return 1
+  fi
+
+  proposals="$(
+    curl -fsS \
+      -H "X-API-Key: ${ADMIN_PASSWORD}" \
+      "${base_url}/api/v1/admin/proposals"
+  )"
+
+  printf '%s' "${proposals}" \
+    | jq -e --arg id "${proposal_id}" \
+      '.proposals[]? | select(.proposalId == $id and .status == "AwaitingApproval")' \
+    >/dev/null
+
+  echo "proposal roundtrip: ok (${proposal_id})"
+}
+
+if [[ -z "${HONUA_CONSOLE_IMAGE:-}" ]]; then
+  echo "HONUA_CONSOLE_IMAGE must point to a compatible published honua-console image." >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for proposal smoke assertions." >&2
+  exit 2
+fi
+
+SMOKE_OVERRIDE_FILE="$(mktemp)"
+cat >"${SMOKE_OVERRIDE_FILE}" <<'YAML'
+services:
+  honua:
+    environment:
+      ControlPlane__PlatformRelease__Version: "2026.07.0-smoke"
+      ControlPlane__PlatformRelease__ServingArtifactReference: "ghcr.io/honua-io/honua-server:quickstart-smoke"
+      ControlPlane__PlatformRelease__Workers__0__ArtifactReference: "ghcr.io/honua-io/honua-worker:quickstart-smoke"
+      ControlPlane__DeployTargets__0__TargetId: "quickstart-smoke-target"
+      ControlPlane__DeployTargets__0__TargetKind: "Kubernetes"
+      ControlPlane__DeployTargets__0__Backend: "honua-gitops-kubernetes"
+      ControlPlane__DeployTargets__0__Environment: "quickstart-smoke"
+      ControlPlane__DeployTargets__0__TargetName: "honua-server"
+YAML
+
+compose_down
+compose up -d --build postgres redis honua console
+
+wait_for_url "http://127.0.0.1:${HONUA_HTTP_PORT}/healthz/ready" "honua ready" 90
+assert_proposal_roundtrip
+wait_for_url "http://127.0.0.1:${HONUA_CONSOLE_PORT}/version.json" "console version" 60
+wait_for_url "http://127.0.0.1:${HONUA_CONSOLE_PORT}/operate" "console operate" 60
+wait_for_url "http://127.0.0.1:${HONUA_CONSOLE_PORT}/operate/health" "console operate health" 60
+wait_for_url "http://127.0.0.1:${HONUA_CONSOLE_PORT}/operate/copilot" "console operate copilot" 60
+
+compose ps


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Related to #2558

## Summary
Wires the Docker quickstart toward the Console Operate dashboard path: Redis is part of the baseline stack, the Honua service defaults to the gate migration policy, and a profiled `console` service can be enabled when a compatible Console image is available.

This intentionally does not close #2558 yet because the repo does not currently have a published/pinned `honua-console` image to use as the final quickstart artifact.

## Changes Made
- Add Redis to the default Docker Compose quickstart and wire Honua to Redis-backed runtime defaults.
- Add an optional `console` Compose profile with server/admin-key wiring, health checks, and hardening defaults.
- Add a quickstart Console smoke script and CI workflow hook that can run when `HONUA_CONSOLE_IMAGE` is configured.
- Update quickstart, deploy, monitoring, and contributor docs to put Console Operate first and keep Grafana/Prometheus as optional depth.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [x] Requires infrastructure changes
- [x] Requires environment variable or secret changes
- [ ] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

## Validation Notes
- `bash -n scripts/ci/smoke-quickstart-console.sh`
- `git diff --check`
- `docker compose -f docker-compose.yml config --services`
- `HONUA_CONSOLE_IMAGE=ghcr.io/honua-io/honua-console:test docker compose -f docker-compose.yml --profile console config --services`
- `.github/workflows/ci.yml` parsed with PyYAML
- `dotnet build Honua.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.sln --verify-no-changes`
- `HONUA_PRE_PR_FAST=1 scripts/ci/pre-pr-check.sh` passed build, format, Core/Core.Security/Load/Postgres tests, and Architecture tests, then failed in the local architecture-review wrapper because Git Bash could not resolve `python`. Full local pre-PR was also attempted but hit long-running server shard/testhost cleanup on this Windows worktree, so this PR is open for CI-driven fix-forward.