### PR TITLE
ci: reduce CodeQL PR latency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,12 +2,10 @@ name: CodeQL
 
 on:
   # Tier: PR gate + weekly full scan.
-  # - pull_request: runs CodeQL on the changed surface so security regressions
-  #   are caught before merge (audit #1144). PR runs reuse the same C# +
-  #   security-extended query pack as the scheduled scan; CodeQL's incremental
-  #   analyzer keeps the wall time within the PR budget.
-  # - schedule: weekly full sweep to catch issues introduced by transitive
-  #   dependency churn or queries-pack updates.
+  # - pull_request: uses C# no-build extraction and the default high-precision
+  #   query suite to keep the required security gate on the PR critical path.
+  # - schedule: performs a full instrumented build with security-extended
+  #   queries to catch lower-confidence findings and dependency churn.
   pull_request:
     branches: [trunk]
     paths:
@@ -37,8 +35,7 @@ jobs:
     name: Analyze C#
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
-    # PR gate budget matches the scheduled full scan: the current C# surface and
-    # security-extended query pack routinely need more than 45 minutes to finish.
+    # The scheduled manual-build scan remains the upper bound for this job.
     timeout-minutes: 90
     permissions:
       actions: read
@@ -50,10 +47,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      # Reclaim runner disk before the CodeQL build. The C# autobuild plus the
-      # security-extended query pack intermittently exhausts the hosted runner's
-      # disk ("No space left on device"); free large preinstalled toolchains first.
+      # The scheduled instrumented build needs more disk than the PR no-build lane.
       - name: Free disk space
+        if: ${{ github.event_name != 'pull_request' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -64,25 +60,38 @@ jobs:
           swap-storage: true
 
       - name: Setup .NET
+        if: ${{ github.event_name != 'pull_request' }}
         uses: ./.github/actions/setup-dotnet-ci
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+      - name: Initialize CodeQL (pull request)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: github/codeql-action/init@v4
         with:
           languages: csharp
           config-file: ./.github/codeql/codeql-config.yml
-          # Use extended security queries for more comprehensive analysis
+          build-mode: none
+          dependency-caching: true
+
+      - name: Initialize CodeQL (full scan)
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: github/codeql-action/init@v4
+        with:
+          languages: csharp
+          config-file: ./.github/codeql/codeql-config.yml
+          build-mode: manual
           queries: security-extended
 
       - name: Restore dependencies
+        if: ${{ github.event_name != 'pull_request' }}
         run: dotnet restore Honua.sln
 
       - name: Build
+        if: ${{ github.event_name != 'pull_request' }}
         run: dotnet build Honua.sln --no-restore --configuration Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:csharp"


### PR DESCRIPTION
## Issue Link
Fixes #2618

## Summary
Reduces the required pull-request CodeQL critical path while preserving the existing weekly deep security analysis.

## Changes Made
- Use CodeQL C# no-build extraction and the default high-precision query suite for pull requests
- Retain the full instrumented Release build and security-extended queries for scheduled and manual scans
- Upgrade CodeQL Action from v3 to v4 and enable PR dependency caching
- Skip scheduled-only disk cleanup, .NET setup, restore, and build steps on pull requests

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Validation:
- `actionlint .github/workflows/codeql.yml`
- Release build: 0 warnings, 0 errors
- `dotnet format Honua.sln --verify-no-changes`: 0 files changed
- Core: 3,477 passed
- Core Security: 12 passed
- Load: 5 passed
- Architecture: 125 passed
- Docker-backed Postgres tests could not run locally because Docker Desktop WSL integration is unavailable; hosted CI remains authoritative

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review