### PR TITLE
ci: move Postgres coverage off PR path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,9 @@ jobs:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
-          POSTGRES_BASELINE='[{"pg_image":"postgis/postgis:16-3.4","pg_suffix":"16","collect_coverage":true}]'
+          # PRs and selective batches run the complete compatibility suite without
+          # coverage instrumentation; scheduled/manual full CI remains authoritative.
+          POSTGRES_BASELINE='[{"pg_image":"postgis/postgis:16-3.4","pg_suffix":"16","collect_coverage":false}]'
           POSTGRES_FULL='[{"pg_image":"postgis/postgis:16-3.4","pg_suffix":"16","collect_coverage":true},{"pg_image":"postgis/postgis:17-3.5","pg_suffix":"17","collect_coverage":false},{"pg_image":"postgis/postgis:18-3.6","pg_suffix":"18","collect_coverage":false}]'
 
           # Fail safe: if the diff range cannot be computed (e.g. no merge-base after a


### PR DESCRIPTION
## Issue Link
Fixes #2622

## Summary
Removes coverage instrumentation from pull-request and selective merge-train Postgres compatibility runs while preserving the complete correctness suite and full-CI coverage authority.

## Changes Made
- Set the baseline PG16 compatibility matrix entry to `collect_coverage: false`
- Keep scheduled/manual full CI coverage enabled for PG16
- Keep the full PG16/17/18 compatibility matrix unchanged

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation:
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Parsed matrix assertions verify baseline PG16 coverage is disabled and full CI PG16 coverage remains enabled
- Same-run evidence: coverage-instrumented PG16 took 26m34s; non-instrumented PG17/18 complete compatibility runs passed in 5m13s and 5m34s
- #2615 selective batch passed Build & Format, Foundation, and all five targeted shards; its coverage-instrumented Postgres auxiliary lane alone hit the job timeout

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review