### PR TITLE
fix(compose): persist local file storage

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -13,6 +13,14 @@ HONUA_REDIS_URL=redis:6379
 HONUA_REDIS_MAXMEMORY=64mb
 
 # =============================================================================
+# FILE STORAGE
+# =============================================================================
+# The Local provider is persisted by docker-compose.yml on this named volume.
+# Use a unique name when running more than one Honua stack on the same host.
+HONUA_STORAGE_PROVIDER=Local
+HONUA_STORAGE_VOLUME_NAME=honua_storage
+
+# =============================================================================
 # FEATURE FLAGS
 # =============================================================================
 HONUA_OBSERVABILITY=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,16 +143,17 @@ COPY --from=build --chown=1001:1001 /app .
 # to at runtime. Under the read-only root filesystem this image is built for
 # (security.read-only-root="true"), any path not provisioned here — and not backed
 # by a writable volume mount by the deployment — is read-only, so a write attempt
-# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /var/lib/honua/storage
-# (FileStorage:LocalStorage:BasePath) back the map-image export href/f=json responses
+# throws. /tmp/honua-temp and /tmp/honua-storage back the default temporary and
+# local-storage paths; /var/lib/honua/storage is the persistent Compose override.
+# These paths back the map-image export href/f=json responses
 # (MapServer export, ImageServer exportImage, OGC API Maps); omitting them here made
 # every rendered-image export fail with a 500 while inline f=image responses (which
 # never touch temp storage) still succeeded. Keep this list in sync with the default
 # storage directories in appsettings.json — DockerfileWritableStorageDirectoryTests
 # enforces it.
-RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
-    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
-    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage
+RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage /var/lib/honua/storage && \
+    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage /var/lib/honua/storage && \
+    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage /var/lib/honua/storage
 
 # Security: Remove unnecessary setuid/setgid binaries
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,16 +143,16 @@ COPY --from=build --chown=1001:1001 /app .
 # to at runtime. Under the read-only root filesystem this image is built for
 # (security.read-only-root="true"), any path not provisioned here — and not backed
 # by a writable volume mount by the deployment — is read-only, so a write attempt
-# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /tmp/honua-storage
+# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /var/lib/honua/storage
 # (FileStorage:LocalStorage:BasePath) back the map-image export href/f=json responses
 # (MapServer export, ImageServer exportImage, OGC API Maps); omitting them here made
 # every rendered-image export fail with a 500 while inline f=image responses (which
 # never touch temp storage) still succeeded. Keep this list in sync with the default
 # storage directories in appsettings.json — DockerfileWritableStorageDirectoryTests
 # enforces it.
-RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
-    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
-    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage
+RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
+    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
+    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage
 
 # Security: Remove unnecessary setuid/setgid binaries
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       # reusing this compose file outside a local developer workstation.
       HONUA_ADMIN_PASSWORD: "${HONUA_ADMIN_PASSWORD:-quickstart-admin-password}"
       FileStorage__Provider: "${HONUA_STORAGE_PROVIDER:-Local}"
+      FileStorage__LocalStorage__BasePath: "/var/lib/honua/storage"
       FileStorage__AwsS3__BucketName: "${HONUA_S3_BUCKET:-}"
       FileStorage__AwsS3__Region: "${HONUA_S3_REGION:-us-east-1}"
       FileStorage__AwsS3__ServiceUrl: "${HONUA_S3_SERVICE_URL:-}"
@@ -112,6 +113,7 @@ services:
     tmpfs:
       - /tmp:noexec,nosuid,size=100m
     volumes:
+      - honua_storage:/var/lib/honua/storage
       - honua_logs:/tmp/honua-logs
       - honua_cache:/tmp/honua-cache
       - dotnet_diagnostics:/tmp/dotnet-diagnostics
@@ -175,6 +177,8 @@ services:
 
 volumes:
   postgres_data:
+  honua_storage:
+    name: "${HONUA_STORAGE_VOLUME_NAME:-honua_storage}"
   honua_logs:
   honua_cache:
   dotnet_diagnostics:

--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -157,16 +157,16 @@ COPY --from=build --chown=1001:1001 /app .
 # to at runtime. Under the read-only root filesystem this image is built for
 # (security.read-only-root="true"), any path not provisioned here — and not backed
 # by a writable volume mount by the deployment — is read-only, so a write attempt
-# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /tmp/honua-storage
+# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /var/lib/honua/storage
 # (FileStorage:LocalStorage:BasePath) back the map-image export href/f=json responses
 # (MapServer export, ImageServer exportImage); omitting them makes every rendered
 # image export fail with a 500 while inline f=image responses (which never touch
 # temp storage) still succeed. Keep this list in sync with the default storage
 # directories in appsettings.json — DockerfileWritableStorageDirectoryTests enforces
 # it for every Dockerfile that declares security.read-only-root="true".
-RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
-    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage && \
-    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage
+RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
+    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
+    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage
 
 # Security: Remove unnecessary setuid/setgid binaries
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true

--- a/docker/Dockerfile.aot
+++ b/docker/Dockerfile.aot
@@ -157,16 +157,17 @@ COPY --from=build --chown=1001:1001 /app .
 # to at runtime. Under the read-only root filesystem this image is built for
 # (security.read-only-root="true"), any path not provisioned here — and not backed
 # by a writable volume mount by the deployment — is read-only, so a write attempt
-# throws. /tmp/honua-temp (TemporaryFiles:StorageDirectory) and /var/lib/honua/storage
-# (FileStorage:LocalStorage:BasePath) back the map-image export href/f=json responses
+# throws. /tmp/honua-temp and /tmp/honua-storage back the default temporary and
+# local-storage paths; /var/lib/honua/storage is the persistent Compose override.
+# These paths back the map-image export href/f=json responses
 # (MapServer export, ImageServer exportImage); omitting them makes every rendered
 # image export fail with a 500 while inline f=image responses (which never touch
 # temp storage) still succeed. Keep this list in sync with the default storage
 # directories in appsettings.json — DockerfileWritableStorageDirectoryTests enforces
 # it for every Dockerfile that declares security.read-only-root="true".
-RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
-    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage && \
-    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /var/lib/honua/storage
+RUN mkdir -p /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage /var/lib/honua/storage && \
+    chown -R 1001:1001 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage /var/lib/honua/storage && \
+    chmod 750 /tmp/honua-logs /tmp/honua-cache /tmp/dotnet-diagnostics /tmp/honua-temp /tmp/honua-storage /var/lib/honua/storage
 
 # Security: Remove unnecessary setuid/setgid binaries
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true

--- a/docs/guides/deploy/backup-and-restore.md
+++ b/docs/guides/deploy/backup-and-restore.md
@@ -40,7 +40,7 @@ ARCHIVE="honua-files-$(date +%Y%m%d).tar.gz"
 docker volume inspect "$STORAGE_VOLUME" >/dev/null
 SOURCE_FILE_COUNT=$(docker run --rm -v "$STORAGE_VOLUME":/data:ro alpine \
   sh -c 'find /data -type f | wc -l')
-docker run --rm -v "$STORAGE_VOLUME":/data -v "$PWD":/backup alpine \
+docker run --rm -v "$STORAGE_VOLUME":/data:ro -v "$PWD":/backup alpine \
   tar czf "/backup/$ARCHIVE" -C /data .
 
 # Prove the archive is readable and contains the same number of files.
@@ -72,7 +72,8 @@ STORAGE_VOLUME="${HONUA_STORAGE_VOLUME_NAME:-honua_storage}"
 ARCHIVE=honua-files-20260609.tar.gz
 docker volume inspect "$STORAGE_VOLUME" >/dev/null
 docker run --rm -v "$STORAGE_VOLUME":/data -v "$PWD":/backup:ro alpine \
-  sh -c 'find /data -mindepth 1 -delete && tar xzf "/backup/'"$ARCHIVE"'" -C /data && chown -R 1001:1001 /data'
+  sh -c 'find /data -mindepth 1 -delete && tar xzf "/backup/$1" -C /data && chown -R 1001:1001 /data' \
+  restore "$ARCHIVE"
 ```
 
 4. Start Honua. Migrations run automatically at startup and roll the restored schema forward to match the running version; set `HONUA_SKIP_MIGRATIONS=true` only if you intend to run them out-of-band, and check state via `GET /api/v1/admin/observability/migrations`.

--- a/docs/guides/deploy/backup-and-restore.md
+++ b/docs/guides/deploy/backup-and-restore.md
@@ -91,13 +91,15 @@ Expected: a PostGIS version row, then `Ready`. Finish with a known feature query
 
 Compose versions before #2624 stored local files under the container's
 `/tmp/honua-storage` and did not mount that directory. Before replacing the old
-container, stop writes and copy any surviving files out of it:
+container, quiesce writes at the edge or through a maintenance window, then copy
+any surviving files from the still-running container before stopping it:
 
 ```bash
-docker compose stop honua
-OLD_HONUA_CONTAINER=$(docker compose ps -a -q honua)
+OLD_HONUA_CONTAINER=$(docker compose ps -q honua)
+test -n "$OLD_HONUA_CONTAINER"
 mkdir -p honua-storage-migration
 docker cp "$OLD_HONUA_CONTAINER:/tmp/honua-storage/." honua-storage-migration/
+docker compose stop honua
 ```
 
 After updating the Compose file, create the new named volume and copy the files

--- a/docs/guides/deploy/backup-and-restore.md
+++ b/docs/guides/deploy/backup-and-restore.md
@@ -33,10 +33,26 @@ psql -h db.example.com -U honua -d honua -c "SHOW archive_mode;"
 3. If you use local file storage, snapshot the volume alongside the database dump so attachments and uploads stay consistent with metadata.
 
 ```bash
-STORAGE_VOLUME=honua_storage
+STORAGE_VOLUME="${HONUA_STORAGE_VOLUME_NAME:-honua_storage}"
+ARCHIVE="honua-files-$(date +%Y%m%d).tar.gz"
+
+# Fail rather than letting `docker run -v` silently create a new empty volume.
+docker volume inspect "$STORAGE_VOLUME" >/dev/null
+SOURCE_FILE_COUNT=$(docker run --rm -v "$STORAGE_VOLUME":/data:ro alpine \
+  sh -c 'find /data -type f | wc -l')
 docker run --rm -v "$STORAGE_VOLUME":/data -v "$PWD":/backup alpine \
-  tar czf /backup/honua-files-$(date +%Y%m%d).tar.gz -C /data .
+  tar czf "/backup/$ARCHIVE" -C /data .
+
+# Prove the archive is readable and contains the same number of files.
+tar tzf "$ARCHIVE"
+ARCHIVE_FILE_COUNT=$(tar tzf "$ARCHIVE" | grep -vc '/$' || true)
+test "$SOURCE_FILE_COUNT" -eq "$ARCHIVE_FILE_COUNT"
 ```
+
+The repo Compose file mounts this named volume at `/var/lib/honua/storage` and
+sets its engine-level name from `HONUA_STORAGE_VOLUME_NAME`. A zero file count is
+valid only when the deployment intentionally has no uploads or attachments; record
+that fact with the backup evidence rather than assuming an empty archive is correct.
 
 ## Restore sequence
 
@@ -48,7 +64,17 @@ PGPASSWORD=replace-with-db-password pg_restore \
   -h db.example.com -U honua -d honua --clean --if-exists honua-20260609.dump
 ```
 
-3. Restore the file-storage volume or bucket from the matching snapshot.
+3. Restore the file-storage volume or bucket from the matching snapshot. For the
+   repo Compose path, keep Honua stopped and restore into the existing declared volume:
+
+```bash
+STORAGE_VOLUME="${HONUA_STORAGE_VOLUME_NAME:-honua_storage}"
+ARCHIVE=honua-files-20260609.tar.gz
+docker volume inspect "$STORAGE_VOLUME" >/dev/null
+docker run --rm -v "$STORAGE_VOLUME":/data -v "$PWD":/backup:ro alpine \
+  sh -c 'find /data -mindepth 1 -delete && tar xzf "/backup/'"$ARCHIVE"'" -C /data && chown -R 1001:1001 /data'
+```
+
 4. Start Honua. Migrations run automatically at startup and roll the restored schema forward to match the running version; set `HONUA_SKIP_MIGRATIONS=true` only if you intend to run them out-of-band, and check state via `GET /api/v1/admin/observability/migrations`.
 
 ## Verify
@@ -59,6 +85,33 @@ curl -s http://localhost:8080/healthz/ready
 ```
 
 Expected: a PostGIS version row, then `Ready`. Finish with a known feature query against a restored layer to confirm data integrity.
+
+### Upgrading an older Compose quickstart
+
+Compose versions before #2624 stored local files under the container's
+`/tmp/honua-storage` and did not mount that directory. Before replacing the old
+container, stop writes and copy any surviving files out of it:
+
+```bash
+docker compose stop honua
+OLD_HONUA_CONTAINER=$(docker compose ps -a -q honua)
+mkdir -p honua-storage-migration
+docker cp "$OLD_HONUA_CONTAINER:/tmp/honua-storage/." honua-storage-migration/
+```
+
+After updating the Compose file, create the new named volume and copy the files
+into it before starting Honua:
+
+```bash
+STORAGE_VOLUME="${HONUA_STORAGE_VOLUME_NAME:-honua_storage}"
+docker volume create "$STORAGE_VOLUME" >/dev/null
+docker run --rm -v "$STORAGE_VOLUME":/data -v "$PWD/honua-storage-migration":/source:ro alpine \
+  sh -c 'cp -a /source/. /data/ && chown -R 1001:1001 /data'
+docker compose up -d
+```
+
+If the old container has already been deleted, its tmpfs contents cannot be
+recovered; restore the matching file-storage backup instead.
 
 ## Troubleshoot
 

--- a/docs/guides/deploy/docker-compose.md
+++ b/docs/guides/deploy/docker-compose.md
@@ -16,11 +16,12 @@ POSTGRES_PASSWORD=replace-with-strong-db-password
 HONUA_ADMIN_PASSWORD=replace-with-strong-admin-password
 HONUA_MASTER_KEY=replace-with-random-string-of-32-plus-characters
 HONUA_CORS_ORIGIN=https://app.example.com
+HONUA_STORAGE_VOLUME_NAME=honua_storage
 EOF
 chmod 600 .env
 ```
 
-2. Create the compose file. Honua is stateless — only PostGIS (and Redis, if enabled) need volumes; the server binds to localhost only, so the proxy is the sole public entrypoint.
+2. Create the compose file. The server process is replaceable, while PostGIS, Redis durable-control-plane state, and local file storage live on persistent volumes. The server binds to localhost only, so the proxy is the sole public entrypoint.
 
 ```bash
 cat > docker-compose.yml <<'EOF'
@@ -39,6 +40,8 @@ services:
       HONUA_OBSERVABILITY: "true"
       ConnectionStrings__Redis: "redis:6379"
       Database__MigrationSafety__ContractApplyPolicy: Gate
+      FileStorage__Provider: Local
+      FileStorage__LocalStorage__BasePath: /var/lib/honua/storage
     depends_on:
       postgres:
         condition: service_healthy
@@ -55,6 +58,8 @@ services:
     security_opt: ["no-new-privileges:true"]
     tmpfs:
       - /tmp:noexec,nosuid,size=100m
+    volumes:
+      - honua_storage:/var/lib/honua/storage
     deploy:
       resources:
         limits:
@@ -91,6 +96,8 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  honua_storage:
+    name: ${HONUA_STORAGE_VOLUME_NAME}
 EOF
 ```
 

--- a/docs/reference/configuration/environment-variables.md
+++ b/docs/reference/configuration/environment-variables.md
@@ -93,7 +93,7 @@ OIDC provider configuration (`Oidc__*` — Azure AD, Google, Okta, Auth0, generi
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `FileStorage__Provider` | `Local` | File storage backend: `Local` or S3-compatible (`AwsS3`). |
-| `FileStorage__LocalStorage__BasePath` | `/var/lib/honua/storage` | Root directory for durable local file storage. Development overrides this to `/tmp/honua-storage`; container deployments must mount the production path on persistent storage. |
+| `FileStorage__LocalStorage__BasePath` | `/tmp/honua-storage` | Root directory for local file storage. The repo Compose path overrides this to `/var/lib/honua/storage` and mounts a persistent named volume; production deployments using Local must likewise choose a durable mount. |
 | `FileStorage__MaxFileSizeBytes` | `1073741824` | Maximum stored file size (1 GiB shipped default). |
 | `FileStorage__AwsS3__BucketName` | — | S3 bucket name. |
 | `FileStorage__AwsS3__Region` | `us-east-1` | S3 region. |

--- a/docs/reference/configuration/environment-variables.md
+++ b/docs/reference/configuration/environment-variables.md
@@ -93,7 +93,7 @@ OIDC provider configuration (`Oidc__*` — Azure AD, Google, Okta, Auth0, generi
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `FileStorage__Provider` | `Local` | File storage backend: `Local` or S3-compatible (`AwsS3`). |
-| `FileStorage__LocalStorage__BasePath` | `/tmp/honua-storage` | Root directory for local file storage. |
+| `FileStorage__LocalStorage__BasePath` | `/var/lib/honua/storage` | Root directory for durable local file storage. Development overrides this to `/tmp/honua-storage`; container deployments must mount the production path on persistent storage. |
 | `FileStorage__MaxFileSizeBytes` | `1073741824` | Maximum stored file size (1 GiB shipped default). |
 | `FileStorage__AwsS3__BucketName` | — | S3 bucket name. |
 | `FileStorage__AwsS3__Region` | `us-east-1` | S3 region. |

--- a/src/Honua.Server/appsettings.json
+++ b/src/Honua.Server/appsettings.json
@@ -146,7 +146,7 @@
   "FileStorage": {
     "Provider": "Local",
     "LocalStorage": {
-      "BasePath": "/var/lib/honua/storage",
+      "BasePath": "/tmp/honua-storage",
       "CreateDirectoryIfNotExists": true
     },
     "DefaultTimeToLive": "24:00:00",

--- a/src/Honua.Server/appsettings.json
+++ b/src/Honua.Server/appsettings.json
@@ -146,7 +146,7 @@
   "FileStorage": {
     "Provider": "Local",
     "LocalStorage": {
-      "BasePath": "/tmp/honua-storage",
+      "BasePath": "/var/lib/honua/storage",
       "CreateDirectoryIfNotExists": true
     },
     "DefaultTimeToLive": "24:00:00",

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Hosting/ContainerGrpcTransportConfigurationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Hosting/ContainerGrpcTransportConfigurationTests.cs
@@ -34,6 +34,36 @@ public sealed class ContainerGrpcTransportConfigurationTests
     }
 
     [Fact]
+    public void ComposeFile_PersistsLocalFileStorageOutsideTmpfs()
+    {
+        var compose = ReadRepoFile("docker-compose.yml");
+        var honuaService = GetComposeServiceBlock(compose, "honua", "console");
+
+        Assert.Contains(
+            "FileStorage__LocalStorage__BasePath: \"/var/lib/honua/storage\"",
+            honuaService,
+            StringComparison.Ordinal);
+        Assert.Contains("- honua_storage:/var/lib/honua/storage", honuaService, StringComparison.Ordinal);
+        Assert.DoesNotContain("honua_storage:/tmp", honuaService, StringComparison.Ordinal);
+        Assert.Contains("  honua_storage:", compose, StringComparison.Ordinal);
+        Assert.Contains(
+            "name: \"${HONUA_STORAGE_VOLUME_NAME:-honua_storage}\"",
+            compose,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BackupGuide_UsesTheMountedComposeStorageVolume()
+    {
+        var guide = ReadRepoFile("docs/guides/deploy/backup-and-restore.md");
+
+        Assert.Contains("HONUA_STORAGE_VOLUME_NAME", guide, StringComparison.Ordinal);
+        Assert.Contains("/var/lib/honua/storage", guide, StringComparison.Ordinal);
+        Assert.Contains("tar tzf", guide, StringComparison.Ordinal);
+        Assert.DoesNotContain("STORAGE_VOLUME=honua_storage", guide, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ClientCompatComposeFile_OverridesContainerHttpPortForLaneBaseUrls()
     {
         var compose = ReadRepoFile("docker/client-compat/compose.yml");


### PR DESCRIPTION
# Pull Request

## Issue Link

Closes #2624
Related to #2552

## Summary

Makes local file storage durable on the stock Docker Compose path and makes backup/restore fail instead of silently archiving a newly created empty volume.

## Changes Made

- Override the repo Compose local-storage path to `/var/lib/honua/storage`, provision both the existing `/tmp` default and the persistent target in both runtime images, and mount the persistent target from a stable named volume.
- Add a Compose contract test proving local storage is outside the `/tmp` tmpfs and is backed by the documented volume.
- Make local-volume backup fail when the volume does not exist, verify archive readability/file count, document restore ownership, and provide a one-time migration path for pre-#2624 containers.
- Align the production-shaped Compose guide, Docker environment example, and configuration reference.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Validated:

- Red phase: the two new Compose/backup contract assertions failed against `trunk`.
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --no-restore --filter FullyQualifiedName~ContainerGrpcTransportConfigurationTests` — 6/6 passed on current trunk.
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~DockerfileWritableStorageDirectoryTests` — 1/1 passed.
- `dotnet format Honua.sln --verify-no-changes --no-restore` — passed.
- `git diff --check origin/trunk...HEAD` — passed.
- `scripts/ci/pre-pr-check.sh` — Release build and full format passed. The focused affected tests passed; the Docker-backed admin shard could not run locally because Docker is unavailable (676 passed, 148 Testcontainers connection failures), so hosted CI is authoritative for that portion.
- `docker compose config --quiet` could not run because this WSL distro has no Docker CLI/socket; merge-train Compose validation remains authoritative.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [x] Requires infrastructure changes
- [x] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes

The repo Compose local-storage path moves from ephemeral `/tmp/honua-storage` to the persistent `/var/lib/honua/storage` mount. Existing Compose users with surviving files in an old container must follow the documented one-time copy procedure before replacing that container. The new Compose path declares and mounts `HONUA_STORAGE_VOLUME_NAME` (default `honua_storage`). The base `/tmp/honua-storage` application default remains unchanged for non-Compose and Helm compatibility.

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
