### PR TITLE
test(mcp): cover autonomy routes in seat parity

### DIFF
--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/ops-parity-map.yaml
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/ops-parity-map.yaml
@@ -9,10 +9,10 @@
 #     # or:
 #     human-only: "Required justification for an operator-only action."
 #
-# Each route in the architecture-test enforced operate/admin-observability/deploy/proposals
+# Each route in the architecture-test enforced operate/admin-observability/autonomy/deploy/proposals
 # partition must appear exactly once with exactly one of `tool`, `resource`, or `human-only`.
-# `human-only` is reserved for actions that must remain human controls, such as approval,
-# rejection, staged submit, and promotion.
+# `human-only` is reserved for surfaces that must remain human trust controls, such as autonomy
+# graduation/kill-switch state, approval, rejection, staged submit, and promotion.
 routes:
   "GET /api/v1/operate/status":
     tool: honua_ops_health
@@ -20,6 +20,16 @@ routes:
     tool: honua_ops_health
   "GET /api/v1/admin/observability/ops-health/history":
     resource: honua://ops/health
+  "GET /api/v1/admin/observability/autonomy/policies":
+    human-only: "Autonomy policy and graduation evidence are human trust controls; agents observe findings and outcomes but do not inspect or change graduation controls."
+  "GET /api/v1/admin/observability/autonomy/policies/{rule}":
+    human-only: "Autonomy policy and graduation evidence are human trust controls; agents observe findings and outcomes but do not inspect or change graduation controls."
+  "PUT /api/v1/admin/observability/autonomy/policies/{rule}":
+    human-only: "Changing a rule to auto-apply can authorize automatic actuation and must remain a human operator trust decision."
+  "GET /api/v1/admin/observability/autonomy/settings":
+    human-only: "The global autonomy kill-switch state is an operator safety control; agents are governed by it but do not receive the control setting surface."
+  "PUT /api/v1/admin/observability/autonomy/settings":
+    human-only: "Changing the global autonomy kill switch must remain a human operator safety decision."
   "GET /api/v1/admin/observability/findings":
     tool: honua_ops_findings
   "POST /api/v1/admin/observability/findings/{findingId}/propose":

--- a/tests/dotnet/Honua.Architecture.Tests/SeatParityContractTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/SeatParityContractTests.cs
@@ -48,7 +48,7 @@ public sealed class SeatParityContractTests
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     [ArchitectureTest]
-    public void OpsParityMap_CoversOperateObservabilityDeployAndProposalRoutes()
+    public void OpsParityMap_CoversOperateObservabilityAutonomyDeployAndProposalRoutes()
     {
         var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
         var parityMap = LoadParityMap(repoRoot);
@@ -61,7 +61,7 @@ public sealed class SeatParityContractTests
         parityMap.Keys.OrderBy(route => route, StringComparer.Ordinal)
             .Should().BeEquivalentTo(
                 expectedRoutes,
-                "every operate/admin-observability/deploy/proposal EndpointRegistry route must be mapped for MCP parity");
+                "every operate/admin-observability/autonomy/deploy/proposal EndpointRegistry route must be mapped for MCP parity");
 
         var implementedMcpTools = LoadImplementedMcpTools(repoRoot);
         foreach (var (route, entry) in parityMap)
@@ -189,6 +189,7 @@ public sealed class SeatParityContractTests
         => endpoint.Path.StartsWith("/api/v1/operate/", StringComparison.Ordinal)
             || endpoint.Path.StartsWith("/api/v1/admin/observability/ops-health", StringComparison.Ordinal)
             || endpoint.Path.StartsWith("/api/v1/admin/observability/findings", StringComparison.Ordinal)
+            || endpoint.Path.StartsWith("/api/v1/admin/observability/autonomy/", StringComparison.Ordinal)
             || endpoint.Path.StartsWith("/api/v1/admin/deploy/", StringComparison.Ordinal)
             || endpoint.Path.StartsWith("/api/v1/admin/proposals", StringComparison.Ordinal)
             || string.Equals(endpoint.Path, "/api/v1/admin/platform-release/converge", StringComparison.Ordinal);


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2629

Related to #2552 and honua-io/honua-console#289.

## Summary

Close the parity-contract blind spot added when graduated-autonomy routes landed after the original seat-parity map. All five autonomy policy/settings routes are now inside the enforced operator partition and carry explicit human-only trust-boundary justifications.

## Changes Made
- Extend the EndpointRegistry parity partition to every `/api/v1/admin/observability/autonomy/**` route.
- Map list/get/update policy and get/update settings as deliberate human trust controls.
- Preserve agent access to findings/outcomes while making policy graduation and the kill switch explicitly operator-only.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

TDD evidence: the focused architecture test failed with exactly five missing autonomy routes, then passed after the map update. The Release architecture project build completed, the focused test passed from rebuilt binaries, scoped `dotnet format --verify-no-changes` passed, and `git diff --check` passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
