### PR TITLE
test(ci): isolate dead-letter fixture rows

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/AgenticOpsLoopDeadLetterE2eTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/AgenticOpsLoopDeadLetterE2eTests.cs
@@ -183,20 +183,40 @@ public sealed class AgenticOpsLoopDeadLetterE2eTests(RedisFixture redis) : IAsyn
             await dispatchStore.EnqueueAsync(eventId.Value, ImmutableArray.Create(AlertChannelType.WebSocket));
         }
 
-        var claimed = await dispatchStore.ClaimPendingAsync(count, DateTimeOffset.UtcNow.AddMinutes(1));
-        claimed.Select(item => item.EventId).Should().BeEquivalentTo(
-            eventIds,
-            "the rows enqueued for the seeded fault must be the rows marked dead-lettered");
+        await MarkSeededDispatchesDeadLetterAsync(fixture, eventIds);
+    }
 
-        foreach (var item in claimed)
+    private static async Task MarkSeededDispatchesDeadLetterAsync(WebAppFixture fixture, HashSet<long> eventIds)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var updated = 0;
+
+        await fixture.Postgres.RunUnderSchemaMutationLockAsync(async () =>
         {
-            await dispatchStore.MarkFailedAsync(
-                item.DispatchId,
-                DateTimeOffset.UtcNow,
-                DateTimeOffset.UtcNow,
-                deadLetter: true,
-                errorMessage: "seeded dead-letter storm for #2568");
-        }
+            await using var connection = await fixture.Postgres.GetConnectionAsync();
+            await using var command = new NpgsqlCommand(
+                """
+                UPDATE honua.alert_dispatch
+                SET status = @status,
+                    attempts = attempts + 1,
+                    next_attempt_at = @now,
+                    last_attempt_at = @now,
+                    last_error = @last_error,
+                    updated_at = now()
+                WHERE event_id = ANY(@event_ids)
+                """,
+                connection);
+            command.Parameters.AddWithValue("status", (short)AlertDispatchStatus.DeadLetter);
+            command.Parameters.AddWithValue("now", now);
+            command.Parameters.AddWithValue("last_error", "seeded dead-letter storm for #2568");
+            command.Parameters.AddWithValue("event_ids", eventIds.ToArray());
+
+            updated = await command.ExecuteNonQueryAsync();
+        });
+
+        updated.Should().Be(
+            eventIds.Count,
+            "only the dispatch rows enqueued for the seeded fault should be marked dead-lettered");
     }
 
     private async Task RefreshCachedBacklogAsync(IAlertDispatchStore store)


### PR DESCRIPTION
# Pull Request

## Issue Link

Related to #2568

## Summary

Makes the agentic dead-letter recovery integration test isolate the dispatch rows it creates so unrelated pending rows cannot deterministically fail the CI shard.

## Changes Made

- Update only the dispatch rows associated with the test's newly inserted event IDs.
- Run the fixture update under the shared Postgres schema-mutation lock.
- Assert that every seeded dispatch row, and no unrelated row, was marked dead-lettered.

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Validated with:

- `HONUA_PRE_PR_FAST=1 scripts/ci/pre-pr-check.sh` - passed the warnings-as-errors affected build, scoped format check, and 125/125 architecture tests.
- Focused `AgenticOpsLoopDeadLetterE2eTests` execution was attempted after a successful Release build; Testcontainers could not connect to the unavailable local `/var/run/docker.sock`, so hosted CI is authoritative for Postgres and Redis execution.
- Hosted run 29081811542 reproduced the old row-selection failure twice with 222/223 peer tests passing, establishing the regression before this fix.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
