### PR TITLE
fix(metadata): bind ImageServer raster layers (#2638)

### DIFF
--- a/src/Honua.Postgres/Features/Metadata/MetadataV2CompatSnapshotSql.cs
+++ b/src/Honua.Postgres/Features/Metadata/MetadataV2CompatSnapshotSql.cs
@@ -333,6 +333,7 @@ internal static class MetadataV2CompatSnapshotSql
                         'connectionId', NULL,
                         'storageType', 'relational-table',
                         'locator', 'honua.raster_data',
+                        'storageLayerId', layer_id,
                         'capabilities', to_jsonb(ARRAY['query', 'filter', 'render', 'tile', 'download']::text[]),
                         'options', '{}'::jsonb,
                         'status', (SELECT value FROM status_doc),

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphStoreCompatFallbackTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Metadata/PostgresMetadataV2GraphStoreCompatFallbackTests.cs
@@ -64,6 +64,14 @@ public sealed class PostgresMetadataV2GraphStoreCompatFallbackTests(PostgresFixt
             var binding = snapshot.Graph.StorageBindings.Should()
                 .ContainSingle(b => b.Metadata.Id == "storage-layer-700").Which;
             binding.StorageLayerId.Should().Be(700);
+
+            // ImageServer resolves the raster sidecar through its storage binding's integer
+            // storage-layer handle. The compat compiler must preserve the V1 layer id here;
+            // otherwise the service exists in metadata but the resolver reports that
+            // ImageServer is not enabled. (honua-server#2638.)
+            var imageBinding = snapshot.Graph.StorageBindings.Should()
+                .ContainSingle(b => b.Metadata.Id == "storage-image-layer-700").Which;
+            imageBinding.StorageLayerId.Should().Be(700);
         }
         finally
         {

--- a/tests/dotnet/Honua.Server.Tests/Seed/CompatCompileBindingAndAccessPolicyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/CompatCompileBindingAndAccessPolicyTests.cs
@@ -184,6 +184,21 @@ public sealed class CompatCompileBindingAndAccessPolicyTests
             options.GetProperty("attributesColumn").GetString().Should().Be("attributes");
         }
 
+        // honua-server#2638 — the ImageServer sidecar must retain the source layer's
+        // integer storage handle. Without it, service discovery succeeds but ImageServer
+        // resolution fails with "ImageServer is not enabled".
+        var imageBindings = root.GetProperty("storageBindings")
+            .EnumerateArray()
+            .Where(binding =>
+            {
+                var id = binding.GetProperty("metadata").GetProperty("id").GetString();
+                return id is "storage-image-layer-4100" or "storage-image-layer-4101";
+            })
+            .ToArray();
+        imageBindings.Should().HaveCount(2);
+        imageBindings.Select(binding => binding.GetProperty("storageLayerId").GetInt32())
+            .Should().BeEquivalentTo([ProtectedPointLayerId, ProtectedLineLayerId]);
+
         // The bound base-schema layer 0 also lives on the shared `features` table
         // and must remain anonymous (no policy seeded => default open).
         var baseService = root.GetProperty("services")

--- a/tests/seed/base-schema.sql
+++ b/tests/seed/base-schema.sql
@@ -810,6 +810,7 @@ BEGIN
                     'connectionId', NULL,
                     'storageType', 'relational-table',
                     'locator', 'honua.raster_data',
+                    'storageLayerId', layer_id,
                     'capabilities', to_jsonb(ARRAY['query', 'filter', 'render', 'tile', 'download']::text[]),
                     'options', '{}'::jsonb,
                     'status', (SELECT value FROM status_doc),

--- a/tests/seed/client-compat-v1.sql
+++ b/tests/seed/client-compat-v1.sql
@@ -564,6 +564,7 @@ BEGIN
                     'connectionId', NULL,
                     'storageType', 'relational-table',
                     'locator', 'honua.raster_data',
+                    'storageLayerId', layer_id,
                     'capabilities', to_jsonb(ARRAY['query', 'filter', 'render', 'tile', 'download']::text[]),
                     'options', '{}'::jsonb,
                     'status', (SELECT value FROM status_doc),

--- a/tests/seed/server.yaml
+++ b/tests/seed/server.yaml
@@ -2597,6 +2597,7 @@ sql:
                           'connectionId', NULL,
                           'storageType', 'relational-table',
                           'locator', 'honua.raster_data',
+                          'storageLayerId', layer_id,
                           'capabilities', to_jsonb(ARRAY['query', 'filter', 'render', 'tile', 'download']::text[]),
                           'options', '{}'::jsonb,
                           'status', (SELECT value FROM status_doc),


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2638

## Summary
Preserve the source layer id on ImageServer raster-sidecar storage bindings synthesized from the V1 catalog. This makes the canonical ImageServer resolver find the backing raster without an external SQL backfill.

## Changes Made
- Add `storageLayerId` to raster-sidecar bindings in the production Metadata v2 compatibility compiler.
- Keep the base, client-compatibility, and server YAML seed compiler mirrors aligned.
- Add graph-store and executable seed regressions proving ImageServer bindings retain their integer storage handle.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent focused pre-PR validation run:

- Warnings-as-errors Release builds through both affected integration-test projects.
- `dotnet format Honua.sln --verify-no-changes --no-restore --include` for all changed C# files.
- `PostgresMetadataV2GraphStoreCompatFallbackTests.GetCurrentAsync_NoV2SnapshotButV1CatalogPresent_SynthesizesCompatSnapshotFromV1`.
- `CompatCompileBindingAndAccessPolicyTests.CompatCompile_ProtectedSharedFeaturesService_CarriesAccessPolicyAndBindingColumns`.