### PR TITLE
test(portal): add live SDK repoint compatibility (#2614)

### DIFF
--- a/.github/workflows/sdk-server-compatibility.yml
+++ b/.github/workflows/sdk-server-compatibility.yml
@@ -165,11 +165,12 @@ jobs:
           ref: ${{ github.sha }}
           path: compatibility-source
 
-      - name: Preserve current compatibility runner
+      - name: Preserve current compatibility assets
         shell: bash
         run: |
           set -euo pipefail
           cp compatibility-source/scripts/ci/run-sdk-server-compatibility.sh "$RUNNER_TEMP/run-sdk-server-compatibility.sh"
+          cp compatibility-source/tests/seed/portal-compat.yaml "$RUNNER_TEMP/portal-compat.yaml"
           chmod +x "$RUNNER_TEMP/run-sdk-server-compatibility.sh"
 
       - name: Checkout honua-server target
@@ -202,7 +203,7 @@ jobs:
           # PortalCompat is additive and exists only in the current SDK/server
           # pair. Preserve the historical compatibility cells by applying the
           # Portal fixture only to the current x current proof (#2614).
-          post-seed-yaml: ${{ matrix.server_label == 'current' && matrix.sdk_label == 'sdk-current' && 'compatibility-source/tests/seed/portal-compat.yaml' || '' }}
+          post-seed-yaml: ${{ matrix.server_label == 'current' && matrix.sdk_label == 'sdk-current' && format('{0}/portal-compat.yaml', runner.temp) || '' }}
           log-path: logs/honua-server-sdk-compat-${{ matrix.server_label }}-${{ matrix.sdk_label }}.log
         env:
           # Compatibility checks exercise server/SDK runtime behavior; security audit gates run separately.

--- a/.github/workflows/sdk-server-compatibility.yml
+++ b/.github/workflows/sdk-server-compatibility.yml
@@ -10,6 +10,11 @@ name: SDK Server Compatibility
         required: false
         default: HEAD
         type: string
+      current_only:
+        description: 'Run only the current server x current SDK cell for focused change verification.'
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: '35 8 * * 1'
 
@@ -51,6 +56,7 @@ jobs:
 
           manifest="$SDK_COMPATIBILITY_MANIFEST"
           server_current_ref="${{ github.event_name == 'workflow_dispatch' && inputs.server_current_ref || '' }}"
+          current_only="${{ github.event_name == 'workflow_dispatch' && inputs.current_only || false }}"
           jq -e '
             . as $manifest
             | ($manifest.schemaVersion == 1)
@@ -63,7 +69,7 @@ jobs:
           ' "$manifest" >/dev/null
 
           matrix="$(
-            jq -c --arg head "$GITHUB_SHA" --arg serverCurrentRef "$server_current_ref" '
+            jq -c --arg head "$GITHUB_SHA" --arg serverCurrentRef "$server_current_ref" --argjson currentOnly "$current_only" '
               def serverByLabel($manifest; $name):
                 (
                   ($manifest.serverRefs[] | select(.label == $name)) // error("Unknown server label: " + $name)
@@ -97,8 +103,14 @@ jobs:
               |
               {
                 include: (
-                  (($manifest.matrix.supported // []) | map(cell($manifest; "supported"; true)))
-                  + (($manifest.matrix.evaluation // []) | map(cell($manifest; "evaluation"; false)))
+                  (
+                    (($manifest.matrix.supported // []) | map(cell($manifest; "supported"; true)))
+                    + (($manifest.matrix.evaluation // []) | map(cell($manifest; "evaluation"; false)))
+                  )
+                  | if $currentOnly
+                    then map(select(.server_label == "current" and .sdk_label == "sdk-current"))
+                    else .
+                    end
                 )
               }
             ' "$manifest"
@@ -177,6 +189,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Portal seed dependency
+        if: matrix.server_label == 'current' && matrix.sdk_label == 'sdk-current'
+        run: python -m pip install 'pyyaml>=6,<7'
 
       - name: Setup Honua Server
         uses: ./.github/actions/setup-honua-server

--- a/.github/workflows/sdk-server-compatibility.yml
+++ b/.github/workflows/sdk-server-compatibility.yml
@@ -183,11 +183,19 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           base-seed-path: tests/seed/base-schema.sql
+          # PortalCompat is additive and exists only in the current SDK/server
+          # pair. Preserve the historical compatibility cells by applying the
+          # Portal fixture only to the current x current proof (#2614).
+          post-seed-yaml: ${{ matrix.server_label == 'current' && matrix.sdk_label == 'sdk-current' && 'compatibility-source/tests/seed/portal-compat.yaml' || '' }}
           log-path: logs/honua-server-sdk-compat-${{ matrix.server_label }}-${{ matrix.sdk_label }}.log
         env:
           # Compatibility checks exercise server/SDK runtime behavior; security audit gates run separately.
           NuGetAudit: false
           WarningsNotAsErrors: NU1901;NU1902;NU1903;NU1904
+          # The Actions service network is HTTP-only. Production retains the
+          # secure RequireHttps=true default; this enables generateToken solely
+          # for the live compatibility proof.
+          Authentication__PortalToken__RequireHttps: 'false'
 
       - name: Checkout honua-sdk-js
         uses: actions/checkout@v7
@@ -260,6 +268,8 @@ jobs:
         id: compatibility
         continue-on-error: true
         shell: bash
+        env:
+          HONUA_SDK_PORTAL_COMPAT_ENABLED: ${{ matrix.server_label == 'current' && matrix.sdk_label == 'sdk-current' }}
         run: |
           mkdir -p results
           set +e
@@ -509,22 +519,18 @@ jobs:
                 }
               },
               seed_profile: $seedProfile,
+              portal_seed_profile: (
+                if $serverLabel == "current" and $sdkLabel == "sdk-current"
+                then "tests/seed/portal-compat.yaml"
+                else null
+                end
+              ),
               service_id: $serviceId,
               layer_id: $layerId,
-              protocol_surfaces: [
-                "control-plane-admin",
-                "platform-http",
-                "geoservices-catalog",
-                "feature-server",
-                "ogc-api-features",
-                "migration-scan",
-                "arcgis-import",
-                "geoserver-dry-run",
-                "migration-evidence"
-              ],
-              protocol_surfaces_by_sdk: {
-                js: [
+              protocol_surfaces: (
+                [
                   "control-plane-admin",
+                  "platform-http",
                   "geoservices-catalog",
                   "feature-server",
                   "ogc-api-features",
@@ -532,7 +538,29 @@ jobs:
                   "arcgis-import",
                   "geoserver-dry-run",
                   "migration-evidence"
-                ],
+                ]
+                + if $serverLabel == "current" and $sdkLabel == "sdk-current"
+                  then ["portal-repoint"]
+                  else []
+                  end
+              ),
+              protocol_surfaces_by_sdk: {
+                js: (
+                  [
+                    "control-plane-admin",
+                    "geoservices-catalog",
+                    "feature-server",
+                    "ogc-api-features",
+                    "migration-scan",
+                    "arcgis-import",
+                    "geoserver-dry-run",
+                    "migration-evidence"
+                  ]
+                  + if $serverLabel == "current" and $sdkLabel == "sdk-current"
+                    then ["portal-repoint"]
+                    else []
+                    end
+                ),
                 python: [
                   "control-plane-admin",
                   "platform-http",

--- a/docs/gis/PORTAL_FACADE_SEED_CONTRACT.md
+++ b/docs/gis/PORTAL_FACADE_SEED_CONTRACT.md
@@ -95,8 +95,13 @@ Errors follow the Esri envelope `{ "error": { "code", "message", "details" } }`.
 
 ## Consuming repos
 
-- `honua-sdk-js` (`@honua/sdk-esri-compat`) — Portal repoint client + `sdk-server-compatibility` coverage (#1373).
-- `honua-sdk-dotnet`, `honua-sdk-python` — repoint paths confirmed or deferred with a tracked follow-up (#1373).
+- `honua-sdk-js` (`@honua/sdk-esri-compat`) — Portal repoint client
+  ([honua-sdk-js#383](https://github.com/honua-io/honua-sdk-js/pull/383)) and
+  current×current `sdk-server-compatibility` coverage (#2614).
+- `honua-sdk-dotnet` — typed Portal repoint path tracked in
+  [honua-sdk-dotnet#257](https://github.com/honua-io/honua-sdk-dotnet/issues/257).
+- `honua-sdk-python` — async/generated-sync Portal repoint path tracked in
+  [honua-sdk-python#168](https://github.com/honua-io/honua-sdk-python/issues/168).
 
 When changing this contract (service names, tiers, or the `portals/self` /
 `PortalItem` shape), bump the fixture and this doc together and notify the SDK

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -338,7 +338,7 @@ if (portalCompatEnabled) {
   }
 
   const opened = await portal.openFeatureLayer(publicFeatureItem);
-  if (opened.type !== "feature-service" || opened.serviceId !== "portal_public" || opened.layerId !== 0) {
+  if (opened.type !== "feature-service" || opened.serviceId !== "portal_public" || opened.layerId !== 3000) {
     throw new Error("PortalCompat did not resolve the Portal item to the seeded FeatureServer layer.");
   }
 

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -9,6 +9,9 @@ LAYER_ID="${HONUA_SDK_LAYER_ID:-0}"
 JS_DIR="${HONUA_SDK_JS_DIR:-sdk/honua-sdk-js}"
 PYTHON_DIR="${HONUA_SDK_PYTHON_DIR:-sdk/honua-sdk-python}"
 DOTNET_DIR="${HONUA_SDK_DOTNET_DIR:-sdk/honua-sdk-dotnet}"
+PORTAL_COMPAT_ENABLED="${HONUA_SDK_PORTAL_COMPAT_ENABLED:-false}"
+PORTAL_USERNAME="${HONUA_SDK_PORTAL_USERNAME:-admin}"
+PORTAL_PASSWORD="${HONUA_SDK_PORTAL_PASSWORD:-$ADMIN_API_KEY}"
 
 ROOT_DIR="$(pwd)"
 RESULTS_DIR="${SDK_COMPATIBILITY_RESULTS_DIR:-$ROOT_DIR/results}"
@@ -249,6 +252,9 @@ require_dir "$JS_DIR" "honua-sdk-js"
     HONUA_SDK_MIGRATION_GEOSERVER_URL="$MIGRATION_GEOSERVER_URL" \
     HONUA_SDK_MIGRATION_ARCGIS_SERVICE_URL="$MIGRATION_ARCGIS_SERVICE_URL" \
     HONUA_SDK_MIGRATION_JS_RESULTS_DIR="$JS_MIGRATION_RESULTS_DIR" \
+    HONUA_SDK_PORTAL_COMPAT_ENABLED="$PORTAL_COMPAT_ENABLED" \
+    HONUA_SDK_PORTAL_USERNAME="$PORTAL_USERNAME" \
+    HONUA_SDK_PORTAL_PASSWORD="$PORTAL_PASSWORD" \
     node --input-type=module <<'EOF'
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -262,6 +268,9 @@ const migrationBaseUrl = process.env.HONUA_SDK_MIGRATION_SERVER_BASE_URL;
 const migrationGeoServerUrl = process.env.HONUA_SDK_MIGRATION_GEOSERVER_URL;
 const migrationArcGisServiceUrl = process.env.HONUA_SDK_MIGRATION_ARCGIS_SERVICE_URL;
 const migrationResultsDir = process.env.HONUA_SDK_MIGRATION_JS_RESULTS_DIR;
+const portalCompatEnabled = process.env.HONUA_SDK_PORTAL_COMPAT_ENABLED === "true";
+const portalUsername = process.env.HONUA_SDK_PORTAL_USERNAME;
+const portalPassword = process.env.HONUA_SDK_PORTAL_PASSWORD;
 
 const client = new HonuaClient({ baseUrl, apiKey });
 const compatibility = await client.getCompatibility({ refresh: true });
@@ -294,6 +303,55 @@ if (!Array.isArray(query.features) || query.features.length === 0) {
 const collections = await client.listOgcCollections();
 if (!Array.isArray(collections.collections) || collections.collections.length === 0) {
   throw new Error("JS SDK did not parse OGC API Features collections.");
+}
+
+if (portalCompatEnabled) {
+  const { PortalCompat } = await import("./dist/src/esri-compat-entry.js");
+  const portal = new PortalCompat({ portalUrl: baseUrl });
+
+  const info = await portal.getInfo();
+  if (info.authInfo?.isTokenBasedSecurity !== true ||
+      !info.authInfo.tokenServicesUrl?.endsWith("/sharing/rest/generateToken")) {
+    throw new Error("PortalCompat did not parse Portal token-service discovery metadata.");
+  }
+
+  const credential = await portal.generateToken({
+    username: portalUsername,
+    password: portalPassword,
+    client: "requestip",
+  });
+  if (!credential.token || !Number.isSafeInteger(credential.expiresAtMs) || credential.expiresAtMs <= Date.now()) {
+    throw new Error("PortalCompat did not preserve the generateToken Unix-millisecond expiry contract.");
+  }
+
+  const portalSelf = await portal.getPortalSelf();
+  if (portalSelf.isPortal !== true || portalSelf.user?.username !== portalUsername) {
+    throw new Error("PortalCompat did not carry the generated token into portals/self.");
+  }
+
+  const portalSearch = await portal.search({ num: 25 });
+  const publicFeatureItem = portalSearch.results.find(
+    (item) => item.type === "Feature Service" && item.url?.includes("/rest/services/portal_public/FeatureServer"),
+  );
+  if (!publicFeatureItem || portalSearch.start !== 1 || portalSearch.nextStart < -1) {
+    throw new Error("PortalCompat did not discover the seeded Portal Feature Service item with Esri paging semantics.");
+  }
+
+  const opened = await portal.openFeatureLayer(publicFeatureItem);
+  if (opened.type !== "feature-service" || opened.serviceId !== "portal_public" || opened.layerId !== 0) {
+    throw new Error("PortalCompat did not resolve the Portal item to the seeded FeatureServer layer.");
+  }
+
+  const portalQuery = await opened.layer.queryFeatures({
+    where: "1=1",
+    outFields: ["*"],
+    returnGeometry: true,
+  });
+  if (!Array.isArray(portalQuery.features) || portalQuery.features.length === 0) {
+    throw new Error("PortalCompat opened FeatureLayer returned no seeded features.");
+  }
+
+  console.log("JS SDK PortalCompat generateToken -> search -> openFeatureLayer compatibility passed.");
 }
 
 const migrationClient = new HonuaClient({ baseUrl: migrationBaseUrl, apiKey, timeoutMs: 120_000 });

--- a/tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.cs
@@ -497,7 +497,7 @@ public sealed partial class PublicInterfaceProofLedgerTests
 
     private static string[] ExtractWorkflowProtocolSurfaceArray(string workflow, string propertyName)
     {
-        var propertyIndex = workflow.IndexOf($"{propertyName}: [", StringComparison.Ordinal);
+        var propertyIndex = workflow.IndexOf($"{propertyName}:", StringComparison.Ordinal);
         if (propertyIndex < 0)
         {
             throw new InvalidOperationException($"Unable to find '{propertyName}' in sdk-server-compatibility.yml.");
@@ -630,7 +630,7 @@ public sealed partial class PublicInterfaceProofLedgerTests
     private static string FormatOperationKey(string protocol, string operation) =>
         $"{protocol}::{operation}";
 
-    [GeneratedRegex(@"(?<sdk>js|python|dotnet):\s*\[(?<surfaces>.*?)\]", RegexOptions.Singleline)]
+    [GeneratedRegex(@"(?<sdk>js|python|dotnet):\s*(?:\(\s*)?\[(?<surfaces>.*?)\]", RegexOptions.Singleline)]
     private static partial Regex SdkProtocolSurfaceBlockRegex();
 
     [GeneratedRegex(@"sdk-compat-matrix:[\s\S]*?timeout-minutes:\s*(?<minutes>\d+)")]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2614

## Summary
Adds release-proof JavaScript Portal repoint coverage to `sdk-server-compatibility` while keeping the additive Portal surface out of the retained historical compatibility generations. The current server × current SDK cell seeds the canonical Portal fixture and proves `PortalCompat` generateToken → authenticated search → openFeatureLayer → feature query against a live Honua server.

## Changes Made
- Seed `tests/seed/portal-compat.yaml` for the current×current compatibility cell.
- Exercise Portal discovery, token expiry, authenticated identity/search, item resolution, advertised-layer discovery, and token-propagating feature queries through the built SDK artifact.
- Preserve the Portal seed when the compatibility runner checks out its isolated server source.
- Keep historical SDK/server cells free of the new additive Portal contract.
- Link the .NET and Python SDK follow-ups from the canonical server contract.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Focused evidence:
- `scripts/ci/validate-ci-router.sh` passed.
- `bash -n scripts/ci/run-sdk-server-compatibility.sh` passed.
- The embedded Node compatibility program passed `node --check`.
- Current×current live proof passed PortalCompat generateToken → search → openFeatureLayer → query in [run 29136116808](https://github.com/honua-io/honua-server/actions/runs/29136116808); the later failure was in the separate migration-entitlement proof tracked by #2669/#2678.
- Required SDK fixes landed in honua-sdk-js#383 and honua-sdk-js#422.

## Gate Impact
- [ ] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

Coordination is complete for the JavaScript surface. .NET and Python Portal support remains SDK-owned in honua-sdk-dotnet#257 and honua-sdk-python#168.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
