### PR TITLE
feat(mcp): expose read-only operation kind discovery

### DIFF
--- a/docs/guides/connect/ai-agents-mcp.md
+++ b/docs/guides/connect/ai-agents-mcp.md
@@ -67,7 +67,7 @@ The endpoint is `POST /mcp`: JSON-RPC 2.0 over HTTP (single requests and batches
    - `honua_alert_events` - GIS alert events and ops notifications.
    - `honua_operate_events` - fused Operate timeline events.
 
-   To propose a mutating control-plane operation, use `honua_propose_operation` and inspect the returned `supportedKinds`. Approval still resolves through the Console inbox; MCP does not approve its own proposals. Platform release status, deploy operation listing, and rollback-specific MCP tools are tracked separately and should not be assumed in a default deployment.
+   Before proposing a mutating control-plane operation, call the read-only `honua_supported_operation_kinds` tool and choose only a returned kind. Then use `honua_propose_operation`; approval still resolves through the Console inbox, and MCP does not approve its own proposals. The `supportedKinds` field on rejected proposal responses remains for compatibility but is deprecated for discovery.
 
 ## Verify
 

--- a/docs/guides/operate/README.md
+++ b/docs/guides/operate/README.md
@@ -62,15 +62,18 @@ The useful split is:
 |---|---|---|
 | Read current posture | Status, health, findings, alerts, timeline | `honua_ops_health`, `honua_ops_findings`, `honua_alert_events`, `honua_operate_events` |
 | Investigate evidence | Drill into the endpoint named by `source` or `evidenceRefs` | Read the same resources and include evidence in the proposal rationale |
-| Propose a fix | `findings/{id}/propose` and approval inbox actions | `honua_propose_operation`; use `supportedKinds` from the response |
+| Discover routable fixes | Operator action catalogs | `honua_supported_operation_kinds` (read-only, live executor catalog) |
+| Propose a fix | `findings/{id}/propose` and approval inbox actions | `honua_propose_operation`; verify the kind with `honua_supported_operation_kinds` first |
 | Approve or reject | Human approval inbox | Not allowed |
 | Mutate source GIS data | Human protocol/API workflows only | Not exposed; ADR-0028 forbids AI-driven source-data editing |
 
 Current MCP status: observability read tools are present. The generic
-`honua_propose_operation` tool reports the actually routable operation classes
-in `supportedKinds`; do not assume unsupported kinds. Richer platform-ops MCP
+`honua_supported_operation_kinds` reports the actually routable operation classes
+without requiring write authority; do not assume unsupported kinds. The
+`supportedKinds` field on rejected `honua_propose_operation` responses remains a
+compatibility aid but is deprecated as a discovery mechanism. Platform-ops MCP
 tools for release status, deploy operation listing, and rollback proposal are
-tracked by #2566 and are not part of this guide's current-trunk baseline.
+also part of the current-trunk baseline.
 
 ## The autonomy ladder
 
@@ -219,8 +222,6 @@ These are intentionally not described as shipped behavior:
 
 - #2557: graduated autonomy policy, AutoApply storage/evaluator, and kill
   switch.
-- #2566: platform-ops MCP tools for release status, deploy operations, and
-  rollback proposal.
 - #2567: seat-parity contract tests proving REST and MCP action parity.
 - #2568: end-to-end dead-letter self-heal through approval and autonomy.
 - #2558: quickstart compose packaging that includes the Console ops dashboard.

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -119,6 +119,7 @@ internal static class McpServiceCollectionExtensions
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, PlatformReleaseStatusTool>());
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, DeployOperationsTool>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, SupportedOperationKindsTool>());
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ProposeRollbackTool>());
         }
 

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpJsonContext.cs
@@ -58,6 +58,7 @@ namespace Honua.Ai.Protocols.Mcp.Models;
 [JsonSerializable(typeof(McpCancelJobOutput))]
 [JsonSerializable(typeof(McpProposeOperationArgument))]
 [JsonSerializable(typeof(McpProposeOperationOutput))]
+[JsonSerializable(typeof(McpSupportedOperationKindsOutput))]
 [JsonSerializable(typeof(McpOpsFindingsArgument))]
 [JsonSerializable(typeof(McpAlertEventsArgument))]
 [JsonSerializable(typeof(McpOperateEventsArgument))]

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpToolModels.cs
@@ -210,6 +210,19 @@ internal sealed class McpProposeOperationOutput
 }
 
 /// <summary>
+/// Read-only projection of the operation kinds that the live gateway can route.
+/// </summary>
+internal sealed class McpSupportedOperationKindsOutput
+{
+    /// <summary>
+    /// Stable <see cref="Honua.Core.Features.Guardrails.Domain.OperationClass"/> identifiers
+    /// backed by registered operation executors.
+    /// </summary>
+    [JsonPropertyName("supportedKinds")]
+    public IReadOnlyList<string> SupportedKinds { get; set; } = [];
+}
+
+/// <summary>
 /// Arguments for <c>honua_publish_service</c>: publish a source table as a
 /// hosted layer/service through the canonical <c>service.publish</c> operation
 /// (#1951). Field names mirror the <c>service.publish</c> operation parameters

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpPlatformOpsReader.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpPlatformOpsReader.cs
@@ -24,6 +24,11 @@ internal interface IMcpPlatformOpsReader
         McpDeployOperationsArgument argument,
         CancellationToken cancellationToken);
 
+    /// <summary>Gets the live operation-executor kind catalog.</summary>
+    Task<McpSupportedOperationKindsOutput> GetSupportedOperationKindsAsync(
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken);
+
     /// <summary>Proposes a forward deploy to a prior revision as a rollback.</summary>
     Task<McpProposeOperationOutput> ProposeRollbackAsync(
         ClaimsPrincipal principal,

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpPlatformOpsSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpPlatformOpsSchemas.cs
@@ -19,6 +19,15 @@ internal static class McpPlatformOpsSchemas
         }
         """);
 
+    public static readonly JsonElement SupportedOperationKindsInputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+        """);
+
     public static readonly JsonElement DeployOperationsInputSchema = Parse(
         """
         {
@@ -132,6 +141,25 @@ internal static class McpPlatformOpsSchemas
             "pageSize": { "type": "integer" },
             "totalCount": { "type": "integer" },
             "hasMore": { "type": "boolean" }
+          }
+        }
+        """);
+
+    public static readonly JsonElement SupportedOperationKindsOutputSchema = Parse(
+        """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["supportedKinds"],
+          "properties": {
+            "supportedKinds": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["AdminConfigChange", "Deploy", "MetadataRelease", "Seed"]
+              },
+              "uniqueItems": true
+            }
           }
         }
         """);

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PlatformOpsTools.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PlatformOpsTools.cs
@@ -102,6 +102,51 @@ internal sealed class DeployOperationsTool(ILogger<DeployOperationsTool> logger)
 }
 
 /// <summary>
+/// MCP tool that reports operation kinds backed by the live executor catalog.
+/// </summary>
+internal sealed class SupportedOperationKindsTool(ILogger<SupportedOperationKindsTool> logger) : IMcpTool
+{
+    public const string ToolName = "honua_supported_operation_kinds";
+
+    public string Name => ToolName;
+
+    public string WorkflowFamily => McpTelemetry.WorkflowFamily.Results;
+
+    public McpToolDescriptor Describe() => new()
+    {
+        Name = ToolName,
+        Title = "Supported operation kinds",
+        Description =
+            "Read-only discovery of stable operation-kind identifiers backed by executors registered "
+            + "in the live operation gateway. Use this before honua_propose_operation; absent kinds "
+            + "remain fail-closed and cannot be routed.",
+        InputSchema = McpPlatformOpsSchemas.SupportedOperationKindsInputSchema,
+        OutputSchema = McpPlatformOpsSchemas.SupportedOperationKindsOutputSchema,
+        Annotations = McpToolAnnotationSets.ReadOnly("Supported operation kinds")
+    };
+
+    public async Task<McpToolsCallResult> InvokeAsync(
+        HttpContext httpContext,
+        JsonElement? arguments,
+        CancellationToken cancellationToken)
+    {
+        McpTelemetry.EnrichActivity("GetSupportedOperationKinds");
+        McpLog.ToolInvoked(logger, ToolName, WorkflowFamily);
+        McpToolHelpers.EnsureNoArguments(arguments);
+
+        var principal = McpAuthorizationHelper.EnsurePrincipal(httpContext);
+        var output = await httpContext.RequestServices
+            .GetRequiredService<IMcpPlatformOpsReader>()
+            .GetSupportedOperationKindsAsync(principal, cancellationToken)
+            .ConfigureAwait(false);
+
+        return McpToolHelpers.SuccessResult(
+            output,
+            McpJsonContext.Default.McpSupportedOperationKindsOutput);
+    }
+}
+
+/// <summary>
 /// MCP tool that proposes a rollback as a new forward Deploy operation to a prior revision.
 /// </summary>
 internal sealed class ProposeRollbackTool(ILogger<ProposeRollbackTool> logger) : IMcpTool

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -112,6 +112,7 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
             ("honua_operate_events", "operate_events", "results"),
             ("honua_platform_release_status", "platform_release_status", "results"),
             ("honua_deploy_operations", "deploy_operations", "results"),
+            ("honua_supported_operation_kinds", "supported_operation_kinds", "results"),
             ("honua_propose_rollback", "propose_rollback", "lifecycle"),
             ("honua_list_layers", "list_layers", "results"),
             ("honua_query_features", "query_features", "results"),

--- a/src/Honua.Core/Features/ControlPlane/Abstractions/IOperationExecutorCatalog.cs
+++ b/src/Honua.Core/Features/ControlPlane/Abstractions/IOperationExecutorCatalog.cs
@@ -8,7 +8,7 @@ namespace Honua.Core.Features.ControlPlane.Abstractions;
 /// <summary>
 /// Small capability surface over the registered <see cref="IOperationExecutor"/> set, kept
 /// separate from <see cref="IOperationGateway"/> so discovery surfaces (for example the MCP
-/// <c>honua_propose_operation</c> tool's <c>supportedKinds</c> reporting) can ask which
+/// <c>honua_supported_operation_kinds</c> tool and the proposal compatibility field) can ask which
 /// <see cref="OperationClass"/> kinds are genuinely routable without widening the gateway's own
 /// routing contract (#2563). A kind absent from <see cref="SupportedKinds"/> always resolves to
 /// <see cref="OperationGatewayOutcome.NotSupported"/> when routed through

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/McpPlatformOpsReader.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/McpPlatformOpsReader.cs
@@ -107,6 +107,22 @@ internal sealed class McpPlatformOpsReader(
         return Serialize(list, DeployControlJsonContext.Default.DeployOperationListResponse);
     }
 
+    public async Task<McpSupportedOperationKindsOutput> GetSupportedOperationKindsAsync(
+        ClaimsPrincipal principal,
+        CancellationToken cancellationToken)
+    {
+        await EnsureOpsReadAsync(principal, cancellationToken).ConfigureAwait(false);
+
+        var catalog = _services.GetService<IOperationExecutorCatalog>();
+        return new McpSupportedOperationKindsOutput
+        {
+            SupportedKinds = catalog?.SupportedKinds
+                .Select(kind => kind.ToString())
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray() ?? []
+        };
+    }
+
     public async Task<McpProposeOperationOutput> ProposeRollbackAsync(
         ClaimsPrincipal principal,
         McpProposeRollbackArgument argument,

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -520,7 +520,8 @@ if (connectedRedis != null)
     builder.Services.AddSingleton<Honua.Core.Features.ControlPlane.Abstractions.IOperationExecutor,
         Honua.ControlPlane.Executors.MetadataReleaseOperationExecutor>();
     // Executor-discovery capability surface (#2563): reflects the exact executors registered above so
-    // discovery consumers (honua_propose_operation's supportedKinds) can never drift from routing reality.
+    // discovery consumers (honua_supported_operation_kinds and the proposal compatibility field)
+    // can never drift from routing reality.
     builder.Services.AddSingleton<Honua.Core.Features.ControlPlane.Abstractions.IOperationExecutorCatalog,
         Honua.ControlPlane.OperationExecutorCatalog>();
 }

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/supported_operation_kinds/supported_operation_kinds.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/supported_operation_kinds/supported_operation_kinds.json
@@ -1,0 +1,8 @@
+{
+  "id": "supported_operation_kinds.discovery",
+  "schemaRef": "tools/supported_operation_kinds.schema.json",
+  "validates": "inputs",
+  "inputs": {},
+  "expected": "tool_result",
+  "canonicalRefs": ["IOperationExecutorCatalog"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/supported_operation_kinds/supported_operation_kinds_result.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/fixtures/tools/supported_operation_kinds/supported_operation_kinds_result.json
@@ -1,0 +1,10 @@
+{
+  "id": "supported_operation_kinds.result",
+  "schemaRef": "tools/supported_operation_kinds.result.schema.json",
+  "validates": "inputs",
+  "inputs": {
+    "supportedKinds": ["AdminConfigChange", "Deploy", "MetadataRelease"]
+  },
+  "expected": "tool_result",
+  "canonicalRefs": ["IOperationExecutorCatalog"]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/index.json
@@ -277,6 +277,14 @@
       "notes": "Read-only platform_release / server_upgrade operation surface (list/get via optional operationId; list filters status, kind, page, pageSize). Paged response envelope {items, page, pageSize, totalCount, hasMore} copied VERBATIM from the wire contract pinned in honua-server#2562 / PR #2577 (tools/deploy_operations.result.schema.json). Distinct from the hosted-content Deployment resource. Reference surface lands via honua-server#2577 under epic #2552; vendored copy synced per honua-server#2496."
     },
     {
+      "standardName": "supported_operation_kinds",
+      "referenceToolName": "honua_supported_operation_kinds",
+      "family": "Platform operations (reference shape)",
+      "schema": "tools/supported_operation_kinds.schema.json",
+      "implementationStatus": "implemented",
+      "notes": "Read-only live executor-catalog discovery for least-privilege observe-diagnose-propose loops. Returns only stable OperationClass identifiers backed by registered executors; unsupported kinds remain fail-closed. Response in tools/supported_operation_kinds.result.schema.json. Reference surface lands via honua-server#2628."
+    },
+    {
       "standardName": "propose_rollback",
       "referenceToolName": "honua_propose_rollback",
       "family": "Control-plane proposal (reference shape)",

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/ops-parity-map.yaml
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/ops-parity-map.yaml
@@ -13,6 +13,9 @@
 # partition must appear exactly once with exactly one of `tool`, `resource`, or `human-only`.
 # `human-only` is reserved for surfaces that must remain human trust controls, such as autonomy
 # graduation/kill-switch state, approval, rejection, staged submit, and promotion.
+# `honua_supported_operation_kinds` is an MCP-native read companion for every
+# `honua_propose_operation` mapping below; it projects the live executor catalog
+# and has no distinct REST mutation route to replace.
 routes:
   "GET /api/v1/operate/status":
     tool: honua_ops_health

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/supported_operation_kinds.result.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/supported_operation_kinds.result.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/supported_operation_kinds.result.schema.json",
+  "title": "supported_operation_kinds result payload",
+  "description": "Read-only projection of operation classes backed by executors registered in the live operation gateway. An empty array truthfully represents a gateway with no routable executors. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["supportedKinds"],
+  "properties": {
+    "supportedKinds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["AdminConfigChange", "Deploy", "MetadataRelease", "Seed"]
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/supported_operation_kinds.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/tools/supported_operation_kinds.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.honua.io/spec/schemas/tools/supported_operation_kinds.schema.json",
+  "title": "supported_operation_kinds inputSchema",
+  "description": "Argument shape for the read-only operation-executor discovery tool (advertised name honua_supported_operation_kinds). Returns stable operation-kind identifiers derived from the live registered executor catalog. Takes no arguments. x-honua-reference-shape: this shape tracks the reference implementation.",
+  "x-honua-reference-shape": true,
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/CapabilityRegistryConformanceTests.cs
@@ -259,7 +259,7 @@ public sealed class CapabilityRegistryConformanceTests
     // -----------------------------------------------------------------------
     // Live-surface construction — mirrors McpTaxonomyAlignmentTests.BuildTools /
     // BuildResources, extended with the two package-review tools those tests
-    // construct separately, so this enumerates the full advertised 25-tool roster.
+    // construct separately, so this enumerates the full advertised tool roster.
     // -----------------------------------------------------------------------
     private static IMcpTool[] BuildLiveTools()
     {
@@ -293,6 +293,7 @@ public sealed class CapabilityRegistryConformanceTests
             new OperateEventsTool(NullLogger<OperateEventsTool>.Instance),
             new PlatformReleaseStatusTool(NullLogger<PlatformReleaseStatusTool>.Instance),
             new DeployOperationsTool(NullLogger<DeployOperationsTool>.Instance),
+            new SupportedOperationKindsTool(NullLogger<SupportedOperationKindsTool>.Instance),
             new ProposeRollbackTool(NullLogger<ProposeRollbackTool>.Instance),
             new ValidatePackageTool(reviewService, jobService, NullLogger<ValidatePackageTool>.Instance),
             new PreviewPackageTool(reviewService, jobService, NullLogger<PreviewPackageTool>.Instance),

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeospatialMcpSchemaConformanceTests.cs
@@ -88,6 +88,7 @@ public sealed partial class McpTaxonomyAlignmentTests
             ["honua_operate_events"] = "operate_events",
             ["honua_platform_release_status"] = "platform_release_status",
             ["honua_deploy_operations"] = "deploy_operations",
+            ["honua_supported_operation_kinds"] = "supported_operation_kinds",
             ["honua_propose_rollback"] = "propose_rollback",
             // Honua extensions over the bare taxonomy (#1949): the standard models
             // entity resolution and capability discovery as CapabilityCatalog reads;

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpPlatformOpsToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpPlatformOpsToolTests.cs
@@ -62,6 +62,25 @@ public sealed class McpPlatformOpsToolTests
     }
 
     [UnitTest]
+    public async Task SupportedOperationKindsTool_Invoke_ReturnsLiveReaderPayload()
+    {
+        var reader = new FakePlatformOpsReader();
+        var context = BuildContext(reader);
+        var tool = new SupportedOperationKindsTool(NullLogger<SupportedOperationKindsTool>.Instance);
+
+        var result = await tool.InvokeAsync(context, Json("{}"), CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        result.StructuredContent!.Value.GetProperty("supportedKinds")
+            .EnumerateArray()
+            .Select(element => element.GetString())
+            .Should()
+            .Equal("AdminConfigChange", "Deploy");
+        reader.SupportedOperationKindsCalls.Should().Be(1);
+        reader.LastPrincipal.Should().BeSameAs(context.User);
+    }
+
+    [UnitTest]
     public async Task ProposeRollbackTool_Invoke_PassesArgumentsAndReturnsProposal()
     {
         var reader = new FakePlatformOpsReader();
@@ -113,6 +132,8 @@ public sealed class McpPlatformOpsToolTests
     {
         public int PlatformReleaseStatusCalls { get; private set; }
 
+        public int SupportedOperationKindsCalls { get; private set; }
+
         public ClaimsPrincipal? LastPrincipal { get; private set; }
 
         public McpDeployOperationsArgument? DeployOperationsArgument { get; private set; }
@@ -136,6 +157,18 @@ public sealed class McpPlatformOpsToolTests
             LastPrincipal = principal;
             DeployOperationsArgument = argument;
             return Task.FromResult(Json("""{"items":[],"page":1,"pageSize":50,"totalCount":0,"hasMore":false}"""));
+        }
+
+        public Task<McpSupportedOperationKindsOutput> GetSupportedOperationKindsAsync(
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken)
+        {
+            LastPrincipal = principal;
+            SupportedOperationKindsCalls++;
+            return Task.FromResult(new McpSupportedOperationKindsOutput
+            {
+                SupportedKinds = ["AdminConfigChange", "Deploy"]
+            });
         }
 
         public Task<McpProposeOperationOutput> ProposeRollbackAsync(

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
@@ -161,6 +161,7 @@ public sealed class McpServiceCollectionExtensionsTests
             {
                 typeof(PlatformReleaseStatusTool),
                 typeof(DeployOperationsTool),
+                typeof(SupportedOperationKindsTool),
                 typeof(ProposeRollbackTool)
             }, "platform-ops tools must only be advertised when the server reader is wired");
     }
@@ -178,6 +179,7 @@ public sealed class McpServiceCollectionExtensionsTests
             {
                 typeof(PlatformReleaseStatusTool),
                 typeof(DeployOperationsTool),
+                typeof(SupportedOperationKindsTool),
                 typeof(ProposeRollbackTool)
             }, "the full server composition registers the MCP platform-ops reader before the operator surface");
     }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -51,6 +51,7 @@ public sealed partial class McpTaxonomyAlignmentTests
         "honua_operate_events",
         "honua_platform_release_status",
         "honua_deploy_operations",
+        "honua_supported_operation_kinds",
         "honua_propose_rollback",
         "honua_list_layers",
         "honua_query_features",
@@ -238,6 +239,7 @@ public sealed partial class McpTaxonomyAlignmentTests
         "honua_operate_events",
         "honua_platform_release_status",
         "honua_deploy_operations",
+        "honua_supported_operation_kinds",
         "honua_list_layers",
         "honua_query_features",
         "honua_render_map",
@@ -606,6 +608,7 @@ public sealed partial class McpTaxonomyAlignmentTests
             new OperateEventsTool(NullLogger<OperateEventsTool>.Instance),
             new PlatformReleaseStatusTool(NullLogger<PlatformReleaseStatusTool>.Instance),
             new DeployOperationsTool(NullLogger<DeployOperationsTool>.Instance),
+            new SupportedOperationKindsTool(NullLogger<SupportedOperationKindsTool>.Instance),
             new ProposeRollbackTool(NullLogger<ProposeRollbackTool>.Instance),
             new Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool(
                 jobService, NullLogger<Honua.Ai.Protocols.Mcp.MapTools.ListLayersTool>.Instance),

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/McpPlatformOpsReaderTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/McpPlatformOpsReaderTests.cs
@@ -69,6 +69,69 @@ public sealed class McpPlatformOpsReaderTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
+    public async Task GetSupportedOperationKinds_Authorized_UsesOpsReadPolicyAndReturnsSortedKinds()
+    {
+        var principal = CreatePrincipal();
+        var authorization = CreateAuthorization(AuthorizationResult.Success());
+        var catalog = new MutableExecutorCatalog(
+            [OperationClass.MetadataRelease, OperationClass.Deploy, OperationClass.AdminConfigChange]);
+
+        using var services = CreateServices(catalog: catalog);
+        var reader = CreateReader(authorization: authorization, services: services);
+
+        var result = await reader.GetSupportedOperationKindsAsync(principal, CancellationToken.None);
+
+        result.SupportedKinds.Should().Equal("AdminConfigChange", "Deploy", "MetadataRelease");
+        await authorization.Received(1).AuthorizeAsync(
+            principal,
+            Arg.Is<object>(resource => IsOpsReadResource(resource, principal)),
+            AuthenticationExtensions.OpsReadPolicy);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task GetSupportedOperationKinds_EmptyCatalog_ReturnsEmptyKinds()
+    {
+        using var services = CreateServices(catalog: new MutableExecutorCatalog([]));
+        var reader = CreateReader(services: services);
+
+        var result = await reader.GetSupportedOperationKindsAsync(CreatePrincipal(), CancellationToken.None);
+
+        result.SupportedKinds.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task GetSupportedOperationKinds_CatalogChanges_ReflectsLatestKinds()
+    {
+        var catalog = new MutableExecutorCatalog([OperationClass.Deploy]);
+        using var services = CreateServices(catalog: catalog);
+        var reader = CreateReader(services: services);
+
+        var initial = await reader.GetSupportedOperationKindsAsync(CreatePrincipal(), CancellationToken.None);
+        catalog.SupportedKinds = [OperationClass.AdminConfigChange, OperationClass.MetadataRelease];
+        var changed = await reader.GetSupportedOperationKindsAsync(CreatePrincipal(), CancellationToken.None);
+
+        initial.SupportedKinds.Should().Equal("Deploy");
+        changed.SupportedKinds.Should().Equal("AdminConfigChange", "MetadataRelease");
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task GetSupportedOperationKinds_WithoutOpsReadPermission_IsRejected()
+    {
+        using var services = CreateServices(catalog: new MutableExecutorCatalog([OperationClass.Deploy]));
+        var reader = CreateReader(
+            authorization: CreateAuthorization(AuthorizationResult.Failed()),
+            services: services);
+
+        var act = () => reader.GetSupportedOperationKindsAsync(CreatePrincipal(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<Honua.Geoprocessing.GeoprocessingAuthorizationException>();
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
     public async Task GetDeployOperations_List_TranslatesFiltersAndClampsPageSize()
     {
         var store = new RecordingWorkflowOperationStore(
@@ -531,6 +594,11 @@ public sealed class McpPlatformOpsReaderTests
     private sealed class StaticExecutorCatalog(IReadOnlyCollection<OperationClass> supportedKinds) : IOperationExecutorCatalog
     {
         public IReadOnlyCollection<OperationClass> SupportedKinds { get; } = supportedKinds;
+    }
+
+    private sealed class MutableExecutorCatalog(IReadOnlyCollection<OperationClass> supportedKinds) : IOperationExecutorCatalog
+    {
+        public IReadOnlyCollection<OperationClass> SupportedKinds { get; set; } = supportedKinds;
     }
 
     private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>


### PR DESCRIPTION
## Issue Link

Closes #2628
Related to #2552

## Summary

Adds a least-privilege MCP read tool that reports the operation kinds backed by the live executor catalog. Agents can now verify routing support before proposing a mutation, without write authority or deliberately submitting an invalid proposal.

## Changes Made

- Add `honua_supported_operation_kinds` as an `ops:read`-gated, read-only MCP tool over `IOperationExecutorCatalog`.
- Return sorted stable operation-class identifiers on every read, including a truthful empty list when no executors are registered.
- Register the tool in the canonical capability roster and add MCP schemas, fixtures, taxonomy, composition, and REST/MCP parity governance.
- Deprecate proposal-rejection `supportedKinds` as the primary discovery mechanism in operator and MCP guidance while preserving it for compatibility.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Focused verification:
- MCP tool/schema/taxonomy suite: 60/60 passed.
- Capability-registry conformance: 11/11 passed.
- Platform-ops reader authorization/live-catalog suite: 9/9 passed.
- Seat-parity and feature-catalog architecture gates: 9/9 passed.
- Changed production and MCP-test formatting verification passed.
- `git diff --check` passed.

The smart FAST pre-PR run expanded the shared capability-registry change to a 68-project closure. Its restore and changed production builds were clean, but the duplicate broad build was stopped under shared-host load after the focused warnings-as-errors builds and tests above had already passed. Affected CI remains the merge gate.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

Adds an additive MCP reference-shape tool and output schema; no REST, gRPC, or SDK contract changes.

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None.

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
  - Equivalent focused warnings-as-errors builds, changed-file formatting, exact affected tests, and architecture gates passed; the redundant expanded FAST build was stopped as documented above.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review