### PR TITLE
fix(raster): align dataset map coverages (#2487)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -6148,6 +6148,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Infrastructure.Rendering.StyledVectorMapRenderTests.RenderDatasetMap_BoundVectorStyle_IsAppliedAtPixelLevelAndVariesByStyle",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetDatasetMap_WithCollections_ReturnsMap",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetDatasetMap_WithMisalignedRasterCollections_ReturnsMap",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsBasicTests.GetDatasetMap_WithoutCollections_ReturnsMap",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsErrorHandlingTests.GetDatasetMap_AllUnknownCollectionIds_ReturnsNotFound",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps.OgcMapsErrorHandlingTests.GetDatasetMap_CollectionsExceedLimit_ReturnsBadRequest",

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterMapRenderer.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterMapRenderer.cs
@@ -70,6 +70,9 @@ internal sealed class PostgresRasterMapRenderer : IRasterMapRenderer
 
         var requestedOutputSrid = request.Crs;
         var bboxSrid = request.BoundingBoxCrs ?? requestedOutputSrid;
+        var effectiveOutputSrid = layerIds.Length > 1
+            ? requestedOutputSrid ?? bboxSrid
+            : requestedOutputSrid;
 
         // Build raster expression with optional bbox clip
         var rasterExpr = "raster";
@@ -100,10 +103,10 @@ internal sealed class PostgresRasterMapRenderer : IRasterMapRenderer
             extraParams.Add(("@bboxMaxY", request.BoundingBox[3]));
         }
 
-        if (requestedOutputSrid.HasValue && requestedOutputSrid.Value > 0)
+        if (effectiveOutputSrid.HasValue && effectiveOutputSrid.Value > 0)
         {
             rasterExpr = $"ST_Transform({rasterExpr}, @outputSrid)";
-            extraParams.Add(("@outputSrid", requestedOutputSrid.Value));
+            extraParams.Add(("@outputSrid", effectiveOutputSrid.Value));
         }
 
         var timeCte = string.Empty;
@@ -180,6 +183,33 @@ internal sealed class PostgresRasterMapRenderer : IRasterMapRenderer
             ? $"ARRAY[{string.Join(", ", gdalOptions.Select((_, i) => $"@gdalOpt{i}"))}]"
             : "NULL";
 
+        // Dataset maps may combine coverages with different native SRIDs, pixel sizes,
+        // origins, or skews. PostGIS ST_Union requires every input raster to share one
+        // alignment and otherwise raises rt_raster_from_two_rasters (honua-server#2487).
+        // Reproject above, then borrow the first raster's grid for every remaining input
+        // before the union. Collection renders avoid this extra resampling step.
+        var alignmentCte = layerIds.Length > 1
+            ? """
+              reference_raster AS (
+                  SELECT rast
+                  FROM windowed
+                  WHERE rast IS NOT NULL
+                  ORDER BY effective_acquisition ASC, created_at ASC, id ASC
+                  LIMIT 1
+              ),
+              aligned AS (
+                  SELECT ST_Resample(windowed.rast, reference_raster.rast, 'Bilinear') AS rast,
+                         windowed.effective_acquisition,
+                         windowed.created_at,
+                         windowed.id
+                  FROM windowed
+                  CROSS JOIN reference_raster
+                  WHERE windowed.rast IS NOT NULL
+              ),
+              """
+            : string.Empty;
+        var unionSource = layerIds.Length > 1 ? "aligned" : sourceTimeFilter;
+
         await using var command = connection.CreateCommand();
         command.CommandText = $"""
             WITH source AS (
@@ -191,9 +221,10 @@ internal sealed class PostgresRasterMapRenderer : IRasterMapRenderer
                 WHERE layer_id IN ({string.Join(", ", layerParams)})
             ),
             {timeCte},
+            {alignmentCte}
             merged AS (
                 SELECT ST_Union(rast, 'LAST' ORDER BY effective_acquisition ASC, created_at ASC, id ASC) AS rast
-                FROM {sourceTimeFilter}
+                FROM {unionSource}
                 WHERE rast IS NOT NULL
             ),
             resized AS (
@@ -228,14 +259,14 @@ internal sealed class PostgresRasterMapRenderer : IRasterMapRenderer
             await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                return CreateEmptyResult(request, contentType, requestedOutputSrid);
+                return CreateEmptyResult(request, contentType, effectiveOutputSrid);
             }
 
             var dataOrd = reader.GetOrdinal("data");
             var sridOrd = reader.GetOrdinal("srid");
             var data = reader.IsDBNull(dataOrd) ? Array.Empty<byte>() : (byte[])reader[dataOrd];
             var srid = reader.IsDBNull(sridOrd)
-                ? requestedOutputSrid
+                ? effectiveOutputSrid
                 : reader.GetInt32(sridOrd);
 
             return new RasterResult
@@ -250,7 +281,7 @@ internal sealed class PostgresRasterMapRenderer : IRasterMapRenderer
         catch (PostgresException ex) when (IsRasterStorageUnavailable(ex))
         {
             PostgresRasterLog.RasterStorageUnavailable(_logger, ex, _rasterDataTable);
-            return CreateEmptyResult(request, contentType, requestedOutputSrid);
+            return CreateEmptyResult(request, contentType, effectiveOutputSrid);
         }
     }
 

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterMapRendererTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterMapRendererTests.cs
@@ -159,6 +159,57 @@ public sealed class PostgresRasterMapRendererTests(PostgresFixture fixture)
         }
     }
 
+    [IntegrationTest]
+    public async Task RenderDatasetMapAsync_WithMisalignedRasterLayers_ReturnsRenderedMap()
+    {
+        var schemaName = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterMapRendererTests));
+        try
+        {
+            await CreateRasterTableAsync(schemaName);
+            await InsertRasterAsync(
+                schemaName,
+                "aligned-layer",
+                DateTimeOffset.Parse("2024-03-01T00:00:00Z", CultureInfo.InvariantCulture),
+                11,
+                layerId: LayerId,
+                upperLeftX: 0,
+                upperLeftY: 1);
+            await InsertRasterAsync(
+                schemaName,
+                "offset-layer",
+                DateTimeOffset.Parse("2024-03-01T00:00:00Z", CultureInfo.InvariantCulture),
+                22,
+                layerId: LayerId + 1,
+                upperLeftX: 0.25,
+                upperLeftY: 1);
+
+            var renderer = new PostgresRasterMapRenderer(
+                new FixtureConnectionProvider(fixture.DataSource),
+                NullLogger<PostgresRasterMapRenderer>.Instance,
+                schemaName);
+
+            var result = await renderer.RenderDatasetMapAsync(
+                [LayerId, LayerId + 1],
+                new MapRenderRequest
+                {
+                    BoundingBox = [0d, 0d, 1.25d, 1d],
+                    BoundingBoxCrs = 4326,
+                    Crs = 4326,
+                    Width = 64,
+                    Height = 64,
+                    Format = RasterFormat.PNG
+                });
+
+            result.Data.Should().NotBeEmpty(
+                "dataset maps must normalize heterogeneous source grids before mosaicking (#2487)");
+            result.ContentType.Should().Be("image/png");
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schemaName);
+        }
+    }
+
     private async Task CreateRasterTableAsync(string schemaName)
     {
         await using var connection = await fixture.GetConnectionAsync(schemaName);
@@ -181,6 +232,7 @@ public sealed class PostgresRasterMapRendererTests(PostgresFixture fixture)
         string name,
         DateTimeOffset acquisitionDate,
         int value,
+        int layerId = LayerId,
         double upperLeftX = 0,
         double upperLeftY = 1)
     {
@@ -199,7 +251,7 @@ public sealed class PostgresRasterMapRendererTests(PostgresFixture fixture)
                    @acquisitionDate,
                    @createdAt;
             """;
-        command.Parameters.AddWithValue("layerId", LayerId);
+        command.Parameters.AddWithValue("layerId", layerId);
         command.Parameters.AddWithValue("name", name);
         command.Parameters.AddWithValue("value", value);
         command.Parameters.AddWithValue("upperLeftX", upperLeftX);

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Maps/OgcMapsBasicTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Npgsql;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Api.Maps;
 
@@ -301,6 +302,53 @@ public class OgcMapsBasicTests : IAsyncLifetime
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /ogc/maps/map")]
+    [Operation(Operations.Render)]
+    public async Task GetDatasetMap_WithMisalignedRasterCollections_ReturnsMap()
+    {
+        const string rasterName = "ogc-maps-misaligned-grid-2487";
+        var dataSource = _fixture.GetService<NpgsqlDataSource>();
+        await using var connection = await dataSource.OpenConnectionAsync();
+
+        try
+        {
+            await using (var insert = connection.CreateCommand())
+            {
+                insert.CommandText = """
+                    INSERT INTO honua.raster_data (layer_id, name, description, raster)
+                    VALUES (
+                        1,
+                        @name,
+                        'Offset raster grid for OGC dataset-map regression coverage',
+                        ST_AddBand(
+                            ST_MakeEmptyRaster(64, 64, -122.49, 37.84, 0.00234375, -0.0021875, 0, 0, 4326),
+                            '8BUI'::text,
+                            64,
+                            0));
+                    """;
+                insert.Parameters.AddWithValue("name", rasterName);
+                await insert.ExecuteNonQueryAsync();
+            }
+
+            var response = await _fixture.Client.GetAsync(
+                "/ogc/maps/map?collections=0,1&bbox=-123,37,-122,38&width=256&height=256&f=png");
+
+            response.StatusCode.Should().Be(
+                HttpStatusCode.OK,
+                "dataset rasters must be normalized to a shared grid before the PostGIS mosaic (#2487)");
+            response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+            (await response.Content.ReadAsByteArrayAsync()).Should().NotBeEmpty();
+        }
+        finally
+        {
+            await using var cleanup = connection.CreateCommand();
+            cleanup.CommandText = "DELETE FROM honua.raster_data WHERE name = @name;";
+            cleanup.Parameters.AddWithValue("name", rasterName);
+            await cleanup.ExecuteNonQueryAsync();
+        }
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2487

## Summary
Make OGC API Maps dataset rendering safe for heterogeneous raster coverages. Multi-layer renders now normalize source SRIDs and grids before the PostGIS mosaic instead of passing incompatible rasters directly to `ST_Union`.

## Changes Made
- Resolve an effective dataset output SRID from the requested CRS or bbox CRS.
- Resample multi-layer rasters to a deterministic reference grid before the ordered union while leaving single-collection rendering unchanged.
- Add provider and endpoint regressions for overlapping raster collections with offset grids.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent focused pre-PR validation:

- `PostgresRasterMapRendererTests.RenderDatasetMapAsync_WithMisalignedRasterLayers_ReturnsRenderedMap` — passed against real PostGIS.
- `OgcMapsBasicTests.GetDatasetMap_WithMisalignedRasterCollections_ReturnsMap` — passed with HTTP 200 and nonempty PNG output.
- Targeted `dotnet format --verify-no-changes` for all changed C# files — passed.
- Direct PostGIS reproduction before the fix produced `rt_raster_from_two_rasters: The two rasters provided do not have the same alignment`; the reference-grid resample completed successfully.
- Live demo probe on 2026-07-10 confirmed `/ogc/maps/map` returned 500 while an individual raster collection returned 200.
