### PR TITLE
feat(mcp): persist promotion resource catalogs

### DIFF
--- a/docs/guides/connect/ai-agents-mcp.md
+++ b/docs/guides/connect/ai-agents-mcp.md
@@ -58,7 +58,10 @@ The endpoint is `POST /mcp`: JSON-RPC 2.0 over HTTP (single requests and batches
    - `honua://jobs/{jobId}/report` — a structured analysis report for the same job
    - `honua://workspaces/{workspaceId}` — workspace lifecycle for job outputs
 
-   Additional published-service/deployment/package resources exist but are opt-in surfaces that hosts enable explicitly; they are not advertised by a default deployment.
+   Postgres-backed deployments also advertise the durable promotion catalog:
+   `honua://published-services`, `honua://deployments`, `honua://map-packages`, and
+   `honua://app-packages` (plus their item resources). Storeless or non-Postgres
+   hosts omit these resources unless they register canonical durable stores.
 
 6. For operational observability, use the read-only ops tools:
 

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -30,9 +30,9 @@ internal static class McpServiceCollectionExtensions
     /// deployments, map/app packages) is intentionally not registered here —
     /// those handlers depend on canonical <see cref="Honua.Core.Features.Publishing.Abstractions.IPublishedServiceStore"/>
     /// and <see cref="Honua.Core.Features.Deployment.Abstractions.IDeploymentStore"/> persistence,
-    /// which is not yet wired by the default composition. Hosts that have
-    /// registered canonical persistence call <see cref="AddMcpPromotionSurface"/>
-    /// to advertise those resources.
+    /// Hosts that have registered canonical persistence call
+    /// <see cref="AddMcpPromotionSurface"/> to advertise those resources; the
+    /// Postgres server profile does this through the server composition gate.
     /// </summary>
     public static IServiceCollection AddMcpOperatorSurface(
         this IServiceCollection services,

--- a/src/Honua.Core/Features/Publishing/Domain/PublishingJsonContext.cs
+++ b/src/Honua.Core/Features/Publishing/Domain/PublishingJsonContext.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Core.Features.Geoprocessing.Domain;
+
+namespace Honua.Core.Features.Publishing.Domain;
+
+/// <summary>
+/// AOT-compatible JSON serialization metadata for durable publishing records.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    Converters =
+    [
+        typeof(JsonStringEnumConverter<PublishSourceKind>),
+        typeof(JsonStringEnumConverter<PublishTargetKind>),
+        typeof(JsonStringEnumConverter<PublishedServiceStatus>),
+        typeof(JsonStringEnumConverter<RefreshMode>),
+        typeof(JsonStringEnumConverter<ArtifactKind>)
+    ])]
+[JsonSerializable(typeof(PublishedServiceRecord))]
+[JsonSerializable(typeof(IReadOnlyList<PublishedServiceRecord>))]
+public sealed partial class PublishingJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Postgres/Features/Publishing/PostgresDeploymentStore.cs
+++ b/src/Honua.Postgres/Features/Publishing/PostgresDeploymentStore.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Deployment.Abstractions;
+using Honua.Core.Features.Deployment.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Publishing;
+
+/// <summary>
+/// Durable Postgres store for canonical deployment lifecycle records.
+/// </summary>
+internal sealed class PostgresDeploymentStore : IDeploymentStore
+{
+    private const string Columns =
+        "deployment_id, source_kind, source_id, target_id, status, document, created_at, updated_at";
+
+    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly string _table;
+
+    public PostgresDeploymentStore(
+        IAdoNetDatabaseConnectionProvider connectionProvider,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _table = SchemaSearchPath.QualifyTable("promotion_deployments", schemaName);
+    }
+
+    public async Task<bool> TryCreateAsync(
+        Deployment deployment,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+        var sql = $"""
+            INSERT INTO {_table} ({Columns})
+            VALUES (@deployment_id, @source_kind, @source_id, @target_id, @status,
+                    @document, @created_at, @updated_at)
+            ON CONFLICT (deployment_id) DO NOTHING
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddParameters(command, deployment);
+        return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) == 1;
+    }
+
+    public async Task<Deployment?> GetAsync(
+        string deploymentId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"SELECT document FROM {_table} WHERE deployment_id = @deployment_id";
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@deployment_id", NpgsqlDbType.Text, deploymentId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
+            ? Deserialize(reader.GetString(0))
+            : null;
+    }
+
+    public async Task SetAsync(
+        Deployment deployment,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+        var sql = $"""
+            INSERT INTO {_table} ({Columns})
+            VALUES (@deployment_id, @source_kind, @source_id, @target_id, @status,
+                    @document, @created_at, @updated_at)
+            ON CONFLICT (deployment_id) DO UPDATE SET
+                source_kind = EXCLUDED.source_kind,
+                source_id = EXCLUDED.source_id,
+                target_id = EXCLUDED.target_id,
+                status = EXCLUDED.status,
+                document = EXCLUDED.document,
+                created_at = EXCLUDED.created_at,
+                updated_at = EXCLUDED.updated_at
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddParameters(command, deployment);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<Deployment>> ListActiveAsync(
+        CancellationToken cancellationToken = default)
+        => ListAsync(
+            "status <> @retired AND status <> @superseded",
+            command =>
+            {
+                command.Parameters.AddWithValue("@retired", NpgsqlDbType.Text, DeploymentStatus.Retired.ToString());
+                command.Parameters.AddWithValue("@superseded", NpgsqlDbType.Text, DeploymentStatus.Superseded.ToString());
+            },
+            cancellationToken);
+
+    public Task<IReadOnlyList<Deployment>> ListBySourceAsync(
+        DeploymentSourceKind sourceKind,
+        string sourceId,
+        CancellationToken cancellationToken = default)
+        => ListAsync(
+            "source_kind = @source_kind AND source_id = @source_id",
+            command =>
+            {
+                command.Parameters.AddWithValue("@source_kind", NpgsqlDbType.Text, sourceKind.ToString());
+                command.Parameters.AddWithValue("@source_id", NpgsqlDbType.Text, sourceId);
+            },
+            cancellationToken);
+
+    public Task<IReadOnlyList<Deployment>> ListByTargetAsync(
+        string targetId,
+        CancellationToken cancellationToken = default)
+        => ListAsync(
+            "target_id = @target_id",
+            command => command.Parameters.AddWithValue("@target_id", NpgsqlDbType.Text, targetId),
+            cancellationToken);
+
+    private async Task<IReadOnlyList<Deployment>> ListAsync(
+        string predicate,
+        Action<NpgsqlCommand> addParameters,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"SELECT document FROM {_table} WHERE {predicate} ORDER BY updated_at DESC, deployment_id";
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        addParameters(command);
+        var deployments = new List<Deployment>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            deployments.Add(Deserialize(reader.GetString(0)));
+        }
+
+        return deployments;
+    }
+
+    private static void AddParameters(NpgsqlCommand command, Deployment deployment)
+    {
+        var document = JsonSerializer.Serialize(
+            deployment,
+            DeploymentJsonContext.Default.Deployment);
+        command.Parameters.AddWithValue("@deployment_id", NpgsqlDbType.Text, deployment.DeploymentId);
+        command.Parameters.AddWithValue("@source_kind", NpgsqlDbType.Text, deployment.Source.Kind.ToString());
+        command.Parameters.AddWithValue("@source_id", NpgsqlDbType.Text, deployment.Source.SourceId);
+        command.Parameters.AddWithValue("@target_id", NpgsqlDbType.Text, deployment.Target.TargetId);
+        command.Parameters.AddWithValue("@status", NpgsqlDbType.Text, deployment.Status.ToString());
+        command.Parameters.Add(new NpgsqlParameter("@document", NpgsqlDbType.Jsonb) { Value = document });
+        command.Parameters.AddWithValue("@created_at", NpgsqlDbType.TimestampTz, deployment.CreatedAt);
+        command.Parameters.AddWithValue("@updated_at", NpgsqlDbType.TimestampTz, deployment.UpdatedAt);
+    }
+
+    private static Deployment Deserialize(string document)
+        => JsonSerializer.Deserialize(
+               document,
+               DeploymentJsonContext.Default.Deployment)
+           ?? throw new InvalidDataException("Deployment document was empty.");
+}

--- a/src/Honua.Postgres/Features/Publishing/PostgresDeploymentStore.cs
+++ b/src/Honua.Postgres/Features/Publishing/PostgresDeploymentStore.cs
@@ -4,8 +4,6 @@
 using System.Text.Json;
 using Honua.Core.Features.Deployment.Abstractions;
 using Honua.Core.Features.Deployment.Domain;
-using Honua.Core.Features.Infrastructure.Abstractions;
-using Honua.Postgres.Features.Infrastructure;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -19,15 +17,15 @@ internal sealed class PostgresDeploymentStore : IDeploymentStore
     private const string Columns =
         "deployment_id, source_kind, source_id, target_id, status, document, created_at, updated_at";
 
-    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly NpgsqlDataSource _dataSource;
     private readonly string _table;
 
     public PostgresDeploymentStore(
-        IAdoNetDatabaseConnectionProvider connectionProvider,
+        NpgsqlDataSource dataSource,
         string? schemaName = null)
     {
-        ArgumentNullException.ThrowIfNull(connectionProvider);
-        _connectionProvider = connectionProvider;
+        ArgumentNullException.ThrowIfNull(dataSource);
+        _dataSource = dataSource;
         _table = SchemaSearchPath.QualifyTable("promotion_deployments", schemaName);
     }
 
@@ -43,7 +41,7 @@ internal sealed class PostgresDeploymentStore : IDeploymentStore
             ON CONFLICT (deployment_id) DO NOTHING
             """;
 
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         AddParameters(command, deployment);
         return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) == 1;
@@ -54,7 +52,7 @@ internal sealed class PostgresDeploymentStore : IDeploymentStore
         CancellationToken cancellationToken = default)
     {
         var sql = $"SELECT document FROM {_table} WHERE deployment_id = @deployment_id";
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("@deployment_id", NpgsqlDbType.Text, deploymentId);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -82,7 +80,7 @@ internal sealed class PostgresDeploymentStore : IDeploymentStore
                 updated_at = EXCLUDED.updated_at
             """;
 
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         AddParameters(command, deployment);
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -126,7 +124,7 @@ internal sealed class PostgresDeploymentStore : IDeploymentStore
         CancellationToken cancellationToken)
     {
         var sql = $"SELECT document FROM {_table} WHERE {predicate} ORDER BY updated_at DESC, deployment_id";
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         addParameters(command);
         var deployments = new List<Deployment>();

--- a/src/Honua.Postgres/Features/Publishing/PostgresPublishedServiceStore.cs
+++ b/src/Honua.Postgres/Features/Publishing/PostgresPublishedServiceStore.cs
@@ -2,10 +2,8 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Text.Json;
-using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Publishing.Abstractions;
 using Honua.Core.Features.Publishing.Domain;
-using Honua.Postgres.Features.Infrastructure;
 using Npgsql;
 using NpgsqlTypes;
 
@@ -19,15 +17,15 @@ internal sealed class PostgresPublishedServiceStore : IPublishedServiceStore
     private const string Columns =
         "service_id, intent_id, source_kind, source_id, target_kind, status, document, published_at, updated_at";
 
-    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly NpgsqlDataSource _dataSource;
     private readonly string _table;
 
     public PostgresPublishedServiceStore(
-        IAdoNetDatabaseConnectionProvider connectionProvider,
+        NpgsqlDataSource dataSource,
         string? schemaName = null)
     {
-        ArgumentNullException.ThrowIfNull(connectionProvider);
-        _connectionProvider = connectionProvider;
+        ArgumentNullException.ThrowIfNull(dataSource);
+        _dataSource = dataSource;
         _table = SchemaSearchPath.QualifyTable("promotion_published_services", schemaName);
     }
 
@@ -43,7 +41,7 @@ internal sealed class PostgresPublishedServiceStore : IPublishedServiceStore
             ON CONFLICT (service_id) DO NOTHING
             """;
 
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         AddParameters(command, service);
         return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) == 1;
@@ -54,7 +52,7 @@ internal sealed class PostgresPublishedServiceStore : IPublishedServiceStore
         CancellationToken cancellationToken = default)
     {
         var sql = $"SELECT document FROM {_table} WHERE service_id = @service_id";
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("@service_id", NpgsqlDbType.Text, serviceId);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -83,7 +81,7 @@ internal sealed class PostgresPublishedServiceStore : IPublishedServiceStore
                 updated_at = EXCLUDED.updated_at
             """;
 
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         AddParameters(command, service);
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -113,7 +111,7 @@ internal sealed class PostgresPublishedServiceStore : IPublishedServiceStore
         CancellationToken cancellationToken)
     {
         var sql = $"SELECT document FROM {_table} WHERE {predicate} ORDER BY updated_at DESC, service_id";
-        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         await using var command = new NpgsqlCommand(sql, connection);
         addParameters(command);
         var services = new List<PublishedServiceRecord>();

--- a/src/Honua.Postgres/Features/Publishing/PostgresPublishedServiceStore.cs
+++ b/src/Honua.Postgres/Features/Publishing/PostgresPublishedServiceStore.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Publishing.Abstractions;
+using Honua.Core.Features.Publishing.Domain;
+using Honua.Postgres.Features.Infrastructure;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Honua.Postgres.Features.Publishing;
+
+/// <summary>
+/// Durable Postgres store for canonical published-service records.
+/// </summary>
+internal sealed class PostgresPublishedServiceStore : IPublishedServiceStore
+{
+    private const string Columns =
+        "service_id, intent_id, source_kind, source_id, target_kind, status, document, published_at, updated_at";
+
+    private readonly IAdoNetDatabaseConnectionProvider _connectionProvider;
+    private readonly string _table;
+
+    public PostgresPublishedServiceStore(
+        IAdoNetDatabaseConnectionProvider connectionProvider,
+        string? schemaName = null)
+    {
+        ArgumentNullException.ThrowIfNull(connectionProvider);
+        _connectionProvider = connectionProvider;
+        _table = SchemaSearchPath.QualifyTable("promotion_published_services", schemaName);
+    }
+
+    public async Task<bool> TryCreateAsync(
+        PublishedServiceRecord service,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        var sql = $"""
+            INSERT INTO {_table} ({Columns})
+            VALUES (@service_id, @intent_id, @source_kind, @source_id, @target_kind, @status,
+                    @document, @published_at, @updated_at)
+            ON CONFLICT (service_id) DO NOTHING
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddParameters(command, service);
+        return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) == 1;
+    }
+
+    public async Task<PublishedServiceRecord?> GetAsync(
+        string serviceId,
+        CancellationToken cancellationToken = default)
+    {
+        var sql = $"SELECT document FROM {_table} WHERE service_id = @service_id";
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("@service_id", NpgsqlDbType.Text, serviceId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
+            ? Deserialize(reader.GetString(0))
+            : null;
+    }
+
+    public async Task SetAsync(
+        PublishedServiceRecord service,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        var sql = $"""
+            INSERT INTO {_table} ({Columns})
+            VALUES (@service_id, @intent_id, @source_kind, @source_id, @target_kind, @status,
+                    @document, @published_at, @updated_at)
+            ON CONFLICT (service_id) DO UPDATE SET
+                intent_id = EXCLUDED.intent_id,
+                source_kind = EXCLUDED.source_kind,
+                source_id = EXCLUDED.source_id,
+                target_kind = EXCLUDED.target_kind,
+                status = EXCLUDED.status,
+                document = EXCLUDED.document,
+                published_at = EXCLUDED.published_at,
+                updated_at = EXCLUDED.updated_at
+            """;
+
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddParameters(command, service);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<IReadOnlyList<PublishedServiceRecord>> ListActiveAsync(
+        CancellationToken cancellationToken = default)
+        => ListAsync(
+            "status <> @decommissioned",
+            command => command.Parameters.AddWithValue(
+                "@decommissioned",
+                NpgsqlDbType.Text,
+                PublishedServiceStatus.Decommissioned.ToString()),
+            cancellationToken);
+
+    public Task<IReadOnlyList<PublishedServiceRecord>> ListBySourceAsync(
+        string sourceId,
+        CancellationToken cancellationToken = default)
+        => ListAsync(
+            "source_id = @source_id",
+            command => command.Parameters.AddWithValue("@source_id", NpgsqlDbType.Text, sourceId),
+            cancellationToken);
+
+    private async Task<IReadOnlyList<PublishedServiceRecord>> ListAsync(
+        string predicate,
+        Action<NpgsqlCommand> addParameters,
+        CancellationToken cancellationToken)
+    {
+        var sql = $"SELECT document FROM {_table} WHERE {predicate} ORDER BY updated_at DESC, service_id";
+        await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = new NpgsqlCommand(sql, connection);
+        addParameters(command);
+        var services = new List<PublishedServiceRecord>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            services.Add(Deserialize(reader.GetString(0)));
+        }
+
+        return services;
+    }
+
+    private static void AddParameters(NpgsqlCommand command, PublishedServiceRecord service)
+    {
+        var document = JsonSerializer.Serialize(
+            service,
+            PublishingJsonContext.Default.PublishedServiceRecord);
+        command.Parameters.AddWithValue("@service_id", NpgsqlDbType.Text, service.ServiceId);
+        command.Parameters.AddWithValue("@intent_id", NpgsqlDbType.Text, service.IntentId);
+        command.Parameters.AddWithValue("@source_kind", NpgsqlDbType.Text, service.SourceKind.ToString());
+        command.Parameters.AddWithValue("@source_id", NpgsqlDbType.Text, service.SourceId);
+        command.Parameters.AddWithValue("@target_kind", NpgsqlDbType.Text, service.TargetKind.ToString());
+        command.Parameters.AddWithValue("@status", NpgsqlDbType.Text, service.Status.ToString());
+        command.Parameters.Add(new NpgsqlParameter("@document", NpgsqlDbType.Jsonb) { Value = document });
+        command.Parameters.AddWithValue("@published_at", NpgsqlDbType.TimestampTz, service.PublishedAt);
+        command.Parameters.AddWithValue("@updated_at", NpgsqlDbType.TimestampTz, service.UpdatedAt);
+    }
+
+    private static PublishedServiceRecord Deserialize(string document)
+        => JsonSerializer.Deserialize(
+               document,
+               PublishingJsonContext.Default.PublishedServiceRecord)
+           ?? throw new InvalidDataException("Published-service document was empty.");
+}

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -32,6 +32,8 @@ using Honua.Core.Features.Metadata;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Caching;
 using Honua.Core.Features.Mobile.FieldCollection.Abstractions;
+using Honua.Core.Features.Deployment.Abstractions;
+using Honua.Core.Features.Publishing.Abstractions;
 using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Share.Abstractions;
 using Honua.Core.Features.Studio.Abstractions;
@@ -293,6 +295,18 @@ internal static class ServiceCollectionExtensions
         // wins over the in-memory default registered by AddContentPublishingServices.
         services.AddScoped<Honua.Core.Features.Publishing.Content.Abstractions.IContentPublicationStore>(serviceProvider =>
             new Features.Publishing.PostgresContentPublicationStore(
+                serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
+
+        // Canonical promotion lifecycle stores (#2482). Their presence causes the
+        // server composition's existing honesty gate to advertise the hosted
+        // published-service/deployment/map/app MCP resources on Postgres profiles.
+        services.AddScoped<IPublishedServiceStore>(serviceProvider =>
+            new Features.Publishing.PostgresPublishedServiceStore(
+                serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
+                configuration["Database:Schema"]));
+        services.AddScoped<IDeploymentStore>(serviceProvider =>
+            new Features.Publishing.PostgresDeploymentStore(
                 serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
                 configuration["Database:Schema"]));
 

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -303,11 +303,11 @@ internal static class ServiceCollectionExtensions
         // published-service/deployment/map/app MCP resources on Postgres profiles.
         services.AddSingleton<IPublishedServiceStore>(serviceProvider =>
             new Features.Publishing.PostgresPublishedServiceStore(
-                serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
+                serviceProvider.GetRequiredService<NpgsqlDataSource>(),
                 configuration["Database:Schema"]));
         services.AddSingleton<IDeploymentStore>(serviceProvider =>
             new Features.Publishing.PostgresDeploymentStore(
-                serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
+                serviceProvider.GetRequiredService<NpgsqlDataSource>(),
                 configuration["Database:Schema"]));
 
         // Register Postgres-backed RBAC role/permission store (#1374). Durable

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -301,11 +301,11 @@ internal static class ServiceCollectionExtensions
         // Canonical promotion lifecycle stores (#2482). Their presence causes the
         // server composition's existing honesty gate to advertise the hosted
         // published-service/deployment/map/app MCP resources on Postgres profiles.
-        services.AddScoped<IPublishedServiceStore>(serviceProvider =>
+        services.AddSingleton<IPublishedServiceStore>(serviceProvider =>
             new Features.Publishing.PostgresPublishedServiceStore(
                 serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
                 configuration["Database:Schema"]));
-        services.AddScoped<IDeploymentStore>(serviceProvider =>
+        services.AddSingleton<IDeploymentStore>(serviceProvider =>
             new Features.Publishing.PostgresDeploymentStore(
                 serviceProvider.GetRequiredService<IAdoNetDatabaseConnectionProvider>(),
                 configuration["Database:Schema"]));

--- a/src/Honua.Server/Migrations/082_CreatePromotionStores.sql
+++ b/src/Honua.Server/Migrations/082_CreatePromotionStores.sql
@@ -1,0 +1,47 @@
+-- Copyright (c) Honua. All rights reserved.
+-- Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+-- Durable canonical stores backing the MCP promotion resources (#2482). Full
+-- domain records are preserved as JSONB for wire-compatible evolution, while
+-- lifecycle/source/target columns keep the store interfaces' list operations
+-- indexed and avoid JSON scans.
+
+CREATE TABLE IF NOT EXISTS honua.promotion_published_services (
+    service_id   TEXT        NOT NULL PRIMARY KEY,
+    intent_id    TEXT        NOT NULL,
+    source_kind  TEXT        NOT NULL,
+    source_id    TEXT        NOT NULL,
+    target_kind  TEXT        NOT NULL,
+    status       TEXT        NOT NULL,
+    document     JSONB       NOT NULL,
+    published_at TIMESTAMPTZ NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_promotion_published_services_active
+    ON honua.promotion_published_services (status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_promotion_published_services_source
+    ON honua.promotion_published_services (source_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS honua.promotion_deployments (
+    deployment_id TEXT        NOT NULL PRIMARY KEY,
+    source_kind   TEXT        NOT NULL,
+    source_id     TEXT        NOT NULL,
+    target_id     TEXT        NOT NULL,
+    status        TEXT        NOT NULL,
+    document      JSONB       NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_promotion_deployments_active
+    ON honua.promotion_deployments (status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_promotion_deployments_source
+    ON honua.promotion_deployments (source_kind, source_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_promotion_deployments_target
+    ON honua.promotion_deployments (target_id, updated_at DESC);
+
+COMMENT ON TABLE honua.promotion_published_services IS
+    'Canonical durable published-service records backing honua://published-services (#2482).';
+COMMENT ON TABLE honua.promotion_deployments IS
+    'Canonical durable deployment lifecycle records backing promotion MCP resources (#2482).';

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
@@ -78,9 +78,9 @@ public sealed class McpServiceCollectionExtensionsTests
         services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
 
         services.Any(d => d.ServiceType == typeof(IPublishedServiceStore))
-            .Should().BeFalse("canonical publishing persistence is not yet registered by the default composition");
+            .Should().BeFalse("the transport registrar must not invent canonical publishing persistence");
         services.Any(d => d.ServiceType == typeof(IDeploymentStore))
-            .Should().BeFalse("canonical deployment persistence is not yet registered by the default composition");
+            .Should().BeFalse("the transport registrar must not invent canonical deployment persistence");
         services.Any(d => d.ServiceType == typeof(IPublishIntentStore))
             .Should().BeFalse("canonical publish-intent persistence is not yet registered by the default composition");
     }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Publishing/PostgresPromotionStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Publishing/PostgresPromotionStoreTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
-using System.Data;
-using System.Data.Common;
 using FluentAssertions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Deployment.Abstractions;
 using Honua.Core.Features.Deployment.Domain;
 using Honua.Core.Features.Geoprocessing.Domain;
-using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Publishing.Abstractions;
 using Honua.Core.Features.Publishing.Domain;
 using Honua.Postgres.Features.Publishing;
@@ -33,9 +30,8 @@ public sealed class PostgresPromotionStoreTests(PostgresFixture fixture)
         try
         {
             await EnsureTablesAsync(schema);
-            var provider = new TestConnectionProvider(fixture.DataSource, schema);
-            var writer = new PostgresPublishedServiceStore(provider, schema);
-            var reader = new PostgresPublishedServiceStore(provider, schema);
+            var writer = new PostgresPublishedServiceStore(fixture.DataSource, schema);
+            var reader = new PostgresPublishedServiceStore(fixture.DataSource, schema);
             var service = BuildPublishedService("service-a", "result-1");
 
             (await writer.TryCreateAsync(service)).Should().BeTrue();
@@ -70,9 +66,8 @@ public sealed class PostgresPromotionStoreTests(PostgresFixture fixture)
         try
         {
             await EnsureTablesAsync(schema);
-            var provider = new TestConnectionProvider(fixture.DataSource, schema);
-            var writer = new PostgresDeploymentStore(provider, schema);
-            var reader = new PostgresDeploymentStore(provider, schema);
+            var writer = new PostgresDeploymentStore(fixture.DataSource, schema);
+            var reader = new PostgresDeploymentStore(fixture.DataSource, schema);
             var deployment = BuildDeployment("deployment-a", "service-a", "production");
 
             (await writer.TryCreateAsync(deployment)).Should().BeTrue();
@@ -206,34 +201,5 @@ public sealed class PostgresPromotionStoreTests(PostgresFixture fixture)
             );
             """;
         await command.ExecuteNonQueryAsync();
-    }
-
-    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IAdoNetDatabaseConnectionProvider
-    {
-        public string GetConnectionString() => dataSource.ConnectionString;
-
-        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
-        {
-            var connection = await dataSource.OpenConnectionAsync(cancellationToken);
-            await using var command = connection.CreateCommand();
-            command.CommandText = $"SET search_path TO \"{schemaName}\", public;";
-            await command.ExecuteNonQueryAsync(cancellationToken);
-            return connection;
-        }
-
-        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
-            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
-            CancellationToken cancellationToken = default)
-        {
-            var connection = await OpenConnectionAsync(cancellationToken);
-            var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
-            return (connection, transaction);
-        }
-
-        public Task<T> ExecuteWithDeadlockRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
-            => operation();
-
-        public Task ExecuteWithDeadlockRetryAsync(Func<Task> operation, CancellationToken cancellationToken = default)
-            => operation();
     }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Publishing/PostgresPromotionStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Publishing/PostgresPromotionStoreTests.cs
@@ -114,10 +114,10 @@ public sealed class PostgresPromotionStoreTests(PostgresFixture fixture)
 
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IPublishedServiceStore) &&
-            descriptor.Lifetime == ServiceLifetime.Scoped);
+            descriptor.Lifetime == ServiceLifetime.Singleton);
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IDeploymentStore) &&
-            descriptor.Lifetime == ServiceLifetime.Scoped);
+            descriptor.Lifetime == ServiceLifetime.Singleton);
     }
 
     private static PublishedServiceRecord BuildPublishedService(string serviceId, string sourceId)

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Publishing/PostgresPromotionStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Publishing/PostgresPromotionStoreTests.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Deployment.Abstractions;
+using Honua.Core.Features.Deployment.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Publishing.Abstractions;
+using Honua.Core.Features.Publishing.Domain;
+using Honua.Postgres.Features.Publishing;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Publishing;
+
+/// <summary>
+/// Durable Postgres proof for the MCP promotion resource stores (#2482).
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresPromotionStoreTests(PostgresFixture fixture)
+{
+    [IntegrationTest]
+    public async Task PublishedServiceStore_RoundTripsAcrossInstances_AndFiltersLifecycleAndSource()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresPromotionStoreTests) + "_Published");
+        try
+        {
+            await EnsureTablesAsync(schema);
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var writer = new PostgresPublishedServiceStore(provider, schema);
+            var reader = new PostgresPublishedServiceStore(provider, schema);
+            var service = BuildPublishedService("service-a", "result-1");
+
+            (await writer.TryCreateAsync(service)).Should().BeTrue();
+            (await writer.TryCreateAsync(service)).Should().BeFalse();
+
+            var stored = await reader.GetAsync(service.ServiceId);
+            stored.Should().BeEquivalentTo(service);
+            (await reader.ListActiveAsync()).Should().ContainSingle(item => item.ServiceId == service.ServiceId);
+            (await reader.ListBySourceAsync("result-1")).Should().ContainSingle(item => item.ServiceId == service.ServiceId);
+
+            var decommissioned = service with
+            {
+                Status = PublishedServiceStatus.Decommissioned,
+                UpdatedAt = service.UpdatedAt.AddMinutes(1),
+                Warnings = ["retired after promotion"]
+            };
+            await writer.SetAsync(decommissioned);
+
+            (await reader.GetAsync(service.ServiceId)).Should().BeEquivalentTo(decommissioned);
+            (await reader.ListActiveAsync()).Should().BeEmpty();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task DeploymentStore_RoundTripsTransitions_AndFiltersLifecycleSourceAndTarget()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresPromotionStoreTests) + "_Deployments");
+        try
+        {
+            await EnsureTablesAsync(schema);
+            var provider = new TestConnectionProvider(fixture.DataSource, schema);
+            var writer = new PostgresDeploymentStore(provider, schema);
+            var reader = new PostgresDeploymentStore(provider, schema);
+            var deployment = BuildDeployment("deployment-a", "service-a", "production");
+
+            (await writer.TryCreateAsync(deployment)).Should().BeTrue();
+            (await writer.TryCreateAsync(deployment)).Should().BeFalse();
+
+            var stored = await reader.GetAsync(deployment.DeploymentId);
+            stored.Should().BeEquivalentTo(deployment);
+            stored!.Transitions.Should().HaveCount(3);
+            (await reader.ListActiveAsync()).Should().ContainSingle(item => item.DeploymentId == deployment.DeploymentId);
+            (await reader.ListBySourceAsync(DeploymentSourceKind.PublishedService, "service-a"))
+                .Should().ContainSingle(item => item.DeploymentId == deployment.DeploymentId);
+            (await reader.ListByTargetAsync("production"))
+                .Should().ContainSingle(item => item.DeploymentId == deployment.DeploymentId);
+
+            var retired = deployment.WithRetired("superseded by release");
+            await writer.SetAsync(retired);
+
+            (await reader.GetAsync(deployment.DeploymentId)).Should().BeEquivalentTo(retired);
+            (await reader.ListActiveAsync()).Should().BeEmpty();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [UnitTest]
+    public void AddPostgreSqlServices_RegistersDurablePromotionStores()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=honua;Username=honua;Password=honua"
+            })
+            .Build();
+
+        services.AddPostgreSqlServices(configuration);
+
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IPublishedServiceStore) &&
+            descriptor.Lifetime == ServiceLifetime.Scoped);
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IDeploymentStore) &&
+            descriptor.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    private static PublishedServiceRecord BuildPublishedService(string serviceId, string sourceId)
+    {
+        var now = new DateTimeOffset(2026, 7, 10, 12, 0, 0, TimeSpan.Zero);
+        return new PublishedServiceRecord
+        {
+            ServiceId = serviceId,
+            IntentId = "intent-a",
+            SourceKind = PublishSourceKind.ResultPackage,
+            SourceId = sourceId,
+            TargetKind = PublishTargetKind.FeatureService,
+            Status = PublishedServiceStatus.Active,
+            Artifacts =
+            [
+                new ArtifactRef
+                {
+                    ArtifactId = "artifact-a",
+                    Kind = ArtifactKind.FeatureLayer,
+                    Label = "Result layer",
+                    Uri = "honua://results/result-1/artifacts/artifact-a",
+                    ContentType = "application/geo+json",
+                    Metadata = new Dictionary<string, string> { ["table"] = "result_a" }
+                }
+            ],
+            Endpoint = "/rest/services/service-a/FeatureServer",
+            RefreshPolicy = RefreshPolicy.Manual(),
+            PublishedAt = now,
+            UpdatedAt = now,
+            Audit = new OperationAuditInfo
+            {
+                RequestedBy = "operator@example.com",
+                CorrelationId = "corr-a",
+                IdempotencyKey = "publish-a"
+            }
+        };
+    }
+
+    private static Deployment BuildDeployment(string deploymentId, string serviceId, string targetId)
+        => Deployment.CreateDraft(
+                deploymentId,
+                DeploymentSource.FromPublishedService(serviceId),
+                new DeploymentTarget
+                {
+                    TargetId = targetId,
+                    Kind = DeploymentKind.FeatureService,
+                    HostingMode = HostingMode.ManagedService,
+                    RoutePrefix = "/services/service-a",
+                    Environment = "production",
+                    Labels = new Dictionary<string, string> { ["region"] = "us-west" }
+                },
+                audit: new OperationAuditInfo
+                {
+                    RequestedBy = "operator@example.com",
+                    CorrelationId = "corr-deploy"
+                })
+            .WithProvisioning("allocate")
+            .WithRollingOut(reason: "roll out")
+            .WithActive("https://example.test/services/service-a", "promote");
+
+    private async Task EnsureTablesAsync(string schema)
+    {
+        await using var connection = await fixture.DataSource.OpenConnectionAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            CREATE TABLE "{schema}".promotion_published_services (
+                service_id TEXT PRIMARY KEY,
+                intent_id TEXT NOT NULL,
+                source_kind TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                target_kind TEXT NOT NULL,
+                status TEXT NOT NULL,
+                document JSONB NOT NULL,
+                published_at TIMESTAMPTZ NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL
+            );
+            CREATE TABLE "{schema}".promotion_deployments (
+                deployment_id TEXT PRIMARY KEY,
+                source_kind TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                document JSONB NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL
+            );
+            """;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private sealed class TestConnectionProvider(NpgsqlDataSource dataSource, string schemaName) : IAdoNetDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var connection = await dataSource.OpenConnectionAsync(cancellationToken);
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"SET search_path TO \"{schemaName}\", public;";
+            await command.ExecuteNonQueryAsync(cancellationToken);
+            return connection;
+        }
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+            return (connection, transaction);
+        }
+
+        public Task<T> ExecuteWithDeadlockRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
+            => operation();
+
+        public Task ExecuteWithDeadlockRetryAsync(Func<Task> operation, CancellationToken cancellationToken = default)
+            => operation();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Startup/PostgresPromotionSurfaceRegistrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Startup/PostgresPromotionSurfaceRegistrationTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Ai.Protocols.Mcp;
+using Honua.Ai.Protocols.Mcp.Resources;
+using Honua.Geoprocessing;
+using Honua.Infrastructure.Hosting;
+using Honua.Postgres;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Startup;
+
+/// <summary>
+/// Verifies that the real Postgres-first server composition advertises the
+/// durable MCP promotion resources (#2482).
+/// </summary>
+public sealed class PostgresPromotionSurfaceRegistrationTests
+{
+    [UnitTest]
+    public void PostgresThenServerFeatures_AdvertisesPromotionResources()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=honua;Username=honua;Password=honua"
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IGeoprocessingJobService>());
+
+        services.AddPostgreSqlServices(configuration);
+        services.AddServerFeatures(configuration);
+
+        var resourceTypes = services
+            .Where(descriptor => descriptor.ServiceType == typeof(IMcpResource))
+            .Select(descriptor => descriptor.ImplementationType)
+            .ToArray();
+        resourceTypes.Should().Contain(new[]
+        {
+            typeof(PublishedServiceResource),
+            typeof(DeploymentResource),
+            typeof(MapPackageResource),
+            typeof(AppPackageResource),
+            typeof(PromotionSurfaceIndexResource)
+        });
+    }
+}


### PR DESCRIPTION
## Issue Link
Fixes #2482
Related to #1948

## Summary
Registers durable Postgres providers for the canonical published-service and deployment catalogs. This satisfies the remaining #2482 gap and makes the existing MCP promotion resources truthfully live in the default Postgres-backed pro profile.

The previously deferred `publish_result`, style authoring, and analysis-artifact render slices are already merged in #2494, #2497, and #2551; this PR closes the persistence and composition remainder without adding an in-memory fallback.

## Changes Made
- Add JSONB-backed `IPublishedServiceStore` and `IDeploymentStore` implementations with indexed lifecycle/source/target queries.
- Add additive migration 082 and register both stores in the Postgres composition so the existing promotion-resource honesty gate activates.
- Prove cross-instance durability, lifecycle filtering, transition-history preservation, DI lifetimes, and real Postgres-first MCP resource registration.
- Update MCP operator documentation to describe Postgres-backed promotion resources and storeless profile behavior.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Focused verification:
- `PostgresPromotionStoreTests`: 3 passed
- `PostgresPromotionSurfaceRegistrationTests`: 1 passed
- `dotnet format Honua.sln --no-restore --include <changed C# files>`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [x] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [ ] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent affected-scope pre-PR validation is recorded above; no protocol, auth, admin API, or gRPC contract changed.