### PR TITLE
fix(seed): enable temporal client compatibility queries

### DIFF
--- a/scripts/client-compat/run-client-compat-smoke.sh
+++ b/scripts/client-compat/run-client-compat-smoke.sh
@@ -527,18 +527,6 @@ run_desktop_lane() {
     '(.features | length) == 3' || lane_failed=1
 
   request_json \
-    "featureserver-query-temporal-window" \
-    "${BASE_URL}/rest/services/${SERVICE_ID}/FeatureServer/${LAYER_ID}/query?where=1%3D1&time=1704240000000%2C1704412799000&returnGeometry=false&f=json" \
-    "200" \
-    '(.features | length) == 2' || lane_failed=1
-
-  request_json \
-    "featureserver-query-temporal-disjoint" \
-    "${BASE_URL}/rest/services/${SERVICE_ID}/FeatureServer/${LAYER_ID}/query?where=1%3D1&time=0%2C1&returnGeometry=false&f=json" \
-    "200" \
-    '(.features | length) == 0' || lane_failed=1
-
-  request_json \
     "mapserver-service-metadata" \
     "${BASE_URL}/rest/services/${SERVICE_ID}/MapServer?f=json" \
     "200" \

--- a/scripts/client-compat/run-client-compat-smoke.sh
+++ b/scripts/client-compat/run-client-compat-smoke.sh
@@ -518,13 +518,25 @@ run_desktop_lane() {
     "featureserver-layer-metadata" \
     "${BASE_URL}/rest/services/${SERVICE_ID}/FeatureServer/${LAYER_ID}?f=json" \
     "200" \
-    '.id == 0 and (.fields | length) > 0 and .geometryType == "esriGeometryPoint"' || lane_failed=1
+    '.id == 0 and (.fields | length) > 0 and .geometryType == "esriGeometryPoint" and .timeInfo.startTimeField == "created_at"' || lane_failed=1
 
   request_json \
     "featureserver-query-active-subset" \
     "${BASE_URL}/rest/services/${SERVICE_ID}/FeatureServer/${LAYER_ID}/query?where=status%20%3D%20%27active%27&resultRecordCount=3&returnGeometry=true&f=json" \
     "200" \
     '(.features | length) == 3' || lane_failed=1
+
+  request_json \
+    "featureserver-query-temporal-window" \
+    "${BASE_URL}/rest/services/${SERVICE_ID}/FeatureServer/${LAYER_ID}/query?where=1%3D1&time=1704240000000%2C1704412799000&returnGeometry=false&f=json" \
+    "200" \
+    '(.features | length) == 2' || lane_failed=1
+
+  request_json \
+    "featureserver-query-temporal-disjoint" \
+    "${BASE_URL}/rest/services/${SERVICE_ID}/FeatureServer/${LAYER_ID}/query?where=1%3D1&time=0%2C1&returnGeometry=false&f=json" \
+    "200" \
+    '(.features | length) == 0' || lane_failed=1
 
   request_json \
     "mapserver-service-metadata" \
@@ -620,8 +632,22 @@ run_full_featureserver() {
   request_json \
     "featureserver-layer-metadata" \
     "${fs_base}/${LAYER_ID}?f=json" "200" \
-    ".id == ${LAYER_ID} and (.fields | length) > 0 and .geometryType == \"esriGeometryPoint\"" || failed=1
+    ".id == ${LAYER_ID} and (.fields | length) > 0 and .geometryType == \"esriGeometryPoint\" and .timeInfo.startTimeField == \"created_at\"" || failed=1
   append_cert_result "$proto" "CERT-DISC-02" "$LAST_STATUS" "$LAST_DURATION_MS" "" "" ""
+
+  # Client-compat extension: the canonical layer is time-aware and constrains
+  # both an in-range window and a disjoint pre-seed window (#2643). These lane
+  # checks stay outside the stable cross-client CERT-* vocabulary.
+  request_json \
+    "fs-temporal-window" \
+    "${fs_base}/${LAYER_ID}/query?where=1%3D1&time=1704240000000%2C1704412799000&returnGeometry=false&f=json" \
+    "200" \
+    '(.features | length) == 2' || failed=1
+  request_json \
+    "fs-temporal-disjoint" \
+    "${fs_base}/${LAYER_ID}/query?where=1%3D1&time=0%2C1&returnGeometry=false&f=json" \
+    "200" \
+    '(.features | length) == 0' || failed=1
 
   # CERT-SCHM-01: Typed fields array
   request_json \

--- a/tests/dotnet/Honua.Server.Tests/Seed/ClientCompatSeedSequenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/ClientCompatSeedSequenceTests.cs
@@ -111,6 +111,15 @@ public sealed class ClientCompatSeedSequenceTests
                 "layer_id",
                 "the features table is shared across layers and reads must be constrained by layer_id");
             options.GetProperty("primaryKeyColumn").GetString().Should().Be("objectid");
+
+            var resource = document.RootElement
+                .GetProperty("resources")
+                .EnumerateArray()
+                .Single(r => r.GetProperty("metadata").GetProperty("id").GetString() == "res-layer-0");
+
+            resource.GetProperty("temporal").GetProperty("startTimeField").GetString().Should().Be(
+                "created_at",
+                "the canonical client-compat layer must opt into FeatureServer time filtering (#2643)");
         }
     }
 

--- a/tests/seed/client-compat-v1.sql
+++ b/tests/seed/client-compat-v1.sql
@@ -889,7 +889,10 @@ ON CONFLICT (layer_id) DO UPDATE SET
     default_visibility = EXCLUDED.default_visibility;
 
 UPDATE honua.layers
-SET metadata = jsonb_build_object('accessPolicy', jsonb_build_object('allowAnonymous', true))
+SET metadata = jsonb_build_object(
+    'accessPolicy', jsonb_build_object('allowAnonymous', true),
+    'timeInfo', jsonb_build_object('startTimeField', 'created_at')
+)
 WHERE layer_id = 0;
 
 INSERT INTO honua.layer_fields (


### PR DESCRIPTION
## Issue Link
Fixes #2643
Related to #2645

## Summary
Makes the canonical client-compat layer explicitly time-aware so downstream SDK conformance can exercise the existing FeatureServer `time=` contract instead of receiving the intentional non-temporal-layer 400 response.

This keeps #2645 separate: that issue can independently make the Python SDK assertion required after this server seed lands.

## Changes Made
- Add `timeInfo.startTimeField = created_at` to `test_service` layer 0 in `client-compat-v1.sql`.
- Prove the compat compiler carries that setting into Metadata v2 as `temporal.startTimeField` for every seeded environment.
- Require time metadata in the 11-check smoke profile without changing its check count.
- Add full client-compat endpoint checks for a two-feature in-range temporal window and a zero-feature disjoint 1970 window, outside the stable CERT-* vocabulary.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Validation:
- Red/green proof: the focused seed test failed on trunk with missing `temporal`, then passed after the seed update (1/1).
- `bash -n scripts/client-compat/run-client-compat-smoke.sh`
- `git diff --check`

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent affected-scope pre-PR validation is recorded above. No runtime protocol implementation, auth behavior, admin API, or gRPC contract changed.
