### PR TITLE
fix(seed): advertise sync in client compat metadata (#2645)

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Seed/ClientCompatSeedSequenceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Seed/ClientCompatSeedSequenceTests.cs
@@ -58,7 +58,7 @@ public sealed class ClientCompatSeedSequenceTests
 
     [IntegrationTest]
     [Operation(Operations.TestInfrastructure)]
-    public async Task ClientCompatSeed_LayerStorageBinding_DeclaresPhysicalFeaturesTableColumns()
+    public async Task ClientCompatSeed_MetadataV2Snapshot_DeclaresBindingAndSyncCapabilities()
     {
         // Regression for the PyQGIS nightly: the certification layer binds to the shared
         // `features` table, whose physical layout stores attributes in the `attributes`
@@ -120,6 +120,22 @@ public sealed class ClientCompatSeedSequenceTests
             resource.GetProperty("temporal").GetProperty("startTimeField").GetString().Should().Be(
                 "created_at",
                 "the canonical client-compat layer must opt into FeatureServer time filtering (#2643)");
+
+            var featureService = document.RootElement
+                .GetProperty("services")
+                .EnumerateArray()
+                .Single(service =>
+                    service.GetProperty("metadata").GetProperty("name").GetString() == "test_service" &&
+                    service.GetProperty("serviceType").GetString() == "esri-feature-service");
+            var capabilities = featureService
+                .GetProperty("options")
+                .GetProperty("capabilities")
+                .EnumerateArray()
+                .Select(capability => capability.GetString())
+                .ToArray();
+
+            capabilities.Should().Contain("Sync",
+                "the client-compat service must advertise the replica/sync surface through Metadata V2");
         }
     }
 

--- a/tests/seed/client-compat-v1.sql
+++ b/tests/seed/client-compat-v1.sql
@@ -309,6 +309,7 @@ BEGIN
             SELECT
                 sl.service_name,
                 COALESCE(s.description, '') AS service_description,
+                COALESCE(s.capabilities, ARRAY['Query']::text[]) AS service_capabilities,
                 l.layer_id,
                 l.layer_name,
                 COALESCE(l.description, '') AS layer_description,
@@ -574,7 +575,7 @@ BEGIN
             FROM layer_rows
         ),
         service_names AS (
-            SELECT DISTINCT service_name, service_part, service_access_policy
+            SELECT DISTINCT service_name, service_part, service_access_policy, service_capabilities
             FROM layer_rows
         ),
         service_rows AS (
@@ -585,7 +586,7 @@ BEGIN
                     'publicationIds', '[]'::jsonb,
                     'protocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'OGC-API-Maps', 'OGC-API-Tiles']::text[]),
                     'enabledProtocols', to_jsonb(ARRAY['FeatureServer', 'MapServer', 'OData', 'Grpc', 'OgcFeatures', 'Wfs20', 'Wms', 'Wmts', 'OGC-API-Maps', 'OGC-API-Tiles']::text[]),
-                    'options', '{}'::jsonb,
+                    'options', jsonb_build_object('capabilities', to_jsonb(service_capabilities)),
                     'accessPolicy', service_access_policy,
                     'status', (SELECT value FROM status_doc),
                     'extensions', '{}'::jsonb
@@ -854,7 +855,7 @@ INSERT INTO honua.services (
 VALUES (
     'test_service', 'Client compatibility certification service', 4326, 1000,
     ARRAY['JSON', 'GeoJSON'],
-    ARRAY['Query', 'Extract', 'Create', 'Update', 'Delete'],
+    ARRAY['Query', 'Extract', 'Create', 'Update', 'Delete', 'Sync'],
     ST_MakeEnvelope(-122.5, 37.7, -122.35, 37.84, 4326)
 )
 ON CONFLICT (service_name) DO UPDATE SET


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2645

## Summary

Repairs the client-compat seed compiler contract so legacy service capabilities flow into Metadata-V2 feature-service options, allowing the certification service's existing replica backend to advertise Sync to SDK clients.

## Changes Made
- Carry each seeded service's declared capability array into the generated Metadata-V2 feature-service options instead of hardcoding `{}`.
- Declare `Sync` on `test_service` alongside its existing query/edit/extract capabilities.
- Extend the fresh-PostGIS snapshot regression to assert every generated environment exposes Sync for the certification FeatureServer.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Focused equivalent proof:
- `dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --filter FullyQualifiedName~ClientCompatSeed_MetadataV2Snapshot_DeclaresBindingAndSyncCapabilities --no-restore` — 1 passed, 0 failed against fresh PostGIS.
- `dotnet format Honua.sln --no-restore --include tests/dotnet/Honua.Server.Tests/Seed/ClientCompatSeedSequenceTests.cs` — passed.
- `git diff --check` — passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
