### PR TITLE
fix(ci): classify historical SDK compatibility cells

### DIFF
--- a/.github/workflows/sdk-server-compatibility.yml
+++ b/.github/workflows/sdk-server-compatibility.yml
@@ -622,12 +622,16 @@ jobs:
 
       - name: Generate compatibility table
         shell: bash
+        env:
+          SELECTED_MATRIX: ${{ needs.load-matrix.outputs.matrix }}
         run: |
           set -euo pipefail
+          printf '%s\n' "$SELECTED_MATRIX" > sdk-compat-selected-matrix.json
           bash scripts/ci/generate-sdk-compatibility-table.sh \
             "$SDK_COMPATIBILITY_MANIFEST" \
             sdk-compat-results \
-            sdk-compat-report
+            sdk-compat-report \
+            sdk-compat-selected-matrix.json
           cat sdk-compat-report/sdk-compatibility-matrix.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload SDK compatibility table

--- a/.github/workflows/sdk-server-compatibility.yml
+++ b/.github/workflows/sdk-server-compatibility.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Checkout honua-server
         uses: actions/checkout@v7
 
+      - name: Validate matrix and capability classification
+        shell: bash
+        run: bash scripts/ci/test-sdk-server-compatibility.sh
+
       - name: Build matrix from manifest
         id: matrix
         shell: bash
@@ -57,63 +61,9 @@ jobs:
           manifest="$SDK_COMPATIBILITY_MANIFEST"
           server_current_ref="${{ github.event_name == 'workflow_dispatch' && inputs.server_current_ref || '' }}"
           current_only="${{ github.event_name == 'workflow_dispatch' && inputs.current_only || false }}"
-          jq -e '
-            . as $manifest
-            | ($manifest.schemaVersion == 1)
-            and ($manifest.adminApiMajor | type == "string" and length > 0)
-            and ($manifest.matrixDepth == 3)
-            and ($manifest.serverRefs | type == "array" and length == $manifest.matrixDepth)
-            and ($manifest.sdkSetVersions | type == "array" and length == $manifest.matrixDepth)
-            and all($manifest.serverRefs[]; (.label | type == "string" and length > 0) and (.ref | type == "string" and length > 0))
-            and all($manifest.sdkSetVersions[]; (.label | type == "string" and length > 0) and (.refs.js | type == "string" and length > 0) and (.refs.python | type == "string" and length > 0) and (.refs.dotnet | type == "string" and length > 0))
-          ' "$manifest" >/dev/null
-
           matrix="$(
-            jq -c --arg head "$GITHUB_SHA" --arg serverCurrentRef "$server_current_ref" --argjson currentOnly "$current_only" '
-              def serverByLabel($manifest; $name):
-                (
-                  ($manifest.serverRefs[] | select(.label == $name)) // error("Unknown server label: " + $name)
-                )
-                | if .label == "current" and ($serverCurrentRef | length) > 0
-                  then . + { ref: $serverCurrentRef }
-                  else .
-                  end;
-              def sdkByLabel($manifest; $name):
-                ($manifest.sdkSetVersions[] | select(.label == $name)) // error("Unknown SDK set label: " + $name);
-              def checkoutRef($ref):
-                  if $ref == "HEAD" then $head else $ref end;
-              def cell($manifest; $status; $expectedSupported):
-                  . as $cell
-                  | (serverByLabel($manifest; $cell.server)) as $server
-                  | (sdkByLabel($manifest; $cell.sdk)) as $sdk
-                  | {
-                      server_label: $server.label,
-                      server_ref: $server.ref,
-                      server_checkout_ref: checkoutRef($server.ref),
-                      server_channel: $server.channel,
-                      sdk_label: $sdk.label,
-                      sdk_channel: $sdk.channel,
-                      sdk_js_ref: $sdk.refs.js,
-                      sdk_python_ref: $sdk.refs.python,
-                      sdk_dotnet_ref: $sdk.refs.dotnet,
-                      cell_status: $status,
-                      expected_supported: $expectedSupported
-                    };
-              . as $manifest
-              |
-              {
-                include: (
-                  (
-                    (($manifest.matrix.supported // []) | map(cell($manifest; "supported"; true)))
-                    + (($manifest.matrix.evaluation // []) | map(cell($manifest; "evaluation"; false)))
-                  )
-                  | if $currentOnly
-                    then map(select(.server_label == "current" and .sdk_label == "sdk-current"))
-                    else .
-                    end
-                )
-              }
-            ' "$manifest"
+            bash scripts/ci/build-sdk-compatibility-matrix.sh \
+              "$manifest" "$GITHUB_SHA" "$server_current_ref" "$current_only"
           )"
 
           cell_count="$(jq '.include | length' <<<"$matrix")"
@@ -171,6 +121,8 @@ jobs:
           set -euo pipefail
           cp compatibility-source/scripts/ci/run-sdk-server-compatibility.sh "$RUNNER_TEMP/run-sdk-server-compatibility.sh"
           cp compatibility-source/tests/seed/portal-compat.yaml "$RUNNER_TEMP/portal-compat.yaml"
+          cp compatibility-source/tests/dotnet/Honua.Postgres.Tests/Features/Import/Fixtures/GeoServer/CatalogApplySlice.json \
+            "$RUNNER_TEMP/geoserver-catalog-apply-slice.json"
           chmod +x "$RUNNER_TEMP/run-sdk-server-compatibility.sh"
 
       - name: Checkout honua-server target
@@ -287,6 +239,10 @@ jobs:
         shell: bash
         env:
           HONUA_SDK_PORTAL_COMPAT_ENABLED: ${{ matrix.server_label == 'current' && matrix.sdk_label == 'sdk-current' }}
+          HONUA_SDK_MIGRATION_AUTOMATION_REQUIRED: ${{ matrix.migration_automation_required }}
+          HONUA_SDK_COMPAT_SERVER_LABEL: ${{ matrix.server_label }}
+          HONUA_SDK_COMPAT_SDK_LABEL: ${{ matrix.sdk_label }}
+          HONUA_SDK_MIGRATION_GEOSERVER_FIXTURE: ${{ runner.temp }}/geoserver-catalog-apply-slice.json
         run: |
           mkdir -p results
           set +e

--- a/docs/developer/sdk-compatibility-versions.json
+++ b/docs/developer/sdk-compatibility-versions.json
@@ -8,18 +8,21 @@
       "label": "current",
       "ref": "HEAD",
       "channel": "preview",
+      "capabilities": { "migrationAutomation": true },
       "description": "The workflow trigger commit. GitHub Actions resolves this to github.sha before checkout so post-merge runs exercise the just-built server revision."
     },
     {
       "label": "trunk-previous-1",
       "ref": "f04c09c0b33a4986d017ea5e1f8c3f1481034fef",
       "channel": "preview",
+      "capabilities": { "migrationAutomation": false },
       "description": "Previous trunk commit retained until tagged server releases are available."
     },
     {
       "label": "trunk-previous-2",
       "ref": "297936162efab3a0d7cdd7e6e8d0031e018c0ecd",
       "channel": "preview",
+      "capabilities": { "migrationAutomation": false },
       "description": "Second previous trunk commit retained until tagged server releases are available."
     }
   ],
@@ -27,6 +30,7 @@
     {
       "label": "sdk-current",
       "channel": "preview",
+      "capabilities": { "migrationAutomation": true },
       "description": "Current trunk heads for the generated JavaScript/TypeScript, Python, and .NET SDKs.",
       "refs": {
         "js": "trunk",
@@ -37,6 +41,7 @@
     {
       "label": "sdk-previous-1",
       "channel": "preview",
+      "capabilities": { "migrationAutomation": false },
       "description": "Previous SDK set snapshot from each SDK trunk lineage.",
       "refs": {
         "js": "091d4b2b47c69721c5e6f55814fcdc0b05681637",
@@ -47,6 +52,7 @@
     {
       "label": "sdk-previous-2",
       "channel": "preview",
+      "capabilities": { "migrationAutomation": false },
       "description": "Second previous SDK set snapshot from each SDK trunk lineage.",
       "refs": {
         "js": "3416b28b43eddc40bb007c84e6ca9020a7b8b70f",

--- a/scripts/ci/build-sdk-compatibility-matrix.sh
+++ b/scripts/ci/build-sdk-compatibility-matrix.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -lt 2 || "$#" -gt 4 ]]; then
+    echo "Usage: $0 <manifest.json> <head-sha> [server-current-ref] [current-only]" >&2
+    exit 2
+fi
+
+manifest="$1"
+head_sha="$2"
+server_current_ref="${3:-}"
+current_only="${4:-false}"
+
+if [[ "$current_only" != "true" && "$current_only" != "false" ]]; then
+    echo "current-only must be true or false" >&2
+    exit 2
+fi
+
+jq -e '
+  . as $manifest
+  | ($manifest.schemaVersion == 1)
+  and ($manifest.adminApiMajor | type == "string" and length > 0)
+  and ($manifest.matrixDepth == 3)
+  and ($manifest.serverRefs | type == "array" and length == $manifest.matrixDepth)
+  and ($manifest.sdkSetVersions | type == "array" and length == $manifest.matrixDepth)
+  and all($manifest.serverRefs[];
+    (.label | type == "string" and length > 0)
+    and (.ref | type == "string" and length > 0)
+    and (.capabilities.migrationAutomation | type == "boolean"))
+  and all($manifest.sdkSetVersions[];
+    (.label | type == "string" and length > 0)
+    and (.refs.js | type == "string" and length > 0)
+    and (.refs.python | type == "string" and length > 0)
+    and (.refs.dotnet | type == "string" and length > 0)
+    and (.capabilities.migrationAutomation | type == "boolean"))
+' "$manifest" >/dev/null
+
+jq -c \
+  --arg head "$head_sha" \
+  --arg serverCurrentRef "$server_current_ref" \
+  --argjson currentOnly "$current_only" '
+    def serverByLabel($manifest; $name):
+      (($manifest.serverRefs[] | select(.label == $name)) // error("Unknown server label: " + $name))
+      | if .label == "current" and ($serverCurrentRef | length) > 0
+        then . + { ref: $serverCurrentRef }
+        else .
+        end;
+    def sdkByLabel($manifest; $name):
+      ($manifest.sdkSetVersions[] | select(.label == $name)) // error("Unknown SDK set label: " + $name);
+    def checkoutRef($ref):
+      if $ref == "HEAD" then $head else $ref end;
+    def cell($manifest; $status; $expectedSupported):
+      . as $cell
+      | (serverByLabel($manifest; $cell.server)) as $server
+      | (sdkByLabel($manifest; $cell.sdk)) as $sdk
+      | {
+          server_label: $server.label,
+          server_ref: $server.ref,
+          server_checkout_ref: checkoutRef($server.ref),
+          server_channel: $server.channel,
+          sdk_label: $sdk.label,
+          sdk_channel: $sdk.channel,
+          sdk_js_ref: $sdk.refs.js,
+          sdk_python_ref: $sdk.refs.python,
+          sdk_dotnet_ref: $sdk.refs.dotnet,
+          migration_automation_required: (
+            $server.capabilities.migrationAutomation == true
+            and $sdk.capabilities.migrationAutomation == true
+          ),
+          cell_status: $status,
+          expected_supported: $expectedSupported
+        };
+    . as $manifest
+    | {
+        include: (
+          (
+            (($manifest.matrix.supported // []) | map(cell($manifest; "supported"; true)))
+            + (($manifest.matrix.evaluation // []) | map(cell($manifest; "evaluation"; false)))
+          )
+          | if $currentOnly
+            then map(select(.server_label == "current" and .sdk_label == "sdk-current"))
+            else .
+            end
+        )
+      }
+  ' "$manifest"

--- a/scripts/ci/generate-sdk-compatibility-table.sh
+++ b/scripts/ci/generate-sdk-compatibility-table.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <manifest.json> <results-dir> <output-dir>" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+    echo "Usage: $0 <manifest.json> <results-dir> <output-dir> [selected-matrix.json]" >&2
     exit 2
 fi
 
@@ -32,6 +32,18 @@ else
     printf '[]\n' > "$results_json"
 fi
 
+selection_json="$tmp_dir/selection.json"
+if [ "$#" -eq 4 ]; then
+    jq -e '(.include | type == "array")' "$4" >/dev/null
+    jq '.' "$4" > "$selection_json"
+else
+    jq '{include: [
+      .serverRefs[].label as $server
+      | .sdkSetVersions[].label as $sdk
+      | {server_label: $server, sdk_label: $sdk}
+    ]}' "$manifest" > "$selection_json"
+fi
+
 jq -e '
   . as $manifest
   | ($manifest.schemaVersion == 1)
@@ -43,18 +55,22 @@ jq -e '
 jq -n \
   --slurpfile manifest "$manifest" \
   --slurpfile results "$results_json" \
+  --slurpfile selection "$selection_json" \
   'def listed($m; $group; $server; $sdk):
       any($m.matrix[$group][]?; .server == $server and .sdk == $sdk);
-  def status($m; $server; $sdk):
-      if listed($m; "supported"; $server; $sdk) then "supported"
+  def selected($selection; $server; $sdk):
+      any($selection.include[]?; .server_label == $server and .sdk_label == $sdk);
+  def status($m; $selection; $server; $sdk):
+      if (selected($selection; $server; $sdk) | not) then "not-run"
+      elif listed($m; "supported"; $server; $sdk) then "supported"
       elif listed($m; "evaluation"; $server; $sdk) then "evaluation"
       elif listed($m; "unsupported"; $server; $sdk) then "unsupported"
       else "not-tested"
       end;
   def resultFor($results; $server; $sdk):
       [$results[]? | select(.server_label == $server and .sdk_label == $sdk)] | last;
-  def cell($m; $results; $server; $sdk):
-      (status($m; $server; $sdk)) as $status
+  def cell($m; $selection; $results; $server; $sdk):
+      (status($m; $selection; $server; $sdk)) as $status
       | (resultFor($results; $server; $sdk)) as $result
       | {
           server_label: $server,
@@ -66,12 +82,13 @@ jq -n \
         };
   ($manifest[0]) as $m
   | ($results[0]) as $results
+  | ($selection[0]) as $selection
   | [$m.serverRefs[].label] as $servers
   | [$m.sdkSetVersions[].label] as $sdks
   | [
       $servers[] as $server
       | $sdks[] as $sdk
-      | cell($m; $results; $server; $sdk)
+      | cell($m; $selection; $results; $server; $sdk)
     ] as $cells
   | ($cells | map(select(.status == "supported"))) as $supported
   | ($cells | map(select(.status == "evaluation"))) as $evaluation
@@ -100,7 +117,8 @@ cell_text() {
       --arg sdk "$sdk" \
       '.cells[]
         | select(.server_label == $server and .sdk_label == $sdk)
-        | if .status == "not-tested" then "NOT TESTED"
+        | if .status == "not-run" then "NOT RUN"
+          elif .status == "not-tested" then "NOT TESTED"
           elif .status == "unsupported" then "UNSUPPORTED"
           elif .status == "evaluation" and .passed == true then "EVAL PASS"
           elif .status == "evaluation" then "EVAL FAIL"
@@ -134,5 +152,5 @@ cell_text() {
         echo
     done
     echo
-    echo "Legend: PASS = supported cell passed; FAIL = supported cell failed; EVAL PASS/EVAL FAIL = non-blocking evaluation cell; NOT TESTED = absent from the runnable matrix; UNSUPPORTED = intentionally excluded."
+    echo "Legend: PASS = supported cell passed; FAIL = supported cell failed; EVAL PASS/EVAL FAIL = non-blocking evaluation cell; NOT RUN = intentionally excluded from this focused dispatch; NOT TESTED = absent from the runnable matrix; UNSUPPORTED = intentionally excluded."
 } > "$table_path"

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -162,6 +162,7 @@ start_migration_honua_server() {
     HONUA_REGISTER_TEST_INFRASTRUCTURE="true" \
     HONUA_TEST_ALLOW_UNSAFE_GEOSERVER_URLS="true" \
     HONUA_ADMIN_PASSWORD="$ADMIN_API_KEY" \
+    Licensing__DevGrantEdition="Enterprise" \
     Security__ConnectionEncryption__MasterKey="test-master-key-that-is-at-least-32-characters-long-for-security" \
     Security__ConnectionEncryption__Salt="dGVzdC1zYWx0LWZvci1lbmNyeXB0aW9uLXRlc3RpbmctcHVycG9zZXM=" \
     dotnet run --project src/Honua.Server --configuration Release --no-build --no-launch-profile \

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -220,7 +220,7 @@ write_migration_automation_summary() {
       --slurpfile dotnet "$dotnet_surfaces" \
       '{
         migration_automation: {
-          required: false,
+          required: true,
           status: "supported",
           passed: true,
           reason: "Implemented SDK-backed migration smoke surfaces passed; remaining unsupported entries are explicit per-SDK API gaps."

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -23,6 +23,9 @@ MIGRATION_SERVER_BASE_URL="${HONUA_SDK_MIGRATION_SERVER_BASE_URL:-http://localho
 MIGRATION_GEOSERVER_URL="${HONUA_SDK_MIGRATION_GEOSERVER_URL:-http://127.0.0.1:5011/geoserver/rest}"
 MIGRATION_GEOSERVER_FIXTURE="${HONUA_SDK_MIGRATION_GEOSERVER_FIXTURE:-tests/dotnet/Honua.Postgres.Tests/Features/Import/Fixtures/GeoServer/CatalogApplySlice.json}"
 MIGRATION_ARCGIS_SERVICE_URL="${HONUA_SDK_MIGRATION_ARCGIS_SERVICE_URL:-https://sampleserver6.arcgisonline.com/arcgis/rest/services/ServiceRequest/FeatureServer}"
+MIGRATION_AUTOMATION_REQUIRED="${HONUA_SDK_MIGRATION_AUTOMATION_REQUIRED:-true}"
+COMPAT_SERVER_LABEL="${HONUA_SDK_COMPAT_SERVER_LABEL:-unknown-server}"
+COMPAT_SDK_LABEL="${HONUA_SDK_COMPAT_SDK_LABEL:-unknown-sdk}"
 
 cleanup_pids=()
 
@@ -69,9 +72,13 @@ cleanup() {
 trap cleanup EXIT
 
 start_geoserver_fixture() {
-    local fixture_path="$ROOT_DIR/$MIGRATION_GEOSERVER_FIXTURE"
+    local fixture_path="$MIGRATION_GEOSERVER_FIXTURE"
     local fixture_port
     local log_path="$RESULTS_DIR/geoserver-fixture.log"
+
+    if [[ "$fixture_path" != /* ]]; then
+        fixture_path="$ROOT_DIR/$fixture_path"
+    fi
 
     fixture_port="$(url_port "$MIGRATION_GEOSERVER_URL")"
 
@@ -225,18 +232,75 @@ write_migration_automation_summary() {
       }' > "$MIGRATION_EVIDENCE_FILE"
 }
 
+write_migration_automation_not_applicable_summary() {
+    local reason="Migration automation is additive and is not claimed by ${COMPAT_SERVER_LABEL} x ${COMPAT_SDK_LABEL}."
+
+    jq -n --arg reason "$reason" '
+      def surface($name; $ticket):
+        {
+          surface: $name,
+          status: "not-applicable",
+          passed: true,
+          linked_ticket: $ticket,
+          reason: $reason
+        };
+      {
+        migration_automation: {
+          required: false,
+          status: "not-applicable",
+          passed: true,
+          reason: $reason
+        },
+        migration_automation_by_sdk: {
+          js: [
+            surface("migration-scan"; "honua-sdk-js#105"),
+            surface("arcgis-import"; "honua-sdk-js#105"),
+            surface("geoserver-dry-run"; "honua-sdk-js#105"),
+            surface("migration-evidence"; "honua-sdk-js#105")
+          ],
+          python: [
+            surface("migration-scan"; "honua-sdk-python#49"),
+            surface("arcgis-import"; "honua-sdk-python#49"),
+            surface("geoserver-dry-run"; "honua-sdk-python#49"),
+            surface("migration-evidence"; "honua-sdk-python#49")
+          ],
+          dotnet: [
+            surface("migration-scan"; "honua-sdk-dotnet#134"),
+            surface("arcgis-import"; "honua-sdk-dotnet#134"),
+            surface("geoserver-dry-run"; "honua-sdk-dotnet#134"),
+            surface("migration-evidence"; "honua-sdk-dotnet#134")
+          ]
+        }
+      }
+    ' > "$MIGRATION_EVIDENCE_FILE"
+}
+
 mkdir -p \
     "$RESULTS_DIR" \
     "$JS_MIGRATION_RESULTS_DIR" \
     "$PYTHON_MIGRATION_RESULTS_DIR" \
     "$DOTNET_MIGRATION_RESULTS_DIR"
 
+if [[ "${SDK_COMPATIBILITY_CLASSIFY_ONLY:-false}" == "true" ]]; then
+    if [[ "$MIGRATION_AUTOMATION_REQUIRED" == "true" ]]; then
+        echo "Current capability cells must execute migration automation; classify-only is invalid." >&2
+        exit 3
+    fi
+    write_migration_automation_not_applicable_summary
+    exit 0
+fi
+
 section "Honua Server readiness"
 curl -fsS "$BASE_URL/healthz/ready" >/dev/null
 
 section "SDK migration fixture readiness"
-start_geoserver_fixture
-start_migration_honua_server
+if [[ "$MIGRATION_AUTOMATION_REQUIRED" == "true" ]]; then
+    start_geoserver_fixture
+    start_migration_honua_server
+else
+    write_migration_automation_not_applicable_summary
+    printf 'Migration automation not applicable for %s x %s.\n' "$COMPAT_SERVER_LABEL" "$COMPAT_SDK_LABEL"
+fi
 
 section "JavaScript SDK live compatibility"
 require_dir "$JS_DIR" "honua-sdk-js"
@@ -252,6 +316,7 @@ require_dir "$JS_DIR" "honua-sdk-js"
     HONUA_SDK_MIGRATION_GEOSERVER_URL="$MIGRATION_GEOSERVER_URL" \
     HONUA_SDK_MIGRATION_ARCGIS_SERVICE_URL="$MIGRATION_ARCGIS_SERVICE_URL" \
     HONUA_SDK_MIGRATION_JS_RESULTS_DIR="$JS_MIGRATION_RESULTS_DIR" \
+    HONUA_SDK_MIGRATION_AUTOMATION_REQUIRED="$MIGRATION_AUTOMATION_REQUIRED" \
     HONUA_SDK_PORTAL_COMPAT_ENABLED="$PORTAL_COMPAT_ENABLED" \
     HONUA_SDK_PORTAL_USERNAME="$PORTAL_USERNAME" \
     HONUA_SDK_PORTAL_PASSWORD="$PORTAL_PASSWORD" \
@@ -268,6 +333,7 @@ const migrationBaseUrl = process.env.HONUA_SDK_MIGRATION_SERVER_BASE_URL;
 const migrationGeoServerUrl = process.env.HONUA_SDK_MIGRATION_GEOSERVER_URL;
 const migrationArcGisServiceUrl = process.env.HONUA_SDK_MIGRATION_ARCGIS_SERVICE_URL;
 const migrationResultsDir = process.env.HONUA_SDK_MIGRATION_JS_RESULTS_DIR;
+const migrationAutomationRequired = process.env.HONUA_SDK_MIGRATION_AUTOMATION_REQUIRED === "true";
 const portalCompatEnabled = process.env.HONUA_SDK_PORTAL_COMPAT_ENABLED === "true";
 const portalUsername = process.env.HONUA_SDK_PORTAL_USERNAME;
 const portalPassword = process.env.HONUA_SDK_PORTAL_PASSWORD;
@@ -352,6 +418,11 @@ if (portalCompatEnabled) {
   }
 
   console.log("JS SDK PortalCompat generateToken -> search -> openFeatureLayer compatibility passed.");
+}
+
+if (!migrationAutomationRequired) {
+  console.log(`JS SDK core compatibility passed for server ${compatibility.serverVersion}; migration automation is not applicable.`);
+  process.exit(0);
 }
 
 const migrationClient = new HonuaClient({ baseUrl: migrationBaseUrl, apiKey, timeoutMs: 120_000 });
@@ -614,14 +685,18 @@ require_dir "$DOTNET_DIR" "honua-sdk-dotnet"
     dotnet add "$smoke_project" reference "$dotnet_admin_project" >/dev/null
     cat > "$smoke_dir/Program.cs" <<'CS'
 using Honua.Sdk.Admin;
+#if MIGRATION_AUTOMATION
 using Honua.Sdk.Admin.Models;
 using System.Text.Json;
+#endif
 
 var baseUrl = Environment.GetEnvironmentVariable("HONUA_SERVER_BASE_URL") ?? "http://localhost:5000";
 var apiKey = Environment.GetEnvironmentVariable("HONUA_ADMIN_API_KEY") ?? "ci-admin-password";
+#if MIGRATION_AUTOMATION
 var migrationBaseUrl = Environment.GetEnvironmentVariable("HONUA_SDK_MIGRATION_SERVER_BASE_URL") ?? baseUrl;
 var migrationGeoServerUrl = Environment.GetEnvironmentVariable("HONUA_SDK_MIGRATION_GEOSERVER_URL") ?? "http://127.0.0.1:5011/geoserver/rest";
 var migrationResultsDir = Environment.GetEnvironmentVariable("HONUA_SDK_MIGRATION_DOTNET_RESULTS_DIR");
+#endif
 
 using var httpClient = new HttpClient { BaseAddress = new Uri(baseUrl) };
 httpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-API-Key", apiKey);
@@ -645,6 +720,7 @@ if (!compatibility.IsSupported)
     throw new InvalidOperationException($".NET SDK rejected the seeded server: {compatibility.UnsupportedReason}");
 }
 
+#if MIGRATION_AUTOMATION
 if (!string.IsNullOrWhiteSpace(migrationResultsDir))
 {
     Directory.CreateDirectory(migrationResultsDir);
@@ -672,6 +748,7 @@ if (!string.IsNullOrWhiteSpace(migrationResultsDir))
         Path.Combine(migrationResultsDir, "migration-scan.json"),
         JsonSerializer.Serialize(scan, jsonOptions) + Environment.NewLine);
 }
+#endif
 
 Console.WriteLine($".NET SDK compatibility passed for server {capabilities.ServerVersion}.");
 CS
@@ -681,8 +758,12 @@ CS
         -p:WarningsAsErrors=
         -p:CodeAnalysisTreatWarningsAsErrors=false
     )
+    if [[ "$MIGRATION_AUTOMATION_REQUIRED" == "true" ]]; then
+        dotnet_msbuild_props+=("-p:DefineConstants=MIGRATION_AUTOMATION")
+    fi
     HONUA_SERVER_BASE_URL="$BASE_URL" \
     HONUA_ADMIN_API_KEY="$ADMIN_API_KEY" \
+    HONUA_SDK_MIGRATION_AUTOMATION_REQUIRED="$MIGRATION_AUTOMATION_REQUIRED" \
     dotnet build "$smoke_project" --configuration Release "${dotnet_msbuild_props[@]}" >/dev/null
     HONUA_SERVER_BASE_URL="$BASE_URL" \
     HONUA_ADMIN_API_KEY="$ADMIN_API_KEY" \
@@ -693,11 +774,19 @@ CS
 )
 
 section "SDK migration automation evidence"
-write_migration_automation_summary
-jq -e '
-  .migration_automation.status == "supported"
-  and (.migration_automation_by_sdk.js | map(select(.status == "supported")) | length == 4)
-  and (.migration_automation_by_sdk.dotnet | map(select(.surface == "migration-scan" and .status == "supported")) | length == 1)
-' "$MIGRATION_EVIDENCE_FILE" >/dev/null
+if [[ "$MIGRATION_AUTOMATION_REQUIRED" == "true" ]]; then
+    write_migration_automation_summary
+    jq -e '
+      .migration_automation.status == "supported"
+      and (.migration_automation_by_sdk.js | map(select(.status == "supported")) | length == 4)
+      and (.migration_automation_by_sdk.dotnet | map(select(.surface == "migration-scan" and .status == "supported")) | length == 1)
+    ' "$MIGRATION_EVIDENCE_FILE" >/dev/null
+else
+    jq -e '
+      .migration_automation.status == "not-applicable"
+      and .migration_automation.passed == true
+      and all(.migration_automation_by_sdk[][]; .status == "not-applicable" and .passed == true)
+    ' "$MIGRATION_EVIDENCE_FILE" >/dev/null
+fi
 
 section "SDK compatibility complete"

--- a/scripts/ci/run-sdk-server-compatibility.sh
+++ b/scripts/ci/run-sdk-server-compatibility.sh
@@ -429,16 +429,17 @@ if (!migrationAutomationRequired) {
 const migrationClient = new HonuaClient({ baseUrl: migrationBaseUrl, apiKey, timeoutMs: 120_000 });
 await mkdir(migrationResultsDir, { recursive: true });
 
-const terminalStatusNames = new Set(["Completed", "Failed", "Cancelled"]);
+const terminalStatusNames = new Set(["Completed", "NeedsReview", "Failed", "Cancelled"]);
 const geoServerStatusNames = {
   7: "Completed",
   8: "Failed",
   9: "Cancelled",
 };
 const geoServicesStatusNames = {
-  6: "Completed",
-  7: "Failed",
-  8: "Cancelled",
+  8: "Completed",
+  9: "NeedsReview",
+  10: "Failed",
+  11: "Cancelled",
 };
 
 function assertArtifact(value, kind, label) {

--- a/scripts/ci/test-sdk-server-compatibility.sh
+++ b/scripts/ci/test-sdk-server-compatibility.sh
@@ -6,6 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MANIFEST="$ROOT_DIR/docs/developer/sdk-compatibility-versions.json"
 MATRIX_BUILDER="$ROOT_DIR/scripts/ci/build-sdk-compatibility-matrix.sh"
 RUNNER="$ROOT_DIR/scripts/ci/run-sdk-server-compatibility.sh"
+REPORTER="$ROOT_DIR/scripts/ci/generate-sdk-compatibility-table.sh"
 WORKFLOW="$ROOT_DIR/.github/workflows/sdk-server-compatibility.yml"
 HEAD_SHA="1111111111111111111111111111111111111111"
 TMP_DIR="$(mktemp -d)"
@@ -39,6 +40,36 @@ jq -e --arg override "$override_sha" '
   and .include[0].server_checkout_ref == $override
   and .include[0].migration_automation_required == true
 ' <<<"$current_matrix" >/dev/null || fail "current_only must retain one strict current x current cell"
+
+printf '%s\n' "$current_matrix" > "$TMP_DIR/current-matrix.json"
+mkdir -p "$TMP_DIR/current-results/cell"
+jq -n '{
+  server_label: "current",
+  sdk_label: "sdk-current",
+  passed: true,
+  exit_code: 0
+}' > "$TMP_DIR/current-results/cell/compat-result.json"
+bash "$REPORTER" "$MANIFEST" "$TMP_DIR/current-results" "$TMP_DIR/current-report" "$TMP_DIR/current-matrix.json"
+jq -e '
+  .total_cells == 1
+  and .supported_cells == 1
+  and .passed == true
+  and (.regressions | length) == 0
+  and ([.cells[] | select(.status == "not-run")] | length) == 8
+' "$TMP_DIR/current-report/sdk-compatibility-summary.json" >/dev/null \
+  || fail "current_only report must evaluate only the selected cell"
+grep -Fq '| `current` | PASS | NOT RUN | NOT RUN |' "$TMP_DIR/current-report/sdk-compatibility-matrix.md" \
+  || fail "current_only table must distinguish intentionally unrun cells"
+
+bash "$REPORTER" "$MANIFEST" "$TMP_DIR/empty-results" "$TMP_DIR/full-report"
+jq -e '
+  .total_cells == 9
+  and .supported_cells == 9
+  and .passed == false
+  and (.regressions | length) == 9
+  and ([.cells[] | select(.status == "not-run")] | length) == 0
+' "$TMP_DIR/full-report/sdk-compatibility-summary.json" >/dev/null \
+  || fail "full report must retain complete 3x3 enforcement"
 
 historical_results="$TMP_DIR/historical-results"
 SDK_COMPATIBILITY_CLASSIFY_ONLY=true \

--- a/scripts/ci/test-sdk-server-compatibility.sh
+++ b/scripts/ci/test-sdk-server-compatibility.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="$ROOT_DIR/docs/developer/sdk-compatibility-versions.json"
+MATRIX_BUILDER="$ROOT_DIR/scripts/ci/build-sdk-compatibility-matrix.sh"
+RUNNER="$ROOT_DIR/scripts/ci/run-sdk-server-compatibility.sh"
+WORKFLOW="$ROOT_DIR/.github/workflows/sdk-server-compatibility.yml"
+HEAD_SHA="1111111111111111111111111111111111111111"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "sdk compatibility test failed: $*" >&2
+    exit 1
+}
+
+full_matrix="$(bash "$MATRIX_BUILDER" "$MANIFEST" "$HEAD_SHA" "" false)"
+jq -e '
+  (.include | length) == 9
+  and ([.include[] | select(.migration_automation_required == true)] | length) == 1
+  and any(.include[];
+    .server_label == "current"
+    and .sdk_label == "sdk-previous-1"
+    and .migration_automation_required == false)
+  and any(.include[];
+    .server_label == "trunk-previous-1"
+    and .sdk_label == "sdk-current"
+    and .migration_automation_required == false)
+' <<<"$full_matrix" >/dev/null || fail "full matrix capability classification is not truthful"
+
+override_sha="2222222222222222222222222222222222222222"
+current_matrix="$(bash "$MATRIX_BUILDER" "$MANIFEST" "$HEAD_SHA" "$override_sha" true)"
+jq -e --arg override "$override_sha" '
+  (.include | length) == 1
+  and .include[0].server_label == "current"
+  and .include[0].sdk_label == "sdk-current"
+  and .include[0].server_checkout_ref == $override
+  and .include[0].migration_automation_required == true
+' <<<"$current_matrix" >/dev/null || fail "current_only must retain one strict current x current cell"
+
+historical_results="$TMP_DIR/historical-results"
+SDK_COMPATIBILITY_CLASSIFY_ONLY=true \
+HONUA_SDK_MIGRATION_AUTOMATION_REQUIRED=false \
+HONUA_SDK_COMPAT_SERVER_LABEL=trunk-previous-1 \
+HONUA_SDK_COMPAT_SDK_LABEL=sdk-previous-1 \
+SDK_COMPATIBILITY_RESULTS_DIR="$historical_results" \
+bash "$RUNNER"
+
+jq -e '
+  .migration_automation.required == false
+  and .migration_automation.status == "not-applicable"
+  and .migration_automation.passed == true
+  and all(.migration_automation_by_sdk[][]; .status == "not-applicable" and .passed == true)
+' "$historical_results/migration-automation.json" >/dev/null \
+  || fail "historical runner evidence must record additive migration surfaces as not applicable"
+
+if SDK_COMPATIBILITY_CLASSIFY_ONLY=true \
+    HONUA_SDK_MIGRATION_AUTOMATION_REQUIRED=true \
+    SDK_COMPATIBILITY_RESULTS_DIR="$TMP_DIR/current-results" \
+    bash "$RUNNER" >/dev/null 2>&1; then
+    fail "current capability cell must not pass through classify-only"
+fi
+
+grep -Fq 'compatibility-source/tests/dotnet/Honua.Postgres.Tests/Features/Import/Fixtures/GeoServer/CatalogApplySlice.json' "$WORKFLOW" \
+  || fail "workflow must source the GeoServer fixture from the compatibility checkout"
+grep -Fq 'HONUA_SDK_MIGRATION_GEOSERVER_FIXTURE: ${{ runner.temp }}/geoserver-catalog-apply-slice.json' "$WORKFLOW" \
+  || fail "workflow must pass the preserved fixture to historical server checkouts"
+
+echo "SDK compatibility matrix and runner tests passed."

--- a/scripts/ci/test-sdk-server-compatibility.sh
+++ b/scripts/ci/test-sdk-server-compatibility.sh
@@ -106,5 +106,8 @@ grep -Fq '9: "NeedsReview"' "$RUNNER" \
   || fail "the ArcGIS import harness must treat operator review as a terminal non-success status"
 grep -Fq '11: "Cancelled"' "$RUNNER" \
   || fail "the ArcGIS import harness must recognize the current cancelled status"
+sed -n '/^write_migration_automation_summary()/,/^write_migration_automation_not_applicable_summary()/p' "$RUNNER" \
+  | grep -Fq 'required: true' \
+  || fail "strict current capability evidence must record migration automation as required"
 
 echo "SDK compatibility matrix and runner tests passed."

--- a/scripts/ci/test-sdk-server-compatibility.sh
+++ b/scripts/ci/test-sdk-server-compatibility.sh
@@ -69,5 +69,11 @@ grep -Fq 'HONUA_SDK_MIGRATION_GEOSERVER_FIXTURE: ${{ runner.temp }}/geoserver-ca
   || fail "workflow must pass the preserved fixture to historical server checkouts"
 grep -Fq 'Licensing__DevGrantEdition="Enterprise"' "$RUNNER" \
   || fail "the strict migration harness must grant the Enterprise entitlement it exercises"
+grep -Fq '8: "Completed"' "$RUNNER" \
+  || fail "the ArcGIS import harness must recognize the current completed status"
+grep -Fq '9: "NeedsReview"' "$RUNNER" \
+  || fail "the ArcGIS import harness must treat operator review as a terminal non-success status"
+grep -Fq '11: "Cancelled"' "$RUNNER" \
+  || fail "the ArcGIS import harness must recognize the current cancelled status"
 
 echo "SDK compatibility matrix and runner tests passed."

--- a/scripts/ci/test-sdk-server-compatibility.sh
+++ b/scripts/ci/test-sdk-server-compatibility.sh
@@ -67,5 +67,7 @@ grep -Fq 'compatibility-source/tests/dotnet/Honua.Postgres.Tests/Features/Import
   || fail "workflow must source the GeoServer fixture from the compatibility checkout"
 grep -Fq 'HONUA_SDK_MIGRATION_GEOSERVER_FIXTURE: ${{ runner.temp }}/geoserver-catalog-apply-slice.json' "$WORKFLOW" \
   || fail "workflow must pass the preserved fixture to historical server checkouts"
+grep -Fq 'Licensing__DevGrantEdition="Enterprise"' "$RUNNER" \
+  || fail "the strict migration harness must grant the Enterprise entitlement it exercises"
 
 echo "SDK compatibility matrix and runner tests passed."


### PR DESCRIPTION
## Issue Link
Fixes #2669
Related to #2614

## Summary
Makes the 3x3 SDK/server compatibility matrix truthful about additive migration automation. Historical generations continue to gate the core compatibility surfaces they actually claim, while migration surfaces that did not exist in those generations are recorded as not applicable instead of creating structural red cells.

Focused `current_only` dispatches now evaluate and publish only the selected current x current cell. Scheduled and unfiltered runs retain full 3x3 enforcement.

## Changes Made
- Add per-generation `migrationAutomation` capability metadata to the canonical compatibility manifest.
- Extract matrix construction into a tested script that preserves all nine cells, full-SHA overrides, and the one-cell `current_only` path.
- Run the additive migration harness only when both selected generations claim it; keep current x current strict and label its evidence as required.
- Emit explicit per-SDK `not-applicable` migration evidence for historical cells while retaining core JS/Python/.NET failures as supported-cell regressions.
- Compile migration-only .NET types behind a current-cell define and short-circuit new JS migration APIs only for historical cells.
- Preserve the GeoServer fixture from the compatibility workflow checkout so historical server checkouts do not need current harness assets.
- Provision the Enterprise development grant required by the migration smoke server.
- Track current ArcGIS import terminal statuses, including `NeedsReview`, without weakening success assertions.
- Scope focused compatibility reports to the selected matrix cells and render excluded cells as `NOT RUN`; preserve complete 3x3 report enforcement for full runs.
- Add matrix, runner, status-map, and report regression tests, executed by the loader before any expensive cell starts.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation:
- `bash scripts/ci/test-sdk-server-compatibility.sh`
- `bash -n` for matrix builder, runner, reporter, and tests
- Workflow YAML parse
- Manifest JSON parse
- `git diff --check`
- Focused post-rebase proof: [SDK Server Compatibility run 29139111697](https://github.com/honua-io/honua-server/actions/runs/29139111697)
  - loader and capability classification: passed
  - current x current supported cell: passed
  - strict JS/.NET migration automation evidence: passed
  - scoped compatibility publisher and regression gate: passed
  - intentionally did not dispatch the other eight cells

## Gate Impact
- [ ] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [x] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

Coordination is evidence-only: historical SDK refs are classified from server-owned manifest metadata; no SDK code release is required.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent CI-only affected-scope validation is recorded above. No runtime protocol, auth, admin API, or gRPC contract changed.
