### PR TITLE
feat: add guarded alert channel isolation (#2679)

### DIFF
--- a/docs/guides/operate/README.md
+++ b/docs/guides/operate/README.md
@@ -102,7 +102,7 @@ Current rung by concern:
 | Aggregate operating posture | L0 | `GET /api/v1/operate/status` gives one server verdict and drill-down sources. |
 | Ops health history and cluster aggregation | L0 | `GET /api/v1/admin/observability/ops-health/history` stores bounded rollups for reconnect gap-fill and trend views. |
 | Alert dispatch dead letters | L3 (opt-in) | The `alert-dispatch-backlog` rule can auto-apply `alerts.redrive_dead_letters`; integration proof covers convergence, durable audit/outcome evidence, and the kill switch stopping the next evaluation. The default remains L2/ProposeOnly. |
-| Alert channel pause/resume | L2 foundation | The action fabric registers pause/resume actuators; automated channel selection remains a policy/finding concern. |
+| Alert channel pause/resume | L2 | Privacy-safe per-channel backlog health identifies a failing channel and offers a scoped `alerts.pause_channel` proposal. Pause remains approval-gated and non-auto-safe because it suppresses delivery; healthy channels continue dispatching. |
 | Database bounded-admission pressure | L2 where supported | The Postgres runtime-tunable admission gate can be lowered through a proposed `db.tune_bounded_admission` action when headroom exists. |
 | Deploy stuck in manual intervention | L2 when a prior revision is known | The finding can propose a rollback Deploy operation only when the previous revision is recorded. |
 | Platform release runtime divergence | L2 | For unpinned divergent serving targets, the finding proposes a Deploy operation to the declared platform release artifact. |

--- a/src/Honua.Core/Features/Alerts/Domain/AlertModels.cs
+++ b/src/Honua.Core/Features/Alerts/Domain/AlertModels.cs
@@ -538,6 +538,38 @@ public sealed record AlertDispatchBacklog
     /// Number of dispatch rows currently in the dead-letter state.
     /// </summary>
     public required long DeadLetteredCount { get; init; }
+
+    /// <summary>
+    /// Active dispatch rows grouped by their stable channel type. Delivered rows and
+    /// destination details are intentionally excluded from this operational projection.
+    /// </summary>
+    public IReadOnlyList<AlertDispatchChannelBacklog> Channels { get; init; } = [];
+}
+
+/// <summary>
+/// Privacy-safe active alert-dispatch health for one configured channel. This model
+/// contains only bounded channel identifiers, counts, and timestamps; it never exposes
+/// destinations, payloads, errors, credentials, or secret references.
+/// </summary>
+public sealed record AlertDispatchChannelBacklog
+{
+    /// <summary>Gets the stable alert delivery channel type.</summary>
+    public required AlertChannelType ChannelType { get; init; }
+
+    /// <summary>Gets a value indicating whether delivery claims are paused for this channel.</summary>
+    public required bool IsPaused { get; init; }
+
+    /// <summary>Gets rows that are pending or currently being processed.</summary>
+    public required long PendingCount { get; init; }
+
+    /// <summary>Gets failed rows scheduled for a bounded retry.</summary>
+    public required long RetryingCount { get; init; }
+
+    /// <summary>Gets rows that exhausted their retry budget.</summary>
+    public required long DeadLetteredCount { get; init; }
+
+    /// <summary>Gets the creation time of the oldest non-delivered row for this channel.</summary>
+    public required DateTimeOffset OldestItemAt { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Alerts/Domain/AlertModels.cs
+++ b/src/Honua.Core/Features/Alerts/Domain/AlertModels.cs
@@ -539,6 +539,12 @@ public sealed record AlertDispatchBacklog
     /// </summary>
     public required long DeadLetteredCount { get; init; }
 
+    /// <summary>Number of failed dispatch rows scheduled for a bounded retry.</summary>
+    public long RetryingCount { get; init; }
+
+    /// <summary>Creation time of the oldest non-delivered dispatch row, when any exist.</summary>
+    public DateTimeOffset? OldestItemAt { get; init; }
+
     /// <summary>
     /// Active dispatch rows grouped by their stable channel type. Delivered rows and
     /// destination details are intentionally excluded from this operational projection.

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
@@ -229,18 +229,10 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
 
     public async Task<AlertDispatchBacklog> GetBacklogAsync(CancellationToken cancellationToken = default)
     {
-        // Pending backlog = rows awaiting delivery: pending (0), in-flight/claimed (1),
-        // and retriable-failed (3). Dead-lettered (4) rows are counted separately.
-        // The `status <> 2` predicate lets the planner serve the count from the
-        // partial ix_alert_dispatch_active index and skip delivered rows entirely,
-        // so this stays cheap even before retention has purged old delivered rows.
+        // One grouped scan supplies both the per-channel projection and the aggregate
+        // totals folded below. The `status <> 2` predicate lets the planner use the
+        // partial active index and skip delivered rows entirely.
         const string sql = """
-            SELECT
-                COUNT(*) FILTER (WHERE status IN (0, 1, 3)) AS pending,
-                COUNT(*) FILTER (WHERE status = 4) AS dead_lettered
-            FROM honua.alert_dispatch
-            WHERE status <> 2;
-
             SELECT
                 d.channel_type,
                 COALESCE(s.is_paused, false) AS is_paused,
@@ -259,34 +251,26 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
         await using var command = new NpgsqlCommand(sql, connection);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            return new AlertDispatchBacklog { PendingCount = 0, DeadLetteredCount = 0 };
-        }
-
-        var pendingCount = reader.IsDBNull(0) ? 0 : reader.GetInt64(0);
-        var deadLetteredCount = reader.IsDBNull(1) ? 0 : reader.GetInt64(1);
         var channels = new List<AlertDispatchChannelBacklog>();
-        if (await reader.NextResultAsync(cancellationToken).ConfigureAwait(false))
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            channels.Add(new AlertDispatchChannelBacklog
             {
-                channels.Add(new AlertDispatchChannelBacklog
-                {
-                    ChannelType = AlertStoreConversions.ToChannelType(reader.GetInt16(0)),
-                    IsPaused = reader.GetBoolean(1),
-                    PendingCount = reader.GetInt64(2),
-                    RetryingCount = reader.GetInt64(3),
-                    DeadLetteredCount = reader.GetInt64(4),
-                    OldestItemAt = reader.GetFieldValue<DateTimeOffset>(5),
-                });
-            }
+                ChannelType = AlertStoreConversions.ToChannelType(reader.GetInt16(0)),
+                IsPaused = reader.GetBoolean(1),
+                PendingCount = reader.GetInt64(2),
+                RetryingCount = reader.GetInt64(3),
+                DeadLetteredCount = reader.GetInt64(4),
+                OldestItemAt = reader.GetFieldValue<DateTimeOffset>(5),
+            });
         }
 
         return new AlertDispatchBacklog
         {
-            PendingCount = pendingCount,
-            DeadLetteredCount = deadLetteredCount,
+            PendingCount = channels.Sum(static channel => channel.PendingCount + channel.RetryingCount),
+            RetryingCount = channels.Sum(static channel => channel.RetryingCount),
+            DeadLetteredCount = channels.Sum(static channel => channel.DeadLetteredCount),
+            OldestItemAt = channels.Count == 0 ? null : channels.Min(static channel => channel.OldestItemAt),
             Channels = channels,
         };
     }

--- a/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
+++ b/src/Honua.Postgres/Features/Alerts/PostgresAlertDispatchStore.cs
@@ -239,7 +239,20 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
                 COUNT(*) FILTER (WHERE status IN (0, 1, 3)) AS pending,
                 COUNT(*) FILTER (WHERE status = 4) AS dead_lettered
             FROM honua.alert_dispatch
-            WHERE status <> 2
+            WHERE status <> 2;
+
+            SELECT
+                d.channel_type,
+                COALESCE(s.is_paused, false) AS is_paused,
+                COUNT(*) FILTER (WHERE d.status IN (0, 1)) AS pending,
+                COUNT(*) FILTER (WHERE d.status = 3) AS retrying,
+                COUNT(*) FILTER (WHERE d.status = 4) AS dead_lettered,
+                MIN(d.created_at) AS oldest_item_at
+            FROM honua.alert_dispatch d
+            LEFT JOIN honua.alert_channel_state s ON s.channel_type = d.channel_type
+            WHERE d.status <> 2
+            GROUP BY d.channel_type, s.is_paused
+            ORDER BY d.channel_type
             """;
 
         await using var connection = await _connectionProvider.OpenNpgsqlConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -251,10 +264,30 @@ internal sealed class PostgresAlertDispatchStore : IAlertDispatchStore
             return new AlertDispatchBacklog { PendingCount = 0, DeadLetteredCount = 0 };
         }
 
+        var pendingCount = reader.IsDBNull(0) ? 0 : reader.GetInt64(0);
+        var deadLetteredCount = reader.IsDBNull(1) ? 0 : reader.GetInt64(1);
+        var channels = new List<AlertDispatchChannelBacklog>();
+        if (await reader.NextResultAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                channels.Add(new AlertDispatchChannelBacklog
+                {
+                    ChannelType = AlertStoreConversions.ToChannelType(reader.GetInt16(0)),
+                    IsPaused = reader.GetBoolean(1),
+                    PendingCount = reader.GetInt64(2),
+                    RetryingCount = reader.GetInt64(3),
+                    DeadLetteredCount = reader.GetInt64(4),
+                    OldestItemAt = reader.GetFieldValue<DateTimeOffset>(5),
+                });
+            }
+        }
+
         return new AlertDispatchBacklog
         {
-            PendingCount = reader.IsDBNull(0) ? 0 : reader.GetInt64(0),
-            DeadLetteredCount = reader.IsDBNull(1) ? 0 : reader.GetInt64(1)
+            PendingCount = pendingCount,
+            DeadLetteredCount = deadLetteredCount,
+            Channels = channels,
         };
     }
 

--- a/src/Honua.Server/Features/ControlPlane/Executors/OpsActionModel.cs
+++ b/src/Honua.Server/Features/ControlPlane/Executors/OpsActionModel.cs
@@ -244,6 +244,11 @@ internal static class OpsActionExecutionPayloads
     public static string RedriveDeadLetters(int? maxCount = null)
         => Build(OpsActionNames.RedriveDeadLetters, target: null, maxCount: maxCount, limit: null, channel: null);
 
+    /// <summary>Builds the approval-gated payload for <see cref="OpsActionNames.PauseChannel"/>.</summary>
+    /// <param name="channel">Canonical external channel name.</param>
+    public static string PauseChannel(string channel)
+        => Build(OpsActionNames.PauseChannel, target: channel, maxCount: null, limit: null, channel: channel);
+
     /// <summary>Builds the payload for <see cref="OpsActionNames.TuneBoundedAdmission"/>.</summary>
     /// <param name="limit">The requested admission target.</param>
     public static string TuneBoundedAdmission(int limit)

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsFindingsService.cs
@@ -4,6 +4,7 @@
 using Honua.Alerts;
 using Honua.ControlPlane;
 using Honua.ControlPlane.Executors;
+using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.ControlPlane.Domain;
 using Honua.Core.Features.Guardrails.Domain;
@@ -25,6 +26,7 @@ internal sealed class OpsFindingsService : IOpsFindingsService
     internal const string RequestedByAgent = "ops-findings";
 
     internal const string RuleAlertDispatchBacklog = "alert-dispatch-backlog";
+    internal const string RuleAlertDispatchChannelFailure = "alert-dispatch-channel-failure";
     internal const string RulePlatformReleaseSkew = "platform-release-skew";
     internal const string RulePendingContractMigrations = "pending-contract-migrations";
     internal const string RuleGpQueueDepth = "gp-queue-depth";
@@ -83,6 +85,7 @@ internal sealed class OpsFindingsService : IOpsFindingsService
         var findings = new List<OpsFinding>();
 
         EvaluateAlertDispatchBacklog(now, options, findings);
+        EvaluateAlertDispatchChannelFailures(now, options, findings);
         EvaluateLocalBackendSubstrate(now, findings);
         EvaluatePlatformReleaseSkew(now, findings);
         EvaluateDbBoundedAdmissionPressure(now, options, findings);
@@ -215,7 +218,7 @@ internal sealed class OpsFindingsService : IOpsFindingsService
                 AutoSafe = true,
                 BlastRadius = backlog.DeadLetteredCount > int.MaxValue ? int.MaxValue : (int)Math.Max(1, backlog.DeadLetteredCount),
             };
-            explanation = $"The alert dispatcher has {backlog.DeadLetteredCount} dead-lettered notification(s) that exhausted retries and require operator triage (pending backlog {backlog.PendingCount}). Redriving re-enqueues them for redelivery; if the underlying channel is unhealthy the same rows will dead-letter again, and repeated storms should be triaged by pausing the affected channel directly (no per-channel breakdown is available from this signal to safely automate that step yet).";
+            explanation = $"The alert dispatcher has {backlog.DeadLetteredCount} dead-lettered notification(s) that exhausted retries and require operator triage (pending backlog {backlog.PendingCount}). Redriving re-enqueues them for redelivery; channel-attributed failures also produce a scoped isolation finding whose pause action remains approval-gated.";
         }
         else
         {
@@ -234,6 +237,66 @@ internal sealed class OpsFindingsService : IOpsFindingsService
             EvidenceRefs = ["healthcheck:alert-dispatch", "GET /monitoring/health/comprehensive"],
             RecommendedAction = action,
         });
+    }
+
+    // Channel-scoped isolation stays deliberately approval-only. Dead-letter attribution is a
+    // deterministic signal for the affected channel, but pausing delivery can suppress alerts and
+    // therefore must never inherit the redrive action's autonomous safety classification.
+    private void EvaluateAlertDispatchChannelFailures(
+        DateTimeOffset now,
+        OpsFindingsOptions options,
+        List<OpsFinding> findings)
+    {
+        if (!_alertHealth.IsDispatcherEnabled || _alertHealth.LastBacklog is not { } backlog)
+        {
+            return;
+        }
+
+        foreach (var channel in backlog.Channels
+                     .Where(channel => channel.DeadLetteredCount >= options.AlertDispatchDeadLetterThreshold)
+                     .OrderBy(channel => channel.ChannelType))
+        {
+            var channelName = channel.ChannelType.ToExternalName();
+            var subject = new OpsFindingSubject { Channel = channelName };
+            var boundedActiveCount = Math.Min(channel.PendingCount, int.MaxValue)
+                + Math.Min(channel.RetryingCount, int.MaxValue)
+                + Math.Min(channel.DeadLetteredCount, int.MaxValue);
+            OpsFindingRecommendedAction? action = null;
+            if (!channel.IsPaused)
+            {
+                action = new OpsFindingRecommendedAction
+                {
+                    Kind = OperationClass.AdminConfigChange,
+                    ActionDiscriminator = OpsActionNames.PauseChannel,
+                    Summary = $"Pause the failing {channelName} alert channel while delivery is investigated.",
+                    ExecutionPayload = OpsActionExecutionPayloads.PauseChannel(channelName),
+                    Reason = $"The {channelName} channel has {channel.DeadLetteredCount} dead-lettered notification(s).",
+                    AutoSafe = false,
+                    BlastRadius = (int)Math.Clamp(boundedActiveCount, 1, int.MaxValue),
+                };
+            }
+
+            var pauseState = channel.IsPaused
+                ? "The channel is already paused, so no additional action is proposed."
+                : "Pausing is approval-gated because it suppresses delivery; healthy channels remain active.";
+            findings.Add(new OpsFinding
+            {
+                Id = OpsFindingId.Create(RuleAlertDispatchChannelFailure, subject),
+                Rule = RuleAlertDispatchChannelFailure,
+                Severity = OpsFindingSeverity.Critical,
+                Title = $"Alert delivery is failing on {channelName}",
+                Explanation = $"The {channelName} channel has {channel.DeadLetteredCount} dead-lettered, "
+                    + $"{channel.RetryingCount} retrying, and {channel.PendingCount} pending notification(s). {pauseState}",
+                DetectedAt = now,
+                Subject = subject,
+                EvidenceRefs =
+                [
+                    "GET /api/v1/admin/observability/ops-health",
+                    $"alert-dispatch-channel:{channelName}",
+                ],
+                RecommendedAction = action,
+            });
+        }
     }
 
     // Rule (f): database connection-pool pressure (utilization and/or acquisition timeouts over

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
@@ -39,6 +39,7 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
     private readonly IOptions<OpsHealthRollupOptions> _rollupOptions;
     private readonly IExecutionJobStore? _jobStore;
     private readonly IOpsHealthRollupStore? _rollupStore;
+    private readonly TimeProvider _timeProvider;
 
     public OpsHealthSnapshotService(
         HealthCheckService healthCheckService,
@@ -47,6 +48,7 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
         IAlertDispatchHealth alertHealth,
         ProductionMetricsCollector metricsCollector,
         IOptions<OpsHealthRollupOptions> rollupOptions,
+        TimeProvider timeProvider,
         IExecutionJobStore? jobStore = null,
         IOpsHealthRollupStore? rollupStore = null)
     {
@@ -56,6 +58,7 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
         _alertHealth = alertHealth;
         _metricsCollector = metricsCollector;
         _rollupOptions = rollupOptions;
+        _timeProvider = timeProvider;
         _jobStore = jobStore;
         _rollupStore = rollupStore;
     }
@@ -236,7 +239,7 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
     private OpsAlertDispatchView BuildAlertDispatchView()
     {
         var backlog = _alertHealth.LastBacklog;
-        var now = DateTimeOffset.UtcNow;
+        var now = _timeProvider.GetUtcNow();
         return new OpsAlertDispatchView
         {
             DispatcherRunning = _alertHealth.IsDispatcherRunning,
@@ -245,6 +248,10 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
             LastPollAt = _alertHealth.LastPollAt,
             PendingCount = backlog?.PendingCount,
             DeadLetteredCount = backlog?.DeadLetteredCount,
+            RetryingCount = backlog?.RetryingCount,
+            OldestItemAgeSeconds = backlog?.OldestItemAt is { } oldestItemAt
+                ? Math.Max(0, (long)(now - oldestItemAt).TotalSeconds)
+                : null,
             Channels = backlog?.Channels
                 .OrderBy(static channel => channel.ChannelType)
                 .Select(channel => new OpsAlertDispatchChannelView

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsHealthSnapshotService.cs
@@ -3,6 +3,7 @@
 
 using Honua.Alerts;
 using Honua.ControlPlane;
+using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Features.ControlPlane.Abstractions;
 using Honua.Core.Features.Observability.Abstractions;
 using Honua.Core.Features.Observability.Domain;
@@ -235,6 +236,7 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
     private OpsAlertDispatchView BuildAlertDispatchView()
     {
         var backlog = _alertHealth.LastBacklog;
+        var now = DateTimeOffset.UtcNow;
         return new OpsAlertDispatchView
         {
             DispatcherRunning = _alertHealth.IsDispatcherRunning,
@@ -243,6 +245,18 @@ internal sealed class OpsHealthSnapshotService : IOpsHealthSnapshotService
             LastPollAt = _alertHealth.LastPollAt,
             PendingCount = backlog?.PendingCount,
             DeadLetteredCount = backlog?.DeadLetteredCount,
+            Channels = backlog?.Channels
+                .OrderBy(static channel => channel.ChannelType)
+                .Select(channel => new OpsAlertDispatchChannelView
+                {
+                    Channel = channel.ChannelType.ToExternalName(),
+                    Paused = channel.IsPaused,
+                    PendingCount = channel.PendingCount,
+                    RetryingCount = channel.RetryingCount,
+                    DeadLetteredCount = channel.DeadLetteredCount,
+                    OldestItemAgeSeconds = Math.Max(0, (long)(now - channel.OldestItemAt).TotalSeconds),
+                })
+                .ToList() ?? [],
         };
     }
 

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
@@ -197,6 +197,14 @@ public sealed class OpsAlertDispatchView
     [JsonPropertyName("deadLetteredCount")]
     public long? DeadLetteredCount { get; init; }
 
+    /// <summary>Gets the retrying count, when a backlog snapshot is available.</summary>
+    [JsonPropertyName("retryingCount")]
+    public long? RetryingCount { get; init; }
+
+    /// <summary>Gets the age in whole seconds of the oldest active row, when one exists.</summary>
+    [JsonPropertyName("oldestItemAgeSeconds")]
+    public long? OldestItemAgeSeconds { get; init; }
+
     /// <summary>
     /// Gets privacy-safe active backlog health grouped by stable configured channel identifier.
     /// Recipient, payload, error, credential, and secret data are never included.

--- a/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
+++ b/src/Honua.Server/Features/Infrastructure/Monitoring/OpsObservabilityModels.cs
@@ -196,6 +196,41 @@ public sealed class OpsAlertDispatchView
     /// <summary>Gets the dead-lettered count, when a backlog snapshot is available.</summary>
     [JsonPropertyName("deadLetteredCount")]
     public long? DeadLetteredCount { get; init; }
+
+    /// <summary>
+    /// Gets privacy-safe active backlog health grouped by stable configured channel identifier.
+    /// Recipient, payload, error, credential, and secret data are never included.
+    /// </summary>
+    [JsonPropertyName("channels")]
+    public IReadOnlyList<OpsAlertDispatchChannelView> Channels { get; init; } = [];
+}
+
+/// <summary>Bounded active alert-dispatch health for one delivery channel.</summary>
+public sealed class OpsAlertDispatchChannelView
+{
+    /// <summary>Gets the canonical channel identifier.</summary>
+    [JsonPropertyName("channel")]
+    public required string Channel { get; init; }
+
+    /// <summary>Gets whether new delivery claims are paused for this channel.</summary>
+    [JsonPropertyName("paused")]
+    public required bool Paused { get; init; }
+
+    /// <summary>Gets rows pending or currently being processed.</summary>
+    [JsonPropertyName("pendingCount")]
+    public required long PendingCount { get; init; }
+
+    /// <summary>Gets failed rows scheduled for retry.</summary>
+    [JsonPropertyName("retryingCount")]
+    public required long RetryingCount { get; init; }
+
+    /// <summary>Gets rows that exhausted their retry budget.</summary>
+    [JsonPropertyName("deadLetteredCount")]
+    public required long DeadLetteredCount { get; init; }
+
+    /// <summary>Gets the age in whole seconds of the oldest non-delivered row.</summary>
+    [JsonPropertyName("oldestItemAgeSeconds")]
+    public required long OldestItemAgeSeconds { get; init; }
 }
 
 /// <summary>Coordinated-deploy readiness and platform-release skew summary view.</summary>

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertDispatchStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertDispatchStoreTests.cs
@@ -49,7 +49,9 @@ public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
         var backlog = await store.GetBacklogAsync();
 
         backlog.PendingCount.Should().Be(3, "pending, processing, and retriable-failed rows are backlog");
+        backlog.RetryingCount.Should().Be(1);
         backlog.DeadLetteredCount.Should().Be(2);
+        backlog.OldestItemAt.Should().BeCloseTo(oldest, TimeSpan.FromSeconds(1));
         backlog.Channels.Should().HaveCount(2);
         backlog.Channels[0].ChannelType.Should().Be(Honua.Core.Features.Alerts.Domain.AlertChannelType.Webhook);
         backlog.Channels[0].IsPaused.Should().BeTrue();
@@ -59,6 +61,9 @@ public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
         backlog.Channels[0].OldestItemAt.Should().BeCloseTo(oldest, TimeSpan.FromSeconds(1));
         backlog.Channels[1].ChannelType.Should().Be(Honua.Core.Features.Alerts.Domain.AlertChannelType.Email);
         backlog.Channels[1].DeadLetteredCount.Should().Be(1);
+        backlog.PendingCount.Should().Be(backlog.Channels.Sum(channel => channel.PendingCount + channel.RetryingCount));
+        backlog.RetryingCount.Should().Be(backlog.Channels.Sum(channel => channel.RetryingCount));
+        backlog.DeadLetteredCount.Should().Be(backlog.Channels.Sum(channel => channel.DeadLetteredCount));
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertDispatchStoreTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Alerts/PostgresAlertDispatchStoreTests.cs
@@ -29,11 +29,18 @@ public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
         await ClearAlertTablesAsync();
 
         var eventId = await InsertRuleAndEventAsync();
-        await InsertDispatchAsync(eventId, status: 0, deliveredAt: null);              // pending
+        var oldest = DateTimeOffset.UtcNow.AddMinutes(-10);
+        await InsertDispatchAsync(eventId, status: 0, deliveredAt: null, createdAt: oldest); // pending
         await InsertDispatchAsync(eventId, status: 1, deliveredAt: null);              // processing
         await InsertDispatchAsync(eventId, status: 3, deliveredAt: null);              // failed (retriable)
         await InsertDispatchAsync(eventId, status: 4, deliveredAt: null);              // dead-letter
+        await InsertDispatchAsync(eventId, status: 4, deliveredAt: null, channelType: 3); // email dead-letter
         await InsertDispatchAsync(eventId, status: 2, deliveredAt: DateTimeOffset.UtcNow); // delivered
+        await fixture.ApplyGlobalSeedSqlAsync("""
+            INSERT INTO honua.alert_channel_state (channel_type, is_paused)
+            VALUES (1, true)
+            ON CONFLICT (channel_type) DO UPDATE SET is_paused = EXCLUDED.is_paused;
+            """);
 
         var store = new PostgresAlertDispatchStore(
             new TestConnectionProvider(fixture.DataSource),
@@ -42,7 +49,16 @@ public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
         var backlog = await store.GetBacklogAsync();
 
         backlog.PendingCount.Should().Be(3, "pending, processing, and retriable-failed rows are backlog");
-        backlog.DeadLetteredCount.Should().Be(1);
+        backlog.DeadLetteredCount.Should().Be(2);
+        backlog.Channels.Should().HaveCount(2);
+        backlog.Channels[0].ChannelType.Should().Be(Honua.Core.Features.Alerts.Domain.AlertChannelType.Webhook);
+        backlog.Channels[0].IsPaused.Should().BeTrue();
+        backlog.Channels[0].PendingCount.Should().Be(2);
+        backlog.Channels[0].RetryingCount.Should().Be(1);
+        backlog.Channels[0].DeadLetteredCount.Should().Be(1);
+        backlog.Channels[0].OldestItemAt.Should().BeCloseTo(oldest, TimeSpan.FromSeconds(1));
+        backlog.Channels[1].ChannelType.Should().Be(Honua.Core.Features.Alerts.Domain.AlertChannelType.Email);
+        backlog.Channels[1].DeadLetteredCount.Should().Be(1);
     }
 
     [IntegrationTest]
@@ -123,20 +139,27 @@ public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
         return eventId;
     }
 
-    private async Task InsertDispatchAsync(long eventId, short status, DateTimeOffset? deliveredAt)
+    private async Task InsertDispatchAsync(
+        long eventId,
+        short status,
+        DateTimeOffset? deliveredAt,
+        DateTimeOffset? createdAt = null,
+        short channelType = 1)
     {
         await fixture.ApplyGlobalSeedSqlAsync(
             """
             INSERT INTO honua.alert_dispatch (
-                event_id, channel_type, status, attempts, max_attempts, next_attempt_at, delivered_at)
+                event_id, channel_type, status, attempts, max_attempts, next_attempt_at, delivered_at, created_at)
             VALUES (
-                @event_id, 1, @status, 0, 5, now(), @delivered_at);
+                @event_id, @channel_type, @status, 0, 5, now(), @delivered_at, @created_at);
             """,
             command =>
             {
                 command.Parameters.AddWithValue("event_id", eventId);
                 command.Parameters.AddWithValue("status", status);
+                command.Parameters.AddWithValue("channel_type", channelType);
                 command.Parameters.AddWithValue("delivered_at", (object?)deliveredAt ?? DBNull.Value);
+                command.Parameters.AddWithValue("created_at", (object?)createdAt ?? DateTimeOffset.UtcNow);
             });
     }
 
@@ -213,6 +236,12 @@ public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
                 created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
             );
+
+            CREATE TABLE IF NOT EXISTS honua.alert_channel_state (
+                channel_type SMALLINT PRIMARY KEY,
+                is_paused BOOLEAN NOT NULL DEFAULT FALSE,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
             """);
     }
 
@@ -221,6 +250,7 @@ public sealed class PostgresAlertDispatchStoreTests(PostgresFixture fixture)
         await fixture.ApplyGlobalSeedSqlAsync("""
             TRUNCATE TABLE
                 honua.alert_dispatch,
+                honua.alert_channel_state,
                 honua.alert_events,
                 honua.alert_rules
             RESTART IDENTITY CASCADE;

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OpsObservabilityEndpointsTests.cs
@@ -4,6 +4,8 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Alerts;
+using Honua.Core.Features.Alerts.Domain;
 using Honua.Core.Features.Observability.Abstractions;
 using Honua.Core.Features.Observability.Domain;
 using Honua.TestKit;
@@ -11,6 +13,7 @@ using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Server.Tests.Features.Admin;
 
@@ -24,6 +27,7 @@ namespace Honua.Server.Tests.Features.Admin;
 public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
 {
     private const string AdminPassword = "ops-observability-admin-key";
+    private static readonly DateTimeOffset TestNow = DateTimeOffset.UtcNow;
 
     private readonly WebAppFixture _fixture;
     private HttpClient _client = null!;
@@ -45,8 +49,42 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
             // booted by at least one host. The sampler's initial jitter + flush interval keep it from
             // flushing mid-test; the history assertions seed the store directly instead.
             .ConfigureServices(services =>
+            {
                 services.PostConfigure<Honua.Infrastructure.Monitoring.OpsHealthRollupOptions>(
-                    options => options.Enabled = true));
+                    options => options.Enabled = true);
+                services.RemoveAll<TimeProvider>();
+                services.AddSingleton<TimeProvider>(new FixedTimeProvider(TestNow));
+                services.RemoveAll<IAlertDispatchHealth>();
+                services.AddSingleton<IAlertDispatchHealth>(new FixedAlertDispatchHealth(
+                    new AlertDispatchBacklog
+                    {
+                        PendingCount = 4,
+                        RetryingCount = 2,
+                        DeadLetteredCount = 2,
+                        OldestItemAt = TestNow.AddMinutes(-10),
+                        Channels =
+                        [
+                            new AlertDispatchChannelBacklog
+                            {
+                                ChannelType = AlertChannelType.Webhook,
+                                IsPaused = false,
+                                PendingCount = 2,
+                                RetryingCount = 1,
+                                DeadLetteredCount = 0,
+                                OldestItemAt = TestNow.AddMinutes(-2),
+                            },
+                            new AlertDispatchChannelBacklog
+                            {
+                                ChannelType = AlertChannelType.Email,
+                                IsPaused = true,
+                                PendingCount = 0,
+                                RetryingCount = 1,
+                                DeadLetteredCount = 2,
+                                OldestItemAt = TestNow.AddMinutes(-10),
+                            },
+                        ],
+                    }));
+            });
     }
 
     public async Task InitializeAsync()
@@ -78,6 +116,45 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
         root.TryGetProperty("alertDispatch", out _).Should().BeTrue();
         root.GetProperty("deploy").TryGetProperty("readyForCoordinatedDeploy", out _).Should().BeTrue();
         root.GetProperty("database").TryGetProperty("cacheHitRatio", out _).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Trait("Tier", "Fast")]
+    [Endpoint("GET /api/v1/admin/observability/ops-health")]
+    public async Task GetOpsHealth_WithMixedChannelHealth_SerializesExactPrivacySafeProjection()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/observability/ops-health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(content);
+        var dispatch = json.RootElement.GetProperty("alertDispatch");
+        dispatch.EnumerateObject().Select(static property => property.Name).Should().BeEquivalentTo(
+            [
+                "dispatcherRunning",
+                "dispatcherEnabled",
+                "storagePollFailing",
+                "lastPollAt",
+                "pendingCount",
+                "deadLetteredCount",
+                "retryingCount",
+                "oldestItemAgeSeconds",
+                "channels",
+            ]);
+        dispatch.GetProperty("pendingCount").GetInt64().Should().Be(4);
+        dispatch.GetProperty("retryingCount").GetInt64().Should().Be(2);
+        dispatch.GetProperty("deadLetteredCount").GetInt64().Should().Be(2);
+        dispatch.GetProperty("oldestItemAgeSeconds").GetInt64().Should().Be(600);
+
+        var channels = dispatch.GetProperty("channels");
+        channels.GetArrayLength().Should().Be(2);
+        AssertChannel(channels[0], "webhook", paused: false, pending: 2, retrying: 1, deadLettered: 0, oldestAge: 120);
+        AssertChannel(channels[1], "email", paused: true, pending: 0, retrying: 1, deadLettered: 2, oldestAge: 600);
+
+        foreach (var forbiddenProperty in new[] { "destination", "payload", "error", "credential", "secret" })
+        {
+            content.Contains($"\"{forbiddenProperty}\"", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+        }
     }
 
     [IntegrationTest]
@@ -146,6 +223,25 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
         });
     }
 
+    private static void AssertChannel(
+        JsonElement channel,
+        string name,
+        bool paused,
+        long pending,
+        long retrying,
+        long deadLettered,
+        long oldestAge)
+    {
+        channel.EnumerateObject().Select(static property => property.Name).Should().BeEquivalentTo(
+            ["channel", "paused", "pendingCount", "retryingCount", "deadLetteredCount", "oldestItemAgeSeconds"]);
+        channel.GetProperty("channel").GetString().Should().Be(name);
+        channel.GetProperty("paused").GetBoolean().Should().Be(paused);
+        channel.GetProperty("pendingCount").GetInt64().Should().Be(pending);
+        channel.GetProperty("retryingCount").GetInt64().Should().Be(retrying);
+        channel.GetProperty("deadLetteredCount").GetInt64().Should().Be(deadLettered);
+        channel.GetProperty("oldestItemAgeSeconds").GetInt64().Should().Be(oldestAge);
+    }
+
     [IntegrationTest]
     [Endpoint("GET /api/v1/admin/observability/ops-health/history")]
     public async Task GetOpsHealthHistory_WithInvalidResolution_Returns400()
@@ -212,5 +308,26 @@ public sealed class OpsObservabilityEndpointsTests : IAsyncLifetime
             content: null);
 
         response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    private sealed class FixedAlertDispatchHealth(AlertDispatchBacklog backlog) : IAlertDispatchHealth
+    {
+        public bool IsDispatcherRunning => true;
+
+        public bool IsDispatcherEnabled => true;
+
+        public DateTimeOffset? LastPollAt => TestNow;
+
+        public AlertDispatchBacklog? LastBacklog => backlog;
+
+        public bool IsStoragePollFailing => false;
+
+        public Task<AlertDispatchBacklog> RefreshBacklogAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(backlog);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OpsActionApplierTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/OpsActionApplierTests.cs
@@ -60,6 +60,7 @@ public sealed class OpsActionApplierTests : IAsyncLifetime
     {
         var channel = AlertChannelType.AwsSqs;
         var eventId = await SeedDispatchAsync(channel);
+        var healthyEventId = await SeedDispatchAsync(AlertChannelType.Webhook);
         var store = _fixture.GetService<IAlertDispatchStore>();
 
         var pauseChangeId = await Applier.ApplyAsync(
@@ -73,6 +74,9 @@ public sealed class OpsActionApplierTests : IAsyncLifetime
         pausedClaims.Should().NotContain(
             item => item.EventId == eventId,
             "a paused channel's rows must not be claimed");
+        pausedClaims.Should().Contain(
+            item => item.EventId == healthyEventId,
+            "pausing one failing channel must not suppress healthy channel delivery");
 
         // Idempotent: pausing an already-paused channel succeeds and stays paused.
         (await Applier.ApplyAsync("""{"action":"alerts.pause_channel","params":{"channel":"aws_sqs"}}"""))

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Monitoring/OpsFindingsServiceTests.cs
@@ -74,6 +74,90 @@ public sealed class OpsFindingsServiceTests
 
     [UnitTest]
     [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_ChannelDeadLetters_ProducesScopedApprovalOnlyPauseFinding()
+    {
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            IsDispatcherRunning = true,
+            LastBacklog = new AlertDispatchBacklog
+            {
+                PendingCount = 8,
+                DeadLetteredCount = 2,
+                Channels =
+                [
+                    new AlertDispatchChannelBacklog
+                    {
+                        ChannelType = AlertChannelType.Email,
+                        IsPaused = false,
+                        PendingCount = 3,
+                        RetryingCount = 2,
+                        DeadLetteredCount = 2,
+                        OldestItemAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+                    },
+                    new AlertDispatchChannelBacklog
+                    {
+                        ChannelType = AlertChannelType.Webhook,
+                        IsPaused = false,
+                        PendingCount = 3,
+                        RetryingCount = 0,
+                        DeadLetteredCount = 0,
+                        OldestItemAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                    },
+                ],
+            },
+        };
+        var service = CreateService(alertHealth: alertHealth);
+
+        var findings = await service.EvaluateAsync();
+
+        var finding = Assert.Single(findings, f => f.Rule == OpsFindingsService.RuleAlertDispatchChannelFailure);
+        Assert.Equal("email", finding.Subject.Channel);
+        Assert.NotNull(finding.RecommendedAction);
+        Assert.Equal(OpsActionNames.PauseChannel, finding.RecommendedAction!.ActionDiscriminator);
+        Assert.False(finding.RecommendedAction.AutoSafe);
+        Assert.Equal(7, finding.RecommendedAction.BlastRadius);
+        Assert.Contains("\"channel\":\"email\"", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+        Assert.DoesNotContain("webhook", finding.RecommendedAction.ExecutionPayload, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Evaluate_AlreadyPausedFailingChannel_ProducesEvidenceWithoutAnotherAction()
+    {
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            LastBacklog = new AlertDispatchBacklog
+            {
+                PendingCount = 0,
+                DeadLetteredCount = 1,
+                Channels =
+                [
+                    new AlertDispatchChannelBacklog
+                    {
+                        ChannelType = AlertChannelType.Slack,
+                        IsPaused = true,
+                        PendingCount = 0,
+                        RetryingCount = 0,
+                        DeadLetteredCount = 1,
+                        OldestItemAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                    },
+                ],
+            },
+        };
+        var service = CreateService(alertHealth: alertHealth);
+
+        var finding = (await service.EvaluateAsync())
+            .Single(f => f.Rule == OpsFindingsService.RuleAlertDispatchChannelFailure);
+
+        Assert.Equal("slack", finding.Subject.Channel);
+        Assert.Null(finding.RecommendedAction);
+        Assert.Contains("already paused", finding.Explanation, StringComparison.Ordinal);
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
     public async Task Evaluate_AlertDispatchBelowThresholds_ProducesNoFinding()
     {
         var alertHealth = new FakeAlertDispatchHealth
@@ -628,6 +712,49 @@ public sealed class OpsFindingsServiceTests
                 r.IdempotencyKey == finding.Id &&
                 r.ExecutionPayload != null &&
                 r.ExecutionPayload.Contains("\"action\":\"alerts.redrive_dead_letters\"", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.TestInfrastructure)]
+    public async Task Propose_ChannelFailureFinding_RoutesApprovalOnlyScopedPauseThroughGateway()
+    {
+        var alertHealth = new FakeAlertDispatchHealth
+        {
+            IsDispatcherEnabled = true,
+            LastBacklog = new AlertDispatchBacklog
+            {
+                PendingCount = 1,
+                DeadLetteredCount = 1,
+                Channels =
+                [
+                    new AlertDispatchChannelBacklog
+                    {
+                        ChannelType = AlertChannelType.MicrosoftTeams,
+                        IsPaused = false,
+                        PendingCount = 1,
+                        RetryingCount = 0,
+                        DeadLetteredCount = 1,
+                        OldestItemAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                    },
+                ],
+            },
+        };
+        var gateway = CreateProposalGateway(OperationClass.AdminConfigChange, "proposal-channel-pause");
+        var service = CreateService(alertHealth: alertHealth, gateway: gateway);
+        var finding = (await service.EvaluateAsync())
+            .Single(f => f.Rule == OpsFindingsService.RuleAlertDispatchChannelFailure);
+
+        var result = await service.ProposeAsync(finding.Id);
+
+        Assert.Equal(OpsFindingProposalStatus.ProposalCreated, result.Status);
+        await gateway.Received(1).RouteAsync(
+            Arg.Is<OperationGatewayRequest>(request =>
+                request.ActionDiscriminator == OpsActionNames.PauseChannel &&
+                request.AutonomyContext != null &&
+                !request.AutonomyContext.ActionMarkedAutoSafe &&
+                request.ExecutionPayload != null &&
+                request.ExecutionPayload.Contains("\"channel\":\"microsoft_teams\"", StringComparison.Ordinal)),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2679

## Summary
Adds bounded, privacy-safe alert dispatch health per channel and turns channel-attributed dead letters into an approval-only isolation proposal. The pause actuator remains `RequiresApproval` and `AutoSafe=false`; this PR does not add auto-pause or generic scaling.

## Changes Made
- Project active dispatch counts, pause state, and oldest-item age by stable channel identifier without destinations, payloads, errors, credentials, or secrets.
- Fold aggregate pending/retrying/dead-lettered/oldest health from the per-channel rows produced by one grouped active-outbox scan.
- Emit a deterministic channel-failure finding with a scoped `alerts.pause_channel` proposal; already-paused channels remain evidence-only.
- Prove mixed-channel convergence: the selected channel stops claiming rows while a healthy channel continues, and resume restores claims.
- Update the operator guide to describe this as L2 assisted isolation.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Focused results:
- `OpsFindingsServiceTests`: 36/36 passed (Release)
- `OpsActionApplierTests.ApplyAsync_PauseAndResumeChannel_TogglePersistedFlagAndClaims`: 1/1 passed
- `PostgresAlertDispatchStoreTests.GetBacklogAsync`: 1/1 passed; aggregate totals equal the channel folds
- Tier=Fast `GetOpsHealth_WithMixedChannelHealth_SerializesExactPrivacySafeProjection`: 1/1 passed with exact JSON and privacy exclusions
- `dotnet format Honua.sln --no-restore --include <changed C# files>` completed successfully

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [x] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

The admin ops-health response gains additive aggregate retry/age fields and an `alertDispatch.channels` projection.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

The focused equivalent pre-PR proof is listed above; broad CI was intentionally left to the PR matrix.
