### PR TITLE
feat: add deterministic CompactV2 TPKX writer (#2686)

### DIFF
--- a/src/Honua.Hosting/Features/Tiles/CompactTilePackageWriter.cs
+++ b/src/Honua.Hosting/Features/Tiles/CompactTilePackageWriter.cs
@@ -1,0 +1,489 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.IO.Compression;
+using System.Text.Json;
+
+namespace Honua.Infrastructure.Tiles;
+
+/// <summary>
+/// Admission limits for uncompressed CompactV2 bundle and package data.
+/// </summary>
+/// <param name="MaximumBundleBytes">Maximum bytes retained by one in-memory bundle.</param>
+/// <param name="MaximumPackageBytes">Maximum aggregate uncompressed bundle bytes admitted to one package.</param>
+internal readonly record struct CompactTilePackageLimits(long MaximumBundleBytes, long MaximumPackageBytes)
+{
+    /// <summary>Default limits suitable for synchronous packaging.</summary>
+    public static CompactTilePackageLimits Default { get; } = new(
+        MaximumBundleBytes: 64L * 1024L * 1024L,
+        MaximumPackageBytes: 1024L * 1024L * 1024L);
+}
+
+/// <summary>
+/// Writes Esri TPKX 1.0 packages containing Compact Cache V2 bundles.
+/// </summary>
+/// <remarks>
+/// Input is streamed one 128-by-128 bundle at a time. Tiles must therefore be
+/// ordered by level, bundle row, and bundle column; order within a bundle is
+/// unrestricted.
+/// </remarks>
+internal static class CompactTilePackageWriter
+{
+    private const int PacketSize = 128;
+    private const int TileCount = PacketSize * PacketSize;
+    private const int HeaderSize = 64;
+    private const int IndexSize = TileCount * sizeof(ulong);
+    private const int BundleDataOffset = HeaderSize + IndexSize;
+    private const int FixedBundleOverheadBytes = BundleDataOffset;
+    private const double WebMercatorOrigin = 20_037_508.342787;
+    private const double ZeroLevelResolution = (WebMercatorOrigin * 2d) / 256d;
+    private const int MaximumCompactTileSize = 0xFF_FF_FF;
+    private static readonly DateTimeOffset ArchiveTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly byte[] ThumbnailBytes = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
+
+    /// <summary>
+    /// Writes tiles to a deterministic TPKX archive and returns the tile count.
+    /// </summary>
+    public static async Task<int> WriteAsync(
+        Stream destination,
+        string cacheName,
+        string tileFormat,
+        double[] bounds,
+        IAsyncEnumerable<TilePackageWriter.PackagedTile> tiles,
+        CancellationToken cancellationToken,
+        CompactTilePackageLimits? limits = null)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        ArgumentNullException.ThrowIfNull(tiles);
+
+        var normalizedTileFormat = NormalizeTileFormat(tileFormat);
+        var effectiveLimits = limits ?? CompactTilePackageLimits.Default;
+        ValidateLimits(effectiveLimits);
+        var levels = new SortedSet<int>();
+        var written = 0;
+        long admittedPackageBytes = 0;
+        BundleKey? activeKey = null;
+        MemoryStream? activeBundle = null;
+        var maximumTileSize = 0;
+
+        using var archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true);
+        await foreach (var tile in tiles.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            ValidateTile(tile);
+            var key = BundleKey.From(tile);
+            if (activeKey is not null && key.CompareTo(activeKey.Value) < 0)
+            {
+                throw new InvalidOperationException("Tiles must be supplied in bundle order (level, bundle row, bundle column).");
+            }
+
+            if (activeKey != key)
+            {
+                // Sparse caches can create many nearly empty bundles. Charge every
+                // bundle's fixed header and embedded index before allocating it so
+                // package admission cannot be bypassed with sparse coordinates.
+                AdmitPackageBytes(ref admittedPackageBytes, FixedBundleOverheadBytes, effectiveLimits);
+                if (activeBundle is not null)
+                {
+                    await WriteBundleEntryAsync(
+                        archive,
+                        activeKey!.Value,
+                        activeBundle,
+                        maximumTileSize,
+                        cancellationToken).ConfigureAwait(false);
+                    await activeBundle.DisposeAsync().ConfigureAwait(false);
+                }
+
+                activeKey = key;
+                activeBundle = CreateBundle();
+                maximumTileSize = 0;
+            }
+
+            var recordBytes = sizeof(uint) + tile.Bytes.LongLength;
+            if (recordBytes > effectiveLimits.MaximumBundleBytes - activeBundle!.Length)
+            {
+                throw new InvalidOperationException(
+                    $"CompactV2 bundle admission limit of {effectiveLimits.MaximumBundleBytes} bytes would be exceeded.");
+            }
+
+            AdmitPackageBytes(ref admittedPackageBytes, recordBytes, effectiveLimits);
+            WriteTile(activeBundle!, key, tile);
+            maximumTileSize = Math.Max(maximumTileSize, tile.Bytes.Length);
+            levels.Add(tile.Level);
+            written++;
+        }
+
+        if (activeBundle is not null)
+        {
+            await WriteBundleEntryAsync(
+                archive,
+                activeKey!.Value,
+                activeBundle,
+                maximumTileSize,
+                cancellationToken).ConfigureAwait(false);
+            await activeBundle.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (written == 0)
+        {
+            throw new InvalidOperationException("A TPKX package requires at least one tile.");
+        }
+
+        if (levels.Count < 2)
+        {
+            throw new InvalidOperationException("A TPKX package requires tiles from at least two levels so minLOD is less than maxLOD.");
+        }
+
+        var minimumLevel = levels.Min;
+        var maximumLevel = levels.Max;
+        var safeName = TilePackageWriter.SanitizeCacheName(cacheName);
+        await WriteJsonEntryAsync(
+            archive,
+            "root.json",
+            writer => WriteRootJson(writer, safeName, normalizedTileFormat, bounds, minimumLevel, maximumLevel),
+            cancellationToken).ConfigureAwait(false);
+        await WriteJsonEntryAsync(
+            archive,
+            "iteminfo.json",
+            writer => WriteItemInfoJson(writer, safeName, bounds),
+            cancellationToken).ConfigureAwait(false);
+        await WriteEntryAsync(archive, "thumbnail.png", ThumbnailBytes, CompressionLevel.NoCompression, cancellationToken)
+            .ConfigureAwait(false);
+
+        return written;
+    }
+
+    private static string NormalizeTileFormat(string tileFormat)
+    {
+        if (string.IsNullOrWhiteSpace(tileFormat))
+        {
+            throw new ArgumentException("A supported TPKX tile format is required.", nameof(tileFormat));
+        }
+
+        var normalized = tileFormat.Trim().ToUpperInvariant();
+        return normalized is "PNG" or "PNG8" or "PNG24" or "PNG32" or "JPEG" or "MIXED"
+            ? normalized
+            : throw new ArgumentException(
+                "The supported TPKX tile formats are PNG, PNG8, PNG24, PNG32, JPEG, and MIXED.",
+                nameof(tileFormat));
+    }
+
+    private static void ValidateLimits(CompactTilePackageLimits limits)
+    {
+        if (limits.MaximumBundleBytes < BundleDataOffset + sizeof(uint) + 1L ||
+            limits.MaximumBundleBytes > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(limits),
+                $"Maximum bundle bytes must be between {BundleDataOffset + sizeof(uint) + 1L} and {int.MaxValue}.");
+        }
+
+        if (limits.MaximumPackageBytes < limits.MaximumBundleBytes)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(limits),
+                "Maximum package bytes must be greater than or equal to maximum bundle bytes.");
+        }
+    }
+
+    private static void AdmitPackageBytes(
+        ref long admittedPackageBytes,
+        long requestedBytes,
+        CompactTilePackageLimits limits)
+    {
+        if (requestedBytes > limits.MaximumPackageBytes - admittedPackageBytes)
+        {
+            throw new InvalidOperationException(
+                $"TPKX package admission limit of {limits.MaximumPackageBytes} uncompressed bundle bytes would be exceeded.");
+        }
+
+        admittedPackageBytes += requestedBytes;
+    }
+
+    private static void ValidateTile(TilePackageWriter.PackagedTile tile)
+    {
+        if (tile.Level < 0 || tile.Column < 0 || tile.Row < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tile), "Tile level, row, and column must be non-negative.");
+        }
+
+        ArgumentNullException.ThrowIfNull(tile.Bytes);
+        if (tile.Bytes.Length == 0)
+        {
+            throw new ArgumentException("CompactV2 tile payloads cannot be empty because a zero size denotes a missing tile.", nameof(tile));
+        }
+
+        if (tile.Bytes.Length > MaximumCompactTileSize)
+        {
+            throw new ArgumentException("CompactV2 tile payloads cannot exceed the 24-bit index size.", nameof(tile));
+        }
+    }
+
+    private static MemoryStream CreateBundle()
+    {
+        var bundle = new MemoryStream(BundleDataOffset + 4096);
+        bundle.SetLength(BundleDataOffset);
+        Span<byte> header = stackalloc byte[HeaderSize];
+        BinaryPrimitives.WriteUInt32LittleEndian(header[0..4], 3);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[4..8], TileCount);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[12..16], 5);
+        BinaryPrimitives.WriteUInt64LittleEndian(header[32..40], 40);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[40..44], IndexSize + 20);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[44..48], 3);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[48..52], 16);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[52..56], TileCount);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[56..60], 5);
+        BinaryPrimitives.WriteUInt32LittleEndian(header[60..64], IndexSize);
+        bundle.Position = 0;
+        bundle.Write(header);
+        return bundle;
+    }
+
+    private static void WriteTile(
+        MemoryStream bundle,
+        BundleKey key,
+        TilePackageWriter.PackagedTile tile)
+    {
+        var relativeRow = tile.Row - key.BaseRow;
+        var relativeColumn = tile.Column - key.BaseColumn;
+        var indexPosition = HeaderSize + (sizeof(ulong) * ((PacketSize * relativeRow) + relativeColumn));
+        bundle.Position = indexPosition;
+        Span<byte> existing = stackalloc byte[sizeof(ulong)];
+        bundle.ReadExactly(existing);
+        if (BinaryPrimitives.ReadUInt64LittleEndian(existing) != 0)
+        {
+            throw new InvalidOperationException("A CompactV2 bundle cannot contain the same tile more than once.");
+        }
+
+        bundle.Position = bundle.Length;
+        Span<byte> sizePrefix = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(sizePrefix, checked((uint)tile.Bytes.Length));
+        bundle.Write(sizePrefix);
+        var tileOffset = checked((ulong)bundle.Position);
+        bundle.Write(tile.Bytes);
+
+        var index = tileOffset | (checked((ulong)tile.Bytes.Length) << 40);
+        bundle.Position = indexPosition;
+        Span<byte> encodedIndex = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(encodedIndex, index);
+        bundle.Write(encodedIndex);
+    }
+
+    private static async Task WriteBundleEntryAsync(
+        ZipArchive archive,
+        BundleKey key,
+        MemoryStream bundle,
+        int maximumTileSize,
+        CancellationToken cancellationToken)
+    {
+        bundle.Position = 8;
+        Span<byte> maximumSize = stackalloc byte[sizeof(uint)];
+        BinaryPrimitives.WriteUInt32LittleEndian(maximumSize, checked((uint)maximumTileSize));
+        bundle.Write(maximumSize);
+        bundle.Position = 24;
+        Span<byte> fileSize = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64LittleEndian(fileSize, checked((ulong)bundle.Length));
+        bundle.Write(fileSize);
+        bundle.Position = 0;
+
+        var path = string.Create(
+            CultureInfo.InvariantCulture,
+            $"tile/L{key.Level:D2}/R{key.BaseRow:x4}C{key.BaseColumn:x4}.bundle");
+        var entry = CreateEntry(archive, path, CompressionLevel.NoCompression);
+        await using var stream = entry.Open();
+        await bundle.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WriteJsonEntryAsync(
+        ZipArchive archive,
+        string path,
+        Action<Utf8JsonWriter> write,
+        CancellationToken cancellationToken)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            write(writer);
+        }
+
+        await WriteEntryAsync(archive, path, buffer.ToArray(), CompressionLevel.Optimal, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task WriteEntryAsync(
+        ZipArchive archive,
+        string path,
+        byte[] bytes,
+        CompressionLevel compressionLevel,
+        CancellationToken cancellationToken)
+    {
+        var entry = CreateEntry(archive, path, compressionLevel);
+        await using var stream = entry.Open();
+        await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ZipArchiveEntry CreateEntry(ZipArchive archive, string path, CompressionLevel compressionLevel)
+    {
+        var entry = archive.CreateEntry(path, compressionLevel);
+        entry.LastWriteTime = ArchiveTimestamp;
+        return entry;
+    }
+
+    private static void WriteRootJson(
+        Utf8JsonWriter writer,
+        string cacheName,
+        string tileFormat,
+        double[] bounds,
+        int minimumLevel,
+        int maximumLevel)
+    {
+        var extent = ProjectBounds(bounds);
+        writer.WriteStartObject();
+        writer.WriteNumber("version", 1d);
+        writer.WriteString("name", cacheName);
+        writer.WriteString("serviceDescription", string.Empty);
+        writer.WriteString("tileBundlesPath", "./tile");
+        writer.WriteNumber("minLOD", minimumLevel);
+        writer.WriteNumber("maxLOD", maximumLevel);
+        writer.WriteNumber("minScale", Scale(minimumLevel));
+        writer.WriteNumber("maxScale", Scale(maximumLevel));
+        writer.WriteString("units", "esriMeters");
+        writer.WriteBoolean("resampling", true);
+        writer.WriteBoolean("exportTilesAllowed", false);
+        WriteSpatialReference(writer, 3857);
+        WriteExtent(writer, "initialExtent", extent, 3857);
+        WriteExtent(writer, "fullExtent", extent, 3857);
+
+        writer.WriteStartObject("tileImageInfo");
+        writer.WriteString("format", tileFormat);
+        writer.WriteNumber("compressionQuality", 0);
+        writer.WriteEndObject();
+
+        writer.WriteStartObject("storageInfo");
+        writer.WriteString("storageFormat", "esriMapCacheStorageModeCompactV2");
+        writer.WriteNumber("packetSize", PacketSize);
+        writer.WriteEndObject();
+
+        writer.WriteStartObject("tileInfo");
+        writer.WriteNumber("rows", 256);
+        writer.WriteNumber("cols", 256);
+        writer.WriteNumber("dpi", 96);
+        writer.WriteString("format", tileFormat);
+        writer.WriteStartObject("origin");
+        writer.WriteNumber("x", -WebMercatorOrigin);
+        writer.WriteNumber("y", WebMercatorOrigin);
+        writer.WriteEndObject();
+        writer.WriteStartArray("lods");
+        for (var level = minimumLevel; level <= maximumLevel; level++)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("level", level);
+            writer.WriteNumber("resolution", Resolution(level));
+            writer.WriteNumber("scale", Scale(level));
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+        WriteSpatialReference(writer, 3857);
+        writer.WriteEndObject();
+        writer.WriteStartArray("layers");
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    private static void WriteItemInfoJson(Utf8JsonWriter writer, string cacheName, double[] bounds)
+    {
+        var normalized = NormalizeBounds(bounds);
+        writer.WriteStartObject();
+        writer.WriteString("id", "00000000000000000000000000000000");
+        writer.WriteString("guid", "00000000-0000-0000-0000-000000000000");
+        writer.WriteString("name", cacheName);
+        writer.WriteString("title", cacheName);
+        writer.WriteString("type", "Compact Tile Package");
+        writer.WriteNumber("version", 1d);
+        writer.WriteString("creator", "Honua");
+        writer.WriteNumber("created", 0);
+        writer.WriteString("thumbnail", "./thumbnail.png");
+        writer.WriteString("snippet", string.Empty);
+        writer.WriteString("description", string.Empty);
+        writer.WriteString("summary", string.Empty);
+        writer.WriteStartArray("typeKeywords");
+        writer.WriteStringValue("Compact Tile Package");
+        writer.WriteStringValue("Tile Package");
+        writer.WriteStringValue("tpkx");
+        writer.WriteEndArray();
+        writer.WriteStartArray("tags");
+        writer.WriteEndArray();
+        WriteExtent(writer, "extent", normalized, 4326);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteSpatialReference(Utf8JsonWriter writer, int wkid)
+    {
+        writer.WriteStartObject("spatialReference");
+        writer.WriteNumber("wkid", wkid);
+        writer.WriteNumber("latestWkid", wkid);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteExtent(Utf8JsonWriter writer, string name, double[] extent, int wkid)
+    {
+        writer.WriteStartObject(name);
+        writer.WriteNumber("xmin", extent[0]);
+        writer.WriteNumber("ymin", extent[1]);
+        writer.WriteNumber("xmax", extent[2]);
+        writer.WriteNumber("ymax", extent[3]);
+        WriteSpatialReference(writer, wkid);
+        writer.WriteEndObject();
+    }
+
+    private static double[] ProjectBounds(double[] bounds)
+    {
+        var normalized = NormalizeBounds(bounds);
+        return
+        [
+            WebMercatorX(normalized[0]),
+            WebMercatorY(normalized[1]),
+            WebMercatorX(normalized[2]),
+            WebMercatorY(normalized[3]),
+        ];
+    }
+
+    private static double[] NormalizeBounds(double[] bounds)
+        => bounds is { Length: 4 }
+            ? [bounds[0], bounds[1], bounds[2], bounds[3]]
+            : [-180d, -85.05112878d, 180d, 85.05112878d];
+
+    private static double WebMercatorX(double longitude)
+        => Math.Clamp(longitude, -180d, 180d) * WebMercatorOrigin / 180d;
+
+    private static double WebMercatorY(double latitude)
+    {
+        var clamped = Math.Clamp(latitude, -85.05112878d, 85.05112878d);
+        return WebMercatorOrigin * Math.Log(Math.Tan(((90d + clamped) * Math.PI) / 360d)) / Math.PI;
+    }
+
+    private static double Resolution(int level) => ZeroLevelResolution / Math.Pow(2d, level);
+
+    private static double Scale(int level) => Resolution(level) * 96d * 39.37d;
+
+    private readonly record struct BundleKey(int Level, int BaseRow, int BaseColumn) : IComparable<BundleKey>
+    {
+        public static BundleKey From(TilePackageWriter.PackagedTile tile)
+            => new(tile.Level, tile.Row / PacketSize * PacketSize, tile.Column / PacketSize * PacketSize);
+
+        public int CompareTo(BundleKey other)
+        {
+            var levelComparison = Level.CompareTo(other.Level);
+            if (levelComparison != 0)
+            {
+                return levelComparison;
+            }
+
+            var rowComparison = BaseRow.CompareTo(other.BaseRow);
+            return rowComparison != 0 ? rowComparison : BaseColumn.CompareTo(other.BaseColumn);
+        }
+    }
+}

--- a/src/Honua.Hosting/Features/Tiles/TilePackageWriter.cs
+++ b/src/Honua.Hosting/Features/Tiles/TilePackageWriter.cs
@@ -22,11 +22,9 @@ namespace Honua.Infrastructure.Tiles;
 /// digits; rows and columns are eight-digit lowercase hexadecimal. ArcGIS
 /// Pro, the ArcGIS Runtime SDKs, and QGIS all read this layout.
 /// </para>
-/// <para>
-/// The proprietary <em>compact</em> bundle form (<c>.bundle</c>/<c>.bundlx</c>,
-/// the basis of TPKX) is intentionally not produced here; see the GeoServices
-/// parity matrix for the documented deferral.
-/// </para>
+/// Compact Cache V2 / TPKX output is implemented separately by
+/// <see cref="CompactTilePackageWriter"/> so each archive format keeps one
+/// focused writer and compatibility contract.
 /// </remarks>
 internal static class TilePackageWriter
 {
@@ -230,7 +228,7 @@ internal static class TilePackageWriter
             CultureInfo.InvariantCulture,
             $"{x:R} {y:R}");
 
-    private static string SanitizeCacheName(string value)
+    internal static string SanitizeCacheName(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/CompactTilePackageWriterTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/CompactTilePackageWriterTests.cs
@@ -1,0 +1,378 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using System.IO.Compression;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Infrastructure.Tiles;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.Tiles;
+
+/// <summary>
+/// Compatibility tests for the Esri TPKX 1.0 / Compact Cache V2 writer.
+/// Specification sources: https://github.com/Esri/tile-package-spec and
+/// https://github.com/Esri/raster-tiles-compactcache.
+/// </summary>
+[Protocol(TestProtocols.MapServer)]
+public sealed class CompactTilePackageWriterTests
+{
+    private const int BundleDataOffset = 131_136;
+    private const string EsriRootSampleShape =
+        """{"minScale":591657527.591555,"maxScale":9027.977411,"resampling":true,"tileImageInfo":{"format":"PNG"}}""";
+    private const string EsriItemInfoSampleShape =
+        """{"version":1.0,"extent":{"xmin":-178.19824218748033,"ymin":18.937464429663208,"xmax":-66.972656250009919,"ymax":71.413176833965693,"spatialReference":{"wkid":4326,"latestWkid":4326}}}""";
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_ProducesDeterministicTpkxLayoutAndReadableCompactV2Bundles()
+    {
+        var tiles = new[]
+        {
+            new TilePackageWriter.PackagedTile(0, 0, 0, [0x01, 0x02, 0x03]),
+            new TilePackageWriter.PackagedTile(8, 128, 0, [0x10, 0x11]),
+            new TilePackageWriter.PackagedTile(8, 130, 129, [0x20, 0x21, 0x22, 0x23]),
+        };
+
+        var first = await WritePackageAsync(tiles);
+        var second = await WritePackageAsync(tiles);
+
+        first.Should().Equal(second, "identical tiles must produce byte-for-byte deterministic packages");
+
+        using var archive = new ZipArchive(new MemoryStream(first), ZipArchiveMode.Read);
+        archive.Entries.Select(static entry => entry.FullName).Should().BeEquivalentTo(
+            [
+                "tile/L00/R0000C0000.bundle",
+                "tile/L08/R0000C0080.bundle",
+                "tile/L08/R0080C0080.bundle",
+                "root.json",
+                "iteminfo.json",
+                "thumbnail.png",
+            ]);
+
+        using (var root = await ReadJsonAsync(archive, "root.json"))
+        using (var esriRootSample = JsonDocument.Parse(EsriRootSampleShape))
+        {
+            root.RootElement.GetProperty("version").GetDouble().Should().Be(1d);
+            root.RootElement.GetProperty("tileBundlesPath").GetString().Should().Be("./tile");
+            root.RootElement.GetProperty("minLOD").GetInt32().Should().Be(0);
+            root.RootElement.GetProperty("maxLOD").GetInt32().Should().Be(8);
+            root.RootElement.GetProperty("minScale").GetDouble().Should()
+                .BeGreaterThan(root.RootElement.GetProperty("maxScale").GetDouble());
+            root.RootElement.GetProperty("resampling").ValueKind.Should().Be(JsonValueKind.True);
+            root.RootElement.GetProperty("resampling").ValueKind.Should()
+                .Be(esriRootSample.RootElement.GetProperty("resampling").ValueKind);
+            root.RootElement.GetProperty("tileImageInfo").GetProperty("format").GetString().Should().Be("PNG");
+            root.RootElement.GetProperty("storageInfo").GetProperty("storageFormat").GetString()
+                .Should().Be("esriMapCacheStorageModeCompactV2");
+            root.RootElement.GetProperty("storageInfo").GetProperty("packetSize").GetInt32().Should().Be(128);
+        }
+
+        using (var itemInfo = await ReadJsonAsync(archive, "iteminfo.json"))
+        using (var esriItemInfoSample = JsonDocument.Parse(EsriItemInfoSampleShape))
+        {
+            itemInfo.RootElement.GetProperty("version").ValueKind.Should()
+                .Be(esriItemInfoSample.RootElement.GetProperty("version").ValueKind);
+            itemInfo.RootElement.GetProperty("type").GetString().Should().Be("Compact Tile Package");
+            itemInfo.RootElement.GetProperty("typeKeywords").EnumerateArray().Select(static value => value.GetString())
+                .Should().Contain(["Compact Tile Package", "Tile Package", "tpkx"]);
+            var extent = itemInfo.RootElement.GetProperty("extent");
+            extent.ValueKind.Should().Be(esriItemInfoSample.RootElement.GetProperty("extent").ValueKind);
+            extent.GetProperty("xmin").GetDouble().Should().Be(-180d);
+            extent.GetProperty("ymin").GetDouble().Should().Be(-85d);
+            extent.GetProperty("xmax").GetDouble().Should().Be(180d);
+            extent.GetProperty("ymax").GetDouble().Should().Be(85d);
+            extent.GetProperty("spatialReference").GetProperty("wkid").GetInt32().Should().Be(4326);
+            extent.GetProperty("spatialReference").ValueKind.Should()
+                .Be(esriItemInfoSample.RootElement.GetProperty("extent").GetProperty("spatialReference").ValueKind);
+            itemInfo.RootElement.TryGetProperty("spatialReference", out _).Should().BeFalse();
+        }
+
+        var levelZeroBundle = await ReadEntryAsync(archive, "tile/L00/R0000C0000.bundle");
+        AssertBundleHeader(levelZeroBundle, maximumTileSize: 3);
+        BinaryPrimitives.ReadUInt64LittleEndian(levelZeroBundle.AsSpan(64, sizeof(ulong))).Should()
+            .Be(0x0000030000020044UL, "Esri CompactV2 stores a 24-bit size above the 40-bit data offset");
+        BinaryPrimitives.ReadUInt32LittleEndian(levelZeroBundle.AsSpan(BundleDataOffset, sizeof(uint))).Should().Be(3);
+        levelZeroBundle.AsSpan(BundleDataOffset + sizeof(uint), 3).ToArray().Should().Equal(0x01, 0x02, 0x03);
+        ReadTile(levelZeroBundle, relativeRow: 0, relativeColumn: 0).Should().Equal(0x01, 0x02, 0x03);
+        ReadTile(levelZeroBundle, relativeRow: 0, relativeColumn: 1).Should().BeEmpty();
+
+        var secondBundle = await ReadEntryAsync(archive, "tile/L08/R0080C0080.bundle");
+        AssertBundleHeader(secondBundle, maximumTileSize: 4);
+        ReadTile(secondBundle, relativeRow: 1, relativeColumn: 2).Should().Equal(0x20, 0x21, 0x22, 0x23);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_OutOfBundleOrder_RejectsAmbiguousStreamingInput()
+    {
+        var tiles = new[]
+        {
+            new TilePackageWriter.PackagedTile(8, 128, 0, [0x01]),
+            new TilePackageWriter.PackagedTile(8, 0, 0, [0x02]),
+        };
+        using var stream = new MemoryStream();
+
+        var act = () => CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*bundle order*");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_DuplicateTile_RejectsAmbiguousBundleIndex()
+    {
+        var tiles = new[]
+        {
+            new TilePackageWriter.PackagedTile(3, 4, 5, [0x01]),
+            new TilePackageWriter.PackagedTile(3, 4, 5, [0x02]),
+        };
+        using var stream = new MemoryStream();
+
+        var act = () => CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*same tile more than once*");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_EmptyInput_RejectsPackageWithoutUsableLodRange()
+    {
+        using var stream = new MemoryStream();
+
+        var act = () => CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync([]),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*at least one tile*");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_SingleLevel_RejectsInvalidLodRange()
+    {
+        using var stream = new MemoryStream();
+        var tiles = new[] { new TilePackageWriter.PackagedTile(2, 0, 0, [0x01]) };
+
+        var act = () => CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*at least two levels*");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_EmptyOrUnsupportedTileFormat_RejectsBeforeReadingTiles()
+    {
+        foreach (var tileFormat in new[] { string.Empty, "WEBP" })
+        {
+            using var stream = new MemoryStream();
+
+            var act = () => CompactTilePackageWriter.WriteAsync(
+                stream,
+                "Layers",
+                tileFormat,
+                [-180d, -85d, 180d, 85d],
+                ToAsync([]),
+                CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("*supported TPKX tile format*");
+            stream.Length.Should().Be(0, "format admission must happen before the archive is opened");
+        }
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Operation(Operations.Export)]
+    [InlineData("png", "PNG")]
+    [InlineData("PNG8", "PNG8")]
+    [InlineData("PNG24", "PNG24")]
+    [InlineData("PNG32", "PNG32")]
+    [InlineData("jpeg", "JPEG")]
+    [InlineData("MIXED", "MIXED")]
+    public async Task WriteAsync_SupportedTileFormat_EmitsDocumentedValue(string tileFormat, string expected)
+    {
+        var tiles = new[]
+        {
+            new TilePackageWriter.PackagedTile(0, 0, 0, [0x01]),
+            new TilePackageWriter.PackagedTile(1, 0, 0, [0x02]),
+        };
+        using var stream = new MemoryStream();
+        await CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            tileFormat,
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None);
+
+        using var archive = new ZipArchive(new MemoryStream(stream.ToArray()), ZipArchiveMode.Read);
+        using var root = await ReadJsonAsync(archive, "root.json");
+        root.RootElement.GetProperty("tileImageInfo").GetProperty("format").GetString().Should().Be(expected);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_BundleAdmissionLimit_RejectsBeforeGrowingBuffer()
+    {
+        using var stream = new MemoryStream();
+        var tiles = new[] { new TilePackageWriter.PackagedTile(0, 0, 0, [0x01, 0x02, 0x03, 0x04]) };
+        var limits = new CompactTilePackageLimits(BundleDataOffset + 7, BundleDataOffset * 2L);
+
+        var act = () => CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None,
+            limits);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*bundle admission limit*");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_PackageAdmissionLimit_RejectsAdditionalBundle()
+    {
+        using var stream = new MemoryStream();
+        var tiles = new[]
+        {
+            new TilePackageWriter.PackagedTile(0, 0, 0, [0x01]),
+            new TilePackageWriter.PackagedTile(1, 0, 0, [0x02]),
+        };
+        var limits = new CompactTilePackageLimits(BundleDataOffset + 5, (BundleDataOffset * 2L) + 9);
+
+        var act = () => CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None,
+            limits);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*package admission limit*");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task WriteAsync_SparseBundles_ChargesFixedHeaderAndIndexToPackageLimit()
+    {
+        using var stream = new MemoryStream();
+        var tiles = new[]
+        {
+            new TilePackageWriter.PackagedTile(0, 0, 0, [0x01]),
+            new TilePackageWriter.PackagedTile(0, 128, 0, [0x02]),
+        };
+        var limits = new CompactTilePackageLimits(
+            BundleDataOffset + sizeof(uint) + 1L,
+            (BundleDataOffset * 2L) - 1L);
+
+        var act = () => CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Layers",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None,
+            limits);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*package admission limit*");
+    }
+
+    private static async Task<byte[]> WritePackageAsync(IEnumerable<TilePackageWriter.PackagedTile> tiles)
+    {
+        using var stream = new MemoryStream();
+        var written = await CompactTilePackageWriter.WriteAsync(
+            stream,
+            "Sample Cache",
+            "PNG",
+            [-180d, -85d, 180d, 85d],
+            ToAsync(tiles),
+            CancellationToken.None);
+        written.Should().Be(3);
+        return stream.ToArray();
+    }
+
+    private static void AssertBundleHeader(byte[] bundle, uint maximumTileSize)
+    {
+        BinaryPrimitives.ReadUInt32LittleEndian(bundle.AsSpan(0, 4)).Should().Be(3);
+        BinaryPrimitives.ReadUInt32LittleEndian(bundle.AsSpan(4, 4)).Should().Be(16_384);
+        BinaryPrimitives.ReadUInt32LittleEndian(bundle.AsSpan(8, 4)).Should().Be(maximumTileSize);
+        BinaryPrimitives.ReadUInt32LittleEndian(bundle.AsSpan(12, 4)).Should().Be(5);
+        BinaryPrimitives.ReadUInt64LittleEndian(bundle.AsSpan(24, 8)).Should().Be((ulong)bundle.Length);
+        BinaryPrimitives.ReadUInt32LittleEndian(bundle.AsSpan(60, 4)).Should().Be(131_072);
+    }
+
+    private static byte[] ReadTile(byte[] bundle, int relativeRow, int relativeColumn)
+    {
+        var indexOffset = 64 + (8 * ((128 * relativeRow) + relativeColumn));
+        var index = BinaryPrimitives.ReadUInt64LittleEndian(bundle.AsSpan(indexOffset, 8));
+        var tileOffset = index & 0xFF_FF_FF_FF_FFUL;
+        var tileSize = index >> 40;
+        if (tileSize == 0)
+        {
+            return [];
+        }
+
+        BinaryPrimitives.ReadUInt32LittleEndian(bundle.AsSpan(checked((int)tileOffset - 4), 4))
+            .Should().Be((uint)tileSize);
+        return bundle.AsSpan(checked((int)tileOffset), checked((int)tileSize)).ToArray();
+    }
+
+    private static async Task<JsonDocument> ReadJsonAsync(ZipArchive archive, string path)
+        => JsonDocument.Parse(await ReadEntryAsync(archive, path));
+
+    private static async Task<byte[]> ReadEntryAsync(ZipArchive archive, string path)
+    {
+        var entry = archive.GetEntry(path);
+        entry.Should().NotBeNull();
+        await using var entryStream = entry!.Open();
+        using var buffer = new MemoryStream();
+        await entryStream.CopyToAsync(buffer);
+        return buffer.ToArray();
+    }
+
+    private static async IAsyncEnumerable<TilePackageWriter.PackagedTile> ToAsync(
+        IEnumerable<TilePackageWriter.PackagedTile> tiles)
+    {
+        foreach (var tile in tiles)
+        {
+            yield return tile;
+        }
+
+        await Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2686
Related to #2660

## Summary
Adds a deterministic Esri TPKX 1.0 writer over the shared tile packaging seam. This establishes the Compact Cache V2 artifact contract before durable jobs and GeoServices adapters consume it.

## Changes Made
- Write 128-by-128 Compact Cache V2 bundles with the documented header, embedded index, length prefixes, and offset/size records.
- Emit deterministic TPKX paths and metadata matching Esri's published sample, including scale ordering, boolean resampling, and item extent nesting.
- Enforce the documented PNG/PNG8/PNG24/PNG32/JPEG/MIXED format set and a usable multi-level LOD range.
- Bound in-memory bundles to 64 MiB and aggregate uncompressed package admission to 1 GiB by default, with injectable limits for later job policy.
- Add official-sample shape assertions and literal CompactV2 index/offset fixtures alongside reader-style compatibility tests.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Focused evidence:

`dotnet test tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj --filter FullyQualifiedName~CompactTilePackageWriterTests --configuration Release --no-restore`

Result: 15 passed, 0 failed.

Targeted `dotnet format` completed for all changed files.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

## Non-goals
- No MapServer or ImageServer HTTP exposure in this slice.
- No durable job, Redis, cancellation, retry, expiry, or multi-node behavior; those are tracked in #2687–#2689.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

