### PR TITLE
ci: target bounded tile and routing shards (#2693)

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -23,7 +23,7 @@
     "src/Honua.Server/Features/Infrastructure/Monitoring/",
     "src/Honua.Server/Startup/"
   ],
-  "_unmapped_source_run_all_prefixes_comment": "Safety net (#1897): a changed file under one of these prefixes that is NOT claimed by any shard's `paths` escalates to run_all. Per-prefix rationale — src/Honua.Core/, src/Honua.Postgres/, src/Honua.Server/, src/Honua.DuckDB/, tests/dotnet/Honua.Server.Tests/: shared canonical pipeline + provider + integration-test host whose unmapped slices cut across every shard. src/Honua.Geometry/, src/Honua.Jobs/, src/Honua.Routing/, src/Honua.Hosting/: cross-cutting geometry/job/routing/host-rendering primitives referenced by nearly every protocol src project (no single owning shard; routing powers NAServer + MCP, Honua.Hosting carries the shared rendering/caching/security/parsing host used by every render+query protocol — both over-included via run_all rather than mis-routed to Core). src/Honua.Aws/, src/Honua.Azure/: cloud-provider runtime whose tests are spread across the Cloud/FileImport/Infra shards; over-include via run_all (moved here from infrastructure_paths so a project-add no longer trips it). src/Honua.Protocols., src/Honua.Scene/, src/Honua.Ai/, src/Honua.Geoprocessing/, src/Honua.Geocoding/, src/Honua.Io/, src/Honua.Import/: their mapped subdirs are claimed by owning shards below (so normal feature PRs stay targeted); the net only fires for a NOT-YET-MAPPED new top-level area under them, e.g. a brand-new src/Honua.Protocols.SensorThings/ project whose tests have no shard yet.",
+  "_unmapped_source_run_all_prefixes_comment": "Safety net (#1897): a changed file under one of these prefixes that is NOT claimed by any shard's `paths` escalates to run_all. Per-prefix rationale — src/Honua.Core/, src/Honua.Postgres/, src/Honua.Server/, src/Honua.DuckDB/, tests/dotnet/Honua.Server.Tests/: shared canonical pipeline + provider + integration-test host whose unmapped slices cut across every shard. src/Honua.Geometry/, src/Honua.Jobs/, src/Honua.Routing/, src/Honua.Hosting/: cross-cutting geometry/job/routing/host primitives remain fail-safe by default; bounded ownership exceptions are declared in shard paths (for example Routing/Features/Routing -> GPServer/NAServer and Hosting/Features/Tiles -> tile/ImageServer owners). src/Honua.Aws/, src/Honua.Azure/: cloud-provider runtime whose tests are spread across the Cloud/FileImport/Infra shards; over-include via run_all (moved here from infrastructure_paths so a project-add no longer trips it). src/Honua.Protocols., src/Honua.Scene/, src/Honua.Ai/, src/Honua.Geoprocessing/, src/Honua.Geocoding/, src/Honua.Io/, src/Honua.Import/: their mapped subdirs are claimed by owning shards below (so normal feature PRs stay targeted); the net only fires for a NOT-YET-MAPPED new top-level area under them, e.g. a brand-new src/Honua.Protocols.SensorThings/ project whose tests have no shard yet.",
   "unmapped_source_run_all_prefixes": [
     "src/Honua.Core/",
     "src/Honua.Postgres/",
@@ -46,7 +46,7 @@
   "default_shards_when_no_match": [
     "Core"
   ],
-  "_targeted_override_prefixes_comment": "Narrows over-broad run_all triggers (ADR-0037 targeting follow-up). A changed file under one of these prefixes is CLAIMED by the listed shard subset instead of escalating to run_all: it is excluded from the infrastructure_paths short-circuit and the unmapped_source_run_all_prefixes net, and the listed shards are unioned into the targeted result. Evaluated AFTER the empty-diff guard and BEFORE the infrastructure_paths check. Two over-broad triggers are narrowed: (1) endpoint-registration PLUMBING — src/Honua.Server/EndpointRegistry.cs, src/Honua.Server/Program.cs, and src/Honua.Server/Startup/JsonContextRegistration.cs — which almost every feature PR touches; these route to a representative SMOKE subset spanning the main protocol families (FeatureServer, OGC API Features, one classic OGC = WMS, OData, MCP) plus the always-on API/governance and admin-infrastructure shards, NOT all 45. The architecture/governance guards that run on EVERY PR (EndpointRegistry/OperationRegistry drift + coverage, proof-ledger, in Honua.Architecture.Tests on the build job) are the safety net that catches a registration mistake regardless of which server-test shards run, which is what makes a smoke subset safe here. (2) shared FEATURE-AREA dirs under src/Honua.Hosting/ — Authentication/ and Security/ — route to the auth/security-relevant shards (Infra and Security, Admin & Infrastructure, OData Core which carries ODataAuthorizationTests), NOT all 45. IMPORTANT: keep these prefixes SPECIFIC. They MUST be narrower than the genuinely cross-cutting paths that must stay run_all: do NOT add Honua.Core abstractions, DI/host bootstrap (Honua.Hosting.csproj, Startup/InfrastructureCompositionRoot.cs), the rest of src/Honua.Hosting/Features/ (Rendering/Caching/etc. stay run_all via the unmapped net), Directory.Build.props/Directory.Packages.props, .github/workflows/**, ci-shards.json, the router scripts, or *.sln here. A registration override prefix must point at a SPECIFIC plumbing file, not a whole shared directory.",
+  "_targeted_override_prefixes_comment": "Narrows over-broad run_all triggers (ADR-0037 targeting follow-up). A changed file under one of these prefixes is CLAIMED by the listed shard subset instead of escalating to run_all: it is excluded from the infrastructure_paths short-circuit and the unmapped_source_run_all_prefixes net, and the listed shards are unioned into the targeted result. Evaluated AFTER the empty-diff guard and BEFORE the infrastructure_paths check. Two over-broad triggers are narrowed: (1) endpoint-registration PLUMBING — src/Honua.Server/EndpointRegistry.cs, src/Honua.Server/Program.cs, and src/Honua.Server/Startup/JsonContextRegistration.cs — which almost every feature PR touches; these route to a representative SMOKE subset spanning the main protocol families (FeatureServer, OGC API Features, one classic OGC = WMS, OData, MCP) plus the always-on API/governance and admin-infrastructure shards, NOT all 45. The architecture/governance guards that run on EVERY PR (EndpointRegistry/OperationRegistry drift + coverage, proof-ledger, in Honua.Architecture.Tests on the build job) are the safety net that catches a registration mistake regardless of which server-test shards run, which is what makes a smoke subset safe here. (2) shared FEATURE-AREA dirs under src/Honua.Hosting/ — Authentication/ and Security/ — route to the auth/security-relevant shards (Infra and Security, Admin & Infrastructure, OData Core which carries ODataAuthorizationTests), NOT all 45. IMPORTANT: keep these prefixes SPECIFIC. They MUST be narrower than the genuinely cross-cutting paths that must stay run_all: do NOT add Honua.Core abstractions, DI/host bootstrap (Honua.Hosting.csproj, Startup/InfrastructureCompositionRoot.cs), or unmapped src/Honua.Hosting/Features areas (Rendering/Caching/etc. stay run_all via the unmapped net; bounded Tiles ownership is declared directly on its shards), Directory.Build.props/Directory.Packages.props, .github/workflows/**, ci-shards.json, the router scripts, or *.sln here. A registration override prefix must point at a SPECIFIC plumbing file, not a whole shared directory.",
   "targeted_override_prefixes": [
     {
       "prefix": "src/Honua.Server/EndpointRegistry.cs",
@@ -168,9 +168,11 @@
         "src/Honua.Postgres/Features/Metadata/",
         "src/Honua.Core/Features/Publishing/",
         "src/Honua.Postgres/Features/Publishing/",
+        "src/Honua.Routing/Features/Routing/",
         "src/Honua.Server/Migrations/082_CreatePromotionStores.sql",
         "tests/dotnet/Honua.Server.Tests/Seed/",
         "tests/dotnet/Honua.Server.Tests/Startup/PostgresPromotionSurfaceRegistrationTests.cs",
+        "tests/dotnet/Honua.Server.Tests/Routing/NAServerPgRoutingEndToEndTests.cs",
         "tests/dotnet/Honua.Server.Tests/Helpers/",
         "tests/dotnet/Honua.Server.Tests/TestData/",
         "tests/dotnet/Honua.Server.Tests/AdvancedSpatialQueryTests.cs",
@@ -635,8 +637,10 @@
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
       "filter": "FullyQualifiedName~Honua.Server.Tests.Features.API",
+      "_paths_comment": "#2693: the exact ImageServer endpoint-registry fragment is bounded protocol registration; pair its ImageServer owner with this API-governance projection without widening other EndpointRegistry fragments.",
       "paths": [
         "src/Honua.Protocols.Stac/",
+        "src/Honua.Server/EndpointRegistry.ImageServer.cs",
         "tests/dotnet/Honua.Server.Tests/Features/API/",
         "src/Honua.Core/Features/Validation/"
       ]
@@ -860,15 +864,18 @@
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
       "_comment": "ADR-0037 finer-sharding: narrowed to the ImageServer + Catalog namespaces; GPServer and NAServer were carved into the GeoServices GPServer and NAServer shard. ImageServer and GPServer/NAServer use disjoint namespaces, so the two shards partition the original suite with no gaps or overlaps.",
-      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.Catalog",
-      "_paths_comment": "src-dir->shard map (#1897 follow-up): src/Honua.Core/Features/Raster/ is the shared raster/coverage pipeline (Zarr/COG sampling, mosaic, statistics) that ImageServer adapts; it is mapped here (and to the OGC API Tiles/Coverages and WFS=Wcs shards) so a raster change like #1939 targets the raster-rendering protocol shards instead of tripping the unmapped-source net. Raster unit tests live in Honua.Core.Tests (not in the shard matrix); the server-test coverage of Raster flows through these protocol shards.",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.Catalog|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.Tiles",
+      "_paths_comment": "src-dir->shard map (#1897 follow-up): src/Honua.Core/Features/Raster/ is the shared raster/coverage pipeline (Zarr/COG sampling, mosaic, statistics) that ImageServer adapts; it is mapped here (and to the OGC API Tiles/Coverages and WFS=Wcs shards) so a raster change like #1939 targets the raster-rendering protocol shards instead of tripping the unmapped-source net. #2693 also assigns the shared Hosting/Tiles package writers and their GeoServices.Tiles tests to this shard; its GeoServices test project/filter explicitly discovers those tests. Raster unit tests live in Honua.Core.Tests (not in the shard matrix); the server-test coverage of Raster flows through these protocol shards.",
       "paths": [
         "src/Honua.Protocols.GeoServices/ImageServer/",
         "src/Honua.Protocols.GeoServices/Catalog/",
+        "src/Honua.Hosting/Features/Tiles/",
+        "src/Honua.Server/EndpointRegistry.ImageServer.cs",
         "src/Honua.Core/Features/Raster/",
         "src/Honua.Postgres/Features/Raster/",
         "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/",
         "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Catalog/",
+        "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/",
         "src/Honua.Core/Features/Validation/"
       ],
       "csproj": "tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj"
@@ -885,9 +892,11 @@
       "upload_odata_evidence": false,
       "_comment": "ADR-0037 finer-sharding: carved from GeoServices ImageServer. Selects the GPServer and NAServer namespaces (GPServerEndpointTests is the heaviest single class in the original ImageServer shard).",
       "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.GPServer|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.GeoServices.NAServer",
+      "_paths_comment": "#2693: the canonical Routing feature belongs to the GPServer/NAServer operator slice. Its Honua.Server.Tests routing coverage is additionally owned by Core, while this shard runs the protocol-level NAServer tests. Unrelated future Honua.Routing areas remain under the unmapped-source fail-safe.",
       "paths": [
         "src/Honua.Protocols.GeoServices/GPServer/",
         "src/Honua.Protocols.GeoServices/NAServer/",
+        "src/Honua.Routing/Features/Routing/",
         "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GPServer/",
         "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/NAServer/",
         "src/Honua.Core/Features/Validation/"
@@ -931,9 +940,11 @@
       "upload_odata_evidence": false,
       "_comment": "Owns the Terrain and Tiles namespaces in the Honua.Server.Tests assembly. NOTE (#1899): the GeometryService namespace was REMOVED from this shard's filter — those tests live in the Honua.Protocols.GeoServices.Tests assembly, not this shard's (default) Honua.Server.Tests assembly, so the filter never matched them here; they are now owned by 'GeoServices Geometry VectorTile and Versioning' which targets the correct csproj.",
       "filter": "FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Terrain|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Tiles",
+      "_paths_comment": "#2693: shared Hosting tile-package primitives are bounded tile infrastructure, so they select this owner plus ImageServer instead of escalating every server-test shard.",
       "paths": [
         "src/Honua.Server/Features/Protocols/Terrain/",
         "src/Honua.Server/Features/Protocols/Tiles/",
+        "src/Honua.Hosting/Features/Tiles/",
         "tests/dotnet/Honua.Server.Tests/Features/Protocols/Terrain/",
         "tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/",
         "src/Honua.Core/Features/Validation/"

--- a/scripts/ci/check-server-test-shard-coverage.py
+++ b/scripts/ci/check-server-test-shard-coverage.py
@@ -295,6 +295,13 @@ def main() -> int:
                         help="print the full class->shard map")
     parser.add_argument("--report-multi", action="store_true",
                         help="also report classes claimed by >1 shard")
+    parser.add_argument(
+        "--assert-owner",
+        action="append",
+        nargs=3,
+        metavar=("FQN", "CSPROJ", "SHARD"),
+        help="assert that SHARD targets CSPROJ and its filter selects FQN; repeatable",
+    )
     args = parser.parse_args()
 
     config = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
@@ -311,6 +318,25 @@ def main() -> int:
                   f"filter: {exc}", file=sys.stderr)
             return 2
         shard_csproj[shard["name"]] = shard.get("csproj") or DEFAULT_CSPROJ
+
+    for fqn, csproj, shard_name in args.assert_owner or []:
+        if shard_name not in parsed:
+            print(f"::error::asserted owner shard {shard_name!r} does not exist", file=sys.stderr)
+            return 2
+        if shard_csproj[shard_name] != csproj:
+            print(
+                f"::error::shard {shard_name!r} targets {shard_csproj[shard_name]!r}, "
+                f"not asserted project {csproj!r}",
+                file=sys.stderr,
+            )
+            return 1
+        if not _eval(parsed[shard_name], fqn):
+            print(
+                f"::error::shard {shard_name!r} filter does not select {fqn!r}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Owner assertion passed: {fqn} -> {shard_name} [{csproj}]")
 
     classes = enumerate_test_classes()
     if not classes:

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -139,6 +139,25 @@ assert_excludes_shard() {
   fi
 }
 
+# Assert a targeted descriptor selects exactly the expected shard set. Use this
+# for measured cumulative diffs where accidental widening would recreate most
+# of the cost that path routing is intended to avoid.
+assert_exact_shards() {
+  local name="$1"
+  local changed_files="$2"
+  local expected_shards_json="$3"
+  local descriptor
+
+  descriptor="$(printf '%s\n' "${changed_files}" | scripts/ci/honua-server-targeted-tests.sh --stdin)"
+  echo "${name}: ${descriptor}"
+
+  jq -e --argjson expected "${expected_shards_json}" '
+    .run_all == false
+    and .reason == "targeted"
+    and ((.shards | sort) == ($expected | sort))
+  ' <<< "${descriptor}" >/dev/null
+}
+
 echo "Dry-running shard router cases..."
 assert_descriptor \
   "ci-shards-only" \
@@ -371,6 +390,75 @@ assert_descriptor \
 assert_descriptor \
   "hosting-rendering-run-all" \
   "src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs" \
+  "unmapped_source_change" \
+  "true" \
+  "Core"
+
+# #2693: bounded operator paths observed in merge-train child 29142991789
+# already had known test owners, but missing path ownership caused the entire
+# cumulative descriptor to fall through to unmapped_source_change.
+assert_descriptor \
+  "hosting-tiles-targets-geometry" \
+  "src/Honua.Hosting/Features/Tiles/TilePackageWriter.cs" \
+  "targeted" \
+  "false" \
+  "Geometry Tiles and Terrain"
+assert_descriptor \
+  "hosting-tiles-includes-imageserver" \
+  "src/Honua.Hosting/Features/Tiles/TilePackageWriter.cs" \
+  "targeted" \
+  "false" \
+  "GeoServices ImageServer"
+assert_descriptor \
+  "routing-feature-targets-naserver" \
+  "src/Honua.Routing/Features/Routing/Providers/PgRoutingProvider.cs" \
+  "targeted" \
+  "false" \
+  "GeoServices GPServer and NAServer"
+assert_descriptor \
+  "routing-feature-includes-server-tests-owner" \
+  "src/Honua.Routing/Features/Routing/Providers/PgRoutingProvider.cs" \
+  "targeted" \
+  "false" \
+  "Core"
+assert_descriptor \
+  "imageserver-registry-targets-imageserver" \
+  "src/Honua.Server/EndpointRegistry.ImageServer.cs" \
+  "targeted" \
+  "false" \
+  "GeoServices ImageServer"
+assert_descriptor \
+  "imageserver-registry-includes-governance" \
+  "src/Honua.Server/EndpointRegistry.ImageServer.cs" \
+  "targeted" \
+  "false" \
+  "STAC and API Governance"
+assert_descriptor \
+  "naserver-pgrouting-test-targeted" \
+  "tests/dotnet/Honua.Server.Tests/Routing/NAServerPgRoutingEndToEndTests.cs" \
+  "targeted" \
+  "false" \
+  "Core"
+assert_descriptor \
+  "compact-tile-writer-test-targeted" \
+  "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/CompactTilePackageWriterTests.cs" \
+  "targeted" \
+  "false" \
+  "GeoServices ImageServer"
+assert_exact_shards \
+  "measured-tile-routing-imageserver-batch" \
+  "$(printf '%s\n%s\n%s\n%s' \
+      'src/Honua.Hosting/Features/Tiles/CompactTilePackageWriter.cs' \
+      'src/Honua.Routing/Features/Routing/Domain/RoutingModels.cs' \
+      'src/Honua.Server/EndpointRegistry.ImageServer.cs' \
+      'tests/dotnet/Honua.Server.Tests/Routing/NAServerPgRoutingEndToEndTests.cs')" \
+  '["Core","Geometry Tiles and Terrain","GeoServices ImageServer","GeoServices GPServer and NAServer","STAC and API Governance"]'
+
+# Keep the safety net for a future unrelated Routing area; #2693 claims only
+# the existing Features/Routing slice.
+assert_descriptor \
+  "unknown-routing-area-still-run-all" \
+  "src/Honua.Routing/Features/Future/FutureRouter.cs" \
   "unmapped_source_change" \
   "true" \
   "Core"
@@ -629,6 +717,14 @@ assert_descriptor \
 # unmapped namespace fails CI here instead of silently never running.
 # ---------------------------------------------------------------------------
 echo "Checking server-test shard coverage (no orphaned test classes)..."
-python3 scripts/ci/check-server-test-shard-coverage.py
+python3 scripts/ci/check-server-test-shard-coverage.py \
+  --assert-owner \
+    "Honua.Server.Tests.Features.Protocols.GeoServices.Tiles.CompactTilePackageWriterTests" \
+    "tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj" \
+    "GeoServices ImageServer" \
+  --assert-owner \
+    "Honua.Server.Tests.Routing.NAServerPgRoutingEndToEndTests" \
+    "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
+    "Core"
 
 echo "CI router validation passed."


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2693

## Summary
Maps the bounded tile-package, canonical routing, ImageServer registry, and gated NAServer routing-test paths observed in merge-train child 29142991789 to their existing server-test owners instead of discarding targeted selection with `unmapped_source_change`.

## Changes Made
- Route `Honua.Hosting/Features/Tiles` to Geometry Tiles and GeoServices ImageServer.
- Route the existing `Honua.Routing/Features/Routing` slice to GeoServices GPServer/NAServer and Core; Core owns the exact gated pgRouting test in `Honua.Server.Tests`.
- Route the exact ImageServer endpoint-registry fragment to ImageServer and API Governance.
- Extend the GeoServices ImageServer filter to execute the GeoServices.Tiles package-writer tests.
- Add individual, exact cumulative-shard, executable `(FQN, csproj, filter)` ownership, and negative fail-safe fixtures.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Focused evidence:

- `bash scripts/ci/validate-ci-router.sh` — passed, including all 681 shard-coverage classes.
- The exact `8b56356c2...726da8557` train diff now emits `run_all=false`, `reason=targeted`, with exactly Core, Geometry Tiles and Terrain, GeoServices ImageServer, GeoServices GPServer and NAServer, and STAC and API Governance.

No broad CI was run locally, and live train run 29142991789 was not altered or rerun.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

## Non-goals
- Removing or weakening the unmapped-source fail-safe.
- Broadly claiming unrelated Hosting, Routing, endpoint-registry, or test paths.
- Changing application code or the live train.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review


