### PR TITLE
feat(tiles): add durable export job runtime

### DIFF
--- a/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
+++ b/src/Honua.Core/Features/ControlPlane/Domain/OperationModels.cs
@@ -220,7 +220,12 @@ public enum ExecutionJobKind
     /// Per-area routing-graph build workload. Clips a road-network feedstock layer to
     /// an area and emits a pgRouting topology artifact a routing endpoint can solve over.
     /// </summary>
-    RouterBuild
+    RouterBuild,
+
+    /// <summary>
+    /// Durable map or imagery tile-package export workload.
+    /// </summary>
+    TileExport
 }
 
 /// <summary>

--- a/src/Honua.Hosting/Features/Tiles/TileExportJobContract.cs
+++ b/src/Honua.Hosting/Features/Tiles/TileExportJobContract.cs
@@ -1,0 +1,288 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Honua.Core.Features.ControlPlane.Domain;
+
+namespace Honua.Infrastructure.Tiles;
+
+internal enum TileExportSourceKind
+{
+    Map,
+    Raster
+}
+
+internal enum TileExportPackageFormat
+{
+    Zip,
+    Tpk,
+    Tpkx
+}
+
+internal sealed record TileExportJobPlan
+{
+    public required TileExportSourceKind SourceKind { get; init; }
+    public required string ResourceId { get; init; }
+    public string? LayerId { get; init; }
+    public required int MinZoom { get; init; }
+    public required int MaxZoom { get; init; }
+    public required double West { get; init; }
+    public required double South { get; init; }
+    public required double East { get; init; }
+    public required double North { get; init; }
+    public required string TileImageFormat { get; init; }
+    public required TileExportPackageFormat PackageFormat { get; init; }
+    public required long MaxArtifactBytes { get; init; }
+    public required int RetentionSeconds { get; init; }
+    public string? StyleId { get; init; }
+}
+
+internal static class TileExportJobParameterKeys
+{
+    internal const string Prefix = "honua.tile_export.";
+    internal const string ContractVersion = Prefix + "contract_version";
+    internal const string SourceKind = Prefix + "source_kind";
+    internal const string ResourceId = Prefix + "resource_id";
+    internal const string LayerId = Prefix + "layer_id";
+    internal const string MinZoom = Prefix + "min_zoom";
+    internal const string MaxZoom = Prefix + "max_zoom";
+    internal const string West = Prefix + "west";
+    internal const string South = Prefix + "south";
+    internal const string East = Prefix + "east";
+    internal const string North = Prefix + "north";
+    internal const string TileImageFormat = Prefix + "tile_image_format";
+    internal const string PackageFormat = Prefix + "package_format";
+    internal const string MaxArtifactBytes = Prefix + "max_artifact_bytes";
+    internal const string RetentionSeconds = Prefix + "retention_seconds";
+    internal const string StyleId = Prefix + "style_id";
+    internal const string ContentIdentity = Prefix + "content_identity";
+}
+
+internal static class TileExportArtifactIdentity
+{
+    internal const string IdentityMetadataKey = "honua-tile-export-identity";
+
+    internal static string Compute(TileExportJobPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        var canonical = string.Join('\n',
+            "1",
+            plan.SourceKind.ToString(),
+            plan.ResourceId,
+            plan.LayerId ?? string.Empty,
+            plan.MinZoom.ToString(CultureInfo.InvariantCulture),
+            plan.MaxZoom.ToString(CultureInfo.InvariantCulture),
+            plan.West.ToString("R", CultureInfo.InvariantCulture),
+            plan.South.ToString("R", CultureInfo.InvariantCulture),
+            plan.East.ToString("R", CultureInfo.InvariantCulture),
+            plan.North.ToString("R", CultureInfo.InvariantCulture),
+            plan.TileImageFormat,
+            plan.PackageFormat.ToString(),
+            plan.MaxArtifactBytes.ToString(CultureInfo.InvariantCulture),
+            plan.RetentionSeconds.ToString(CultureInfo.InvariantCulture),
+            plan.StyleId ?? string.Empty);
+
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+
+    internal static string BuildObjectKey(TileExportJobPlan plan)
+        => $"tile-exports/{Compute(plan)}.{GetExtension(plan.PackageFormat)}";
+
+    internal static string GetExtension(TileExportPackageFormat format)
+        => format switch
+        {
+            TileExportPackageFormat.Zip => "zip",
+            TileExportPackageFormat.Tpk => "tpk",
+            TileExportPackageFormat.Tpkx => "tpkx",
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported tile package format.")
+        };
+}
+
+internal static class TileExportExecutionSpecBuilder
+{
+    private const int ContractVersion = 1;
+    private const int MaximumZoom = 30;
+    private const long MaximumArtifactBytes = 1024L * 1024 * 1024;
+    private const int MaximumRetentionSeconds = 7 * 24 * 60 * 60;
+
+    internal static ExecutionJobSpec Build(
+        TileExportJobPlan plan,
+        BatchComputeTargetKind targetKind = BatchComputeTargetKind.LocalProcess,
+        string backend = "local")
+    {
+        Validate(plan);
+        ArgumentException.ThrowIfNullOrWhiteSpace(backend);
+
+        return new ExecutionJobSpec
+        {
+            TargetKind = targetKind,
+            Backend = backend,
+            Kind = ExecutionJobKind.TileExport,
+            WorkloadName = $"tile-export:{plan.SourceKind.ToString().ToLowerInvariant()}:{plan.ResourceId}",
+            ContractVersion = ContractVersion,
+            Parameters = ImmutableDictionary.CreateRange(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [TileExportJobParameterKeys.ContractVersion] = ContractVersion.ToString(CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.SourceKind] = plan.SourceKind.ToString(),
+                [TileExportJobParameterKeys.ResourceId] = plan.ResourceId,
+                [TileExportJobParameterKeys.LayerId] = plan.LayerId ?? string.Empty,
+                [TileExportJobParameterKeys.MinZoom] = plan.MinZoom.ToString(CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.MaxZoom] = plan.MaxZoom.ToString(CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.West] = plan.West.ToString("R", CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.South] = plan.South.ToString("R", CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.East] = plan.East.ToString("R", CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.North] = plan.North.ToString("R", CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.TileImageFormat] = plan.TileImageFormat,
+                [TileExportJobParameterKeys.PackageFormat] = plan.PackageFormat.ToString(),
+                [TileExportJobParameterKeys.MaxArtifactBytes] = plan.MaxArtifactBytes.ToString(CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.RetentionSeconds] = plan.RetentionSeconds.ToString(CultureInfo.InvariantCulture),
+                [TileExportJobParameterKeys.StyleId] = plan.StyleId ?? string.Empty,
+                [TileExportJobParameterKeys.ContentIdentity] = TileExportArtifactIdentity.Compute(plan)
+            })
+        };
+    }
+
+    internal static bool TryParse(
+        IReadOnlyDictionary<string, string> parameters,
+        out TileExportJobPlan? plan,
+        out string? error)
+    {
+        plan = null;
+        error = null;
+
+        try
+        {
+            if (parameters.Count > 32 || parameters.Values.Any(static value => value is null || value.Length >= 1024))
+            {
+                error = "Tile-export parameters exceed the bounded contract size.";
+                return false;
+            }
+
+            if (!TryGet(parameters, TileExportJobParameterKeys.ContractVersion, out var version) ||
+                !int.TryParse(version, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedVersion) ||
+                parsedVersion != ContractVersion)
+            {
+                error = "Unsupported or missing tile-export contract version.";
+                return false;
+            }
+
+            if (!TryGetEnum(parameters, TileExportJobParameterKeys.SourceKind, out TileExportSourceKind sourceKind) ||
+                !TryGetEnum(parameters, TileExportJobParameterKeys.PackageFormat, out TileExportPackageFormat packageFormat) ||
+                !TryGetInt(parameters, TileExportJobParameterKeys.MinZoom, out var minZoom) ||
+                !TryGetInt(parameters, TileExportJobParameterKeys.MaxZoom, out var maxZoom) ||
+                !TryGetDouble(parameters, TileExportJobParameterKeys.West, out var west) ||
+                !TryGetDouble(parameters, TileExportJobParameterKeys.South, out var south) ||
+                !TryGetDouble(parameters, TileExportJobParameterKeys.East, out var east) ||
+                !TryGetDouble(parameters, TileExportJobParameterKeys.North, out var north) ||
+                !TryGetLong(parameters, TileExportJobParameterKeys.MaxArtifactBytes, out var maxArtifactBytes) ||
+                !TryGetInt(parameters, TileExportJobParameterKeys.RetentionSeconds, out var retentionSeconds) ||
+                !TryGet(parameters, TileExportJobParameterKeys.ResourceId, out var resourceId) ||
+                !TryGet(parameters, TileExportJobParameterKeys.TileImageFormat, out var tileImageFormat) ||
+                !TryGet(parameters, TileExportJobParameterKeys.ContentIdentity, out var suppliedIdentity))
+            {
+                error = "Tile-export parameters are incomplete or malformed.";
+                return false;
+            }
+
+            parameters.TryGetValue(TileExportJobParameterKeys.LayerId, out var layerId);
+            parameters.TryGetValue(TileExportJobParameterKeys.StyleId, out var styleId);
+            var candidate = new TileExportJobPlan
+            {
+                SourceKind = sourceKind,
+                ResourceId = resourceId,
+                LayerId = NullIfEmpty(layerId),
+                MinZoom = minZoom,
+                MaxZoom = maxZoom,
+                West = west,
+                South = south,
+                East = east,
+                North = north,
+                TileImageFormat = tileImageFormat,
+                PackageFormat = packageFormat,
+                MaxArtifactBytes = maxArtifactBytes,
+                RetentionSeconds = retentionSeconds,
+                StyleId = NullIfEmpty(styleId)
+            };
+
+            Validate(candidate);
+            if (!string.Equals(
+                    suppliedIdentity,
+                    TileExportArtifactIdentity.Compute(candidate),
+                    StringComparison.Ordinal))
+            {
+                error = "Tile-export content identity does not match the serialized plan.";
+                return false;
+            }
+
+            plan = candidate;
+            return true;
+        }
+        catch (ArgumentException exception)
+        {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    private static void Validate(TileExportJobPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        if (!Enum.IsDefined(plan.SourceKind) || !Enum.IsDefined(plan.PackageFormat))
+            throw new ArgumentException("Tile-export source or package format is unsupported.", nameof(plan));
+        if (string.IsNullOrWhiteSpace(plan.ResourceId) || plan.ResourceId.Length > 256)
+            throw new ArgumentException("Tile-export resource id must contain 1 to 256 characters.", nameof(plan));
+        if (plan.LayerId?.Length > 128 || plan.StyleId?.Length > 256)
+            throw new ArgumentException("Tile-export layer and style identifiers exceed their limits.", nameof(plan));
+        if (plan.MinZoom < 0 || plan.MaxZoom > MaximumZoom || plan.MinZoom > plan.MaxZoom)
+            throw new ArgumentException("Tile-export zoom levels must form an ordered range from 0 to 30.", nameof(plan));
+        if (!double.IsFinite(plan.West) || !double.IsFinite(plan.South) ||
+            !double.IsFinite(plan.East) || !double.IsFinite(plan.North) ||
+            plan.West < -180 || plan.East > 180 || plan.South < -90 || plan.North > 90 ||
+            plan.West >= plan.East || plan.South >= plan.North)
+            throw new ArgumentException("Tile-export bounds must be finite, ordered WGS 84 coordinates.", nameof(plan));
+        if (plan.TileImageFormat is not ("PNG" or "PNG8" or "PNG24" or "PNG32" or "JPEG" or "MIXED"))
+            throw new ArgumentException("Tile-export image format is unsupported.", nameof(plan));
+        if (plan.MaxArtifactBytes <= 0 || plan.MaxArtifactBytes > MaximumArtifactBytes)
+            throw new ArgumentException("Tile-export artifact limit must be between 1 byte and 1 GiB.", nameof(plan));
+        if (plan.RetentionSeconds < 60 || plan.RetentionSeconds > MaximumRetentionSeconds)
+            throw new ArgumentException("Tile-export retention must be between 60 seconds and 7 days.", nameof(plan));
+    }
+
+    private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
+
+    private static bool TryGet(IReadOnlyDictionary<string, string> values, string key, out string value)
+        => values.TryGetValue(key, out value!) && value is not null;
+
+    private static bool TryGetInt(IReadOnlyDictionary<string, string> values, string key, out int value)
+    {
+        value = default;
+        return TryGet(values, key, out var raw) &&
+               int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryGetLong(IReadOnlyDictionary<string, string> values, string key, out long value)
+    {
+        value = default;
+        return TryGet(values, key, out var raw) &&
+               long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryGetDouble(IReadOnlyDictionary<string, string> values, string key, out double value)
+    {
+        value = default;
+        return TryGet(values, key, out var raw) &&
+               double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryGetEnum<TEnum>(IReadOnlyDictionary<string, string> values, string key, out TEnum value)
+        where TEnum : struct, Enum
+    {
+        value = default;
+        return TryGet(values, key, out var raw) &&
+               Enum.TryParse(raw, ignoreCase: false, out value) &&
+               Enum.IsDefined(value);
+    }
+}

--- a/src/Honua.Hosting/Features/Tiles/TileExportJobContract.cs
+++ b/src/Honua.Hosting/Features/Tiles/TileExportJobContract.cs
@@ -18,7 +18,6 @@ internal enum TileExportSourceKind
 internal enum TileExportPackageFormat
 {
     Zip,
-    Tpk,
     Tpkx
 }
 
@@ -65,27 +64,32 @@ internal static class TileExportArtifactIdentity
 {
     internal const string IdentityMetadataKey = "honua-tile-export-identity";
 
+    // This is a deterministic consistency/content-addressing key over public job parameters,
+    // not an authentication code. Authorization and job-record integrity remain substrate concerns.
     internal static string Compute(TileExportJobPlan plan)
     {
         ArgumentNullException.ThrowIfNull(plan);
-        var canonical = string.Join('\n',
-            "1",
-            plan.SourceKind.ToString(),
-            plan.ResourceId,
-            plan.LayerId ?? string.Empty,
-            plan.MinZoom.ToString(CultureInfo.InvariantCulture),
-            plan.MaxZoom.ToString(CultureInfo.InvariantCulture),
-            plan.West.ToString("R", CultureInfo.InvariantCulture),
-            plan.South.ToString("R", CultureInfo.InvariantCulture),
-            plan.East.ToString("R", CultureInfo.InvariantCulture),
-            plan.North.ToString("R", CultureInfo.InvariantCulture),
-            plan.TileImageFormat,
-            plan.PackageFormat.ToString(),
-            plan.MaxArtifactBytes.ToString(CultureInfo.InvariantCulture),
-            plan.RetentionSeconds.ToString(CultureInfo.InvariantCulture),
-            plan.StyleId ?? string.Empty);
+        using var canonical = new MemoryStream(capacity: 512);
+        using (var writer = new BinaryWriter(canonical, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(1);
+            writer.Write((int)plan.SourceKind);
+            WriteString(writer, plan.ResourceId);
+            WriteString(writer, plan.LayerId ?? string.Empty);
+            writer.Write(plan.MinZoom);
+            writer.Write(plan.MaxZoom);
+            writer.Write(BitConverter.DoubleToInt64Bits(plan.West));
+            writer.Write(BitConverter.DoubleToInt64Bits(plan.South));
+            writer.Write(BitConverter.DoubleToInt64Bits(plan.East));
+            writer.Write(BitConverter.DoubleToInt64Bits(plan.North));
+            WriteString(writer, plan.TileImageFormat);
+            writer.Write((int)plan.PackageFormat);
+            writer.Write(plan.MaxArtifactBytes);
+            writer.Write(plan.RetentionSeconds);
+            WriteString(writer, plan.StyleId ?? string.Empty);
+        }
 
-        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+        return Convert.ToHexStringLower(SHA256.HashData(canonical.GetBuffer().AsSpan(0, checked((int)canonical.Length))));
     }
 
     internal static string BuildObjectKey(TileExportJobPlan plan)
@@ -95,10 +99,16 @@ internal static class TileExportArtifactIdentity
         => format switch
         {
             TileExportPackageFormat.Zip => "zip",
-            TileExportPackageFormat.Tpk => "tpk",
             TileExportPackageFormat.Tpkx => "tpkx",
             _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported tile package format.")
         };
+
+    private static void WriteString(BinaryWriter writer, string value)
+    {
+        var byteCount = Encoding.UTF8.GetByteCount(value);
+        writer.Write(byteCount);
+        writer.Write(Encoding.UTF8.GetBytes(value));
+    }
 }
 
 internal static class TileExportExecutionSpecBuilder
@@ -107,6 +117,24 @@ internal static class TileExportExecutionSpecBuilder
     private const int MaximumZoom = 30;
     private const long MaximumArtifactBytes = 1024L * 1024 * 1024;
     private const int MaximumRetentionSeconds = 7 * 24 * 60 * 60;
+    private static readonly ImmutableHashSet<string> ExpectedParameterKeys = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        TileExportJobParameterKeys.ContractVersion,
+        TileExportJobParameterKeys.SourceKind,
+        TileExportJobParameterKeys.ResourceId,
+        TileExportJobParameterKeys.LayerId,
+        TileExportJobParameterKeys.MinZoom,
+        TileExportJobParameterKeys.MaxZoom,
+        TileExportJobParameterKeys.West,
+        TileExportJobParameterKeys.South,
+        TileExportJobParameterKeys.East,
+        TileExportJobParameterKeys.North,
+        TileExportJobParameterKeys.TileImageFormat,
+        TileExportJobParameterKeys.PackageFormat,
+        TileExportJobParameterKeys.MaxArtifactBytes,
+        TileExportJobParameterKeys.RetentionSeconds,
+        TileExportJobParameterKeys.StyleId,
+        TileExportJobParameterKeys.ContentIdentity);
 
     internal static ExecutionJobSpec Build(
         TileExportJobPlan plan,
@@ -155,7 +183,13 @@ internal static class TileExportExecutionSpecBuilder
 
         try
         {
-            if (parameters.Count > 32 || parameters.Values.Any(static value => value is null || value.Length >= 1024))
+            if (!ExpectedParameterKeys.SetEquals(parameters.Keys))
+            {
+                error = "Tile-export parameters do not match the exact versioned contract key set.";
+                return false;
+            }
+
+            if (parameters.Values.Any(static value => value is null || value.Length >= 1024))
             {
                 error = "Tile-export parameters exceed the bounded contract size.";
                 return false;
@@ -236,6 +270,10 @@ internal static class TileExportExecutionSpecBuilder
             throw new ArgumentException("Tile-export resource id must contain 1 to 256 characters.", nameof(plan));
         if (plan.LayerId?.Length > 128 || plan.StyleId?.Length > 256)
             throw new ArgumentException("Tile-export layer and style identifiers exceed their limits.", nameof(plan));
+        if (ContainsControlCharacter(plan.ResourceId) ||
+            ContainsControlCharacter(plan.LayerId) ||
+            ContainsControlCharacter(plan.StyleId))
+            throw new ArgumentException("Tile-export identifiers must not contain control characters.", nameof(plan));
         if (plan.MinZoom < 0 || plan.MaxZoom > MaximumZoom || plan.MinZoom > plan.MaxZoom)
             throw new ArgumentException("Tile-export zoom levels must form an ordered range from 0 to 30.", nameof(plan));
         if (!double.IsFinite(plan.West) || !double.IsFinite(plan.South) ||
@@ -252,6 +290,9 @@ internal static class TileExportExecutionSpecBuilder
     }
 
     private static string? NullIfEmpty(string? value) => string.IsNullOrEmpty(value) ? null : value;
+
+    private static bool ContainsControlCharacter(string? value)
+        => value?.Any(char.IsControl) == true;
 
     private static bool TryGet(IReadOnlyDictionary<string, string> values, string key, out string value)
         => values.TryGetValue(key, out value!) && value is not null;

--- a/src/Honua.Hosting/Features/Tiles/TileExportJobExecutor.cs
+++ b/src/Honua.Hosting/Features/Tiles/TileExportJobExecutor.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Microsoft.Extensions.Logging;
+
+namespace Honua.Infrastructure.Tiles;
+
+internal interface ITileExportPackageProducer
+{
+    bool CanProduce(TileExportJobPlan plan);
+
+    Task ProduceAsync(TileExportJobPlan plan, Stream destination, CancellationToken cancellationToken);
+}
+
+internal sealed partial class TileExportJobExecutor(
+    ICloudFileStorage storage,
+    IEnumerable<ITileExportPackageProducer> producers,
+    TimeProvider timeProvider,
+    ILogger<TileExportJobExecutor> logger) : IJobExecutor
+{
+    public ExecutionJobKind Kind => ExecutionJobKind.TileExport;
+
+    public async Task<JobExecutionResult> ExecuteAsync(
+        ExecutionJobRecord job,
+        IJobExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(job);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!TileExportExecutionSpecBuilder.TryParse(job.Spec.Parameters, out var plan, out var parseError))
+            return JobExecutionResult.Failed(parseError ?? "Invalid tile-export job plan.");
+
+        var parsedPlan = plan!;
+        var artifactKey = TileExportArtifactIdentity.BuildObjectKey(parsedPlan);
+        var existing = await storage.GetMetadataAsync(artifactKey, cancellationToken).ConfigureAwait(false);
+        if (IsReusable(existing, parsedPlan))
+        {
+            await context.ReportProgressAsync(100, "Reused existing tile package", cancellationToken).ConfigureAwait(false);
+            await context.PublishArtifactAsync(artifactKey, cancellationToken).ConfigureAwait(false);
+            return JobExecutionResult.Succeeded();
+        }
+
+        var producer = producers.FirstOrDefault(candidate => candidate.CanProduce(parsedPlan));
+        if (producer is null)
+            return JobExecutionResult.Failed("No tile-export package producer can execute this plan.");
+
+        var temporaryPath = Path.Combine(Path.GetTempPath(), $"honua-tile-export-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await context.ReportProgressAsync(0, "Generating tile package", cancellationToken).ConfigureAwait(false);
+            await using var temporaryFile = new FileStream(
+                temporaryPath,
+                FileMode.CreateNew,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                bufferSize: 64 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            await using (var bounded = new BoundedWriteStream(temporaryFile, parsedPlan.MaxArtifactBytes, leaveOpen: true))
+            {
+                await producer.ProduceAsync(parsedPlan, bounded, cancellationToken).ConfigureAwait(false);
+                await bounded.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (temporaryFile.Length == 0)
+                return JobExecutionResult.Failed("Tile-export package producer emitted an empty artifact.");
+
+            temporaryFile.Position = 0;
+            await context.ReportProgressAsync(90, "Publishing tile package", cancellationToken).ConfigureAwait(false);
+            var upload = await storage.UploadAsync(new FileUploadRequest
+            {
+                Content = temporaryFile,
+                FileName = Path.GetFileName(artifactKey),
+                ContentType = parsedPlan.PackageFormat == TileExportPackageFormat.Zip
+                    ? "application/zip"
+                    : "application/octet-stream",
+                SizeBytes = temporaryFile.Length,
+                TimeToLive = TimeSpan.FromSeconds(parsedPlan.RetentionSeconds),
+                ObjectKeyOverride = artifactKey,
+                Metadata = ImmutableDictionary<string, string>.Empty
+                    .Add(TileExportArtifactIdentity.IdentityMetadataKey, TileExportArtifactIdentity.Compute(parsedPlan))
+                    .Add("honua-job-kind", ExecutionJobKind.TileExport.ToString())
+            }, cancellationToken).ConfigureAwait(false);
+
+            if (!upload.Success || upload.File is null)
+                return JobExecutionResult.Failed(upload.ErrorMessage ?? "Tile-export artifact upload failed.");
+
+            await context.PublishArtifactAsync(upload.File.FileId, cancellationToken).ConfigureAwait(false);
+            await context.ReportProgressAsync(100, "Tile package ready", cancellationToken).ConfigureAwait(false);
+            return JobExecutionResult.Succeeded();
+        }
+        catch (TileExportArtifactLimitExceededException exception)
+        {
+            return JobExecutionResult.Failed(exception.Message);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            Log.ExecutionFailed(logger, context.OperationId, exception);
+            return JobExecutionResult.Failed("Tile-export package generation failed.");
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (IOException exception)
+            {
+                Log.CleanupFailed(logger, context.OperationId, exception);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                Log.CleanupFailed(logger, context.OperationId, exception);
+            }
+        }
+    }
+
+    private bool IsReusable(CloudFile? file, TileExportJobPlan plan)
+        => file is
+        {
+            SizeBytes: > 0,
+            ExpiresAt: { } expiresAt
+        } &&
+        file.SizeBytes <= plan.MaxArtifactBytes &&
+        expiresAt > timeProvider.GetUtcNow() &&
+        file.Metadata.TryGetValue(TileExportArtifactIdentity.IdentityMetadataKey, out var identity) &&
+        string.Equals(identity, TileExportArtifactIdentity.Compute(plan), StringComparison.Ordinal);
+
+    private sealed class BoundedWriteStream(Stream inner, long maximumBytes, bool leaveOpen) : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => inner.FlushAsync(cancellationToken);
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            EnsureCapacity(count);
+            inner.Write(buffer, offset, count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            EnsureCapacity(buffer.Length);
+            inner.Write(buffer);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            EnsureCapacity(count);
+            return inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            EnsureCapacity(buffer.Length);
+            return inner.WriteAsync(buffer, cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !leaveOpen)
+                inner.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        private void EnsureCapacity(int writeCount)
+        {
+            if (writeCount < 0 || inner.Position > maximumBytes - writeCount)
+                throw new TileExportArtifactLimitExceededException(maximumBytes);
+        }
+    }
+
+    private sealed class TileExportArtifactLimitExceededException(long limit)
+        : IOException($"Tile-export artifact limit of {limit} bytes was exceeded.");
+
+    private static partial class Log
+    {
+        [LoggerMessage(9260, LogLevel.Error, "Tile-export job {OperationId} failed")]
+        internal static partial void ExecutionFailed(ILogger logger, string operationId, Exception exception);
+
+        [LoggerMessage(9261, LogLevel.Warning, "Could not delete tile-export temporary file for job {OperationId}")]
+        internal static partial void CleanupFailed(ILogger logger, string operationId, Exception exception);
+    }
+}

--- a/src/Honua.Hosting/Features/Tiles/TileExportJobExecutor.cs
+++ b/src/Honua.Hosting/Features/Tiles/TileExportJobExecutor.cs
@@ -46,9 +46,13 @@ internal sealed partial class TileExportJobExecutor(
             return JobExecutionResult.Succeeded();
         }
 
-        var producer = producers.FirstOrDefault(candidate => candidate.CanProduce(parsedPlan));
-        if (producer is null)
+        var matchingProducers = producers.Where(candidate => candidate.CanProduce(parsedPlan)).Take(2).ToArray();
+        if (matchingProducers.Length == 0)
             return JobExecutionResult.Failed("No tile-export package producer can execute this plan.");
+        if (matchingProducers.Length > 1)
+            return JobExecutionResult.Failed("Multiple tile-export package producers matched this plan.");
+
+        var producer = matchingProducers[0];
 
         var temporaryPath = Path.Combine(Path.GetTempPath(), $"honua-tile-export-{Guid.NewGuid():N}.tmp");
         try

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/TileExportJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/TileExportJobExecutorTests.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Abstractions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Domain;
+using Honua.Infrastructure.Tiles;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.Tiles;
+
+/// <summary>
+/// Focused contract tests for the canonical durable tile-export executor.
+/// </summary>
+[Protocol(TestProtocols.MapServer)]
+public sealed class TileExportJobExecutorTests
+{
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public void BuildAndTryParse_RoundTripsValidatedPlanWithStableIdentity()
+    {
+        var plan = CreatePlan();
+
+        var first = TileExportExecutionSpecBuilder.Build(plan);
+        var second = TileExportExecutionSpecBuilder.Build(plan);
+
+        first.Kind.Should().Be(ExecutionJobKind.TileExport);
+        first.Parameters.Should().Equal(second.Parameters);
+        first.Parameters.Should().ContainKey(TileExportJobParameterKeys.ContentIdentity);
+        first.Parameters.Values.Should().OnlyContain(static value => value.Length < 1024,
+            "execution-job metadata must never embed tile or package bytes");
+        TileExportExecutionSpecBuilder.TryParse(first.Parameters, out var parsed, out var error).Should().BeTrue(error);
+        parsed.Should().Be(plan);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public void TryParse_TamperedPlanIdentity_IsRejected()
+    {
+        var parameters = TileExportExecutionSpecBuilder.Build(CreatePlan()).Parameters
+            .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
+        parameters[TileExportJobParameterKeys.MaxZoom] = "3";
+
+        TileExportExecutionSpecBuilder.TryParse(parameters, out var plan, out var error).Should().BeFalse();
+
+        plan.Should().BeNull();
+        error.Should().Contain("identity");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExecuteAsync_UnexpiredMatchingArtifact_ReusesWithoutGeneration()
+    {
+        var plan = CreatePlan();
+        var storage = Substitute.For<ICloudFileStorage>();
+        var producer = Substitute.For<ITileExportPackageProducer>();
+        producer.CanProduce(plan).Returns(true);
+        var key = TileExportArtifactIdentity.BuildObjectKey(plan);
+        storage.GetMetadataAsync(key, Arg.Any<CancellationToken>()).Returns(StoredFile(
+            key,
+            plan,
+            DateTimeOffset.UtcNow.AddHours(1)));
+        var context = new RecordingContext("export-reuse");
+        var executor = CreateExecutor(storage, producer);
+
+        var result = await executor.ExecuteAsync(JobFor(plan, context.OperationId), context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        context.Artifacts.Should().ContainSingle().Which.Should().Be(key);
+        await producer.DidNotReceiveWithAnyArgs().ProduceAsync(default!, default!, default);
+        await storage.DidNotReceiveWithAnyArgs().UploadAsync((FileUploadRequest)null!, default);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExecuteAsync_ExpiredArtifact_RegeneratesWithBoundedStorageTtl()
+    {
+        var plan = CreatePlan() with { RetentionSeconds = 3600 };
+        var storage = Substitute.For<ICloudFileStorage>();
+        var producer = Substitute.For<ITileExportPackageProducer>();
+        producer.CanProduce(plan).Returns(true);
+        producer.ProduceAsync(plan, Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var stream = call.ArgAt<Stream>(1);
+                await stream.WriteAsync(new byte[] { 0x01, 0x02, 0x03 });
+            });
+        var key = TileExportArtifactIdentity.BuildObjectKey(plan);
+        storage.GetMetadataAsync(key, Arg.Any<CancellationToken>()).Returns(StoredFile(
+            key,
+            plan,
+            DateTimeOffset.UtcNow.AddMinutes(-1)));
+
+        FileUploadRequest? captured = null;
+        storage.UploadAsync(Arg.Do<FileUploadRequest>(request => captured = request), Arg.Any<CancellationToken>())
+            .Returns(_ => UploadResult.CreateSuccess(StoredFile(key, plan, DateTimeOffset.UtcNow.AddHours(1))));
+        var context = new RecordingContext("export-expired");
+        var executor = CreateExecutor(storage, producer);
+
+        var result = await executor.ExecuteAsync(JobFor(plan, context.OperationId), context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        captured.Should().NotBeNull();
+        captured!.ObjectKeyOverride.Should().Be(key);
+        captured.SizeBytes.Should().Be(3);
+        captured.TimeToLive.Should().Be(TimeSpan.FromHours(1));
+        captured.Metadata[TileExportArtifactIdentity.IdentityMetadataKey].Should()
+            .Be(TileExportArtifactIdentity.Compute(plan));
+        context.Artifacts.Should().ContainSingle(key);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExecuteAsync_MissingArtifact_GeneratesAndPublishesStableReference()
+    {
+        var plan = CreatePlan();
+        var key = TileExportArtifactIdentity.BuildObjectKey(plan);
+        var storage = Substitute.For<ICloudFileStorage>();
+        storage.GetMetadataAsync(key, Arg.Any<CancellationToken>()).Returns((CloudFile?)null);
+        storage.UploadAsync(Arg.Any<FileUploadRequest>(), Arg.Any<CancellationToken>())
+            .Returns(UploadResult.CreateSuccess(StoredFile(key, plan, DateTimeOffset.UtcNow.AddHours(1))));
+        var producer = Substitute.For<ITileExportPackageProducer>();
+        producer.CanProduce(plan).Returns(true);
+        producer.ProduceAsync(plan, Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<Stream>(1).WriteAsync(new byte[] { 0x01 }).AsTask());
+        var context = new RecordingContext("export-missing");
+        var executor = CreateExecutor(storage, producer);
+
+        var result = await executor.ExecuteAsync(JobFor(plan, context.OperationId), context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Succeeded);
+        context.Artifacts.Should().ContainSingle(key);
+        await producer.Received(1).ProduceAsync(plan, Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExecuteAsync_ProducerExceedsArtifactLimit_FailsWithoutUpload()
+    {
+        var plan = CreatePlan() with { MaxArtifactBytes = 8 };
+        var storage = Substitute.For<ICloudFileStorage>();
+        storage.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((CloudFile?)null);
+        var producer = Substitute.For<ITileExportPackageProducer>();
+        producer.CanProduce(plan).Returns(true);
+        producer.ProduceAsync(plan, Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var stream = call.ArgAt<Stream>(1);
+                await stream.WriteAsync(new byte[9]);
+            });
+        var executor = CreateExecutor(storage, producer);
+
+        var result = await executor.ExecuteAsync(
+            JobFor(plan, "export-too-large"),
+            new RecordingContext("export-too-large"),
+            CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("artifact limit");
+        await storage.DidNotReceiveWithAnyArgs().UploadAsync((FileUploadRequest)null!, default);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExecuteAsync_CancelledGeneration_PropagatesWithoutUpload()
+    {
+        var plan = CreatePlan();
+        var storage = Substitute.For<ICloudFileStorage>();
+        storage.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((CloudFile?)null);
+        var producer = Substitute.For<ITileExportPackageProducer>();
+        producer.CanProduce(plan).Returns(true);
+        producer.ProduceAsync(plan, Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromCanceled(call.ArgAt<CancellationToken>(2)));
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        var executor = CreateExecutor(storage, producer);
+
+        var act = () => executor.ExecuteAsync(
+            JobFor(plan, "export-cancel"),
+            new RecordingContext("export-cancel"),
+            cancellation.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await storage.DidNotReceiveWithAnyArgs().UploadAsync((FileUploadRequest)null!, default);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExecuteAsync_NoProducer_FailsCleanlyWithoutArtifact()
+    {
+        var plan = CreatePlan();
+        var storage = Substitute.For<ICloudFileStorage>();
+        storage.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((CloudFile?)null);
+        var context = new RecordingContext("export-no-producer");
+        var executor = CreateExecutor(storage);
+
+        var result = await executor.ExecuteAsync(JobFor(plan, context.OperationId), context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("producer");
+        context.Artifacts.Should().BeEmpty();
+    }
+
+    private static TileExportJobExecutor CreateExecutor(
+        ICloudFileStorage storage,
+        params ITileExportPackageProducer[] producers)
+        => new(storage, producers, TimeProvider.System, NullLogger<TileExportJobExecutor>.Instance);
+
+    private static TileExportJobPlan CreatePlan()
+        => new()
+        {
+            SourceKind = TileExportSourceKind.Map,
+            ResourceId = "world-basemap",
+            LayerId = "0",
+            MinZoom = 0,
+            MaxZoom = 2,
+            West = -180,
+            South = -85,
+            East = 180,
+            North = 85,
+            TileImageFormat = "PNG",
+            PackageFormat = TileExportPackageFormat.Tpkx,
+            MaxArtifactBytes = 1024 * 1024,
+            RetentionSeconds = 3600,
+            StyleId = "default"
+        };
+
+    private static ExecutionJobRecord JobFor(TileExportJobPlan plan, string operationId)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new ExecutionJobRecord
+        {
+            OperationId = operationId,
+            Status = ExecutionJobStatus.Running,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Spec = TileExportExecutionSpecBuilder.Build(plan)
+        };
+    }
+
+    private static CloudFile StoredFile(string key, TileExportJobPlan plan, DateTimeOffset expiresAt)
+        => new()
+        {
+            FileId = key,
+            FileName = Path.GetFileName(key),
+            StoragePath = key,
+            ContentType = "application/octet-stream",
+            SizeBytes = 3,
+            UploadedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = expiresAt,
+            Provider = CloudStorageProvider.Local,
+            Metadata = ImmutableDictionary<string, string>.Empty.Add(
+                TileExportArtifactIdentity.IdentityMetadataKey,
+                TileExportArtifactIdentity.Compute(plan))
+        };
+
+    private sealed class RecordingContext(string operationId) : IJobExecutionContext
+    {
+        public string OperationId { get; } = operationId;
+        public List<string> Artifacts { get; } = [];
+        public List<(double? Percent, string? Phase)> Progress { get; } = [];
+
+        public Task ReportProgressAsync(
+            double? percentComplete,
+            string? phase,
+            CancellationToken cancellationToken = default)
+        {
+            Progress.Add((percentComplete, phase));
+            return Task.CompletedTask;
+        }
+
+        public Task AppendLogAsync(ExecutionLogEntry entry, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task PublishArtifactAsync(string artifactReference, CancellationToken cancellationToken = default)
+        {
+            Artifacts.Add(artifactReference);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/TileExportJobExecutorTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/TileExportJobExecutorTests.cs
@@ -41,7 +41,7 @@ public sealed class TileExportJobExecutorTests
 
     [UnitTest]
     [Operation(Operations.Export)]
-    public void TryParse_TamperedPlanIdentity_IsRejected()
+    public void TryParse_InconsistentPlanIdentity_IsRejected()
     {
         var parameters = TileExportExecutionSpecBuilder.Build(CreatePlan()).Parameters
             .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
@@ -51,6 +51,58 @@ public sealed class TileExportJobExecutorTests
 
         plan.Should().BeNull();
         error.Should().Contain("identity");
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public void Build_AdjacentStringBoundaries_ProduceDistinctCanonicalIdentities()
+    {
+        var first = CreatePlan() with { ResourceId = "ab", LayerId = "c" };
+        var second = CreatePlan() with { ResourceId = "a", LayerId = "bc" };
+
+        TileExportArtifactIdentity.Compute(first).Should().NotBe(TileExportArtifactIdentity.Compute(second));
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public void Build_ControlCharacterInAnyIdentifier_IsRejected()
+    {
+        var invalidPlans = new[]
+        {
+            CreatePlan() with { ResourceId = "world\nbasemap" },
+            CreatePlan() with { LayerId = "0\rlayer" },
+            CreatePlan() with { StyleId = "default\tstyle" }
+        };
+
+        foreach (var plan in invalidPlans)
+        {
+            var act = () => TileExportExecutionSpecBuilder.Build(plan);
+
+            act.Should().Throw<ArgumentException>().WithMessage("*control characters*");
+        }
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public void PackageFormats_AdvertiseOnlyImplementedRuntimeSeams()
+    {
+        Enum.GetValues<TileExportPackageFormat>().Should().Equal(
+            TileExportPackageFormat.Zip,
+            TileExportPackageFormat.Tpkx);
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public void TryParse_UnknownContractKey_IsRejected()
+    {
+        var parameters = TileExportExecutionSpecBuilder.Build(CreatePlan()).Parameters
+            .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
+        parameters[TileExportJobParameterKeys.Prefix + "future"] = "ignored-state";
+
+        TileExportExecutionSpecBuilder.TryParse(parameters, out var plan, out var error).Should().BeFalse();
+
+        plan.Should().BeNull();
+        error.Should().Contain("exact versioned contract key set");
     }
 
     [UnitTest]
@@ -205,6 +257,29 @@ public sealed class TileExportJobExecutorTests
         result.Status.Should().Be(ExecutionJobStatus.Failed);
         result.ErrorMessage.Should().Contain("producer");
         context.Artifacts.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    [Operation(Operations.Export)]
+    public async Task ExecuteAsync_MultipleMatchingProducers_FailsDeterministically()
+    {
+        var plan = CreatePlan();
+        var storage = Substitute.For<ICloudFileStorage>();
+        storage.GetMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((CloudFile?)null);
+        var first = Substitute.For<ITileExportPackageProducer>();
+        var second = Substitute.For<ITileExportPackageProducer>();
+        first.CanProduce(plan).Returns(true);
+        second.CanProduce(plan).Returns(true);
+        var context = new RecordingContext("export-ambiguous-producer");
+        var executor = CreateExecutor(storage, first, second);
+
+        var result = await executor.ExecuteAsync(JobFor(plan, context.OperationId), context, CancellationToken.None);
+
+        result.Status.Should().Be(ExecutionJobStatus.Failed);
+        result.ErrorMessage.Should().Contain("Multiple");
+        context.Artifacts.Should().BeEmpty();
+        await first.DidNotReceiveWithAnyArgs().ProduceAsync(default!, default!, default);
+        await second.DidNotReceiveWithAnyArgs().ProduceAsync(default!, default!, default);
     }
 
     private static TileExportJobExecutor CreateExecutor(


### PR DESCRIPTION
## Issue Link
Fixes #2697
Related to #2687

## Summary
Adds the canonical internal runtime contract and executor seam for durable map and imagery tile-package exports. Retries reuse a matching unexpired artifact, while missing or expired artifacts are regenerated through a bounded producer stream and published under a deterministic storage reference.

## Changes Made
- Add the `TileExport` execution-job kind and a versioned, exact-key serialized plan with an unambiguous consistency identity. The identity is content addressing over public parameters, not authentication.
- Add deterministic artifact identity, bounded temporary-file generation, TTL-backed object storage publication, cooperative cancellation, and deterministic rejection of ambiguous producer registrations.
- Support only runtime-backed `Zip` and `Tpkx` package formats and reject control characters, unknown contract keys, and inconsistent identities.
- Add focused tests for contract round trips and consistency, canonical boundaries, validation, reuse, expiry/missing regeneration, artifact limits, cancellation, and producer selection.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent scoped checks run:
- `dotnet build src/Honua.Hosting/Honua.Hosting.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true` (0 warnings, 0 errors)
- `dotnet test tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj --no-restore --filter FullyQualifiedName~TileExportJobExecutorTests --configuration Release /p:TreatWarningsAsErrors=true` (13 passed)
- `dotnet format Honua.sln --verify-no-changes --no-restore --include <touched files>`