### PR TITLE
ci: map routing tests to core shard (#2693)

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -172,7 +172,7 @@
         "src/Honua.Server/Migrations/082_CreatePromotionStores.sql",
         "tests/dotnet/Honua.Server.Tests/Seed/",
         "tests/dotnet/Honua.Server.Tests/Startup/PostgresPromotionSurfaceRegistrationTests.cs",
-        "tests/dotnet/Honua.Server.Tests/Routing/NAServerPgRoutingEndToEndTests.cs",
+        "tests/dotnet/Honua.Server.Tests/Routing/",
         "tests/dotnet/Honua.Server.Tests/Helpers/",
         "tests/dotnet/Honua.Server.Tests/TestData/",
         "tests/dotnet/Honua.Server.Tests/AdvancedSpatialQueryTests.cs",

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -440,6 +440,12 @@ assert_descriptor \
   "false" \
   "Core"
 assert_descriptor \
+  "routing-solver-test-targeted" \
+  "tests/dotnet/Honua.Server.Tests/Routing/LocationAllocationSolverTests.cs" \
+  "targeted" \
+  "false" \
+  "Core"
+assert_descriptor \
   "compact-tile-writer-test-targeted" \
   "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/Tiles/CompactTilePackageWriterTests.cs" \
   "targeted" \
@@ -453,6 +459,16 @@ assert_exact_shards \
       'src/Honua.Server/EndpointRegistry.ImageServer.cs' \
       'tests/dotnet/Honua.Server.Tests/Routing/NAServerPgRoutingEndToEndTests.cs')" \
   '["Core","Geometry Tiles and Terrain","GeoServices ImageServer","GeoServices GPServer and NAServer","STAC and API Governance"]'
+
+# Follow-up proof from draft PR #2700: pure routing tests share the Core owner
+# with the real pgRouting fixture and must not widen the canonical NAServer diff.
+assert_exact_shards \
+  "location-allocation-routing-batch" \
+  "$(printf '%s\n%s\n%s' \
+      'src/Honua.Routing/Features/Routing/Providers/LocationAllocationSolver.cs' \
+      'src/Honua.Protocols.GeoServices/NAServer/NAServerParameterTranslation.cs' \
+      'tests/dotnet/Honua.Server.Tests/Routing/LocationAllocationSolverTests.cs')" \
+  '["Core","GeoServices GPServer and NAServer"]'
 
 # Keep the safety net for a future unrelated Routing area; #2693 claims only
 # the existing Features/Routing slice.


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2693

## Summary
Closes the remaining targeted-CI ownership gap found while reviewing #2700: pure routing tests now select the Core shard instead of escalating an otherwise bounded NAServer change to all 54 server-test shards.

## Changes Made
- Replace the single pgRouting fixture path with the bounded `Honua.Server.Tests/Routing/` directory owned by Core.
- Add individual proof for the location-allocation solver test.
- Add an exact cumulative fixture proving location-allocation changes select only Core and GeoServices GPServer/NAServer.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent CI-only evidence: `scripts/ci/validate-ci-router.sh` passed all router fixtures, JSON/shell/Python/YAML validation, all 682 shard ownership checks, and the new exact two-shard location-allocation assertion. `git diff --check` passed. No application build or broad test suite is warranted for metadata-only routing changes.
