### PR TITLE
perf(imageserver): push raster catalog spatial query predicates into providers (#2666)

### DIFF
--- a/src/Honua.Core/Features/Raster/Abstractions/IRasterStore.cs
+++ b/src/Honua.Core/Features/Raster/Abstractions/IRasterStore.cs
@@ -42,6 +42,31 @@ public interface IRasterStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Queries a layer's raster catalog with the neutral <see cref="RasterCatalogQuery"/> contract,
+    /// pushing the validated envelope-intersects predicate, identity, temporal, and paging inputs
+    /// into storage <b>before materialization</b> so large imagery catalogs are never fully read to
+    /// satisfy a spatial browse.
+    /// </summary>
+    /// <remarks>
+    /// Implementations that can push the predicate into indexed storage (PostGIS) MUST do so and set
+    /// <see cref="RasterCatalogPage.PredicatePushedDown"/> to <see langword="true"/>. Providers that
+    /// cannot push down MUST fall back to a bounded materialization — delegate to
+    /// <see cref="Honua.Core.Features.Raster.Services.RasterCatalogQueryEvaluator.EvaluateAsync"/> over
+    /// <see cref="ListRastersAsync"/> — which preserves identical result count, aggregate extent,
+    /// paging, and envelope-intersects semantics while declaring the fallback via
+    /// <see cref="RasterCatalogPage.PredicatePushedDown"/> = <see langword="false"/>. The envelope
+    /// predicate is intentionally an inclusive bounding-box overlap, not exact geometry.
+    /// </remarks>
+    /// <param name="layerId">Layer identifier to query.</param>
+    /// <param name="query">The validated neutral catalog query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The matched page plus pre-paging count/extent and read-bounding telemetry counters.</returns>
+    Task<RasterCatalogPage> QueryCatalogAsync(
+        int layerId,
+        RasterCatalogQuery query,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Exports raster data with optional clipping, reprojection, and resampling.
     /// Equivalent to Esri Image Server exportImage operation.
     /// </summary>

--- a/src/Honua.Core/Features/Raster/Domain/RasterCatalogQuery.cs
+++ b/src/Honua.Core/Features/Raster/Domain/RasterCatalogQuery.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Core.Features.Raster.Domain;
+
+/// <summary>
+/// Thrown when a <see cref="RasterCatalogQuery"/> or <see cref="RasterCatalogSpatialPredicate"/>
+/// carries invalid spatial, CRS, or paging input. The message is deliberately free of any
+/// storage detail (SQL, connection strings, paths) so it is safe to surface, translated, to
+/// clients as a generic bad-request.
+/// </summary>
+public sealed class RasterCatalogValidationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RasterCatalogValidationException"/> class.
+    /// </summary>
+    /// <param name="message">A storage-agnostic validation message.</param>
+    public RasterCatalogValidationException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// Validated axis-aligned spatial predicate applied against raster footprint extents by the
+/// neutral raster-catalog query contract. The predicate is an <b>envelope-intersects</b> test:
+/// a footprint matches when its extent's bounding box overlaps this box (edge contact counts as
+/// a match), mirroring the Esri <c>esriSpatialRelEnvelopeIntersects</c> semantics at
+/// footprint-extent granularity. This is intentionally <b>not</b> an exact-geometry predicate.
+/// </summary>
+/// <remarks>
+/// When <see cref="Srid"/> differs from a footprint's SRID the implementation transforms this box
+/// into the footprint SRID (PostGIS via <c>ST_Transform</c>; the in-memory fallback via the shared
+/// CRS pipeline) before the overlap test, so the comparison always stays in a single coordinate
+/// system.
+/// </remarks>
+public readonly record struct RasterCatalogSpatialPredicate
+{
+    private RasterCatalogSpatialPredicate(double xMin, double yMin, double xMax, double yMax, int? srid)
+    {
+        XMin = xMin;
+        YMin = yMin;
+        XMax = xMax;
+        YMax = yMax;
+        Srid = srid;
+    }
+
+    /// <summary>Minimum X of the filter box.</summary>
+    public double XMin { get; }
+
+    /// <summary>Minimum Y of the filter box.</summary>
+    public double YMin { get; }
+
+    /// <summary>Maximum X of the filter box.</summary>
+    public double XMax { get; }
+
+    /// <summary>Maximum Y of the filter box.</summary>
+    public double YMax { get; }
+
+    /// <summary>
+    /// SRID the filter box is expressed in, or <see langword="null"/> when the caller wants the
+    /// footprint's native SRID assumed (no cross-CRS transform).
+    /// </summary>
+    public int? Srid { get; }
+
+    /// <summary>
+    /// Creates a validated predicate, throwing <see cref="RasterCatalogValidationException"/> when
+    /// the input is not a finite, well-ordered box or the SRID is negative.
+    /// </summary>
+    /// <param name="xMin">Minimum X.</param>
+    /// <param name="yMin">Minimum Y.</param>
+    /// <param name="xMax">Maximum X.</param>
+    /// <param name="yMax">Maximum Y.</param>
+    /// <param name="srid">Optional SRID; must be positive when supplied.</param>
+    /// <returns>The validated predicate.</returns>
+    public static RasterCatalogSpatialPredicate Create(double xMin, double yMin, double xMax, double yMax, int? srid)
+    {
+        if (!TryCreate(xMin, yMin, xMax, yMax, srid, out var predicate, out var error))
+        {
+            throw new RasterCatalogValidationException(error);
+        }
+
+        return predicate;
+    }
+
+    /// <summary>
+    /// Attempts to create a validated predicate. Rejects non-finite coordinates (NaN/Infinity),
+    /// inverted boxes (<c>xMin &gt; xMax</c> or <c>yMin &gt; yMax</c>), and non-positive SRIDs
+    /// without throwing.
+    /// </summary>
+    /// <param name="xMin">Minimum X.</param>
+    /// <param name="yMin">Minimum Y.</param>
+    /// <param name="xMax">Maximum X.</param>
+    /// <param name="yMax">Maximum Y.</param>
+    /// <param name="srid">Optional SRID; must be positive when supplied.</param>
+    /// <param name="predicate">The validated predicate on success.</param>
+    /// <param name="error">A storage-agnostic error message on failure.</param>
+    /// <returns><see langword="true"/> when the input is valid; otherwise <see langword="false"/>.</returns>
+    public static bool TryCreate(
+        double xMin,
+        double yMin,
+        double xMax,
+        double yMax,
+        int? srid,
+        out RasterCatalogSpatialPredicate predicate,
+        out string error)
+    {
+        predicate = default;
+        error = string.Empty;
+
+        if (!IsFinite(xMin) || !IsFinite(yMin) || !IsFinite(xMax) || !IsFinite(yMax))
+        {
+            error = "Spatial filter envelope coordinates must be finite numbers.";
+            return false;
+        }
+
+        if (xMin > xMax || yMin > yMax)
+        {
+            error = "Spatial filter envelope is inverted: min coordinates must not exceed max coordinates.";
+            return false;
+        }
+
+        if (srid is { } value && value <= 0)
+        {
+            error = string.Create(
+                CultureInfo.InvariantCulture,
+                $"Spatial filter SRID must be a positive integer; got {value}.");
+            return false;
+        }
+
+        predicate = new RasterCatalogSpatialPredicate(xMin, yMin, xMax, yMax, srid);
+        return true;
+    }
+
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+}
+
+/// <summary>
+/// Neutral, provider-agnostic raster-catalog query. Carries the validated spatial predicate plus
+/// the identity, temporal, and paging inputs a provider needs to filter and page a raster catalog
+/// <b>before materialization</b>. Protocol-specific concerns (Esri <c>where</c> evaluation, computed
+/// field ordering, field masking) are layered on top by the adapter and are intentionally absent
+/// here so the contract stays storage-neutral.
+/// </summary>
+public sealed record RasterCatalogQuery
+{
+    /// <summary>
+    /// Optional validated envelope-intersects predicate against footprint extents. <c>null</c>
+    /// applies no spatial filter.
+    /// </summary>
+    public RasterCatalogSpatialPredicate? SpatialPredicate { get; init; }
+
+    /// <summary>
+    /// Optional identity filter. When set, only rasters whose id is in this set match. An empty
+    /// list matches nothing.
+    /// </summary>
+    public IReadOnlyList<long>? ObjectIds { get; init; }
+
+    /// <summary>
+    /// Optional temporal instant applying "newest batch" snapshot semantics: only rasters whose
+    /// effective acquisition (acquisition date, falling back to created-at) equals the single
+    /// most-recent effective acquisition across the layer at or before this instant match. When no
+    /// acquisition is at or before the instant, nothing matches.
+    /// </summary>
+    public DateTimeOffset? Timestamp { get; init; }
+
+    /// <summary>Zero-based paging offset. Ignored when <see cref="Limit"/> is <c>null</c>.</summary>
+    public int Offset { get; init; }
+
+    /// <summary>
+    /// Maximum number of rows to return. <c>null</c> returns every matching row (no paging pushdown),
+    /// used by the adapter when a post-read step it owns (e.g. Esri <c>where</c> or computed-field
+    /// ordering) still needs the full spatially-filtered set.
+    /// </summary>
+    public int? Limit { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the provider computes the total matched-row count (pre-paging)
+    /// so the adapter can report it without a second round trip.
+    /// </summary>
+    public bool IncludeTotalCount { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the provider computes the aggregate (union) extent of the
+    /// matched set (pre-paging), in the catalog's native SRID.
+    /// </summary>
+    public bool IncludeAggregateExtent { get; init; }
+
+    /// <summary>
+    /// Validates the paging inputs, throwing <see cref="RasterCatalogValidationException"/> for a
+    /// negative offset or a non-positive limit. Providers call this at entry so invalid input is
+    /// rejected safely before any storage access.
+    /// </summary>
+    public void Validate()
+    {
+        if (Offset < 0)
+        {
+            throw new RasterCatalogValidationException("Paging offset must not be negative.");
+        }
+
+        if (Limit is { } limit && limit <= 0)
+        {
+            throw new RasterCatalogValidationException("Paging limit must be a positive integer when supplied.");
+        }
+
+        if (ObjectIds is { Count: > 10000 })
+        {
+            throw new RasterCatalogValidationException("Too many objectIds supplied in a single catalog query.");
+        }
+    }
+}
+
+/// <summary>
+/// A page of raster-catalog rows returned by the neutral query contract, plus the pre-paging
+/// aggregate metadata and the read-bounding telemetry counters the adapter surfaces (without
+/// leaking any SQL).
+/// </summary>
+public sealed record RasterCatalogPage
+{
+    /// <summary>The materialized page of matching rasters, in the catalog's natural order.</summary>
+    public required IReadOnlyList<RasterInfo> Rasters { get; init; }
+
+    /// <summary>
+    /// Total number of rows matching the predicate before paging. Equals <see cref="Rasters"/> count
+    /// when <see cref="RasterCatalogQuery.IncludeTotalCount"/> was not requested.
+    /// </summary>
+    public required long TotalCount { get; init; }
+
+    /// <summary>
+    /// Aggregate (union) extent of the matched set in the catalog's native SRID, or <c>null</c> when
+    /// not requested or when no matching row carries an extent.
+    /// </summary>
+    public RasterExtent? AggregateExtent { get; init; }
+
+    /// <summary>
+    /// Number of rows the predicate matched (the bound the storage read is limited to). For an
+    /// indexed pushdown this is the count of index-qualified rows, not the whole catalog.
+    /// </summary>
+    public long RowsScanned { get; init; }
+
+    /// <summary>Number of rows materialized into <see cref="Rasters"/> (the page size).</summary>
+    public long RowsReturned { get; init; }
+
+    /// <summary>
+    /// Provider-side duration for the query, surfaced as telemetry. Never includes SQL text.
+    /// </summary>
+    public TimeSpan ProviderDuration { get; init; }
+
+    /// <summary>
+    /// <see langword="true"/> when the provider pushed the predicate and paging into storage;
+    /// <see langword="false"/> when it fell back to a bounded in-memory materialization.
+    /// </summary>
+    public bool PredicatePushedDown { get; init; }
+}

--- a/src/Honua.Core/Features/Raster/Services/RasterCatalogQueryEvaluator.cs
+++ b/src/Honua.Core/Features/Raster/Services/RasterCatalogQueryEvaluator.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+
+namespace Honua.Core.Features.Raster.Services;
+
+/// <summary>
+/// Reference in-memory evaluation of the neutral <see cref="RasterCatalogQuery"/> contract. This is
+/// the <b>explicitly-declared bounded fallback</b> for raster providers that cannot push the
+/// predicate into storage: they materialize the layer's rasters once and hand them here. PostGIS
+/// overrides the contract with an indexed, paged SQL pushdown instead; this path exists so a
+/// non-pushdown provider still produces byte-for-byte identical envelope-intersects, identity,
+/// temporal, paging, count, and aggregate-extent semantics.
+/// </summary>
+/// <remarks>
+/// Evaluation order mirrors the canonical provider query so the fallback and the pushdown agree:
+/// temporal "newest batch" (layer-wide) → identity (<c>objectIds</c>) → envelope-intersects → paging.
+/// Input order is preserved (no re-sort) so the catalog's natural order flows through unchanged.
+/// </remarks>
+public static class RasterCatalogQueryEvaluator
+{
+    /// <summary>
+    /// Evaluates <paramref name="query"/> against an already-materialized raster set.
+    /// </summary>
+    /// <param name="rasters">The layer's rasters, in the catalog's natural order.</param>
+    /// <param name="query">The validated neutral query.</param>
+    /// <param name="transformService">
+    /// Optional CRS pipeline used to transform the spatial predicate into a footprint's SRID when
+    /// they differ. When <c>null</c> and the SRIDs differ, the footprint is conservatively excluded.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The evaluated page, with <see cref="RasterCatalogPage.PredicatePushedDown"/> false.</returns>
+    public static async Task<RasterCatalogPage> EvaluateAsync(
+        IReadOnlyList<RasterInfo> rasters,
+        RasterCatalogQuery query,
+        ICoordinateTransformService? transformService,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(rasters);
+        ArgumentNullException.ThrowIfNull(query);
+        query.Validate();
+
+        IEnumerable<RasterInfo> matched = rasters;
+
+        // 1. Temporal newest-batch, computed layer-wide (before identity/spatial narrowing) so the
+        //    snapshot instant selects the same acquisition the canonical provider query would.
+        if (query.Timestamp is { } timestamp)
+        {
+            var target = rasters
+                .Select(EffectiveAcquisition)
+                .Where(t => t <= timestamp)
+                .DefaultIfEmpty(default)
+                .Max();
+
+            matched = target == default
+                ? Enumerable.Empty<RasterInfo>()
+                : rasters.Where(r => EffectiveAcquisition(r) == target);
+        }
+
+        // 2. Identity filter.
+        if (query.ObjectIds is { } objectIds)
+        {
+            var idSet = new HashSet<long>(objectIds);
+            matched = matched.Where(r => idSet.Contains(r.Id));
+        }
+
+        // 3. Envelope-intersects against footprint extents.
+        var filtered = new List<RasterInfo>();
+        if (query.SpatialPredicate is { } predicate)
+        {
+            foreach (var raster in matched)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (raster.Extent is not { } extent)
+                {
+                    continue;
+                }
+
+                var box = await ResolveFilterBoxAsync(predicate, extent.Srid, transformService, cancellationToken)
+                    .ConfigureAwait(false);
+                if (box is { } resolved && EnvelopesIntersect(resolved, extent))
+                {
+                    filtered.Add(raster);
+                }
+            }
+        }
+        else
+        {
+            filtered.AddRange(matched);
+        }
+
+        var totalCount = filtered.Count;
+
+        RasterExtent? aggregateExtent = null;
+        if (query.IncludeAggregateExtent)
+        {
+            aggregateExtent = ComputeAggregateExtent(filtered);
+        }
+
+        List<RasterInfo> page;
+        if (query.Limit is { } limit)
+        {
+            var offset = Math.Max(0, query.Offset);
+            var end = Math.Min(totalCount, offset + limit);
+            page = offset < end ? filtered.GetRange(offset, end - offset) : [];
+        }
+        else
+        {
+            page = filtered;
+        }
+
+        return new RasterCatalogPage
+        {
+            Rasters = page,
+            TotalCount = totalCount,
+            AggregateExtent = aggregateExtent,
+            RowsScanned = totalCount,
+            RowsReturned = page.Count,
+            ProviderDuration = TimeSpan.Zero,
+            PredicatePushedDown = false,
+        };
+    }
+
+    private static DateTimeOffset EffectiveAcquisition(RasterInfo raster)
+        => raster.AcquisitionDate ?? raster.CreatedAt;
+
+    /// <summary>
+    /// Axis-aligned envelope intersection. Edge contact counts as an intersection, matching the
+    /// inclusive semantics of <c>esriSpatialRelEnvelopeIntersects</c> and the PostGIS <c>&amp;&amp;</c>
+    /// bounding-box operator used by the pushdown.
+    /// </summary>
+    private static bool EnvelopesIntersect(RasterCatalogSpatialPredicate filter, RasterExtent extent)
+        => filter.XMin <= extent.XMax &&
+           filter.XMax >= extent.XMin &&
+           filter.YMin <= extent.YMax &&
+           filter.YMax >= extent.YMin;
+
+    private static async ValueTask<RasterCatalogSpatialPredicate?> ResolveFilterBoxAsync(
+        RasterCatalogSpatialPredicate filter,
+        int? footprintSrid,
+        ICoordinateTransformService? transformService,
+        CancellationToken cancellationToken)
+    {
+        if (!filter.Srid.HasValue || !footprintSrid.HasValue || filter.Srid.Value == footprintSrid.Value)
+        {
+            return filter;
+        }
+
+        if (transformService is null)
+        {
+            return null;
+        }
+
+        var transformed = await transformService.TransformExtentAsync(
+            filter.XMin, filter.YMin, filter.XMax, filter.YMax,
+            filter.Srid.Value, footprintSrid.Value, cancellationToken).ConfigureAwait(false);
+
+        return transformed.HasValue
+            ? RasterCatalogSpatialPredicate.Create(
+                transformed.Value.MinX, transformed.Value.MinY,
+                transformed.Value.MaxX, transformed.Value.MaxY, footprintSrid)
+            : null;
+    }
+
+    private static RasterExtent? ComputeAggregateExtent(IReadOnlyList<RasterInfo> rasters)
+    {
+        double xMin = double.MaxValue, yMin = double.MaxValue;
+        double xMax = double.MinValue, yMax = double.MinValue;
+        int? srid = null;
+        var any = false;
+
+        foreach (var raster in rasters)
+        {
+            if (raster.Extent is not { } extent)
+            {
+                continue;
+            }
+
+            any = true;
+            if (extent.XMin < xMin) xMin = extent.XMin;
+            if (extent.YMin < yMin) yMin = extent.YMin;
+            if (extent.XMax > xMax) xMax = extent.XMax;
+            if (extent.YMax > yMax) yMax = extent.YMax;
+            srid ??= extent.Srid;
+        }
+
+        return any
+            ? new RasterExtent { XMin = xMin, YMin = yMin, XMax = xMax, YMax = yMax, Srid = srid }
+            : null;
+    }
+}

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterLog.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterLog.cs
@@ -172,4 +172,11 @@ internal static partial class PostgresRasterLog
         Level = LogLevel.Information,
         Message = "Updated raster metadata for layer {LayerId}, raster {RasterId}")]
     public static partial void RasterMetadataUpdated(ILogger logger, int layerId, long rasterId);
+
+    [LoggerMessage(
+        EventId = 7827,
+        Level = LogLevel.Debug,
+        Message = "Catalog query pushdown for layer {LayerId}: scanned={RowsScanned}, returned={RowsReturned}, {DurationMs}ms")]
+    public static partial void CatalogQueryExecuted(
+        ILogger logger, int layerId, long rowsScanned, long rowsReturned, double durationMs);
 }

--- a/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresRasterStore.cs
@@ -203,6 +203,249 @@ internal sealed class PostgresRasterStore : IRasterStore
     }
 
     /// <inheritdoc />
+    public async Task<RasterCatalogPage> QueryCatalogAsync(
+        int layerId,
+        RasterCatalogQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        query.Validate();
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        var (ctePrefix, parameters) = BuildCatalogFilterCte(layerId, query);
+        var wantsAggregate = query.IncludeTotalCount || query.IncludeAggregateExtent;
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = BuildCatalogCommandText(ctePrefix, query, includeAggregate: wantsAggregate);
+        foreach (var (name, value) in parameters)
+        {
+            AddParameter(command, name, value);
+        }
+
+        var rasters = new List<RasterInfo>();
+        long totalCount;
+        RasterExtent? aggregateExtent = null;
+
+        await using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                rasters.Add(ReadRasterInfo(reader));
+            }
+
+            totalCount = rasters.Count;
+
+            if (wantsAggregate && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false)
+                && await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                totalCount = reader.GetInt64(reader.GetOrdinal("total"));
+
+                if (query.IncludeAggregateExtent)
+                {
+                    var xMinOrd = reader.GetOrdinal("agg_xmin");
+                    var yMinOrd = reader.GetOrdinal("agg_ymin");
+                    var xMaxOrd = reader.GetOrdinal("agg_xmax");
+                    var yMaxOrd = reader.GetOrdinal("agg_ymax");
+                    var sridOrd = reader.GetOrdinal("agg_srid");
+
+                    if (!reader.IsDBNull(xMinOrd))
+                    {
+                        aggregateExtent = new RasterExtent
+                        {
+                            XMin = reader.GetDouble(xMinOrd),
+                            YMin = reader.GetDouble(yMinOrd),
+                            XMax = reader.GetDouble(xMaxOrd),
+                            YMax = reader.GetDouble(yMaxOrd),
+                            Srid = reader.IsDBNull(sridOrd) ? null : reader.GetInt32(sridOrd),
+                        };
+                    }
+                }
+            }
+        }
+
+        stopwatch.Stop();
+
+        var rowsScanned = query.IncludeTotalCount ? totalCount : rasters.Count;
+        PostgresRasterLog.CatalogQueryExecuted(
+            _logger, layerId, rowsScanned, rasters.Count, stopwatch.Elapsed.TotalMilliseconds);
+
+        return new RasterCatalogPage
+        {
+            Rasters = rasters,
+            TotalCount = totalCount,
+            AggregateExtent = aggregateExtent,
+            RowsScanned = rowsScanned,
+            RowsReturned = rasters.Count,
+            ProviderDuration = stopwatch.Elapsed,
+            PredicatePushedDown = true,
+        };
+    }
+
+    /// <summary>
+    /// Builds the shared <c>WITH ... filtered AS (...)</c> CTE that applies the layer, spatial
+    /// (envelope-intersects, index-backed via the GiST <c>ST_Envelope(raster)</c> expression index),
+    /// identity, and temporal predicates for the catalog query. The single-row <c>filter_env</c> CTE
+    /// is MATERIALIZED so its transformed envelope is treated as a constant, keeping the
+    /// <c>ST_Envelope(raster) &amp;&amp; fe.geom</c> comparison index-eligible.
+    /// </summary>
+    private (string CtePrefix, List<(string Name, object Value)> Parameters) BuildCatalogFilterCte(
+        int layerId,
+        RasterCatalogQuery query)
+    {
+        var parameters = new List<(string Name, object Value)> { ("@layerId", layerId) };
+        var cteParts = new List<string>();
+        var whereClauses = new List<string> { "layer_id = @layerId" };
+        var fromClause = _rasterDataTable + " rd";
+
+        // Representative native SRID for the layer; used to project the filter box into the raster
+        // coordinate system so the bbox overlap stays in one CRS (and index-eligible).
+        var layerSridExpr =
+            $"(SELECT srid FROM {_rasterDataTable} WHERE layer_id = @layerId AND srid IS NOT NULL AND srid > 0 LIMIT 1)";
+
+        if (query.SpatialPredicate is { } predicate)
+        {
+            string filterGeom;
+            parameters.Add(("@fxmin", predicate.XMin));
+            parameters.Add(("@fymin", predicate.YMin));
+            parameters.Add(("@fxmax", predicate.XMax));
+            parameters.Add(("@fymax", predicate.YMax));
+
+            if (predicate.Srid is { } filterSrid)
+            {
+                parameters.Add(("@fsrid", filterSrid));
+                filterGeom =
+                    $"ST_Transform(ST_MakeEnvelope(@fxmin, @fymin, @fxmax, @fymax, @fsrid), COALESCE({layerSridExpr}, @fsrid))";
+            }
+            else
+            {
+                // No filter SRID: the box is assumed to already be in the footprint's native CRS.
+                filterGeom = $"ST_MakeEnvelope(@fxmin, @fymin, @fxmax, @fymax, COALESCE({layerSridExpr}, 0))";
+            }
+
+            cteParts.Add($"filter_env AS MATERIALIZED (SELECT {filterGeom} AS geom)");
+            fromClause += " CROSS JOIN filter_env fe";
+            whereClauses.Add("ST_Envelope(rd.raster) && fe.geom");
+        }
+
+        if (query.ObjectIds is { } objectIds)
+        {
+            parameters.Add(("@objectIds", objectIds.ToArray()));
+            whereClauses.Add("id = ANY(@objectIds)");
+        }
+
+        if (query.Timestamp is { } timestamp)
+        {
+            cteParts.Add($"""
+                selected_time AS (
+                    SELECT MAX(COALESCE(acquisition_date, created_at)) AS target_acquisition
+                    FROM {_rasterDataTable}
+                    WHERE layer_id = @layerId
+                      AND COALESCE(acquisition_date, created_at) <= @timestamp
+                )
+                """);
+            whereClauses.Add("COALESCE(acquisition_date, created_at) = (SELECT target_acquisition FROM selected_time)");
+            parameters.Add(("@timestamp", timestamp.UtcDateTime));
+        }
+
+        var filteredCte = $"""
+            filtered AS (
+                SELECT id, layer_id, name, width, height, band_count, pixel_type, srid,
+                       ST_BandNoDataValue(raster, 1) AS nodata_value,
+                       ST_UpperLeftX(raster) AS upper_left_x,
+                       ST_ScaleX(raster) AS scale_x,
+                       ST_SkewX(raster) AS skew_x,
+                       ST_UpperLeftY(raster) AS upper_left_y,
+                       ST_SkewY(raster) AS skew_y,
+                       ST_ScaleY(raster) AS scale_y,
+                       ST_XMin(ST_Envelope(raster)) AS xmin,
+                       ST_YMin(ST_Envelope(raster)) AS ymin,
+                       ST_XMax(ST_Envelope(raster)) AS xmax,
+                       ST_YMax(ST_Envelope(raster)) AS ymax,
+                       acquisition_date,
+                       created_at,
+                       updated_at,
+                       COALESCE(acquisition_date, created_at) AS effective_acquisition
+                FROM {fromClause}
+                WHERE {string.Join("\n                  AND ", whereClauses)}
+            )
+            """;
+
+        cteParts.Add(filteredCte);
+        var ctePrefix = "WITH " + string.Join(",\n", cteParts);
+        return (ctePrefix, parameters);
+    }
+
+    private static string BuildCatalogCommandText(string ctePrefix, RasterCatalogQuery query, bool includeAggregate)
+    {
+        var pagingClause = query.Limit is { } limit
+            ? $"LIMIT {limit.ToString(CultureInfo.InvariantCulture)} OFFSET {Math.Max(0, query.Offset).ToString(CultureInfo.InvariantCulture)}"
+            : string.Empty;
+
+        var rowsSql = $"""
+            {ctePrefix}
+            SELECT id, layer_id, name, width, height, band_count, pixel_type, srid,
+                   nodata_value, upper_left_x, scale_x, skew_x, upper_left_y, skew_y, scale_y,
+                   xmin, ymin, xmax, ymax, acquisition_date, created_at, updated_at
+            FROM filtered
+            ORDER BY effective_acquisition DESC, created_at DESC, id DESC
+            {pagingClause}
+            """;
+
+        if (!includeAggregate)
+        {
+            return rowsSql;
+        }
+
+        var aggregateSql = $"""
+            {ctePrefix}
+            SELECT COUNT(*)::bigint AS total,
+                   MIN(xmin) AS agg_xmin,
+                   MIN(ymin) AS agg_ymin,
+                   MAX(xmax) AS agg_xmax,
+                   MAX(ymax) AS agg_ymax,
+                   MAX(srid) AS agg_srid
+            FROM filtered
+            """;
+
+        return rowsSql + ";\n" + aggregateSql;
+    }
+
+    /// <summary>
+    /// Test-only hook: returns the <c>EXPLAIN (ANALYZE, FORMAT TEXT)</c> plan for the paged catalog
+    /// query so provider integration tests can assert the footprint predicate is served by an index
+    /// scan and that only a bounded number of rows are read. Never surfaced to clients.
+    /// </summary>
+    internal async Task<string> ExplainCatalogQueryAsync(
+        int layerId,
+        RasterCatalogQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        query.Validate();
+        await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        var (ctePrefix, parameters) = BuildCatalogFilterCte(layerId, query);
+        var rowsSql = BuildCatalogCommandText(ctePrefix, query, includeAggregate: false);
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "EXPLAIN (ANALYZE, FORMAT TEXT) " + rowsSql;
+        foreach (var (name, value) in parameters)
+        {
+            AddParameter(command, name, value);
+        }
+
+        var builder = new StringBuilder();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            builder.AppendLine(reader.GetString(0));
+        }
+
+        return builder.ToString();
+    }
+
+    /// <inheritdoc />
     public async Task<RasterResult> ExportImageAsync(int layerId, long rasterId, RasterQuery query, CancellationToken cancellationToken = default)
     {
         await using var connection = await _connectionProvider.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCatalogQueryHandler.cs
@@ -107,6 +107,12 @@ internal sealed class ImageServerCatalogQueryHandler
                 : ImmutableArray<string>.Empty;
 
             ImageServerLog.CatalogQueryCompleted(_logger, layerId, page.Items.Count, page.TotalCount);
+
+            // Emit read-bounding + provider-duration telemetry (no SQL is ever attached), so the
+            // catalog pushdown's rows-scanned vs rows-returned ratio is observable per request.
+            scope.WithTag(HonuaTelemetry.Tags.RowsScanned, page.RowsScanned);
+            scope.WithTag(HonuaTelemetry.Tags.RowsReturned, page.RowsReturned);
+            scope.WithTag(HonuaTelemetry.Tags.ProviderDurationMs, page.ProviderDuration.TotalMilliseconds);
             scope.SetSuccess(page.Items.Count);
 
             return BuildResponse(page, query, maskedFields);

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogReader.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerCatalogReader.cs
@@ -36,6 +36,17 @@ internal sealed class ImageServerCatalogPage
     public required RasterExtent? AggregateExtent { get; init; }
 
     public int? NativeSrid { get; init; }
+
+    /// <summary>
+    /// Rows the provider matched with the pushed predicate (the read bound). Surfaced as telemetry.
+    /// </summary>
+    public long RowsScanned { get; init; }
+
+    /// <summary>Rows materialized into this page. Surfaced as telemetry.</summary>
+    public long RowsReturned { get; init; }
+
+    /// <summary>Provider-side query duration. Surfaced as telemetry; never carries SQL.</summary>
+    public TimeSpan ProviderDuration { get; init; }
 }
 
 /// <summary>
@@ -169,10 +180,13 @@ internal sealed record ImageServerCatalogSpatialFilter(
 
 /// <summary>
 /// Default <see cref="IImageServerCatalogReader"/> built on <see cref="IRasterStore"/>.
-/// Wraps the existing raster listing surface and projects each row into Esri-compatible
-/// catalog metadata. Spatial WHERE/ordering is applied in-memory for the MVP because the
-/// raster catalog is normally small (1–N rasters per layer) and adding a SQL emitter for
-/// the catalog table is reserved for the dedicated raster ingestion ticket.
+/// Delegates the spatial (envelope-intersects), identity, and temporal predicates — and, on the
+/// common browse path, paging, count, and aggregate extent — to the provider via
+/// <see cref="IRasterStore.QueryCatalogAsync"/> so a large imagery catalog is filtered and paged in
+/// storage <b>before materialization</b> rather than fully read and filtered in memory (#2666).
+/// The Esri-only concerns the neutral contract deliberately omits — <c>where</c> evaluation and
+/// computed-field <c>orderByFields</c> ordering — are applied here, in memory, over the
+/// spatially-bounded set the provider returns (a bounded fallback for those query shapes).
 /// </summary>
 internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
 {
@@ -197,93 +211,135 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var rasters = await _rasterStore.ListRastersAsync(layerId, cancellationToken).ConfigureAwait(false);
-        if (rasters.Length == 0)
-        {
-            return new ImageServerCatalogPage
-            {
-                Items = Array.Empty<ImageServerCatalogItem>(),
-                TotalCount = 0,
-                ExceededTransferLimit = false,
-                AggregateExtent = null,
-                NativeSrid = null,
-            };
-        }
-
         var includeGeometry = query.ReturnGeometry &&
             !query.ReturnIdsOnly &&
             !query.ReturnCountOnly &&
             !query.ReturnExtentOnly;
 
-        // Hydrate sensor/orientation metadata for the layer's rasters in a single batch. Most
-        // rasters carry none, so this is usually an empty lookup; the catalog item exposes it
-        // for orientation-ranked find, height mensuration, and image-coordinate-system warps.
-        var sensorMetadata = await _rasterStore
-            .GetSensorMetadataAsync(rasters.Select(static r => r.Id).ToArray(), cancellationToken)
+        // The neutral contract pushes the spatial/identity/temporal predicates into the provider.
+        // Esri `where` evaluation and computed-field `orderByFields` ordering are not part of the
+        // neutral contract, so when either is present we finish those steps in memory over the
+        // (already spatially bounded) provider result — a declared bounded fallback for those shapes.
+        var hasWhere = !string.IsNullOrWhiteSpace(query.Where);
+        var hasCustomOrder = query.OrderBy is { Count: > 0 };
+        var pushPaging = !hasWhere && !hasCustomOrder && !query.ReturnIdsOnly;
+
+        // returnCountOnly / returnExtentOnly do not consume the row page, so on the pushdown path we
+        // ask the provider for a single row plus the aggregate metadata rather than a full page.
+        var metadataOnly = pushPaging && (query.ReturnCountOnly || query.ReturnExtentOnly);
+        int? pushLimit = metadataOnly ? 1 : (pushPaging ? query.Limit : null);
+
+        RasterCatalogSpatialPredicate? predicate = null;
+        if (query.SpatialFilter is { } spatialFilter)
+        {
+            if (!RasterCatalogSpatialPredicate.TryCreate(
+                    spatialFilter.XMin, spatialFilter.YMin, spatialFilter.XMax, spatialFilter.YMax,
+                    spatialFilter.Srid, out var built, out var predicateError))
+            {
+                throw new ImageServerCatalogFilterException(predicateError);
+            }
+
+            predicate = built;
+        }
+
+        var neutralQuery = new RasterCatalogQuery
+        {
+            SpatialPredicate = predicate,
+            ObjectIds = query.ObjectIds,
+            Timestamp = query.Time,
+            Offset = pushPaging ? Math.Max(0, query.Offset) : 0,
+            Limit = pushLimit,
+            IncludeTotalCount = pushPaging,
+            IncludeAggregateExtent = pushPaging,
+        };
+
+        var page = await _rasterStore.QueryCatalogAsync(layerId, neutralQuery, cancellationToken)
             .ConfigureAwait(false);
 
-        // Project each raster row into the catalog item shape Esri expects.
-        // We need to retain the source raster reference so the aggregate extent uses the
-        // same filtered set as the returned features.
-        var projected = new List<(ImageServerCatalogItem Item, RasterInfo Source)>(rasters.Length);
-        foreach (var raster in rasters)
+        if (page.Rasters.Count == 0 && !pushPaging)
+        {
+            return EmptyPage(page);
+        }
+
+        // Hydrate sensor/orientation metadata only for the rasters actually returned (bounded).
+        var sensorMetadata = await _rasterStore
+            .GetSensorMetadataAsync(page.Rasters.Select(static r => r.Id).ToArray(), cancellationToken)
+            .ConfigureAwait(false);
+
+        var projected = new List<(ImageServerCatalogItem Item, RasterInfo Source)>(page.Rasters.Count);
+        foreach (var raster in page.Rasters)
         {
             var sensor = sensorMetadata.TryGetValue(raster.Id, out var meta) ? meta : raster.SensorMetadata;
             projected.Add((ProjectRaster(raster, includeGeometry, sensor), raster));
         }
 
-        if (query.Time.HasValue)
-        {
-            var selectedAcquisition = projected
-                .Select(p => p.Item.AcquisitionDate)
-                .Where(t => t.HasValue && t.Value <= query.Time.Value)
-                .OrderByDescending(t => t)
-                .FirstOrDefault();
+        return pushPaging
+            ? await BuildPushdownPageAsync(query, page, projected, includeGeometry, cancellationToken)
+                .ConfigureAwait(false)
+            : await BuildInMemoryPageAsync(query, page, projected, includeGeometry, cancellationToken)
+                .ConfigureAwait(false);
+    }
 
-            if (selectedAcquisition.HasValue)
-            {
-                projected = projected
-                    .Where(p => p.Item.AcquisitionDate == selectedAcquisition)
-                    .ToList();
-            }
-            else
-            {
-                projected.Clear();
-            }
+    /// <summary>
+    /// Fast path: the provider already applied the spatial/identity/temporal predicates, natural
+    /// ordering, paging, total count, and aggregate extent, so we trust its page and only project,
+    /// reproject to <c>outSR</c>, and carry the telemetry counters forward.
+    /// </summary>
+    private async Task<ImageServerCatalogPage> BuildPushdownPageAsync(
+        ImageServerCatalogQuery query,
+        RasterCatalogPage page,
+        List<(ImageServerCatalogItem Item, RasterInfo Source)> projected,
+        bool includeGeometry,
+        CancellationToken cancellationToken)
+    {
+        var nativeSrid = page.AggregateExtent?.Srid
+            ?? projected.Select(p => p.Item.FootprintSrid).FirstOrDefault(srid => srid.HasValue);
+
+        var aggregateExtent = page.AggregateExtent;
+        if (query.OutputSrid is { } targetSrid && aggregateExtent is { } nativeExtent)
+        {
+            aggregateExtent = await TransformExtentAsync(nativeExtent, targetSrid, cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        // Apply objectIds filter (cheap; usually provided alongside or instead of where).
-        if (query.ObjectIds is { Count: > 0 })
+        var window = projected.Select(p => p.Item).ToList();
+        if (query.OutputSrid is { } outSrid && includeGeometry)
         {
-            var idSet = new HashSet<long>(query.ObjectIds);
-            projected = projected.Where(p => idSet.Contains(p.Item.ObjectId)).ToList();
-        }
-
-        // Apply the spatial geometry filter against footprint extents. The filter box
-        // is transformed into each footprint's SRID (via the shared CRS pipeline) before
-        // the intersect test so the comparison stays in a single coordinate system.
-        // Footprints without an extent cannot satisfy a spatial filter and are dropped.
-        if (query.SpatialFilter is { } spatialFilter)
-        {
-            var kept = new List<(ImageServerCatalogItem Item, RasterInfo Source)>(projected.Count);
-            foreach (var entry in projected)
+            for (var i = 0; i < window.Count; i++)
             {
-                if (entry.Source.Extent is not { } extent)
-                {
-                    continue;
-                }
-
-                var box = await ResolveFilterBoxAsync(spatialFilter, extent.Srid, cancellationToken)
+                window[i] = await ReprojectFootprintAsync(window[i], outSrid, cancellationToken)
                     .ConfigureAwait(false);
-                if (box is { } resolved && EnvelopesIntersect(resolved, extent))
-                {
-                    kept.Add(entry);
-                }
             }
-
-            projected = kept;
         }
 
+        var exceeded = Math.Max(0, query.Offset) + window.Count < page.TotalCount;
+
+        return new ImageServerCatalogPage
+        {
+            Items = window,
+            TotalCount = page.TotalCount,
+            ExceededTransferLimit = exceeded,
+            AggregateExtent = aggregateExtent,
+            NativeSrid = nativeSrid,
+            RowsScanned = page.RowsScanned,
+            RowsReturned = window.Count,
+            ProviderDuration = page.ProviderDuration,
+        };
+    }
+
+    /// <summary>
+    /// Bounded fallback: the provider returned every spatially-filtered row (no paging) because the
+    /// query carries an Esri <c>where</c> clause or a computed-field ordering the neutral contract
+    /// cannot express. We finish <c>where</c>/<c>orderByFields</c>, aggregate extent, and paging in
+    /// memory over that bounded set, preserving the pre-pushdown semantics exactly.
+    /// </summary>
+    private async Task<ImageServerCatalogPage> BuildInMemoryPageAsync(
+        ImageServerCatalogQuery query,
+        RasterCatalogPage page,
+        List<(ImageServerCatalogItem Item, RasterInfo Source)> projected,
+        bool includeGeometry,
+        CancellationToken cancellationToken)
+    {
         // Apply WHERE filter via the shared GeoServices SQL parser.
         if (!string.IsNullOrWhiteSpace(query.Where))
         {
@@ -338,10 +394,6 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
         var nativeSrid = aggregateExtent?.Srid
             ?? projected.Select(p => p.Item.FootprintSrid).FirstOrDefault(srid => srid.HasValue);
 
-        // Reproject the aggregate extent into the requested outSR when it differs from the
-        // native SRID and the shared CRS pipeline can perform the transform. When the
-        // transform is unavailable or fails, the native-SRID extent is retained so the
-        // response geometry SR always matches the actual coordinates.
         if (query.OutputSrid is { } targetSrid && aggregateExtent is { } nativeExtent)
         {
             aggregateExtent = await TransformExtentAsync(nativeExtent, targetSrid, cancellationToken)
@@ -349,7 +401,7 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
         }
 
         // ArcGIS returns all matching IDs for returnIdsOnly, without maxRecordCount pagination.
-        IReadOnlyList<ImageServerCatalogItem> pageItems;
+        List<ImageServerCatalogItem> pageItems;
         bool exceeded;
         if (query.ReturnIdsOnly)
         {
@@ -366,10 +418,6 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
                 : new List<ImageServerCatalogItem>();
             exceeded = pageEnd < totalMatched;
 
-            // Reproject footprint rings into the requested outSR. Footprints are
-            // axis-aligned rectangles derived from each raster extent, so transforming the
-            // extent corners and rebuilding the rectangle is an exact representation in the
-            // target CRS. When reprojection is not possible the native-SRID rings are kept.
             if (query.OutputSrid is { } outSrid && includeGeometry)
             {
                 for (var i = 0; i < window.Count; i++)
@@ -389,8 +437,23 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
             ExceededTransferLimit = exceeded,
             AggregateExtent = aggregateExtent,
             NativeSrid = nativeSrid,
+            RowsScanned = page.RowsScanned,
+            RowsReturned = pageItems.Count,
+            ProviderDuration = page.ProviderDuration,
         };
     }
+
+    private static ImageServerCatalogPage EmptyPage(RasterCatalogPage page) => new()
+    {
+        Items = Array.Empty<ImageServerCatalogItem>(),
+        TotalCount = 0,
+        ExceededTransferLimit = false,
+        AggregateExtent = null,
+        NativeSrid = null,
+        RowsScanned = page.RowsScanned,
+        RowsReturned = 0,
+        ProviderDuration = page.ProviderDuration,
+    };
 
     /// <summary>
     /// Applies the requested <c>orderByFields</c> terms in priority order. The
@@ -489,53 +552,6 @@ internal sealed class ImageServerCatalogReader : IImageServerCatalogReader
                     return false;
             }
         }
-    }
-
-    /// <summary>
-    /// Axis-aligned envelope intersection test between the spatial filter box and a
-    /// raster footprint extent. Edge contact counts as an intersection, matching the
-    /// inclusive semantics of <c>esriSpatialRelIntersects</c>/<c>EnvelopeIntersects</c>.
-    /// </summary>
-    private static bool EnvelopesIntersect(ImageServerCatalogSpatialFilter filter, RasterExtent extent)
-        => filter.XMin <= extent.XMax &&
-           filter.XMax >= extent.XMin &&
-           filter.YMin <= extent.YMax &&
-           filter.YMax >= extent.YMin;
-
-    /// <summary>
-    /// Returns the spatial filter box expressed in <paramref name="footprintSrid"/>. When the
-    /// filter and footprint share a SRID (or either is unknown) the filter is used verbatim;
-    /// otherwise the shared CRS pipeline transforms the box. A transform failure returns
-    /// <see langword="null"/> so the footprint is conservatively excluded rather than matched
-    /// against a mismatched coordinate system.
-    /// </summary>
-    private async ValueTask<ImageServerCatalogSpatialFilter?> ResolveFilterBoxAsync(
-        ImageServerCatalogSpatialFilter filter,
-        int? footprintSrid,
-        CancellationToken cancellationToken)
-    {
-        if (!filter.Srid.HasValue || !footprintSrid.HasValue || filter.Srid.Value == footprintSrid.Value)
-        {
-            return filter;
-        }
-
-        if (_transformService is null)
-        {
-            // No CRS pipeline available: comparing across SRIDs would be wrong, so skip
-            // the footprint. The handler validates SRIDs up front, so this is a degraded-
-            // deployment guard rather than an expected path.
-            return null;
-        }
-
-        var transformed = await _transformService.TransformExtentAsync(
-            filter.XMin, filter.YMin, filter.XMax, filter.YMax,
-            filter.Srid.Value, footprintSrid.Value, cancellationToken).ConfigureAwait(false);
-
-        return transformed.HasValue
-            ? new ImageServerCatalogSpatialFilter(
-                transformed.Value.MinX, transformed.Value.MinY,
-                transformed.Value.MaxX, transformed.Value.MaxY, footprintSrid)
-            : null;
     }
 
     /// <summary>

--- a/src/Honua.ServiceDefaults/HonuaTelemetry.cs
+++ b/src/Honua.ServiceDefaults/HonuaTelemetry.cs
@@ -411,6 +411,15 @@ public static class HonuaTelemetry
         /// <summary>SQL query complexity score.</summary>
         public const string QueryComplexity = "honua.query.complexity_score";
 
+        /// <summary>Rows a provider matched with a pushed predicate (the read bound for a query).</summary>
+        public const string RowsScanned = "honua.catalog.rows_scanned";
+
+        /// <summary>Rows a provider materialized/returned for a query.</summary>
+        public const string RowsReturned = "honua.catalog.rows_returned";
+
+        /// <summary>Provider-side query duration in milliseconds.</summary>
+        public const string ProviderDurationMs = "honua.provider.duration_ms";
+
         /// <summary>Memory allocation size category.</summary>
         public const string MemoryCategory = "honua.memory.allocation_category";
     }

--- a/tests/dotnet/Honua.Core.Tests/Features/Raster/RasterCatalogQueryTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Raster/RasterCatalogQueryTests.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.Services;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Raster;
+
+/// <summary>
+/// Contract tests for the neutral raster-catalog query abstraction (#2666): validated spatial
+/// predicate / CRS / paging input, and the reference in-memory evaluation that is the declared
+/// bounded fallback and the oracle the PostGIS pushdown must match (envelope-intersects, identity,
+/// temporal newest-batch, natural ordering, paging, count, aggregate extent).
+/// </summary>
+public sealed class RasterCatalogQueryTests
+{
+    [UnitTest]
+    public void SpatialPredicate_ValidBox_IsAccepted()
+    {
+        RasterCatalogSpatialPredicate.TryCreate(0, 0, 10, 10, 4326, out var predicate, out var error)
+            .Should().BeTrue();
+        error.Should().BeEmpty();
+        predicate.XMin.Should().Be(0);
+        predicate.XMax.Should().Be(10);
+        predicate.Srid.Should().Be(4326);
+    }
+
+    [UnitTest]
+    public void SpatialPredicate_NullSrid_IsAccepted()
+    {
+        RasterCatalogSpatialPredicate.TryCreate(0, 0, 1, 1, srid: null, out var predicate, out _)
+            .Should().BeTrue();
+        predicate.Srid.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void SpatialPredicate_InvertedBox_IsRejected()
+    {
+        RasterCatalogSpatialPredicate.TryCreate(10, 0, 0, 10, 4326, out _, out var error)
+            .Should().BeFalse();
+        error.Should().Contain("inverted");
+    }
+
+    [UnitTest]
+    public void SpatialPredicate_NonFiniteCoordinate_IsRejected()
+    {
+        RasterCatalogSpatialPredicate.TryCreate(0, 0, double.NaN, 10, 4326, out _, out var nanError)
+            .Should().BeFalse();
+        nanError.Should().Contain("finite");
+
+        RasterCatalogSpatialPredicate.TryCreate(0, 0, double.PositiveInfinity, 10, 4326, out _, out _)
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void SpatialPredicate_NonPositiveSrid_IsRejected()
+    {
+        RasterCatalogSpatialPredicate.TryCreate(0, 0, 1, 1, srid: 0, out _, out var error)
+            .Should().BeFalse();
+        error.Should().Contain("SRID");
+    }
+
+    [UnitTest]
+    public void SpatialPredicate_Create_ThrowsOnInvalidInput()
+    {
+        var act = () => RasterCatalogSpatialPredicate.Create(10, 0, 0, 10, 4326);
+        act.Should().Throw<RasterCatalogValidationException>();
+    }
+
+    [UnitTest]
+    public void Query_Validate_RejectsNegativeOffset()
+    {
+        var query = new RasterCatalogQuery { Offset = -1 };
+        var act = query.Validate;
+        act.Should().Throw<RasterCatalogValidationException>();
+    }
+
+    [UnitTest]
+    public void Query_Validate_RejectsNonPositiveLimit()
+    {
+        var query = new RasterCatalogQuery { Limit = 0 };
+        var act = query.Validate;
+        act.Should().Throw<RasterCatalogValidationException>();
+    }
+
+    [UnitTest]
+    public async Task Evaluate_EnvelopeIntersects_IsEdgeInclusive()
+    {
+        var rasters = new[]
+        {
+            Raster(1, xMin: 0, yMin: 0, xMax: 1, yMax: 1),
+            Raster(2, xMin: 5, yMin: 5, xMax: 6, yMax: 6),
+        };
+
+        // A filter box whose left edge exactly touches raster 1's right edge must still match it
+        // (inclusive envelope-intersects), mirroring the PostGIS && bounding-box operator.
+        var query = new RasterCatalogQuery
+        {
+            SpatialPredicate = RasterCatalogSpatialPredicate.Create(1, 0, 4, 1, 4326),
+        };
+
+        var page = await RasterCatalogQueryEvaluator.EvaluateAsync(rasters, query, null, default);
+
+        page.Rasters.Select(r => r.Id).Should().Equal(1);
+        page.PredicatePushedDown.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task Evaluate_ObjectIds_FiltersToIdentitySet()
+    {
+        var rasters = new[] { Raster(1), Raster(2), Raster(3) };
+        var query = new RasterCatalogQuery { ObjectIds = [1, 3] };
+
+        var page = await RasterCatalogQueryEvaluator.EvaluateAsync(rasters, query, null, default);
+
+        page.Rasters.Select(r => r.Id).Should().BeEquivalentTo([1L, 3L]);
+    }
+
+    [UnitTest]
+    public async Task Evaluate_Timestamp_SelectsNewestBatchAtOrBeforeInstant()
+    {
+        var rasters = new[]
+        {
+            Raster(1, acquisition: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+            Raster(2, acquisition: new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero)),
+            Raster(3, acquisition: new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero)),
+        };
+
+        var query = new RasterCatalogQuery
+        {
+            Timestamp = new DateTimeOffset(2024, 2, 15, 0, 0, 0, TimeSpan.Zero),
+        };
+
+        var page = await RasterCatalogQueryEvaluator.EvaluateAsync(rasters, query, null, default);
+
+        // Newest acquisition at or before 2024-02-15 is 2024-01-01 (raster 1 only).
+        page.Rasters.Select(r => r.Id).Should().Equal(1);
+    }
+
+    [UnitTest]
+    public async Task Evaluate_PagingPreservesInputOrderAndReportsTotal()
+    {
+        var rasters = new[] { Raster(10), Raster(20), Raster(30), Raster(40) };
+        var query = new RasterCatalogQuery { Offset = 1, Limit = 2, IncludeTotalCount = true };
+
+        var page = await RasterCatalogQueryEvaluator.EvaluateAsync(rasters, query, null, default);
+
+        page.Rasters.Select(r => r.Id).Should().Equal(20, 30);
+        page.TotalCount.Should().Be(4);
+        page.RowsReturned.Should().Be(2);
+        page.RowsScanned.Should().Be(4);
+    }
+
+    [UnitTest]
+    public async Task Evaluate_AggregateExtent_UnionsMatchedSet()
+    {
+        var rasters = new[]
+        {
+            Raster(1, xMin: -10, yMin: -5, xMax: 0, yMax: 5),
+            Raster(2, xMin: 0, yMin: -5, xMax: 10, yMax: 5),
+        };
+        var query = new RasterCatalogQuery { IncludeAggregateExtent = true };
+
+        var page = await RasterCatalogQueryEvaluator.EvaluateAsync(rasters, query, null, default);
+
+        page.AggregateExtent.Should().NotBeNull();
+        page.AggregateExtent!.Value.XMin.Should().Be(-10);
+        page.AggregateExtent.Value.XMax.Should().Be(10);
+    }
+
+    [UnitTest]
+    public async Task Evaluate_CrossSridPredicate_TransformsBeforeIntersect()
+    {
+        // Footprint is in 3857; the filter is in 4326 and the fake CRS pipeline maps it onto the
+        // footprint. Without a transform service the SRID mismatch conservatively excludes the row.
+        var rasters = new[] { Raster(1, xMin: 0, yMin: 0, xMax: 100, yMax: 100, srid: 3857) };
+        var query = new RasterCatalogQuery
+        {
+            SpatialPredicate = RasterCatalogSpatialPredicate.Create(-1, -1, 1, 1, 4326),
+        };
+
+        var withTransform = await RasterCatalogQueryEvaluator.EvaluateAsync(
+            rasters, query, new StubTransform(10, 10, 50, 50), default);
+        withTransform.Rasters.Select(r => r.Id).Should().Equal(1);
+
+        var withoutTransform = await RasterCatalogQueryEvaluator.EvaluateAsync(rasters, query, null, default);
+        withoutTransform.Rasters.Should().BeEmpty();
+    }
+
+    private static RasterInfo Raster(
+        long id,
+        double xMin = -1,
+        double yMin = -1,
+        double xMax = 1,
+        double yMax = 1,
+        int srid = 4326,
+        DateTimeOffset? acquisition = null) => new()
+        {
+            Id = id,
+            LayerId = 1,
+            Name = $"raster-{id}",
+            Width = 256,
+            Height = 256,
+            BandCount = 1,
+            PixelType = "8BUI",
+            Srid = srid,
+            Extent = new RasterExtent { XMin = xMin, YMin = yMin, XMax = xMax, YMax = yMax, Srid = srid },
+            AcquisitionDate = acquisition,
+            CreatedAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+
+    private sealed class StubTransform(double minX, double minY, double maxX, double maxY)
+        : ICoordinateTransformService
+    {
+        public ValueTask<(double MinX, double MinY, double MaxX, double MaxY)?> TransformExtentAsync(
+            double minXIn, double minYIn, double maxXIn, double maxYIn,
+            int fromSrid, int toSrid, CancellationToken cancellationToken = default)
+            => new(((double, double, double, double)?)(minX, minY, maxX, maxY));
+
+        public ValueTask<(double X, double Y)?> TransformPointAsync(
+            double x, double y, int fromSrid, int toSrid, CancellationToken cancellationToken = default)
+            => new(((double, double)?)(x, y));
+    }
+}

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreCatalogQueryTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresRasterStoreCatalogQueryTests.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using FluentAssertions;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Raster.Domain;
+using Honua.Postgres.Features.Raster;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Raster;
+
+/// <summary>
+/// Provider integration + scale tests for the raster-catalog spatial pushdown (#2666). These prove
+/// PostGIS performs the indexed footprint (envelope-intersects) filter and paging in SQL before
+/// materialization, that only a bounded number of rows are read on a large catalog, and that result
+/// count, extent, paging, and envelope-intersects semantics match the neutral contract.
+/// </summary>
+[Collection("Database")]
+public sealed class PostgresRasterStoreCatalogQueryTests(PostgresFixture fixture)
+{
+    private const int LayerId = 9100;
+
+    [IntegrationTest]
+    public async Task QueryCatalogAsync_EnvelopeFilter_ReturnsOnlyIntersectingFootprints()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreCatalogQueryTests));
+        try
+        {
+            await CreateIndexedRasterTableAsync(schema);
+            var west = await InsertRasterAsync(schema, "west", 0, 10);   // extent [0,10]x[0,10]
+            var east = await InsertRasterAsync(schema, "east", 20, 30);  // extent [20,30]x[0,10]
+            var store = CreateStore(schema);
+
+            var query = new RasterCatalogQuery
+            {
+                SpatialPredicate = RasterCatalogSpatialPredicate.Create(21, 1, 29, 9, 4326),
+                IncludeTotalCount = true,
+                IncludeAggregateExtent = true,
+                Limit = 10,
+            };
+
+            var page = await store.QueryCatalogAsync(LayerId, query);
+
+            page.PredicatePushedDown.Should().BeTrue();
+            page.Rasters.Select(r => r.Id).Should().Equal(east);
+            page.TotalCount.Should().Be(1);
+            _ = west;
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task QueryCatalogAsync_EnvelopeFilter_IsEdgeInclusive()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreCatalogQueryTests));
+        try
+        {
+            await CreateIndexedRasterTableAsync(schema);
+            var raster = await InsertRasterAsync(schema, "tile", 0, 10);
+            var store = CreateStore(schema);
+
+            // Filter box whose left edge exactly meets the footprint's right edge (x = 10) must match
+            // — the same inclusive envelope-intersects the in-memory contract guarantees.
+            var query = new RasterCatalogQuery
+            {
+                SpatialPredicate = RasterCatalogSpatialPredicate.Create(10, 0, 20, 10, 4326),
+                Limit = 10,
+            };
+
+            var page = await store.QueryCatalogAsync(LayerId, query);
+
+            page.Rasters.Select(r => r.Id).Should().Equal(raster);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task QueryCatalogAsync_Paging_ReturnsBoundedWindowWithTotalCount()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreCatalogQueryTests));
+        try
+        {
+            await CreateIndexedRasterTableAsync(schema);
+            for (var i = 0; i < 5; i++)
+            {
+                await InsertRasterAsync(schema, $"tile-{i}", i * 10, (i * 10) + 5);
+            }
+
+            var store = CreateStore(schema);
+            var query = new RasterCatalogQuery { Offset = 1, Limit = 2, IncludeTotalCount = true };
+
+            var page = await store.QueryCatalogAsync(LayerId, query);
+
+            page.Rasters.Should().HaveCount(2);
+            page.TotalCount.Should().Be(5);
+            page.RowsReturned.Should().Be(2);
+            page.RowsScanned.Should().Be(5);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    [IntegrationTest]
+    public async Task QueryCatalogAsync_AggregateExtent_UnionsFilteredSet()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreCatalogQueryTests));
+        try
+        {
+            await CreateIndexedRasterTableAsync(schema);
+            await InsertRasterAsync(schema, "west", 0, 10);
+            await InsertRasterAsync(schema, "east", 20, 30);
+            var store = CreateStore(schema);
+
+            var query = new RasterCatalogQuery { IncludeAggregateExtent = true, IncludeTotalCount = true, Limit = 10 };
+
+            var page = await store.QueryCatalogAsync(LayerId, query);
+
+            page.AggregateExtent.Should().NotBeNull();
+            page.AggregateExtent!.Value.XMin.Should().Be(0);
+            page.AggregateExtent.Value.XMax.Should().Be(30);
+            page.TotalCount.Should().Be(2);
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    /// <summary>
+    /// Scale test: seed a large catalog, then prove the selective footprint query is served by the
+    /// GiST envelope index (EXPLAIN plan) and reads only a bounded number of rows — never the full
+    /// catalog — while returning the correct small matched set and total count.
+    /// </summary>
+    [ScaleTest]
+    public async Task QueryCatalogAsync_LargeCatalog_UsesFootprintIndexAndBoundsReads()
+    {
+        var schema = await fixture.CreateIsolatedSchemaAsync(nameof(PostgresRasterStoreCatalogQueryTests));
+        try
+        {
+            await CreateIndexedRasterTableAsync(schema);
+
+            // 40 x 40 = 1600 footprints tiled across a wide area; only a 3x3 pocket sits inside the
+            // query envelope, so a full-catalog scan would read ~1600 rows to answer a ~9-row query.
+            const int grid = 40;
+            await SeedGridAsync(schema, grid, cell: 10);
+            await AnalyzeAsync(schema);
+
+            var store = CreateStore(schema);
+            var query = new RasterCatalogQuery
+            {
+                // Covers footprints whose lower-left corner is at x,y in {110,120,130} => 9 tiles.
+                SpatialPredicate = RasterCatalogSpatialPredicate.Create(111, 111, 139, 139, 4326),
+                IncludeTotalCount = true,
+                IncludeAggregateExtent = true,
+                Limit = 100,
+            };
+
+            var plan = await store.ExplainCatalogQueryAsync(LayerId, query);
+            var page = await store.QueryCatalogAsync(LayerId, query);
+
+            // Query-plan evidence: the footprint predicate is served by the GiST envelope index,
+            // not a full sequential scan of the catalog.
+            plan.Should().Contain("idx_raster_data_envelope");
+            plan.Should().MatchRegex("Index Scan|Bitmap Index Scan|Bitmap Heap Scan");
+
+            // Bounded reads: far fewer than the full 1600-row catalog were matched/returned.
+            page.TotalCount.Should().BeLessThan(50);
+            page.TotalCount.Should().BeGreaterThan(0);
+            page.Rasters.Count.Should().Be((int)page.TotalCount);
+            page.RowsReturned.Should().BeLessThan(50);
+            page.PredicatePushedDown.Should().BeTrue();
+        }
+        finally
+        {
+            await fixture.DropSchemaAsync(schema);
+        }
+    }
+
+    private PostgresRasterStore CreateStore(string schema)
+        => new(new FixtureConnectionProvider(fixture.DataSource), NullLogger<PostgresRasterStore>.Instance, schema);
+
+    private async Task SeedGridAsync(string schema, int grid, double cell)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        // One INSERT ... SELECT generating grid*grid tiny 1x1 rasters via generate_series.
+        command.CommandText = """
+            INSERT INTO raster_data (layer_id, name, raster, created_at)
+            SELECT @layerId,
+                   'tile-' || gx || '-' || gy,
+                   ST_AddBand(
+                       ST_MakeEmptyRaster(1, 1, gx * @cell, (gy * @cell) + @cell, @cell, -@cell, 0, 0, 4326),
+                       '8BUI'::text, 1, NULL),
+                   NOW()
+            FROM generate_series(0, @grid - 1) AS gx,
+                 generate_series(0, @grid - 1) AS gy;
+            """;
+        command.Parameters.AddWithValue("layerId", LayerId);
+        command.Parameters.AddWithValue("grid", grid);
+        command.Parameters.AddWithValue("cell", cell);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task AnalyzeAsync(string schema)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "ANALYZE raster_data;";
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<long> InsertRasterAsync(string schema, string name, double minX, double maxX)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        // A single-cell raster spanning [minX,maxX] x [0,10]; scale derived from the span.
+        command.CommandText = """
+            INSERT INTO raster_data (layer_id, name, raster, created_at)
+            SELECT @layerId,
+                   @name,
+                   ST_AddBand(
+                       ST_MakeEmptyRaster(1, 1, @minX, 10, @maxX - @minX, -10, 0, 0, 4326),
+                       '8BUI'::text, 1, NULL),
+                   NOW()
+            RETURNING id;
+            """;
+        command.Parameters.AddWithValue("layerId", LayerId);
+        command.Parameters.AddWithValue("name", name);
+        command.Parameters.AddWithValue("minX", minX);
+        command.Parameters.AddWithValue("maxX", maxX);
+        return (long)(await command.ExecuteScalarAsync().ConfigureAwait(false))!;
+    }
+
+    private async Task CreateIndexedRasterTableAsync(string schema)
+    {
+        await using var connection = await fixture.GetConnectionAsync(schema);
+        await using var command = connection.CreateCommand();
+        // Mirrors migration 001 including the GiST envelope expression index the pushdown relies on.
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS raster_data (
+                id BIGSERIAL PRIMARY KEY,
+                layer_id INTEGER NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                raster raster NOT NULL,
+                acquisition_date TIMESTAMPTZ,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ,
+                width INTEGER GENERATED ALWAYS AS (ST_Width(raster)) STORED,
+                height INTEGER GENERATED ALWAYS AS (ST_Height(raster)) STORED,
+                band_count INTEGER GENERATED ALWAYS AS (ST_NumBands(raster)) STORED,
+                pixel_type VARCHAR(10) GENERATED ALWAYS AS (ST_BandPixelType(raster, 1)) STORED,
+                srid INTEGER GENERATED ALWAYS AS (ST_SRID(raster)) STORED
+            );
+            CREATE INDEX IF NOT EXISTS idx_raster_data_layer_id ON raster_data(layer_id);
+            CREATE INDEX IF NOT EXISTS idx_raster_data_envelope ON raster_data USING GIST (ST_Envelope(raster));
+            """;
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private sealed class FixtureConnectionProvider(NpgsqlDataSource dataSource) : IAdoNetDatabaseConnectionProvider
+    {
+        public string GetConnectionString() => dataSource.ConnectionString;
+
+        public async Task<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await dataSource.OpenConnectionAsync(cancellationToken);
+
+        public async Task<(DbConnection Connection, DbTransaction Transaction)> OpenTransactionAsync(
+            IsolationLevel isolationLevel = IsolationLevel.RepeatableRead,
+            CancellationToken cancellationToken = default)
+        {
+            var connection = await OpenConnectionAsync(cancellationToken);
+            try
+            {
+                var transaction = await connection.BeginTransactionAsync(isolationLevel, cancellationToken);
+                return (connection, transaction);
+            }
+            catch
+            {
+                await connection.DisposeAsync();
+                throw;
+            }
+        }
+
+        public async Task<T> ExecuteWithDeadlockRetryAsync<T>(
+            Func<Task<T>> operation, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await operation();
+        }
+
+        public async Task ExecuteWithDeadlockRetryAsync(
+            Func<Task> operation, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await operation();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerCatalogQueryHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerCatalogQueryHandlerTests.cs
@@ -10,6 +10,7 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.TestKit.Infrastructure;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.Services;
 using Honua.Protocols.GeoServices.ImageServer.Handlers;
 using Honua.Protocols.GeoServices.ImageServer.Models;
 using Honua.Protocols.GeoServices.ImageServer.Services;
@@ -812,8 +813,8 @@ public class ImageServerCatalogQueryHandlerTests
     [Operation(Operations.Query)]
     public async Task QueryCatalogAsync_RasterStoreThrows_ReturnsServerError()
     {
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns<Task<RasterInfo[]>>(_ => throw new InvalidOperationException("boom"));
+        _rasterStore.QueryCatalogAsync(1, Arg.Any<RasterCatalogQuery>(), Arg.Any<CancellationToken>())
+            .Returns<Task<RasterCatalogPage>>(_ => throw new InvalidOperationException("boom"));
 
         var context = CreateImageServerContext();
         var result = await _handler.QueryCatalogAsync(context, 1, EmptyValues(), CancellationToken.None);
@@ -953,19 +954,18 @@ public class ImageServerCatalogQueryHandlerTests
     public async Task QueryCatalogAsync_GeometryFilterCrossSrid_TransformsFilterBox()
     {
         // Footprint is in 3857; the filter box is supplied in 4326 and must be transformed
-        // into 3857 before the intersect test. The stub transform maps the 4326 box onto the
-        // footprint so the raster is kept.
-        SetupLayerWithRasters([
-            CreateRaster(100, "scene", xMin: 0, yMin: 0, xMax: 100, yMax: 100, srid: 3857),
-        ]);
-
+        // into 3857 before the intersect test. The transform (a provider concern under the
+        // pushdown contract — PostGIS does this in SQL via ST_Transform) maps the 4326 box onto
+        // the footprint so the raster is kept.
         var transform = Substitute.For<ICoordinateTransformService>();
         transform.TransformExtentAsync(
                 Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>(), Arg.Any<double>(),
                 4326, 3857, Arg.Any<CancellationToken>())
             .Returns(((double MinX, double MinY, double MaxX, double MaxY)?)(10.0, 10.0, 50.0, 50.0));
 
-        var handler = BuildHandler(transform);
+        SetupLayerWithRasters(
+            [CreateRaster(100, "scene", xMin: 0, yMin: 0, xMax: 100, yMax: 100, srid: 3857)],
+            filterTransform: transform);
 
         var values = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
         {
@@ -975,7 +975,7 @@ public class ImageServerCatalogQueryHandlerTests
         };
 
         var context = CreateImageServerContext();
-        var result = await handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
+        var result = await _handler.QueryCatalogAsync(context, 1, values, CancellationToken.None);
 
         var jsonResult = result as JsonHttpResult<CatalogQueryResponse>;
         jsonResult.Should().NotBeNull();
@@ -983,10 +983,18 @@ public class ImageServerCatalogQueryHandlerTests
             .Should().BeEquivalentTo([100L]);
     }
 
-    private void SetupLayerWithRasters(RasterInfo[] rasters)
+    private void SetupLayerWithRasters(RasterInfo[] rasters, ICoordinateTransformService? filterTransform = null)
     {
-        _rasterStore.ListRastersAsync(1, Arg.Any<CancellationToken>())
-            .Returns(rasters);
+        // The reader now drives the neutral IRasterStore.QueryCatalogAsync pushdown contract. The
+        // provider is exercised for real (indexed SQL) in Honua.Postgres.Tests; here we back it with
+        // the shared reference evaluator so the handler-level count/extent/paging/ordering/masking and
+        // envelope-intersects assertions run against the exact semantics a provider must preserve.
+        _rasterStore.QueryCatalogAsync(1, Arg.Any<RasterCatalogQuery>(), Arg.Any<CancellationToken>())
+            .Returns(ci => RasterCatalogQueryEvaluator.EvaluateAsync(
+                rasters,
+                ci.ArgAt<RasterCatalogQuery>(1),
+                filterTransform,
+                ci.ArgAt<CancellationToken>(2)));
         _rasterStore.GetSensorMetadataAsync(Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<long, RasterSensorMetadata>());
     }


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2666

## Summary
Moves ImageServer raster-catalog spatial filtering from post-read footprint-envelope
evaluation (materialize-the-whole-layer, then filter/page in memory) into the canonical
provider query contract. A large imagery catalog is now filtered and paged **in storage
before materialization** while preserving the current ArcGIS query semantics exactly —
including the inclusive **envelope-intersects** relationship (this is explicitly *not*
changed to exact geometry). Parent: #2636.

The old path in `ImageServerCatalogReader` called `IRasterStore.ListRastersAsync` (full
layer) then applied the spatial/objectIds/temporal/where/order/paging filters in memory.
This PR pushes the neutral (spatial + identity + temporal + ordering + paging + count +
extent) predicates into PostGIS via an indexed SQL query; the Esri-only `where` and
computed-field `orderByFields` — which the neutral contract deliberately does not model —
are finished in memory over the already spatially-bounded set (a declared bounded fallback
for those query shapes only).

## Changes Made
- **Neutral contract (Honua.Core):** new `RasterCatalogQuery`, `RasterCatalogSpatialPredicate`
  (validated envelope/CRS input — rejects NaN/Infinity, inverted boxes, non-positive SRIDs,
  negative offset, non-positive limit via `RasterCatalogValidationException`), and
  `RasterCatalogPage` (rows + pre-paging total count + aggregate extent + rows-scanned/returned
  + provider-duration counters). Added `IRasterStore.QueryCatalogAsync`.
- **Reference evaluator (Honua.Core):** `RasterCatalogQueryEvaluator` — the explicitly-declared
  bounded fallback for providers that cannot push down, and the shared oracle the PostGIS
  pushdown must match (temporal newest-batch → identity → envelope-intersects → paging, input
  order preserved).
- **PostGIS pushdown (Honua.Postgres):** `PostgresRasterStore.QueryCatalogAsync` filters on
  `ST_Envelope(raster) && <filter envelope>` (served by the existing GiST expression index
  `idx_raster_data_envelope`), applies identity/temporal predicates, natural ordering,
  `LIMIT/OFFSET`, and a single-round-trip count + aggregate-extent query. Cross-SRID handled in
  SQL via `ST_Transform` against a MATERIALIZED single-row `filter_env` CTE so the box is a
  constant and the comparison stays index-eligible.
- **Adapter (Honua.Protocols.GeoServices):** `ImageServerCatalogReader` now drives the pushdown;
  spatial CRS transform for filtering moved from the reader into the provider. Output
  reprojection to `outSR`, field masking, and Esri response shaping are unchanged.
- **Telemetry:** `honua.catalog.rows_scanned`, `honua.catalog.rows_returned`,
  `honua.provider.duration_ms` span tags emitted by the handler; a debug `LoggerMessage` in the
  provider. No SQL text is attached to any telemetry.
- **Tests:** Core contract/unit tests, PostGIS provider integration tests, and a scale test with
  EXPLAIN index + bounded-read evidence.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Ran locally (Docker/Testcontainers PostGIS available):
- `Honua.Core.Tests` — `RasterCatalogQueryTests` (14 tests) **passed**.
- `Honua.Postgres.Tests` — `PostgresRasterStoreCatalogQueryTests` (5, incl. the `[ScaleTest]`)
  **passed**; existing `PostgresRasterStoreQueryTests` (18) still **pass** (23 total, 0 failures).
- `Honua.Protocols.GeoServices.Tests` — `ImageServerCatalogQueryHandlerTests`: all 28
  value-asserting regression tests (envelope-intersects, bbox shorthand, cross-SRID transform,
  objectIds, where, orderBy asc/desc/multi-key/before-paging, paging, count/ids/extent-only,
  extent-shrink-with-objectIds/where, outSR reprojection, native-SRID stamping, field set)
  **pass**. The 11 remaining tests in that file that assert via `IResult.ExecuteAsync(context)` +
  `context.Response.StatusCode` fail identically on the pristine `origin/trunk` version of the
  file (verified with `LayerNotFound`, whose code path never reaches the store/reader) — a
  pre-existing test-infra issue on this branch line, independent of #2666.

### Query-plan / bounded-read evidence
`EXPLAIN (ANALYZE)` of the pushdown against a **1600-row** catalog with a selective envelope
(asserted by `QueryCatalogAsync_LargeCatalog_UsesFootprintIndexAndBoundsReads`):

```
Limit  (actual time=0.109..0.126 rows=9 loops=1)
  CTE filter_env
    ->  Result (rows=1)                         -- MATERIALIZED constant filter envelope
  ->  Sort  Sort Key: COALESCE(acquisition_date, created_at) DESC, created_at DESC, id DESC
        ->  Nested Loop  (actual rows=9)
              ->  CTE Scan on filter_env fe  (rows=1)
              ->  Index Scan using idx_raster_data_envelope on raster_data rd  (actual rows=9)
                    Index Cond: (st_envelope(raster) && fe.geom)
                    Filter: (layer_id = 9100)
Execution Time: 0.225 ms
```
Only **9 of 1600** rows are read — the footprint predicate is served by the GiST envelope
index, not a full catalog scan.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

No public HTTP query parameters were added or changed. `IRasterStore` (an internal provider
abstraction) gains one method.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

**No migration required.** The predicate is served by the pre-existing GiST expression index
`idx_raster_data_envelope ON honua.raster_data USING GIST (ST_Envelope(raster))`
(migration `001_CreateRasterTables.sql`), verified index-backed by the EXPLAIN evidence above.

## Breaking Changes
None — no public API change. Envelope-intersects semantics are preserved (a non-goal to change
them to exact geometry).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
