### PR TITLE
ci: reuse exact-head shard builds on rerun (#2735)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,7 +977,57 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: Plan shard-local exact-head cache
+        id: shard-cache-plan
+        shell: bash
+        env:
+          SHARD_NAME: ${{ matrix.shard_name }}
+          SHARD_CSPROJ: ${{ matrix.csproj }}
+          SELECTED_SHARDS_JSON: ${{ needs.targeted-shards.outputs.matrix_include }}
+        run: |
+          scripts/ci/server-test-shard-cache.sh plan \
+            --shard "${SHARD_NAME}" \
+            --project "${SHARD_CSPROJ}" \
+            --matrix-json "${SELECTED_SHARDS_JSON}" \
+            --source-sha '${{ github.sha }}' \
+            --runner-os '${{ runner.os }}' \
+            --sdk "$(dotnet --version)"
+
+      - name: Start exact-head cache restore timer
+        if: github.run_attempt > 1
+        id: shard-cache-restore-start
+        shell: bash
+        run: echo "epoch_ms=$(date +%s%3N)" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore exact-head shard cache
+        if: github.run_attempt > 1
+        id: shard-cache-download
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.shard-cache-plan.outputs.payload_dir }}
+          key: ${{ steps.shard-cache-plan.outputs.cache_key }}
+          fail-on-cache-miss: false
+
+      - name: Record exact-head cache restore duration
+        if: always() && github.run_attempt > 1
+        id: shard-cache-restore-elapsed
+        shell: bash
+        run: echo "milliseconds=$(( $(date +%s%3N) - ${{ steps.shard-cache-restore-start.outputs.epoch_ms }} ))" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify and unpack exact-head shard cache
+        id: shard-cache-materialize
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.shard-cache-download.outputs.cache-hit }}
+        run: |
+          scripts/ci/server-test-shard-cache.sh restore \
+            --project '${{ steps.shard-cache-plan.outputs.project }}' \
+            --source-sha '${{ github.sha }}' \
+            --payload '${{ steps.shard-cache-plan.outputs.payload_dir }}' \
+            --cache-hit "${CACHE_HIT:-false}"
+
       - name: Restore
+        if: steps.shard-cache-materialize.outputs.restored != 'true'
         # Phase 2 / ADR-0042 routing: each shard targets its declared csproj
         # (matrix.csproj) and falls back to Honua.Server.Tests.csproj for
         # legacy shards that have not been migrated to a per-protocol project.
@@ -991,6 +1041,8 @@ jobs:
         run: mkdir -p ./tests/TestResults
 
       - name: Build server test binaries
+        id: shard-cache-build
+        if: steps.shard-cache-materialize.outputs.restored != 'true'
         timeout-minutes: 20
         env:
           SHARD_CSPROJ: ${{ matrix.csproj }}
@@ -999,6 +1051,74 @@ jobs:
           dotnet build "${csproj}" \
             --no-restore \
             --configuration Release
+
+      - name: Package shard-local cache payload
+        id: shard-cache-package
+        if: ${{ steps.shard-cache-build.outcome == 'success' && (steps.shard-cache-plan.outputs.cache_writer == 'true' || github.run_attempt > 1) }}
+        shell: bash
+        run: |
+          rm -rf '${{ steps.shard-cache-plan.outputs.payload_dir }}'
+          mkdir -p '${{ steps.shard-cache-plan.outputs.payload_dir }}'
+          scripts/ci/package-server-test-binaries.sh \
+            --project '${{ steps.shard-cache-plan.outputs.project }}' \
+            --output '${{ steps.shard-cache-plan.outputs.payload_dir }}' \
+            --source-sha '${{ github.sha }}'
+
+      - name: Start exact-head cache save timer
+        if: steps.shard-cache-package.outcome == 'success'
+        id: shard-cache-save-start
+        shell: bash
+        run: echo "epoch_ms=$(date +%s%3N)" >> "${GITHUB_OUTPUT}"
+
+      - name: Save exact-head shard cache
+        if: steps.shard-cache-package.outcome == 'success'
+        id: shard-cache-save
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.shard-cache-plan.outputs.payload_dir }}
+          key: ${{ steps.shard-cache-plan.outputs.cache_key }}
+
+      - name: Record exact-head cache save duration
+        if: always() && steps.shard-cache-package.outcome == 'success'
+        id: shard-cache-save-elapsed
+        shell: bash
+        run: echo "milliseconds=$(( $(date +%s%3N) - ${{ steps.shard-cache-save-start.outputs.epoch_ms }} ))" >> "${GITHUB_OUTPUT}"
+
+      - name: Report shard cache decision
+        if: always()
+        shell: bash
+        env:
+          CACHE_KEY: ${{ steps.shard-cache-plan.outputs.cache_key }}
+          CACHE_WRITER: ${{ steps.shard-cache-plan.outputs.cache_writer }}
+          CACHE_WRITER_SHARD: ${{ steps.shard-cache-plan.outputs.cache_writer_shard }}
+          CACHE_HIT: ${{ steps.shard-cache-download.outputs.cache-hit }}
+          MATERIALIZED: ${{ steps.shard-cache-materialize.outputs.restored }}
+          REASON: ${{ steps.shard-cache-materialize.outputs.reason }}
+          TRANSFER_MS: ${{ steps.shard-cache-restore-elapsed.outputs.milliseconds }}
+          INTEGRITY_MS: ${{ steps.shard-cache-materialize.outputs.integrity_check_ms }}
+          UNPACK_MS: ${{ steps.shard-cache-materialize.outputs.unpack_ms }}
+          SAVE_MS: ${{ steps.shard-cache-save-elapsed.outputs.milliseconds }}
+          PAYLOAD_DIR: ${{ steps.shard-cache-plan.outputs.payload_dir }}
+          PROJECT_SUFFIX: ${{ steps.shard-cache-plan.outputs.project_suffix }}
+        run: |
+          package_ms=0
+          manifest="${PAYLOAD_DIR}/server-test-binaries-${PROJECT_SUFFIX}.manifest.json"
+          if [[ -f "${manifest}" ]]; then
+            package_ms="$(jq -r '.package_milliseconds' "${manifest}")"
+          fi
+          {
+            echo '### Server-test shard cache'
+            echo
+            echo "- Key: \`${CACHE_KEY:-unavailable}\`"
+            echo "- Attempt: \`${{ github.run_attempt }}\`"
+            echo "- Decision: \`${REASON:-not_evaluated}\`"
+            echo "- Exact cache hit: \`${CACHE_HIT:-false}\`"
+            echo "- Materialized without build: \`${MATERIALIZED:-false}\`"
+            echo "- Attempt-1 writer: \`${CACHE_WRITER:-false}\` (\`${CACHE_WRITER_SHARD:-unknown}\`)"
+            echo "- Transfer / integrity / unpack: \`${TRANSFER_MS:-0} / ${INTEGRITY_MS:-0} / ${UNPACK_MS:-0} ms\`"
+            echo "- Package / save: \`${package_ms} / ${SAVE_MS:-0} ms\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Run server test shard
         # Advisory shards (matrix.advisory==true) swallow their test failure HERE so

--- a/.github/workflows/server-test-shard-cache-proof.yml
+++ b/.github/workflows/server-test-shard-cache-proof.yml
@@ -1,0 +1,230 @@
+name: Server Test Shard Cache Proof
+
+on:
+  push:
+    branches:
+      - ci/2735-shard-local-rerun-cache
+    paths:
+      - .github/workflows/ci.yml
+      - .github/workflows/server-test-shard-cache-proof.yml
+      - scripts/ci/server-test-shard-cache.sh
+      - scripts/ci/validate-server-test-shard-cache.sh
+  workflow_dispatch:
+
+run-name: Shard-local cache proof @ ${{ github.sha }} (attempt ${{ github.run_attempt }})
+
+concurrency:
+  group: shard-local-cache-proof-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+
+env:
+  DOTNET_VERSION: 10.0.x
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+  PROOF_PROJECT: tests/dotnet/Honua.Geoprocessing.Cli.Tests/Honua.Geoprocessing.Cli.Tests.csproj
+  PROOF_FILTER: FullyQualifiedName=Honua.Geoprocessing.Cli.Tests.GpCliEndToEndTests.RunAsync_Help_PrintsUsageAndSucceeds
+  PROOF_MATRIX: >-
+    [{"shard_name":"a-writer","csproj":"tests/dotnet/Honua.Geoprocessing.Cli.Tests/Honua.Geoprocessing.Cli.Tests.csproj"},{"shard_name":"b-cache-hit","csproj":"tests/dotnet/Honua.Geoprocessing.Cli.Tests/Honua.Geoprocessing.Cli.Tests.csproj"},{"shard_name":"c-cache-miss","csproj":"tests/dotnet/Honua.Geoprocessing.Cli.Tests/Honua.Geoprocessing.Cli.Tests.csproj"}]
+
+jobs:
+  shard-proof:
+    name: Shard cache proof / ${{ matrix.identity }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identity: a-writer
+            force_miss: false
+          - identity: b-cache-hit
+            force_miss: false
+          - identity: c-cache-miss
+            force_miss: true
+    steps:
+      - id: job-start
+        name: Start job timer
+        shell: bash
+        run: echo "epoch_ms=$(date +%s%3N)" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Plan shard-local cache
+        id: cache-plan
+        shell: bash
+        run: |
+          scripts/ci/server-test-shard-cache.sh plan \
+            --shard '${{ matrix.identity }}' \
+            --project '${{ env.PROOF_PROJECT }}' \
+            --matrix-json '${{ env.PROOF_MATRIX }}' \
+            --source-sha '${{ github.sha }}' \
+            --runner-os '${{ runner.os }}' \
+            --sdk "$(dotnet --version)"
+
+      - name: Select exact proof key
+        id: cache-key
+        shell: bash
+        run: |
+          key='${{ steps.cache-plan.outputs.cache_key }}'
+          if [[ '${{ matrix.force_miss }}' == 'true' && '${{ github.run_attempt }}' -gt 1 ]]; then
+            key="${key}-forced-miss"
+          fi
+          echo "value=${key}" >> "${GITHUB_OUTPUT}"
+
+      - name: Start cache restore timer
+        if: github.run_attempt > 1
+        id: restore-start
+        shell: bash
+        run: echo "epoch_ms=$(date +%s%3N)" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore exact-head cache
+        if: github.run_attempt > 1
+        id: cache-download
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.cache-plan.outputs.payload_dir }}
+          key: ${{ steps.cache-key.outputs.value }}
+          fail-on-cache-miss: false
+
+      - name: Record cache restore duration
+        if: always() && github.run_attempt > 1
+        id: restore-elapsed
+        shell: bash
+        run: echo "milliseconds=$(( $(date +%s%3N) - ${{ steps.restore-start.outputs.epoch_ms }} ))" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify and unpack cache
+        id: materialize
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache-download.outputs.cache-hit }}
+        run: |
+          scripts/ci/server-test-shard-cache.sh restore \
+            --project '${{ env.PROOF_PROJECT }}' \
+            --source-sha '${{ github.sha }}' \
+            --payload '${{ steps.cache-plan.outputs.payload_dir }}' \
+            --cache-hit "${CACHE_HIT:-false}"
+
+      - name: Restore project on fallback path
+        if: steps.materialize.outputs.restored != 'true'
+        run: scripts/ci/dotnet-restore-retry.sh '${{ env.PROOF_PROJECT }}'
+
+      - name: Build project on fallback path
+        id: build
+        if: steps.materialize.outputs.restored != 'true'
+        run: dotnet build '${{ env.PROOF_PROJECT }}' --no-restore --configuration Release /p:TreatWarningsAsErrors=true
+
+      - name: Package one project payload
+        id: package
+        if: ${{ steps.build.outcome == 'success' && (steps.cache-plan.outputs.cache_writer == 'true' || github.run_attempt > 1) }}
+        shell: bash
+        run: |
+          rm -rf '${{ steps.cache-plan.outputs.payload_dir }}'
+          mkdir -p '${{ steps.cache-plan.outputs.payload_dir }}'
+          scripts/ci/package-server-test-binaries.sh \
+            --project '${{ env.PROOF_PROJECT }}' \
+            --output '${{ steps.cache-plan.outputs.payload_dir }}' \
+            --source-sha '${{ github.sha }}'
+
+      - name: Save exact-head project cache
+        if: steps.package.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.cache-plan.outputs.payload_dir }}
+          key: ${{ steps.cache-key.outputs.value }}
+
+      - name: Run no-build proof selection
+        run: >-
+          dotnet test '${{ env.PROOF_PROJECT }}'
+          --no-build --no-restore --configuration Release
+          --filter '${{ env.PROOF_FILTER }}'
+          --logger 'console;verbosity=minimal'
+
+      - name: Write proof metrics
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p metrics
+          jq -nS \
+            --arg identity '${{ matrix.identity }}' \
+            --arg cache_key '${{ steps.cache-key.outputs.value }}' \
+            --arg reason '${{ steps.materialize.outputs.reason }}' \
+            --arg restored '${{ steps.materialize.outputs.restored }}' \
+            --arg build_outcome '${{ steps.build.outcome }}' \
+            --arg cache_writer '${{ steps.cache-plan.outputs.cache_writer }}' \
+            --arg run_attempt '${{ github.run_attempt }}' \
+            --arg transfer_ms '${{ steps.restore-elapsed.outputs.milliseconds }}' \
+            --arg integrity_ms '${{ steps.materialize.outputs.integrity_check_ms }}' \
+            --arg unpack_ms '${{ steps.materialize.outputs.unpack_ms }}' \
+            --arg elapsed_ms "$(( $(date +%s%3N) - ${{ steps.job-start.outputs.epoch_ms }} ))" \
+            '{identity:$identity,cache_key:$cache_key,reason:$reason,restored:($restored=="true"),
+              build_outcome:$build_outcome,cache_writer:($cache_writer=="true"),
+              run_attempt:($run_attempt|tonumber),transfer_ms:($transfer_ms//"0"|tonumber),
+              integrity_ms:($integrity_ms//"0"|tonumber),unpack_ms:($unpack_ms//"0"|tonumber),
+              elapsed_ms:($elapsed_ms|tonumber)}' > "metrics/${{ matrix.identity }}-attempt-${{ github.run_attempt }}.json"
+
+      - name: Upload proof metrics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shard-cache-proof-${{ matrix.identity }}-attempt-${{ github.run_attempt }}
+          path: metrics/
+          retention-days: 7
+
+      - name: Deliberately fail hit and miss consumers on attempt one
+        if: matrix.identity != 'a-writer' && github.run_attempt == 1
+        shell: bash
+        run: |
+          echo "Intentional failure for failed-only rerun proof."
+          exit 1
+
+  evidence:
+    name: Shard cache proof evidence
+    needs: shard-proof
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download proof metrics
+        uses: actions/download-artifact@v8
+        with:
+          pattern: shard-cache-proof-*
+          path: evidence/metrics
+      - name: Capture hosted job/cache evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          mkdir -p evidence/jobs
+          for attempt in $(seq 1 '${{ github.run_attempt }}'); do
+            curl --fail --silent --show-error \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/'"${attempt}"'/jobs?per_page=100' \
+              > "evidence/jobs/attempt-${attempt}.json"
+          done
+          curl --fail --silent --show-error --get \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --data-urlencode 'ref=${{ github.ref }}' \
+            --data-urlencode 'per_page=100' \
+            '${{ github.api_url }}/repos/${{ github.repository }}/actions/caches' \
+            > evidence/jobs/caches.json
+      - name: Upload hosted proof evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: shard-local-cache-evidence-attempt-${{ github.run_attempt }}
+          path: evidence/
+          retention-days: 7

--- a/.github/workflows/server-test-shard-cache-proof.yml
+++ b/.github/workflows/server-test-shard-cache-proof.yml
@@ -169,8 +169,10 @@ jobs:
             --arg elapsed_ms "$(( $(date +%s%3N) - ${{ steps.job-start.outputs.epoch_ms }} ))" \
             '{identity:$identity,cache_key:$cache_key,reason:$reason,restored:($restored=="true"),
               build_outcome:$build_outcome,cache_writer:($cache_writer=="true"),
-              run_attempt:($run_attempt|tonumber),transfer_ms:($transfer_ms//"0"|tonumber),
-              integrity_ms:($integrity_ms//"0"|tonumber),unpack_ms:($unpack_ms//"0"|tonumber),
+              run_attempt:($run_attempt|tonumber),
+              transfer_ms:($transfer_ms|if .=="" then 0 else tonumber end),
+              integrity_ms:($integrity_ms|if .=="" then 0 else tonumber end),
+              unpack_ms:($unpack_ms|if .=="" then 0 else tonumber end),
               elapsed_ms:($elapsed_ms|tonumber)}' > "metrics/${{ matrix.identity }}-attempt-${{ github.run_attempt }}.json"
 
       - name: Upload proof metrics

--- a/docs/internal/ci/server-test-binary-artifacts.md
+++ b/docs/internal/ci/server-test-binary-artifacts.md
@@ -72,6 +72,17 @@ attribution and advisory semantics. The deterministic contract fixture is:
 scripts/ci/validate-server-test-shard-cache.sh
 ```
 
+Hosted proof [run 29167891150](https://github.com/honua-io/honua-server/actions/runs/29167891150)
+used three independent jobs over the 46.4 MiB geoprocessing CLI project cache.
+Attempt 1 built all three shards in parallel; the sole writer completed in
+145.3 seconds versus 144.9 seconds for its non-writer sibling (0.27% delta).
+Two consumers then failed deliberately. Failed-only attempt 2 left the writer's
+original timestamps unchanged: the exact-hit consumer verified/unpacked the
+cache, skipped build, and completed in 51.1 seconds (64.7% faster than its cold
+attempt; 1.8 second transfer, 1.0 second integrity check, 0.8 second unpack).
+The forced-miss consumer rebuilt successfully in 148.0 seconds and saved its
+new exact key. The run completed successfully on attempt 2.
+
 ## Baseline evidence
 
 Measured on commit `b9ef5d78858e4cc0a42c7f835dac4f663b6b3209` with .NET SDK

--- a/docs/internal/ci/server-test-binary-artifacts.md
+++ b/docs/internal/ci/server-test-binary-artifacts.md
@@ -46,6 +46,32 @@ The fast fixture used by CI router validation is:
 scripts/ci/validate-server-test-binary-artifacts.sh
 ```
 
+## Shard-local failed-rerun cache
+
+Production `Server Tests (<shard>)` jobs keep their independent attempt-1
+restore/build path. For each selected project, the lexicographically first
+selected shard is the only attempt-1 cache writer; siblings still build and test
+independently but do not package duplicate project payloads. The writer packages
+and saves its exact project payload after build and before tests, so a test
+failure cannot prevent reuse.
+
+On workflow attempts after the first, a failed shard requests exactly one cache
+key containing the full commit SHA, resolved .NET SDK, archive contract version,
+project identity, runner OS, and artifact-registry digest. There are no prefix
+fallback keys. A valid hit is verified and unpacked before the unchanged
+`--no-build --no-restore` shard test command. A miss or rejected/expired payload
+cleans partial test-project output and safely executes the normal restore/build
+path. A rebuilding rerun may save the exact key for a subsequent attempt.
+
+Every job reports the hit/miss/rejection reason plus transfer, integrity,
+unpack, package, and save timings in its step summary. Cache save contention or
+service failure is non-gating; test/build failures keep their existing
+attribution and advisory semantics. The deterministic contract fixture is:
+
+```bash
+scripts/ci/validate-server-test-shard-cache.sh
+```
+
 ## Baseline evidence
 
 Measured on commit `b9ef5d78858e4cc0a42c7f835dac4f663b6b3209` with .NET SDK

--- a/scripts/ci/server-test-shard-cache.sh
+++ b/scripts/ci/server-test-shard-cache.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Plan and safely materialize shard-local exact-head server-test caches.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_ROOT="${HONUA_SERVER_TEST_CACHE_REPO_ROOT:-${DEFAULT_REPO_ROOT}}"
+REGISTRY="${HONUA_SERVER_TEST_CACHE_REGISTRY:-${REPO_ROOT}/.github/server-test-artifact-projects.json}"
+DEFAULT_PROJECT="tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj"
+CONTRACT_VERSION="1"
+OUTPUT_FILE="${GITHUB_OUTPUT:-/dev/stdout}"
+
+emit() {
+  printf '%s=%s\n' "$1" "$2" >> "${OUTPUT_FILE}"
+}
+
+effective_project() {
+  if [[ -n "$1" ]]; then
+    printf '%s\n' "$1"
+  else
+    printf '%s\n' "${DEFAULT_PROJECT}"
+  fi
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  server-test-shard-cache.sh plan --shard NAME --project CSPROJ --matrix-json JSON --source-sha SHA --runner-os OS --sdk VERSION
+  server-test-shard-cache.sh restore --project CSPROJ --source-sha SHA --payload DIR --cache-hit true|false
+EOF
+}
+
+mode="${1:-}"
+[[ -n "${mode}" ]] || { usage; exit 2; }
+shift
+
+shard=""
+project=""
+matrix_json=""
+source_sha=""
+runner_os=""
+sdk=""
+payload=""
+cache_hit="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --shard) shard="${2:-}"; shift 2 ;;
+    --project) project="${2:-}"; shift 2 ;;
+    --matrix-json) matrix_json="${2:-}"; shift 2 ;;
+    --source-sha) source_sha="${2:-}"; shift 2 ;;
+    --runner-os) runner_os="${2:-}"; shift 2 ;;
+    --sdk) sdk="${2:-}"; shift 2 ;;
+    --payload) payload="${2:-}"; shift 2 ;;
+    --cache-hit) cache_hit="${2:-}"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+for command in jq sha256sum; do
+  command -v "${command}" >/dev/null || { echo "::error::Required command '${command}' is unavailable." >&2; exit 2; }
+done
+
+if [[ ! "${source_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "::error::A full source commit SHA is required." >&2
+  exit 2
+fi
+project="$(effective_project "${project}")"
+suffix="$(jq -er --arg project "${project}" '.projects[] | select(.csproj == $project) | .artifact_suffix' "${REGISTRY}")" || {
+  echo "::error::Project '${project}' is not registered for server-test artifacts." >&2
+  exit 2
+}
+
+case "${mode}" in
+  plan)
+    if [[ -z "${shard}" || -z "${matrix_json}" || -z "${runner_os}" || -z "${sdk}" ]]; then
+      usage
+      exit 2
+    fi
+    if [[ ! "${runner_os}" =~ ^[A-Za-z0-9._-]+$ ]] || [[ ! "${sdk}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+      echo "::error::Runner/toolchain cache-key inputs are invalid." >&2
+      exit 2
+    fi
+    jq -e 'type == "array" and length > 0 and all(.[]; (.shard_name | type == "string" and length > 0))' \
+      <<<"${matrix_json}" >/dev/null || { echo "::error::Selected shard matrix is invalid." >&2; exit 2; }
+    jq -e --arg shard "${shard}" 'any(.[]; .shard_name == $shard)' <<<"${matrix_json}" >/dev/null || {
+      echo "::error::Current shard '${shard}' is absent from the selected matrix." >&2
+      exit 2
+    }
+    writer="$(jq -r --arg project "${project}" --arg fallback "${DEFAULT_PROJECT}" '
+      [ .[]
+        | select((if ((.csproj // "") == "") then $fallback else .csproj end) == $project)
+        | .shard_name ]
+      | sort | first
+    ' <<<"${matrix_json}")"
+    [[ -n "${writer}" && "${writer}" != "null" ]] || {
+      echo "::error::Selected matrix has no writer for '${project}'." >&2
+      exit 2
+    }
+    registry_hash="$(sha256sum "${REGISTRY}" | cut -d' ' -f1)"
+    cache_key="honua-server-test-v${CONTRACT_VERSION}-${runner_os}-${source_sha,,}-${sdk}-${suffix}-${registry_hash}"
+    payload_dir="${RUNNER_TEMP:-/tmp}/honua-server-test-cache/${suffix}"
+
+    emit project "${project}"
+    emit project_suffix "${suffix}"
+    emit cache_key "${cache_key}"
+    emit payload_dir "${payload_dir}"
+    emit cache_writer "$([[ "${shard}" == "${writer}" ]] && echo true || echo false)"
+    emit cache_writer_shard "${writer}"
+    ;;
+
+  restore)
+    if [[ -z "${payload}" || ! "${cache_hit}" =~ ^(true|false)$ ]]; then
+      usage
+      exit 2
+    fi
+    if [[ "${cache_hit}" != "true" ]]; then
+      emit restored false
+      emit reason exact_cache_miss
+      emit integrity_check_ms 0
+      emit unpack_ms 0
+      exit 0
+    fi
+
+    manifest="${payload}/server-test-binaries-${suffix}.manifest.json"
+    timing_file="${payload}/restore-timing.json"
+    restore_log="${payload}/restore.log"
+    set +e
+    HONUA_SERVER_TEST_ARTIFACT_TIMING_FILE="${timing_file}" \
+      "${SCRIPT_DIR}/restore-server-test-binaries.sh" \
+        --manifest "${manifest}" --destination "${REPO_ROOT}" \
+        --project "${project}" --source-sha "${source_sha}" >"${restore_log}" 2>&1
+    restore_status=$?
+    set -e
+    if (( restore_status != 0 )); then
+      cat "${restore_log}" >&2 || true
+      project_dir="${REPO_ROOT}/$(dirname "${project}")"
+      rm -rf "${project_dir}/bin/${HONUA_SERVER_TEST_ARTIFACT_CONFIGURATION:-Release}" "${project_dir}/obj"
+      emit restored false
+      emit reason rejected_cache_evidence
+      emit integrity_check_ms 0
+      emit unpack_ms 0
+      echo "::warning::Exact shard cache evidence was rejected; falling back to restore/build."
+      exit 0
+    fi
+
+    cat "${restore_log}"
+    emit restored true
+    emit reason exact_cache_hit
+    emit integrity_check_ms "$(jq -r '.integrity_check_ms' "${timing_file}")"
+    emit unpack_ms "$(jq -r '.unpack_ms' "${timing_file}")"
+    ;;
+
+  *) usage; exit 2 ;;
+esac

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -65,6 +65,7 @@ jq -e '
 # its package/restore contract must fail closed on RID leakage, tampering and limits.
 scripts/ci/validate-server-test-binary-artifacts.sh
 scripts/ci/validate-server-test-transfer-benchmark.sh
+scripts/ci/validate-server-test-shard-cache.sh
 
 echo "Validating targeted_override_prefixes reference real shards..."
 jq -e '

--- a/scripts/ci/validate-server-test-shard-cache.sh
+++ b/scripts/ci/validate-server-test-shard-cache.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Deterministic fixture validation for shard-local exact-head cache routing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HELPER="${SCRIPT_DIR}/server-test-shard-cache.sh"
+SERVER_PROJECT="tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj"
+ODATA_PROJECT="tests/dotnet/Honua.Protocols.OData.Tests/Honua.Protocols.OData.Tests.csproj"
+SOURCE_SHA="0123456789abcdef0123456789abcdef01234567"
+
+fixture="$(mktemp -d "${RUNNER_TEMP:-/tmp}/honua-shard-cache-fixture.XXXXXX")"
+cleanup() { rm -rf "${fixture}"; }
+trap cleanup EXIT
+
+same_project_matrix="$(jq -nc --arg project "${SERVER_PROJECT}" '[
+  {shard_name:"z-second",csproj:$project},
+  {shard_name:"a-writer",csproj:$project}
+]')"
+mixed_matrix="$(jq -nc --arg server "${SERVER_PROJECT}" --arg odata "${ODATA_PROJECT}" '[
+  {shard_name:"server",csproj:$server},
+  {shard_name:"odata",csproj:$odata}
+]')"
+
+plan() {
+  local output="${fixture}/$1.out"
+  shift
+  GITHUB_OUTPUT="${output}" "${HELPER}" plan "$@"
+  cat "${output}"
+}
+
+writer="$(plan writer --shard a-writer --project "${SERVER_PROJECT}" --matrix-json "${same_project_matrix}" \
+  --source-sha "${SOURCE_SHA}" --runner-os Linux --sdk 10.0.301)"
+second="$(plan second --shard z-second --project "${SERVER_PROJECT}" --matrix-json "${same_project_matrix}" \
+  --source-sha "${SOURCE_SHA}" --runner-os Linux --sdk 10.0.301)"
+server="$(plan server --shard server --project "${SERVER_PROJECT}" --matrix-json "${mixed_matrix}" \
+  --source-sha "${SOURCE_SHA}" --runner-os Linux --sdk 10.0.301)"
+odata="$(plan odata --shard odata --project "${ODATA_PROJECT}" --matrix-json "${mixed_matrix}" \
+  --source-sha "${SOURCE_SHA}" --runner-os Linux --sdk 10.0.301)"
+
+grep -qx 'cache_writer=true' <<<"${writer}"
+grep -qx 'cache_writer=false' <<<"${second}"
+grep -qx 'cache_writer=true' <<<"${server}"
+grep -qx 'cache_writer=true' <<<"${odata}"
+grep -qx 'cache_writer_shard=a-writer' <<<"${writer}"
+writer_key="$(sed -n 's/^cache_key=//p' <<<"${writer}")"
+second_key="$(sed -n 's/^cache_key=//p' <<<"${second}")"
+[[ "${writer_key}" == "${second_key}" ]]
+[[ "${writer_key}" == honua-server-test-v1-Linux-${SOURCE_SHA}-10.0.301-server-* ]]
+[[ "${writer_key}" != *restore-keys* ]]
+odata_key="$(sed -n 's/^cache_key=//p' <<<"${odata}")"
+[[ "${odata_key}" != "${writer_key}" ]]
+[[ "${odata_key}" == *-odata-* ]]
+
+fallback_matrix='[{"shard_name":"fallback","csproj":""}]'
+fallback="$(plan fallback --shard fallback --project '' --matrix-json "${fallback_matrix}" \
+  --source-sha "${SOURCE_SHA}" --runner-os Linux --sdk 10.0.301)"
+grep -qx "project=${SERVER_PROJECT}" <<<"${fallback}"
+grep -qx 'cache_writer=true' <<<"${fallback}"
+
+miss_output="${fixture}/miss.out"
+GITHUB_OUTPUT="${miss_output}" "${HELPER}" restore --project "${SERVER_PROJECT}" \
+  --source-sha "${SOURCE_SHA}" --payload "${fixture}/missing" --cache-hit false
+grep -qx 'restored=false' "${miss_output}"
+grep -qx 'reason=exact_cache_miss' "${miss_output}"
+
+mkdir -p "${fixture}/repo/tests/dotnet/Honua.Server.Tests/bin/Release" \
+  "${fixture}/repo/tests/dotnet/Honua.Server.Tests/obj"
+rejected_output="${fixture}/rejected.out"
+HONUA_SERVER_TEST_CACHE_REPO_ROOT="${fixture}/repo" \
+HONUA_SERVER_TEST_CACHE_REGISTRY="${REPO_ROOT}/.github/server-test-artifact-projects.json" \
+GITHUB_OUTPUT="${rejected_output}" "${HELPER}" restore --project "${SERVER_PROJECT}" \
+  --source-sha "${SOURCE_SHA}" --payload "${fixture}/missing" --cache-hit true >/dev/null 2>&1
+grep -qx 'restored=false' "${rejected_output}"
+grep -qx 'reason=rejected_cache_evidence' "${rejected_output}"
+[[ ! -e "${fixture}/repo/tests/dotnet/Honua.Server.Tests/bin/Release" ]]
+[[ ! -e "${fixture}/repo/tests/dotnet/Honua.Server.Tests/obj" ]]
+
+if GITHUB_OUTPUT="${fixture}/invalid.out" "${HELPER}" plan --shard absent --project "${SERVER_PROJECT}" \
+  --matrix-json "${same_project_matrix}" --source-sha "${SOURCE_SHA}" --runner-os Linux --sdk 10.0.301 \
+  >/dev/null 2>&1; then
+  echo "::error::Plan accepted a shard outside the selected matrix." >&2
+  exit 1
+fi
+
+workflow="${REPO_ROOT}/.github/workflows/ci.yml"
+proof_workflow="${REPO_ROOT}/.github/workflows/server-test-shard-cache-proof.yml"
+grep -Fq 'name: Server Tests (${{ matrix.shard_name }})' "${workflow}"
+grep -q 'actions/cache/restore@v5' "${workflow}"
+grep -q 'actions/cache/save@v5' "${workflow}"
+grep -q 'github.run_attempt > 1' "${workflow}"
+grep -Fq "steps.shard-cache-materialize.outputs.restored != 'true'" "${workflow}"
+grep -Fq "steps.shard-cache-plan.outputs.cache_writer == 'true' || github.run_attempt > 1" "${workflow}"
+if grep -A8 'Restore exact-head shard cache' "${workflow}" | grep -q 'restore-keys:'; then
+  echo "::error::Shard cache restore must not use fallback keys." >&2
+  exit 1
+fi
+if grep -A10 '^  server-tests:' "${workflow}" | grep -qE 'producer|needs:.*build'; then
+  echo "::error::Server-test shards must remain independent of shared producers/build jobs." >&2
+  exit 1
+fi
+grep -Fq 'ci/2735-shard-local-rerun-cache' "${proof_workflow}"
+grep -Fq "matrix.identity != 'a-writer' && github.run_attempt == 1" "${proof_workflow}"
+if grep -qE 'pull_request:|schedule:' "${proof_workflow}"; then
+  echo "::error::Hosted cache proof must remain opt-in and outside production triggers." >&2
+  exit 1
+fi
+
+echo "Server-test shard cache validation passed."

--- a/scripts/ci/validate-server-test-shard-cache.sh
+++ b/scripts/ci/validate-server-test-shard-cache.sh
@@ -102,6 +102,7 @@ if grep -A10 '^  server-tests:' "${workflow}" | grep -qE 'producer|needs:.*build
 fi
 grep -Fq 'ci/2735-shard-local-rerun-cache' "${proof_workflow}"
 grep -Fq "matrix.identity != 'a-writer' && github.run_attempt == 1" "${proof_workflow}"
+grep -Fq 'if .=="" then 0 else tonumber end' "${proof_workflow}"
 if grep -qE 'pull_request:|schedule:' "${proof_workflow}"; then
   echo "::error::Hosted cache proof must remain opt-in and outside production triggers." >&2
   exit 1


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2735
Related to #2708
Prerequisite #2727 (merged)
Depends on #2726

## Summary
Adds shard-local exact-head cache reuse to the existing independent server-test jobs. Attempt 1 keeps restore/build parallel, elects one deterministic writer per selected project, and saves before tests; failed-only reruns restore exact evidence or safely rebuild on a miss. No shared producer or check-name/filter change is introduced.

## Changes Made
- Add exact SHA/SDK/contract/project/registry cache planning with no prefix or cross-head fallback.
- Elect one attempt-1 writer per selected project so same-project shards do not create duplicate payloads.
- Verify and unpack exact hits, skip restore/build on valid evidence, and cleanly fall back to the existing restore/build path on missing, expired, or rejected evidence.
- Preserve independent `Server Tests (<shard>)` attribution, advisory behavior, Testcontainers/PostGIS services, timeouts, filters, and evidence uploads.
- Report hit/miss/rejection plus transfer, integrity, unpack, package, and save timings.
- Add deterministic fixtures and a branch-scoped hosted proof covering exact hit, forced miss fallback, and failed-only rerun.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Focused validation:

- `scripts/ci/validate-server-test-shard-cache.sh`
- `scripts/ci/validate-server-test-binary-artifacts.sh`
- `scripts/ci/validate-server-test-transfer-benchmark.sh`
- `scripts/ci/validate-ci-router.sh` — full router, workflow YAML, shell/Python syntax, and 683-class ownership validation passed
- [Exact-head hosted proof run 29176383228](https://github.com/honua-io/honua-server/actions/runs/29176383228), attempt 2: success after `gh run rerun --failed`; the green writer retained its attempt-1 timestamps
- Attempt 1: one writer success, two deliberate consumer failures; all three cold builds/tests passed before the deliberate failures
- Attempt 2 exact hit: build skipped, 51.1s total versus 144.9s cold (64.7% faster), 1.8s transfer / 1.0s integrity / 0.8s unpack
- Attempt 2 forced miss: safe restore/build/test fallback passed in 148.0s and saved a new exact key
- Green writer retained its original attempt-1 timestamps
- Attempt-1 writer overhead versus same-project non-writer: 0.27%
- CI-only change; no C# source or runtime surface changed
- After trunk synchronization to 4630f3606, the combined cache and WMTS router validators passed locally; the merged WMTS delta was independently green in hosted run 29173376430.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

Internal CI cache contract only; no public API or protocol contract changes.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None. Exact cache misses preserve the current restore/build behavior.

---

## Pre-PR Checklist
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review