### PR TITLE
feat(customcode): enforce custom-code execution is AWS-Batch-only (ADR-0063)

### DIFF
--- a/docker/worker-customcode-python/harness/tests/test_dockerfile_guards.py
+++ b/docker/worker-customcode-python/harness/tests/test_dockerfile_guards.py
@@ -1,0 +1,76 @@
+"""Defense-in-depth guards for the sanctioned custom-code Batch worker images.
+
+Custom-code (untrusted, operator-supplied GP tool) execution is AWS-Batch-only
+(ADR-0063). These images are the ONE sanctioned execution path, so their safety
+guards must be asserted, not assumed. The token/credential scrub is locked in by
+``test_sandbox.py``; this module locks in the container-level guard: both
+custom-code worker Dockerfiles (python + dotnet) must declare a **non-root**
+``USER`` and keep the harness as their ``ENTRYPOINT``, so a future edit that drops
+back to root — which would run untrusted user code as root in the container —
+trips a red test instead of silently landing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# tests/ -> harness/ -> worker-customcode-python/ -> docker/
+_DOCKER_ROOT = Path(__file__).resolve().parents[3]
+
+_PYTHON_DOCKERFILE = _DOCKER_ROOT / "worker-customcode-python" / "Dockerfile"
+_DOTNET_DOCKERFILE = _DOCKER_ROOT / "worker-customcode-dotnet" / "Dockerfile"
+
+_ALL_DOCKERFILES = (_PYTHON_DOCKERFILE, _DOTNET_DOCKERFILE)
+
+
+def _last_user_directive(dockerfile: Path) -> str | None:
+    """Return the argument of the final ``USER`` instruction, or None if absent."""
+    last: str | None = None
+    for raw in dockerfile.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line.upper().startswith("USER "):
+            last = line[len("USER ") :].strip()
+    return last
+
+
+@pytest.mark.parametrize("dockerfile", _ALL_DOCKERFILES, ids=lambda p: p.parent.name)
+def test_dockerfile_exists(dockerfile: Path) -> None:
+    assert dockerfile.is_file(), f"missing sanctioned worker Dockerfile: {dockerfile}"
+
+
+@pytest.mark.parametrize("dockerfile", _ALL_DOCKERFILES, ids=lambda p: p.parent.name)
+def test_dockerfile_declares_non_root_user(dockerfile: Path) -> None:
+    user = _last_user_directive(dockerfile)
+    assert user is not None, (
+        f"{dockerfile.parent.name}/Dockerfile declares no USER directive; the "
+        "custom-code worker must run as a non-root user (ADR-0063)."
+    )
+
+    # Reject root by name or uid (e.g. "root", "0", "0:0", "root:root").
+    uid = user.split(":", 1)[0].strip()
+    assert uid not in {"root", "0"}, (
+        f"{dockerfile.parent.name}/Dockerfile runs as root ('USER {user}'); untrusted "
+        "custom-code must run as a non-root user in the sanctioned Batch container "
+        "(ADR-0063)."
+    )
+    # The images standardize on uid 1001 (matching docker/worker-gdal).
+    assert uid == "1001", (
+        f"{dockerfile.parent.name}/Dockerfile USER is '{user}', expected the non-root "
+        "uid 1001 the custom-code workers standardize on."
+    )
+
+
+@pytest.mark.parametrize("dockerfile", _ALL_DOCKERFILES, ids=lambda p: p.parent.name)
+def test_dockerfile_entrypoint_is_the_harness(dockerfile: Path) -> None:
+    text = dockerfile.read_text(encoding="utf-8")
+    assert "ENTRYPOINT" in text, f"{dockerfile.parent.name}/Dockerfile declares no ENTRYPOINT."
+    # The sanctioned entrypoint is the credential-scrubbing harness, not a raw shell
+    # or the user's own code.
+    assert (
+        "honua-customcode-harness" in text or "Honua.CustomCode.Harness" in text
+    ), (
+        f"{dockerfile.parent.name}/Dockerfile ENTRYPOINT is not the custom-code harness; "
+        "the harness is what scrubs HONUA_JOB_TOKEN + ambient credentials before user code."
+    )

--- a/docs/internal/contributor/adr/0063-custom-code-execution-is-aws-batch-only.md
+++ b/docs/internal/contributor/adr/0063-custom-code-execution-is-aws-batch-only.md
@@ -1,0 +1,131 @@
+# ADR-0063: Custom-code (custom GP tool) execution is AWS-Batch-only
+
+## Status
+
+Accepted (2026-07)
+
+## Context
+
+Honua lets an operator register a **custom geoprocessing tool** — user-authored
+code (a Python entrypoint or a .NET `IGeoprocessingTool`) fetched from a pinned
+git commit and run as a geoprocessing job. This is the `custom-code` runtime
+profile in the geoprocessing job model
+(`Honua.Geoprocessing/.../CustomCode`). Unlike a built-in process
+([ADR-0057](0057-geoprocessing-capability-boundaries.md)), the code that runs is
+**operator-supplied and untrusted** from the server's perspective: it can read
+files, open sockets, spawn processes, and attempt to reach ambient cloud
+credentials.
+
+The execution substrate for a geoprocessing job is chosen by the control-plane
+**execution-workload catalog** (`ControlPlane:ExecutionWorkloads`). A custom-code
+job is routed (in `GeoprocessingJobDispatcher.ResolveWorkloadAsync`) to the
+workload whose `RuntimeProfile == "custom-code"`; that workload names an
+`IBatchComputeBackend` by `(Backend, TargetKind)`. Several backend families are
+wired on trunk:
+
+| Backend name          | `TargetKind`    | Isolation                                   |
+|-----------------------|-----------------|---------------------------------------------|
+| `honua-aws-batch`     | `AwsBatch`      | isolated, cloud-managed per-job container    |
+| `honua-azure-batch`   | `AzureBatch`    | cloud batch                                  |
+| `honua-kubernetes-job`| `KubernetesJob` | cluster job                                  |
+| `local`               | `KubernetesJob` | **on-host**, in-process local queue          |
+| `honua-local-process` | `LocalProcess`  | **on-host**, server-managed subprocess pool  |
+
+The on-host backends (`local`, `honua-local-process`, ADR-0060) are legitimate,
+zero-cloud executors for *trusted* built-in GP/ETL work on on-prem/air-gapped
+hosts. But nothing at configuration time stopped an operator from pointing the
+`custom-code` workload at one of them — which would run **untrusted operator code
+as a subprocess of (or in-process with) the honua-server host**.
+
+A local-process custom-code backend was evaluated in **honua-server#2672
+(`LocalProcessCustomCodeBackend`) and CLOSED as a no-go**. Its isolation depended
+on deployment-specific boundaries plus an operator-configured privilege drop, and
+its unconfined mode let untrusted code read honua-server's own secrets and
+environment and fork-bomb the host process. The existing runtime backstop
+(`CustomCodeDispatchJobExecutor` fails a custom-code job that is ever claimed
+in-process) is a last-resort fence, not a configuration-time gate: it fires only
+*after* a misconfiguration has shipped.
+
+## Decision
+
+**Custom-code (custom geoprocessing tool) execution is AWS-Batch-only.** Untrusted,
+operator-supplied geoprocessing code runs **only** inside an isolated,
+cloud-managed **AWS Batch** container — never as a subprocess of, or in-process
+with, the honua-server host, and (for now) not on any other batch family either.
+
+Concretely:
+
+1. **The only sanctioned substrate for the `custom-code` runtime profile is the
+   AWS Batch backend family** (`TargetKind = AwsBatch`, `Backend =
+   honua-aws-batch`), executing the sanctioned worker images
+   (`docker/worker-customcode-python`, `docker/worker-customcode-dotnet`).
+2. **On-host execution of custom code is prohibited.** The `local` and
+   `honua-local-process` backends remain available for *trusted* built-in GP/ETL
+   workloads; they must never carry the `custom-code` profile.
+3. **Other cloud batch families (Azure Batch, Kubernetes Job) are not sanctioned
+   for custom code** at this time. They are isolated from the host but have not
+   been through the same sandbox review as the AWS Batch worker images (non-root
+   user, credential/token scrub, network posture). Extending custom-code to
+   another family is a deliberate future decision that must add the equivalent
+   sandbox guards and amend this ADR — not a config change.
+
+This does not narrow where *built-in* GP runs (ADR-0057 / ADR-0060 are
+unchanged); it constrains only the untrusted `custom-code` profile.
+
+## How this is enforced
+
+1. **Startup configuration gate (primary).**
+   `ControlPlaneOptionsValidator` (registered with `ValidateOnStart`) fails
+   startup when any `ControlPlane:ExecutionWorkloads` entry declares
+   `RuntimeProfile = "custom-code"` with a `TargetKind` other than `AwsBatch`. The
+   failure message names the offending workload and points here. A future PR that
+   reintroduces an on-host (or other) custom-code backend therefore trips an
+   explicit, documented gate rather than silently landing.
+   *(Unit tests: `ControlPlaneOptionsValidatorTests` — a non-AWS-Batch custom-code
+   workload fails; an AWS-Batch one, and an on-host **non**-custom-code workload,
+   succeed.)*
+2. **Runtime claim fence (backstop).** `CustomCodeDispatchJobExecutor` fails a
+   custom-code job that is ever claimed by an in-process worker, so even if a job
+   reached a host worker it would fail loudly instead of running untrusted code in
+   the server process.
+3. **Sanctioned-container defense-in-depth.** The AWS Batch custom-code worker
+   images run as a **non-root** user (`USER 1001:1001`) and the harness **scrubs
+   `HONUA_JOB_TOKEN`** and the AWS ambient-credential env vars
+   (`AWS_CONTAINER_CREDENTIALS_*`, `ECS_CONTAINER_METADATA_URI*`, static keys)
+   **before importing user code**, leaving the tool only a least-privilege,
+   job-bound scoped client. These guards are asserted by tests
+   (`docker/worker-customcode-python/harness/tests`: `test_sandbox.py` for the
+   token scrub, `test_dockerfile_guards.py` for the non-root `USER` in both worker
+   Dockerfiles) so they cannot silently regress. The isolation expectation is that
+   the Batch job's network egress and task-role scope are restricted by the
+   deployment IaC; user code is denied the task role by the scrub regardless.
+4. **SDK exposes no local-execution path.** `honua-sdk-python` has **no**
+   custom-code job-submission surface and cannot influence backend selection
+   (backend is server configuration). Its ArcPy/ModelBuilder migration codemod
+   translates recognized tools only to **built-in server processes**
+   (`EXECUTABLE_PROCESS_IDS`); unrecognized tools become `manual-review`, never an
+   auto-submitted custom-code job. A tripwire test locks in the absence of any
+   custom-code/local-execution surface in the SDK.
+
+## Consequences
+
+- Untrusted operator code has exactly one execution path, and that path is an
+  isolated cloud-managed container — its blast radius excludes the honua-server
+  process, its secrets, and its host.
+- Operators who want custom GP tools must run an AWS Batch substrate; a
+  deployment without one cannot enable custom code (submission fails cleanly
+  rather than falling back on-host). This is an accepted trade for the security
+  boundary.
+- On-prem/air-gapped deployments that lack AWS Batch cannot run custom code
+  today. Supporting custom code on an isolated non-AWS substrate (e.g. a hardened
+  Kubernetes Job) is deferred and, per Decision 3, requires porting the container
+  guards and amending this ADR.
+- The guard is additive and fail-closed: it locks in behavior that is already the
+  intent, so no currently-valid deployment regresses.
+
+## References
+
+- [ADR-0057: Geoprocessing capability boundaries](0057-geoprocessing-capability-boundaries.md)
+- [ADR-0060: Two-Plane Operability Architecture — substrate-neutral executors](0060-two-plane-operability-architecture.md)
+- honua-io/honua-server#2672 (`LocalProcessCustomCodeBackend`) — evaluated and **closed** as a no-go (local-process custom-code execution)
+- Sanctioned worker images: `docker/worker-customcode-python`, `docker/worker-customcode-dotnet`

--- a/docs/internal/contributor/adr/README.md
+++ b/docs/internal/contributor/adr/README.md
@@ -65,6 +65,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0060](0060-two-plane-operability-architecture.md) | Two-Plane Operability Architecture — Substrate-Neutral Executors Over a Unified Catalog | Proposed | 2026-07 |
 | [0061](0061-mcp-native-elicitation-mapping.md) | Map the Clarification Envelope onto MCP-Native Elicitation | Accepted | 2026-07 |
 | [0062](0062-graduated-ops-autonomy-policy.md) | Graduated Autonomy Policy for Ops Findings | Accepted | 2026-07 |
+| [0063](0063-custom-code-execution-is-aws-batch-only.md) | Custom-code (custom GP tool) execution is AWS-Batch-only | Accepted | 2026-07 |
 
 ## Template
 

--- a/src/Honua.Server/Features/ControlPlane/ControlPlaneOptions.cs
+++ b/src/Honua.Server/Features/ControlPlane/ControlPlaneOptions.cs
@@ -397,8 +397,19 @@ internal sealed class ConfigurationParameterEntryOptions
 
 internal sealed class ControlPlaneOptionsValidator : OptionsValidator<ControlPlaneOptions>
 {
+    /// <summary>
+    /// The runtime-profile discriminator carried by a custom-code execution workload.
+    /// Kept as a literal (mirroring <c>ExecutionWorkloadGate</c>'s literal contract
+    /// keys) so this validator takes no dependency on the internal
+    /// <c>Honua.Geoprocessing</c> <c>CustomCodeJobContract.RuntimeProfile</c> constant,
+    /// whose value this must stay in lockstep with.
+    /// </summary>
+    private const string CustomCodeRuntimeProfile = "custom-code";
+
     protected override void ValidateOptions(ControlPlaneOptions options, List<string> failures)
     {
+        ValidateCustomCodeWorkloadsAreBatchOnly(options.ExecutionWorkloads, failures);
+
         ValidateKubernetes(options.Kubernetes, failures);
 
         PlatformReleaseValidation.Validate(
@@ -455,6 +466,51 @@ internal sealed class ControlPlaneOptionsValidator : OptionsValidator<ControlPla
             if (connection.TimeoutSeconds <= 0)
             {
                 failures.Add($"{propertyPrefix}:TimeoutSeconds must be greater than 0.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enforces the custom-code-is-AWS-Batch-only policy (ADR-0063) at startup: a
+    /// configuration-declared execution workload that carries the
+    /// <see cref="CustomCodeRuntimeProfile"/> runtime profile may target ONLY the AWS
+    /// Batch backend family (<see cref="BatchComputeTargetKind.AwsBatch"/>).
+    /// </summary>
+    /// <remarks>
+    /// Custom (operator-supplied, untrusted) geoprocessing code must run only inside an
+    /// isolated, cloud-managed AWS Batch container, never in-process/on-host with
+    /// honua-server. On-host batch backends exist for ordinary trusted workloads
+    /// (<c>LocalBatchComputeBackend</c> = <c>local</c>/KubernetesJob family,
+    /// <c>LocalProcessPoolBatchComputeBackend</c> = <c>honua-local-process</c>/LocalProcess
+    /// family), and other cloud families (Azure Batch, Kubernetes Job) are not sanctioned
+    /// for custom code. Pointing a <c>custom-code</c> workload at any of them would route
+    /// untrusted code onto a non-AWS-Batch substrate, so we fail startup here rather than
+    /// let it silently land. The in-process claim fence
+    /// (<c>CustomCodeDispatchJobExecutor</c>) is the runtime backstop; this is the
+    /// configuration-time gate. Local-process execution was evaluated in the closed
+    /// honua-server#2672 and rejected — reintroducing it must trip this explicit gate.
+    /// </remarks>
+    private static void ValidateCustomCodeWorkloadsAreBatchOnly(
+        List<ExecutionWorkloadOptions> workloads,
+        List<string> failures)
+    {
+        for (var i = 0; i < workloads.Count; i++)
+        {
+            var workload = workloads[i];
+            if (!string.Equals(workload.RuntimeProfile?.Trim(), CustomCodeRuntimeProfile, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (workload.TargetKind != BatchComputeTargetKind.AwsBatch)
+            {
+                failures.Add(
+                    $"ControlPlane:ExecutionWorkloads:{i} (WorkloadId '{workload.WorkloadId}') declares the "
+                    + $"'{CustomCodeRuntimeProfile}' runtime profile with TargetKind '{workload.TargetKind}', but "
+                    + "custom-code (custom geoprocessing tool) execution is AWS-Batch-only: untrusted operator "
+                    + "code must run only in an isolated cloud-managed AWS Batch container, never on-host with "
+                    + "honua-server. Set TargetKind='AwsBatch' (Backend='honua-aws-batch') or remove the workload. "
+                    + "See ADR-0063 (custom-code execution is AWS-Batch-only).");
             }
         }
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneOptionsValidatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/ControlPlane/ControlPlaneOptionsValidatorTests.cs
@@ -4,6 +4,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Honua.ControlPlane;
+using Honua.Core.Features.ControlPlane.Domain;
 using Honua.TestKit.Attributes;
 
 namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
@@ -11,6 +12,85 @@ namespace Honua.Server.Tests.Features.Infrastructure.ControlPlane;
 public sealed class ControlPlaneOptionsValidatorTests
 {
     private readonly ControlPlaneOptionsValidator _validator = new();
+
+    [UnitTest]
+    public void Validate_WithCustomCodeWorkloadOnAwsBatch_Succeeds()
+    {
+        var options = new ControlPlaneOptions
+        {
+            ExecutionWorkloads =
+            [
+                new ExecutionWorkloadOptions
+                {
+                    WorkloadId = "customcode-python",
+                    RuntimeProfile = "custom-code",
+                    TargetKind = BatchComputeTargetKind.AwsBatch,
+                    Backend = "honua-aws-batch"
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join(" | ", result.Failures ?? []));
+    }
+
+    [Theory]
+    [InlineData(BatchComputeTargetKind.LocalProcess)]
+    [InlineData(BatchComputeTargetKind.KubernetesJob)]
+    [InlineData(BatchComputeTargetKind.AzureBatch)]
+    [Trait("Category", "Unit")]
+    public void Validate_WithCustomCodeWorkloadOnNonAwsBatchBackend_FailsStartup(BatchComputeTargetKind targetKind)
+    {
+        // ADR-0063: custom-code (untrusted operator code) is AWS-Batch-only. Pointing a
+        // custom-code workload at an on-host (LocalProcess / the KubernetesJob-family local
+        // backend) or any non-AWS-Batch substrate must fail startup, not silently land.
+        var options = new ControlPlaneOptions
+        {
+            ExecutionWorkloads =
+            [
+                new ExecutionWorkloadOptions
+                {
+                    WorkloadId = "customcode-onhost",
+                    RuntimeProfile = "custom-code",
+                    TargetKind = targetKind,
+                    Backend = "honua-local-process"
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures ?? Array.Empty<string>(), failure =>
+            failure.Contains("custom-code", StringComparison.Ordinal) &&
+            failure.Contains("AWS-Batch-only", StringComparison.Ordinal) &&
+            failure.Contains("ADR-0063", StringComparison.Ordinal));
+    }
+
+    [UnitTest]
+    public void Validate_WithNonCustomCodeWorkloadOnLocalProcess_Succeeds()
+    {
+        // The Batch-only gate must not touch ordinary (trusted) GP workloads, which may
+        // legitimately run on the on-host LocalProcess pool.
+        var options = new ControlPlaneOptions
+        {
+            ExecutionWorkloads =
+            [
+                new ExecutionWorkloadOptions
+                {
+                    WorkloadId = "gp-local",
+                    RuntimeProfile = "gdal",
+                    TargetKind = BatchComputeTargetKind.LocalProcess,
+                    Backend = "honua-local-process"
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded, string.Join(" | ", result.Failures ?? []));
+    }
 
     [UnitTest]
     public void Validate_WithPublicHttpsTelemetryConnection_ReturnsSuccess()


### PR DESCRIPTION
## Summary

Codifies and enforces the policy that **custom-code (custom geoprocessing tool) execution is AWS-Batch-only**: untrusted, operator-supplied GP code runs only inside an isolated, cloud-managed AWS Batch container, never as a subprocess of / in-process with the honua-server host. Local-process custom-code execution was evaluated in **#2672** and closed as a no-go.

## What changed

- **ADR-0063** (`docs/internal/contributor/adr/0063-custom-code-execution-is-aws-batch-only.md`, indexed in the ADR README) — states the policy, rationale, and the "how this is enforced" section. References ADR-0057, ADR-0060, and closed #2672.
- **Server-side startup guard (primary):** `ControlPlaneOptionsValidator` (registered with `ValidateOnStart`) now fails startup when a `ControlPlane:ExecutionWorkloads` entry declares `RuntimeProfile = "custom-code"` with any `TargetKind` other than `AwsBatch`. On-host backends (`local`, `honua-local-process`) and other cloud families (Azure Batch, Kubernetes Job) are rejected for custom code, with a message pointing at ADR-0063. A future PR reintroducing an on-host custom-code backend therefore trips an explicit, documented gate.
  - Unit tests: a non-AWS-Batch custom-code workload fails startup (LocalProcess / KubernetesJob / AzureBatch); an AWS-Batch one succeeds; an on-host **non**-custom-code workload stays valid (the gate does not touch trusted built-in GP/ETL).
- **Docker harness guard (defense-in-depth):** the sanctioned worker images already run non-root (`USER 1001:1001`) and scrub `HONUA_JOB_TOKEN` + AWS ambient creds before user code (`test_sandbox.py`). Added `test_dockerfile_guards.py` to lock in that both custom-code worker Dockerfiles (python + dotnet) keep a non-root `USER` and the harness `ENTRYPOINT`, so a regression to root trips a red test.

## Context

On trunk, backend selection for a custom-code job is via the `custom-code` execution-workload's `(Backend, TargetKind)`. Nothing at config time prevented pointing it at an on-host backend (`LocalProcessPoolBatchComputeBackend` / `LocalBatchComputeBackend`, both of which exist independent of #2672). The runtime `CustomCodeDispatchJobExecutor` fence only fails *after* a misconfiguration ships; this adds the config-time gate.

## Verification

- `dotnet build src/Honua.Server` — clean.
- `dotnet test tests/dotnet/Honua.Server.Tests --filter ~ControlPlaneOptionsValidatorTests` — 24 passed.
- `pytest docker/worker-customcode-python/harness/tests/test_dockerfile_guards.py` — 6 passed.
