### PR TITLE
fix(ci): fail merge train closed on incomplete runs (#2755)

### DIFF
--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -14,6 +14,8 @@
 #                           reproduce-twice => real.
 #   7. ff-cas-race       -> concurrent trunk advance => FF push rejected +
 #                           re-assemble signaled (rc=10).
+#   8. fail-closed CI    -> cancelled/incomplete jobs cannot use the
+#                           non-blocking failure bypass.
 #
 # Roll-forward auto-fix loop (offline-mocked; NO real Bedrock/AI calls):
 #   Cap.1 pre-existing filter -> all-pre-existing => rc11 (land); some
@@ -206,6 +208,59 @@ __fake_fmt_noop() { :; }
 export TRAIN_FORMAT_CMD=__fake_fmt_noop; export -f __fake_fmt_noop
 train_forward_fix fwdfix-batch 2 && bad "fwdfix: cap not enforced" || ok "fwdfix: cap (2) enforced"
 unset TRAIN_FORMAT_CMD
+
+echo "== Case 4b: non-blocking bypass fails closed on incomplete CI =="
+export TRAIN_CI_JOBS_READER=__ci_jobs
+__ci_jobs() {
+  case "${CI_JOBS_CASE}" in
+    safe)
+      printf 'success\tBuild & Format Check\nsuccess\tServer Tests (Core)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n'
+      ;;
+    cancelled)
+      printf 'success\tBuild & Format Check\ncancelled\tServer Tests (Core)\nfailure\tTest Suite Summary\ncancelled\tCI Gate\n'
+      ;;
+    missing-shards)
+      printf 'failure\tTest Suite Summary\nfailure\tCI Gate\n'
+      ;;
+    partial-missing)
+      printf 'success\tBuild & Format Check\nsuccess\tServer Tests (Core)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n'
+      ;;
+    blocking-skipped)
+      printf 'success\tBuild & Format Check\nsuccess\tServer Tests (Core)\nskipped\tServer Tests (Workflow Packages)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n'
+      ;;
+    timed-out)
+      printf 'success\tBuild & Format Check\ntimed_out\tServer Tests (Core)\nfailure\tTest Suite Summary\nfailure\tCI Gate\n'
+      ;;
+  esac
+}
+export -f __ci_jobs
+SAFE_DESCRIPTOR='{"run_all":false,"shards":["Core"]}'
+TWO_SHARD_DESCRIPTOR='{"run_all":false,"shards":["Core","Workflow Packages"]}'
+CI_JOBS_CASE=safe train_nonblocking_failures_are_safe 1 "${SAFE_DESCRIPTOR}" \
+  && ok "ci-safe: optional failures with successful blocking jobs may land" \
+  || bad "ci-safe: valid optional-only failure was rejected"
+CI_JOBS_CASE=safe train_ci_jobs_are_terminal 1 \
+  && ok "ci-safe: success/failure jobs are terminal evidence" \
+  || bad "ci-safe: terminal job set was rejected"
+CI_JOBS_CASE=cancelled train_nonblocking_failures_are_safe 2 "${SAFE_DESCRIPTOR}" \
+  && bad "ci-safe: cancelled gate/shard must fail closed" \
+  || ok "ci-safe: cancelled gate/shard fails closed"
+CI_JOBS_CASE=cancelled train_ci_jobs_are_terminal 2 \
+  && bad "ci-safe: cancelled jobs must make the run unusable" \
+  || ok "ci-safe: cancelled jobs make the run unusable"
+CI_JOBS_CASE=missing-shards train_nonblocking_failures_are_safe 3 "${SAFE_DESCRIPTOR}" \
+  && bad "ci-safe: missing blocking jobs must fail closed" \
+  || ok "ci-safe: missing blocking jobs fail closed"
+CI_JOBS_CASE=timed-out train_nonblocking_failures_are_safe 4 "${SAFE_DESCRIPTOR}" \
+  && bad "ci-safe: timed-out shard must fail closed" \
+  || ok "ci-safe: timed-out shard fails closed"
+CI_JOBS_CASE=partial-missing train_expected_shards_are_classifiable 5 "${TWO_SHARD_DESCRIPTOR}" \
+  && bad "ci-safe: partially missing selected shard must fail closed" \
+  || ok "ci-safe: partially missing selected shard fails closed"
+CI_JOBS_CASE=blocking-skipped train_expected_shards_are_classifiable 6 "${TWO_SHARD_DESCRIPTOR}" \
+  && bad "ci-safe: skipped selected shard must fail closed" \
+  || ok "ci-safe: skipped selected shard fails closed"
+unset TRAIN_CI_JOBS_READER CI_JOBS_CASE SAFE_DESCRIPTOR TWO_SHARD_DESCRIPTOR
 
 echo "== Case 5: real-test-fail (attribute + drop; 0-suspect escalates) =="
 # Build a 2-PR batch where pr401 touches a FeatureServer path and pr402 an OGC

--- a/scripts/ci/merge-train/smart-ci.sh
+++ b/scripts/ci/merge-train/smart-ci.sh
@@ -85,3 +85,93 @@ train_failing_jobs() {
   gh run view "${run_id}" --json jobs \
     --jq '.jobs[] | select(.conclusion=="failure") | .name'
 }
+
+# train_ci_jobs <run-id>: emit every job as "<conclusion>\t<name>". Tests may
+# override the reader so cancellation/incomplete-run safety is exercised
+# offline without GitHub access.
+train_ci_jobs() {
+  local run_id="$1"
+  if [[ -n "${TRAIN_CI_JOBS_READER:-}" ]]; then
+    "${TRAIN_CI_JOBS_READER}" "${run_id}"
+    return
+  fi
+  gh run view "${run_id}" --json jobs \
+    --jq '.jobs[] | [.conclusion, .name] | @tsv'
+}
+
+# train_ci_jobs_are_terminal <run-id>: success/failure/skipped are the only
+# conclusions safe to classify. Any cancellation or incomplete conclusion
+# makes the entire run unusable as merge evidence.
+train_ci_jobs_are_terminal() {
+  local run_id="$1" rows conclusion name saw_gate=0
+  rows="$(train_ci_jobs "${run_id}")" || return 1
+  [[ -n "${rows//[$'\n'$'\t' ]/}" ]] || return 1
+
+  while IFS=$'\t' read -r conclusion name; do
+    [[ -n "${name}" ]] || return 1
+    conclusion="$(tr '[:upper:]' '[:lower:]' <<<"${conclusion}")"
+    case "${conclusion}" in
+      success|failure|skipped) ;;
+      *) return 1 ;;
+    esac
+    [[ "${name}" == "CI Gate" ]] && saw_gate=1
+  done <<<"${rows}"
+
+  [[ "${saw_gate}" == "1" ]]
+}
+
+# train_expected_shards_are_classifiable <run-id> <shard-descriptor>
+# Every shard selected by the router must exist exactly once and conclude
+# SUCCESS or FAILURE. A missing or skipped selected shard is not evidence.
+train_expected_shards_are_classifiable() {
+  local run_id="$1" descriptor="$2" rows shard expected matches conclusion
+  jq -e '.shards | type == "array" and length > 0' <<<"${descriptor}" >/dev/null 2>&1 || return 1
+  rows="$(train_ci_jobs "${run_id}")" || return 1
+
+  while IFS= read -r shard; do
+    [[ -n "${shard}" ]] || return 1
+    expected="Server Tests (${shard})"
+    matches="$(awk -F '\t' -v expected="${expected}" '$2 == expected { print $1 }' <<<"${rows}")"
+    [[ "$(sed '/^$/d' <<<"${matches}" | wc -l | tr -d ' ')" == "1" ]] || return 1
+    conclusion="$(tr '[:upper:]' '[:lower:]' <<<"${matches}")"
+    [[ "${conclusion}" == "success" || "${conclusion}" == "failure" ]] || return 1
+  done < <(jq -r '.shards[]' <<<"${descriptor}")
+}
+
+# train_nonblocking_failures_are_safe <run-id> <shard-descriptor>
+#
+# The optimistic non-blocking bypass is valid only when GitHub reports the
+# failed CI Gate, every non-blocking exception is an ordinary FAILURE, and at
+# least one blocking job explicitly succeeded. CANCELLED, missing, pending,
+# timed-out, neutral, or otherwise incomplete jobs always fail closed.
+train_nonblocking_failures_are_safe() {
+  local run_id="$1" descriptor="$2" rows conclusion name
+  train_ci_jobs_are_terminal "${run_id}" || return 1
+  train_expected_shards_are_classifiable "${run_id}" "${descriptor}" || return 1
+  rows="$(train_ci_jobs "${run_id}")" || return 1
+  [[ -n "${rows//[$'\n'$'\t' ]/}" ]] || return 1
+
+  local saw_failed_gate=0 saw_blocking_success=0
+  while IFS=$'\t' read -r conclusion name; do
+    [[ -n "${name}" ]] || return 1
+    conclusion="$(tr '[:upper:]' '[:lower:]' <<<"${conclusion}")"
+    case "${conclusion}" in
+      success)
+        if ! grep -Fxiq -- "${name}" <<<"${TRAIN_NONBLOCKING_JOBS}"; then
+          saw_blocking_success=1
+        fi
+        ;;
+      skipped)
+        ;;
+      failure)
+        grep -Fxiq -- "${name}" <<<"${TRAIN_NONBLOCKING_JOBS}" || return 1
+        [[ "${name}" == "CI Gate" ]] && saw_failed_gate=1
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  done <<<"${rows}"
+
+  [[ "${saw_failed_gate}" == "1" && "${saw_blocking_success}" == "1" ]]
+}

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -208,6 +208,23 @@ main() {
   local autofix_attempts=0
   while [[ "${gate}" != "SUCCESS" ]]; do
     local run_id; run_id="$(cat "${TRAIN_RUN_ID_FILE}" 2>/dev/null || echo "")"
+
+    # Only an ordinary FAILURE has actionable failed jobs. A cancelled,
+    # missing, timed-out, stale, neutral, or otherwise incomplete gate must
+    # never flow into failure subtraction/classification: doing so can turn an
+    # empty failure list into a false success and land unvalidated code.
+    if [[ "${gate}" != "FAILURE" ]] \
+      || ! train_ci_jobs_are_terminal "${run_id}" \
+      || ! train_expected_shards_are_classifiable "${run_id}" "${shard_descriptor}"; then
+      _write_state "${batch}" "${trunk_sha}" "${included}" "ci-incomplete" "${run_id}" "${fwdfix}" "${flake_reruns}"
+      train_annotate_warn "CI Gate/run is ${gate} with incomplete or unusable jobs; failing closed without landing or dropping PRs"
+      train_step_end ci-gate >/dev/null; train_endgroup
+      _emit_metrics "ci-incomplete" "${trunk_sha}" "" "${shard_descriptor}"
+      _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+        "STOPPED: CI Gate/run ${gate} is incomplete or unusable; explicit successful validation required"
+      return 1
+    fi
+
     local failing; failing="$(train_failing_jobs "${run_id}")"
 
     # --- (0) NON-BLOCKING aux/aggregator filter (deterministic) --------------
@@ -216,11 +233,23 @@ main() {
     # aggregators. The train lands on its SHARD results; real regressions in the
     # aux jobs are caught by post-merge trunk CI. If nothing real-fails after
     # stripping, the batch is green-enough → land.
+    local nonblocking_only=0
+    train_nonblocking_failures_are_safe "${run_id}" "${shard_descriptor}" && nonblocking_only=1
     failing="$(train_subtract_lines "${TRAIN_NONBLOCKING_JOBS}" "${failing}")"
     if [[ -z "${failing//[$'\n'$'\t' ]/}" ]]; then
-      train_metric_set nonblocking_passes 1
-      train_notice "only non-blocking aux/aggregator jobs failed; landing on shard results"
-      gate="SUCCESS"; continue
+      if [[ "${nonblocking_only}" == "1" ]]; then
+        train_metric_set nonblocking_passes 1
+        train_notice "only non-blocking aux/aggregator jobs failed and every selected shard explicitly succeeded; landing on shard results"
+        gate="SUCCESS"; continue
+      fi
+
+      _write_state "${batch}" "${trunk_sha}" "${included}" "ci-incomplete" "${run_id}" "${fwdfix}" "${flake_reruns}"
+      train_annotate_warn "CI has no blocking failures to classify but selected-shard evidence is missing or skipped; failing closed"
+      train_step_end ci-gate >/dev/null; train_endgroup
+      _emit_metrics "ci-incomplete" "${trunk_sha}" "" "${shard_descriptor}"
+      _dashboard "${batch}" "${selected}" "${trunk_sha}" "${shard_descriptor}" \
+        "STOPPED: selected-shard evidence missing or skipped; explicit successful validation required"
+      return 1
     fi
 
     # forward-fix: only when the SOLE failure is the format-verify step.


### PR DESCRIPTION
## Issue Link

Fixes #2755

## Summary

Prevents the live merge train from interpreting cancelled, timed-out, missing, or skipped selected CI work as a successful optional-only batch. This repairs the fail-open path that landed #2747 and #2751 after their child CI run was cancelled.

## Changes Made

- Reject every non-`FAILURE` gate and every non-terminal job set before failure classification.
- Reconcile GitHub jobs against the router descriptor; every selected server-test shard must exist exactly once with a success/failure conclusion.
- Permit the optional-only bypass only when all selected shards explicitly succeeded, and stop rather than fall through on unsafe empty failure sets.
- Add offline regression fixtures for cancelled, timed-out, missing, partially missing, and skipped selected jobs.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Shell-only pre-PR equivalent passed: canonical instruction sync; recursive `bash -n`; CI router validation (684 classes owned); merge-train mode fixtures; merge-train suite (151 passed, 0 failed). The current pre-PR script's irrelevant .NET build path was stopped after diagnosis; #2756 adds the hosted-routing-aligned shell-only fast path.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (shell-only equivalent detailed above)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract (not applicable)
- [x] If breaking admin/control-plane API changes: updated migration guide (not applicable)
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review (not applicable)
