### PR TITLE
ci: add shell-only pre-PR fast path (#2756)

### DIFF
--- a/scripts/ci/classify-pre-pr-changes.sh
+++ b/scripts/ci/classify-pre-pr-changes.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Classify the complete local pre-PR diff, including committed and working-tree
+# changes. The first output line is CI_ONLY, NORMAL, or UNKNOWN; remaining lines
+# are the sorted changed paths when they could be determined safely.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+base_ref="${1:-${BASE_REF:-origin/trunk}}"
+head_ref="${2:-${HEAD_REF:-HEAD}}"
+scratch="$(mktemp -d)"
+trap 'rm -rf "${scratch}"' EXIT
+
+unknown() {
+  echo "UNKNOWN"
+  exit 0
+}
+
+git rev-parse --verify --quiet "${base_ref}" >/dev/null 2>&1 || unknown
+git rev-parse --verify --quiet "${head_ref}" >/dev/null 2>&1 || unknown
+
+# Keep each command separate so any git failure produces UNKNOWN instead of an
+# accidentally empty list that could select the no-build path.
+git diff --name-only "${base_ref}...${head_ref}" >"${scratch}/committed" 2>/dev/null || unknown
+git diff --name-only >"${scratch}/unstaged" 2>/dev/null || unknown
+git diff --cached --name-only >"${scratch}/staged" 2>/dev/null || unknown
+git ls-files --others --exclude-standard >"${scratch}/untracked" 2>/dev/null || unknown
+
+LC_ALL=C sort -u \
+  "${scratch}/committed" \
+  "${scratch}/unstaged" \
+  "${scratch}/staged" \
+  "${scratch}/untracked" >"${scratch}/changed"
+
+# Match the hosted BUILD_FILES exclusions in ci.yml. In particular,
+# .github/actions/setup-dotnet-ci is intentionally not eligible.
+classification="CI_ONLY"
+while IFS= read -r path; do
+  [[ -z "${path}" ]] && continue
+  case "${path}" in
+    README.md|docs/*|.github/ci-shards.json|scripts/ci/*)
+      ;;
+    .github/workflows/*.yml)
+      # Hosted routing accepts direct workflow files only (`[^/]+.yml`). Bash's
+      # case glob crosses slashes, so reject nested paths explicitly.
+      workflow_path="${path#.github/workflows/}"
+      [[ "${workflow_path}" != */* ]] || classification="NORMAL"
+      ;;
+    *)
+      classification="NORMAL"
+      ;;
+  esac
+  [[ "${classification}" == "CI_ONLY" ]] || break
+done <"${scratch}/changed"
+
+# An empty diff is not positive evidence for bypassing normal validation.
+[[ -s "${scratch}/changed" ]] || classification="NORMAL"
+
+echo "${classification}"
+cat "${scratch}/changed"

--- a/scripts/ci/fixtures/validate-pre-pr-routing.sh
+++ b/scripts/ci/fixtures/validate-pre-pr-routing.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Offline fixtures for the local pre-PR CI-only fast-path classifier.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLASSIFIER="${SCRIPT_DIR}/classify-pre-pr-changes.sh"
+SYNTAX_VALIDATOR="${SCRIPT_DIR}/validate-shell-syntax.sh"
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+REPO="${SCRATCH}/repo"
+git init -q "${REPO}"
+git -C "${REPO}" config user.name Test
+git -C "${REPO}" config user.email test@honua.io
+mkdir -p "${REPO}/scripts/ci/fixtures" "${REPO}/src/App" "${REPO}/.github/workflows" "${REPO}/.github/actions/setup-dotnet-ci"
+cp "${CLASSIFIER}" "${REPO}/scripts/ci/classify-pre-pr-changes.sh"
+cp "${SYNTAX_VALIDATOR}" "${REPO}/scripts/ci/validate-shell-syntax.sh"
+printf '#!/usr/bin/env bash\ntrue\n' >"${REPO}/scripts/ci/fixtures/nested.sh"
+printf '<Project />\n' >"${REPO}/src/App/App.csproj"
+git -C "${REPO}" add .
+git -C "${REPO}" commit -qm seed
+BASE="$(git -C "${REPO}" rev-parse HEAD)"
+
+classification() {
+  (cd "${REPO}" && scripts/ci/classify-pre-pr-changes.sh "${BASE}" HEAD | head -1)
+}
+
+# Committed CI shell changes are eligible.
+printf '# fixture\n' >>"${REPO}/scripts/ci/fixtures/nested.sh"
+git -C "${REPO}" add scripts/ci/fixtures/nested.sh
+git -C "${REPO}" commit -qm 'ci shell change'
+[[ "$(classification)" == "CI_ONLY" ]] && pass "committed CI shell change" || fail "committed CI shell change"
+
+# Staged, unstaged, and untracked paths all participate in classification.
+printf '# staged\n' >>"${REPO}/scripts/ci/fixtures/nested.sh"
+git -C "${REPO}" add scripts/ci/fixtures/nested.sh
+printf '# unstaged\n' >>"${REPO}/scripts/ci/validate-shell-syntax.sh"
+printf '#!/usr/bin/env bash\ntrue\n' >"${REPO}/scripts/ci/untracked.sh"
+[[ "$(classification)" == "CI_ONLY" ]] && pass "working-tree CI shell changes" || fail "working-tree CI shell changes"
+
+# Hosted build-routing exclusions remain eligible as a mixed metadata diff.
+mkdir -p "${REPO}/docs"
+printf 'docs\n' >"${REPO}/docs/ci.md"
+printf 'name: ci\n' >"${REPO}/.github/workflows/ci.yml"
+printf '{}\n' >"${REPO}/.github/ci-shards.json"
+[[ "$(classification)" == "CI_ONLY" ]] && pass "hosted CI metadata parity" || fail "hosted CI metadata parity"
+
+# Runtime/build inputs and setup-dotnet action changes must use normal checks.
+printf 'class Runtime {}\n' >"${REPO}/src/App/Runtime.cs"
+[[ "$(classification)" == "NORMAL" ]] && pass "runtime change falls back" || fail "runtime change falls back"
+rm "${REPO}/src/App/Runtime.cs"
+printf 'name: setup\n' >"${REPO}/.github/actions/setup-dotnet-ci/action.yml"
+[[ "$(classification)" == "NORMAL" ]] && pass "setup-dotnet action falls back" || fail "setup-dotnet action falls back"
+rm "${REPO}/.github/actions/setup-dotnet-ci/action.yml"
+mkdir -p "${REPO}/.github/workflows/nested"
+printf 'name: nested\n' >"${REPO}/.github/workflows/nested/ci.yml"
+[[ "$(classification)" == "NORMAL" ]] && pass "nested workflow path falls back" || fail "nested workflow path falls back"
+rm -rf "${REPO}/.github/workflows/nested"
+
+# Missing refs are uncertainty, never CI-only.
+unknown="$(cd "${REPO}" && scripts/ci/classify-pre-pr-changes.sh refs/heads/missing HEAD | head -1)"
+[[ "${unknown}" == "UNKNOWN" ]] && pass "missing base fails safe" || fail "missing base fails safe"
+
+# Recursive syntax validation must reach nested scripts.
+printf '#!/usr/bin/env bash\nif then\n' >"${REPO}/scripts/ci/fixtures/bad.sh"
+if (cd "${REPO}" && scripts/ci/validate-shell-syntax.sh >/dev/null 2>&1); then
+  fail "recursive syntax rejects nested error"
+else
+  pass "recursive syntax rejects nested error"
+fi
+printf '#!/usr/bin/env bash\ntrue\n' >"${REPO}/scripts/ci/fixtures/bad.sh"
+(cd "${REPO}" && scripts/ci/validate-shell-syntax.sh >/dev/null) \
+  && pass "recursive syntax accepts valid scripts" \
+  || fail "recursive syntax accepts valid scripts"
+
+echo "RESULT: ${PASS} passed, ${FAIL} failed"
+[[ "${FAIL}" -eq 0 ]]

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -29,6 +29,10 @@ set -euo pipefail
 #                           concurrently in SMART/FULL mode (default 2). Each
 #                           shard is a separate dotnet-test process with its own
 #                           Postgres container, so keep this modest.
+#
+# A diff containing only the same CI/docs paths excluded from hosted CI's
+# BUILD_FILES takes a shell-only path: governance and shell fixtures run, but
+# package restore, managed builds/tests, Docker and AOT do not.
 
 BASE_REF="${HONUA_PRE_PR_BASE:-origin/trunk}"
 FULL="${HONUA_PRE_PR_FULL:-0}"
@@ -54,6 +58,50 @@ echo "🔍 Running pre-PR validation..."
 if [[ "${FULL}" == "1" ]]; then
     FAST=0
 fi
+
+# Include committed, staged, unstaged and untracked files. Only positive,
+# complete CI_ONLY evidence can bypass managed validation; UNKNOWN and NORMAL
+# both continue through the existing fail-safe path.
+PRE_PR_SCOPE="NORMAL"
+PRE_PR_CHANGED_FILES=""
+if [[ "${FULL}" != "1" ]]; then
+    scope_output="$(scripts/ci/classify-pre-pr-changes.sh "${BASE_REF}" HEAD 2>/dev/null || echo UNKNOWN)"
+    PRE_PR_SCOPE="$(head -1 <<< "${scope_output}")"
+    PRE_PR_CHANGED_FILES="$(tail -n +2 <<< "${scope_output}")"
+fi
+
+if [[ "${PRE_PR_SCOPE}" == "CI_ONLY" ]]; then
+    echo "    Mode: CI-SHELL-ONLY (committed + working tree vs ${BASE_REF})."
+    echo "1. Checking canonical instructions..."
+    bash scripts/ci/check-instructions-sync.sh
+
+    mapfile -t changed_shell_scripts < <(
+        printf '%s\n' "${PRE_PR_CHANGED_FILES}" \
+            | sed '/^$/d' \
+            | while IFS= read -r path; do
+                [[ "${path}" == *.sh && -f "${path}" ]] && printf '%s\n' "${path}"
+              done
+    )
+    echo "2. Checking changed shell script syntax..."
+    scripts/ci/validate-shell-syntax.sh "${changed_shell_scripts[@]}"
+
+    echo "3. Validating CI workflow and shard routing..."
+    scripts/ci/validate-ci-router.sh
+
+    echo "4. Running merge-train mode fixtures..."
+    scripts/ci/merge-train/fixtures/validate-mode.sh
+
+    if grep -qE '^scripts/ci/merge-train/' <<< "${PRE_PR_CHANGED_FILES}"; then
+        echo "5. Running merge-train fixtures..."
+        scripts/ci/merge-train/fixtures/validate-merge-train.sh
+    else
+        echo "5. Merge-train fixtures not required (surface unchanged)."
+    fi
+
+    echo "✅ CI shell-only pre-PR checks passed; managed build/test work was not required."
+    exit 0
+fi
+
 if [[ "${FAST}" == "1" ]]; then
     echo "    Tier: FAST (build + format + unit + architecture; server-test shards"
     echo "          and AOT deferred to CI / the merge queue). Run without"

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -74,7 +74,10 @@ jq -e '
   || { echo "::error::a targeted_override_prefixes entry references an unknown shard name" >&2; exit 1; }
 
 echo "Checking shell script syntax..."
-bash -n scripts/ci/*.sh
+scripts/ci/validate-shell-syntax.sh
+
+echo "Checking local pre-PR change routing..."
+scripts/ci/fixtures/validate-pre-pr-routing.sh
 
 echo "Checking Python helper syntax..."
 python3 -m py_compile scripts/ci/*.py

--- a/scripts/ci/validate-shell-syntax.sh
+++ b/scripts/ci/validate-shell-syntax.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Validate shell syntax recursively, or validate the explicitly supplied paths.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+scripts=()
+if [[ "$#" -eq 0 ]]; then
+  while IFS= read -r -d '' path; do
+    scripts+=("${path}")
+  done < <(find scripts/ci -type f -name '*.sh' -print0 | LC_ALL=C sort -z)
+else
+  for path in "$@"; do
+    [[ "${path}" == *.sh && -f "${path}" ]] && scripts+=("${path}")
+  done
+fi
+
+if [[ "${#scripts[@]}" -eq 0 ]]; then
+  echo "No shell scripts require syntax validation."
+  exit 0
+fi
+
+printf 'Checking shell syntax for %d script(s)...\n' "${#scripts[@]}"
+for script in "${scripts[@]}"; do
+  bash -n "${script}"
+done


### PR DESCRIPTION
## Issue Link

Fixes #2756

## Summary

Adds a fail-safe CI-shell-only path to the local pre-PR check so CI orchestration changes receive focused governance validation without waiting for unrelated managed builds.

## Changes Made

- Classify committed, staged, unstaged, and untracked paths against the hosted CI build exclusions.
- Run canonical instruction, recursive shell syntax, router, and merge-train fixture checks on eligible CI-only diffs.
- Fall back to the existing SMART/FULL path for runtime inputs, setup-dotnet action changes, missing refs, or uncertain classification.
- Add offline fixtures for committed and working-tree detection, hosted-routing parity, recursive syntax, and fail-safe behavior.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review