### PR TITLE
fix: correct MySQL spatialRel operand order and SQL Server geography winding

### DIFF
--- a/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/FeatureQuery.cs
+++ b/src/Honua.Core.Abstractions/Features/FeatureStore/Domain/FeatureQuery.cs
@@ -533,13 +533,29 @@ public enum SpatialRelationship
     Intersects,
 
     /// <summary>
-    /// Features completely within the filter geometry
+    /// Esri <c>esriSpatialRelWithin</c>: the filter geometry lies within each matched feature.
+    /// Returns features that enclose (contain) the filter geometry, evaluated as
+    /// <c>ST_Within(filter, feature)</c>.
     /// </summary>
+    /// <remarks>
+    /// The relationship is taken from the query-geometry perspective, matching Esri GeoServices
+    /// semantics: the filter geometry is the subject and the feature is the container. All SQL
+    /// providers lead with the filter geometry as the first operand — do not flip the operands.
+    /// See issue #2068.
+    /// </remarks>
     Within,
 
     /// <summary>
-    /// Features that contain the filter geometry
+    /// Esri <c>esriSpatialRelContains</c>: the filter geometry contains each matched feature.
+    /// Returns features that lie within the filter geometry, evaluated as
+    /// <c>ST_Contains(filter, feature)</c>.
     /// </summary>
+    /// <remarks>
+    /// The relationship is taken from the query-geometry perspective, matching Esri GeoServices
+    /// semantics: the filter geometry is the subject and the feature is the contained geometry.
+    /// All SQL providers lead with the filter geometry as the first operand — do not flip the
+    /// operands. See issue #2068.
+    /// </remarks>
     Contains,
 
     /// <summary>

--- a/src/Honua.MySql/Features/FeatureStore/Services/MySqlFeatureQueryBuilder.Spatial.cs
+++ b/src/Honua.MySql/Features/FeatureStore/Services/MySqlFeatureQueryBuilder.Spatial.cs
@@ -51,10 +51,14 @@ internal sealed partial class MySqlFeatureQueryBuilder
                 $"MBRIntersects({geomCol}, {filterGeom}) AND ST_Intersects({geomCol}, {filterGeom})",
             SpatialRelationship.EnvelopeIntersects =>
                 $"MBRIntersects({geomCol}, {filterGeom})",
+            // Esri semantics: esriSpatialRelWithin = filter geometry is within feature geometry.
+            // MySQL/MariaDB: ST_Within(filter, feature) = filter is within feature.
             SpatialRelationship.Within =>
-                $"ST_Within({geomCol}, {filterGeom})",
+                $"ST_Within({filterGeom}, {geomCol})",
+            // Esri semantics: esriSpatialRelContains = filter geometry contains feature geometry.
+            // MySQL/MariaDB: ST_Contains(filter, feature) = filter contains feature.
             SpatialRelationship.Contains =>
-                $"ST_Contains({geomCol}, {filterGeom})",
+                $"ST_Contains({filterGeom}, {geomCol})",
             SpatialRelationship.Crosses =>
                 $"ST_Crosses({geomCol}, {filterGeom})",
             SpatialRelationship.Touches =>

--- a/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
+++ b/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
@@ -310,9 +310,6 @@ internal static partial class SqlServerFeatureQueryBuilder
                 $"Pre-project the filter geometry to the layer's SRID before submitting the request.");
         }
 
-        var wkbParam = "@p" + parameters.Count.ToString(CultureInfo.InvariantCulture);
-        parameters.Add(filter.Geometry);
-
         // SQL Server's geometry/geography static parsers require an explicit SRID. Use the
         // filter's SRID when supplied; otherwise inherit the layer SRID for safe comparison.
         // If neither is available the expression resolves to SRID 0, which causes SQL Server
@@ -327,10 +324,27 @@ internal static partial class SqlServerFeatureQueryBuilder
                 "Set the layer SRID in the mapping or provide an explicit SRID on the spatial filter.");
         }
 
+        var isGeography = mapping.GeometryColumnType == SqlServerGeometryColumnType.Geography;
+
+        // SQL Server's geography type uses the left-hand rule: a polygon's interior lies to the
+        // left of each ring's traversal direction, i.e. exterior rings must be counter-clockwise
+        // (and holes clockwise). Esri clients commonly emit clockwise-exterior polygons, which the
+        // geography parser interprets as the polygon's complement (the "everything but this" ring)
+        // and rejects with error 24205 when that complement spans more than a hemisphere. Normalize
+        // polygon/multipolygon winding to CCW-exterior before serialization so every geography
+        // predicate sees the intended region. The geometry (planar) type is orientation-insensitive,
+        // so its WKB is passed through untouched.
+        var wkb = isGeography
+            ? SqlServerGeographyWinding.NormalizeToCcwExterior(filter.Geometry)
+            : filter.Geometry;
+
+        var wkbParam = "@p" + parameters.Count.ToString(CultureInfo.InvariantCulture);
+        parameters.Add(wkb);
+
         var srid = filter.Srid is > 0 ? filter.Srid.Value : mapping.Srid ?? 0;
         var sridLiteral = srid.ToString(CultureInfo.InvariantCulture);
 
-        return mapping.GeometryColumnType == SqlServerGeometryColumnType.Geography
+        return isGeography
             ? $"geography::STGeomFromWKB({wkbParam}, {sridLiteral})"
             : $"geometry::STGeomFromWKB({wkbParam}, {sridLiteral})";
     }

--- a/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerGeographyWinding.cs
+++ b/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerGeographyWinding.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IO;
+using NetTopologySuite.Algorithm;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.SqlServer.Features.FeatureStore.Services;
+
+/// <summary>
+/// Normalizes polygon ring orientation for SQL Server <c>geography</c> filter geometries.
+/// SQL Server's geography type applies the left-hand rule, so exterior rings must be
+/// counter-clockwise (CCW) and interior rings (holes) clockwise (CW). Clockwise-exterior
+/// polygons — commonly produced by Esri clients — are otherwise interpreted as the polygon's
+/// complement, selecting the wrong region or raising error 24205 when the complement spans more
+/// than a hemisphere.
+/// </summary>
+internal static class SqlServerGeographyWinding
+{
+    [ThreadStatic]
+    private static WKBReader? _reader;
+
+    [ThreadStatic]
+    private static WKBWriter? _writer;
+
+    /// <summary>
+    /// Returns WKB whose polygonal rings are oriented for SQL Server geography (CCW exterior,
+    /// CW holes). Non-polygonal geometries and already-normalized polygons are returned as the
+    /// original bytes; unparseable input is passed through untouched so parsing errors surface at
+    /// the SQL Server engine rather than here.
+    /// </summary>
+    /// <param name="wkb">The client-supplied filter geometry as well-known binary.</param>
+    /// <returns>WKB with CCW-exterior polygon winding, or the original bytes when no change applies.</returns>
+    public static byte[] NormalizeToCcwExterior(byte[] wkb)
+    {
+        ArgumentNullException.ThrowIfNull(wkb);
+
+        Geometry geometry;
+        try
+        {
+            _reader ??= new WKBReader();
+            geometry = _reader.Read(wkb);
+        }
+        catch (Exception ex) when (ex is ParseException or EndOfStreamException or ArgumentException or IndexOutOfRangeException)
+        {
+            // Leave malformed/short WKB alone; the geography parser will report a precise error.
+            return wkb;
+        }
+
+        var oriented = OrientPolygonal(geometry);
+        if (oriented is null)
+        {
+            return wkb;
+        }
+
+        _writer ??= new WKBWriter();
+        return _writer.Write(oriented);
+    }
+
+    private static Geometry? OrientPolygonal(Geometry geometry)
+    {
+        switch (geometry)
+        {
+            case Polygon polygon:
+                return OrientPolygon(polygon);
+            case MultiPolygon multiPolygon:
+                var polygons = new Polygon[multiPolygon.NumGeometries];
+                for (var i = 0; i < multiPolygon.NumGeometries; i++)
+                {
+                    polygons[i] = OrientPolygon((Polygon)multiPolygon.GetGeometryN(i));
+                }
+
+                return geometry.Factory.CreateMultiPolygon(polygons);
+            default:
+                // Points, lines, and collections carry no meaningful ring orientation.
+                return null;
+        }
+    }
+
+    private static Polygon OrientPolygon(Polygon polygon)
+    {
+        var factory = polygon.Factory;
+        var shell = EnsureOrientation((LinearRing)polygon.ExteriorRing, wantCcw: true);
+
+        var holes = new LinearRing[polygon.NumInteriorRings];
+        for (var i = 0; i < polygon.NumInteriorRings; i++)
+        {
+            holes[i] = EnsureOrientation((LinearRing)polygon.GetInteriorRingN(i), wantCcw: false);
+        }
+
+        return factory.CreatePolygon(shell, holes);
+    }
+
+    private static LinearRing EnsureOrientation(LinearRing ring, bool wantCcw)
+    {
+        var isCcw = Orientation.IsCCW(ring.CoordinateSequence);
+        return isCcw == wantCcw ? ring : (LinearRing)ring.Reverse();
+    }
+}

--- a/src/Honua.SqlServer/Honua.SqlServer.csproj
+++ b/src/Honua.SqlServer/Honua.SqlServer.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="NetTopologySuite" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/tests/dotnet/Honua.MySql.Tests/MySqlFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.MySql.Tests/MySqlFeatureQueryBuilderTests.cs
@@ -269,6 +269,45 @@ public class MySqlFeatureQueryBuilderTests
     }
 
     [Fact]
+    public void BuildSelectQuery_WithinFilter_LeadsWithFilterGeometry()
+    {
+        // Esri esriSpatialRelWithin = filter geometry is within feature geometry, so the filter
+        // geometry must be the FIRST operand: ST_Within(filter, feature). Leading with the
+        // feature column inverts the relationship and returns the wrong set (#2068, #2730).
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(
+                geometry: [0x01, 0x02, 0x03],
+                spatialRelationship: SpatialRelationship.Within,
+                srid: 4326)
+        };
+
+        var result = _builder.BuildSelectQuery(LayerId, query);
+
+        Assert.Contains("ST_Within(ST_GeomFromWKB(@p0, 4326, 'axis-order=long-lat'), `geom`)", result.Sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("ST_Within(`geom`", result.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_ContainsFilter_LeadsWithFilterGeometry()
+    {
+        // Esri esriSpatialRelContains = filter geometry contains feature geometry: the filter
+        // geometry must be the FIRST operand, ST_Contains(filter, feature) (#2068, #2730).
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(
+                geometry: [0x01, 0x02, 0x03],
+                spatialRelationship: SpatialRelationship.Contains,
+                srid: 4326)
+        };
+
+        var result = _builder.BuildSelectQuery(LayerId, query);
+
+        Assert.Contains("ST_Contains(ST_GeomFromWKB(@p0, 4326, 'axis-order=long-lat'), `geom`)", result.Sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("ST_Contains(`geom`", result.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuildSelectQuery_CrossSridFilter_ThrowsNotSupported()
     {
         var query = new FeatureQuery

--- a/tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj
+++ b/tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NetTopologySuite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/dotnet/Honua.SqlServer.Tests/SqlServerGeographyWindingTests.cs
+++ b/tests/dotnet/Honua.SqlServer.Tests/SqlServerGeographyWindingTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.SqlServer.Features.FeatureStore.Services;
+using NetTopologySuite.Algorithm;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace Honua.SqlServer.Tests;
+
+/// <summary>
+/// Verifies that SQL Server geography filter WKB is normalized to CCW-exterior ring orientation
+/// (left-hand rule) so clockwise-exterior Esri polygons select the intended region instead of the
+/// complement (#2741).
+/// </summary>
+public class SqlServerGeographyWindingTests
+{
+    private const int TestLayerId = 7;
+
+    private static readonly IReadOnlyList<string> _attributeColumns = ["name"];
+
+    private static readonly GeometryFactory _factory =
+        NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+
+    // A simple unit square. Listed counter-clockwise (right-hand rule / CCW exterior).
+    private static readonly Coordinate[] _ccwRing =
+    [
+        new(0, 0),
+        new(1, 0),
+        new(1, 1),
+        new(0, 1),
+        new(0, 0),
+    ];
+
+    [Fact]
+    public void NormalizeToCcwExterior_ClockwiseExterior_ProducesCcwExterior()
+    {
+        var cwWkb = WritePolygonWkb(reverseShell: true);
+
+        var normalized = SqlServerGeographyWinding.NormalizeToCcwExterior(cwWkb);
+
+        var polygon = (Polygon)new WKBReader().Read(normalized);
+        Assert.True(Orientation.IsCCW(polygon.ExteriorRing.CoordinateSequence));
+    }
+
+    [Fact]
+    public void NormalizeToCcwExterior_ClockwiseAndCounterClockwise_ProduceIdenticalWkb()
+    {
+        var cwWkb = WritePolygonWkb(reverseShell: true);
+        var ccwWkb = WritePolygonWkb(reverseShell: false);
+
+        // The two inputs describe the same region with opposite winding; after normalization the
+        // serialized WKB must be byte-for-byte identical.
+        var normalizedCw = SqlServerGeographyWinding.NormalizeToCcwExterior(cwWkb);
+        var normalizedCcw = SqlServerGeographyWinding.NormalizeToCcwExterior(ccwWkb);
+
+        Assert.Equal(normalizedCcw, normalizedCw);
+    }
+
+    [Fact]
+    public void NormalizeToCcwExterior_AlreadyCcwExterior_ReturnsUnchangedBytes()
+    {
+        var ccwWkb = WritePolygonWkb(reverseShell: false);
+
+        var normalized = SqlServerGeographyWinding.NormalizeToCcwExterior(ccwWkb);
+
+        Assert.Equal(ccwWkb, normalized);
+    }
+
+    [Fact]
+    public void NormalizeToCcwExterior_NonPolygonalGeometry_ReturnsUnchangedBytes()
+    {
+        var point = _factory.CreatePoint(new Coordinate(3, 4));
+        var pointWkb = new WKBWriter().Write(point);
+
+        var normalized = SqlServerGeographyWinding.NormalizeToCcwExterior(pointWkb);
+
+        Assert.Equal(pointWkb, normalized);
+    }
+
+    [Fact]
+    public void NormalizeToCcwExterior_UnparseableWkb_ReturnsInputUnchanged()
+    {
+        var malformed = new byte[] { 0xFF };
+
+        var normalized = SqlServerGeographyWinding.NormalizeToCcwExterior(malformed);
+
+        Assert.Same(malformed, normalized);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_GeographyMapping_ClockwiseAndCounterClockwiseFilter_ProduceSameParameter()
+    {
+        var mapping = BuildGeographyMapping();
+        var cwQuery = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(WritePolygonWkb(reverseShell: true), SpatialRelationship.Intersects, srid: 4326)
+        };
+        var ccwQuery = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(WritePolygonWkb(reverseShell: false), SpatialRelationship.Intersects, srid: 4326)
+        };
+
+        var cwResult = SqlServerFeatureQueryBuilder.BuildSelectQuery(mapping, cwQuery, _attributeColumns);
+        var ccwResult = SqlServerFeatureQueryBuilder.BuildSelectQuery(mapping, ccwQuery, _attributeColumns);
+
+        Assert.Equal((byte[])ccwResult.WhereParameters[0], (byte[])cwResult.WhereParameters[0]);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_GeometryMapping_DoesNotReorientFilterWkb()
+    {
+        // The planar geometry type is orientation-insensitive, so the clockwise WKB must reach the
+        // parameter list untouched.
+        var mapping = BuildGeometryMapping();
+        var cwWkb = WritePolygonWkb(reverseShell: true);
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(cwWkb, SpatialRelationship.Intersects, srid: 4326)
+        };
+
+        var result = SqlServerFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
+
+        Assert.Equal(cwWkb, (byte[])result.WhereParameters[0]);
+    }
+
+    private static byte[] WritePolygonWkb(bool reverseShell)
+    {
+        var coordinates = reverseShell ? Reverse(_ccwRing) : _ccwRing;
+        var polygon = _factory.CreatePolygon(coordinates);
+        return new WKBWriter().Write(polygon);
+    }
+
+    private static Coordinate[] Reverse(Coordinate[] ring)
+    {
+        var reversed = new Coordinate[ring.Length];
+        for (var i = 0; i < ring.Length; i++)
+        {
+            reversed[i] = ring[ring.Length - 1 - i];
+        }
+
+        return reversed;
+    }
+
+    private static SqlServerLayerMapping BuildGeographyMapping()
+        => BuildMapping(SqlServerGeometryColumnType.Geography);
+
+    private static SqlServerLayerMapping BuildGeometryMapping()
+        => BuildMapping(SqlServerGeometryColumnType.Geometry);
+
+    private static SqlServerLayerMapping BuildMapping(SqlServerGeometryColumnType columnType)
+    {
+        var providerOptions = new Dictionary<string, string>
+        {
+            [SqlServerProviderOptions.GeometryType] = columnType == SqlServerGeometryColumnType.Geography ? "geography" : "geometry"
+        };
+
+        var storage = new LayerStorageMapping(
+            TableName: "parcels",
+            SchemaName: "dbo",
+            CatalogName: null,
+            DatabaseName: null,
+            PrimaryKeyColumn: "objectid",
+            GeometryColumn: "shape",
+            StorageSrid: 4326,
+            ProviderOptions: providerOptions);
+
+        return SqlServerLayerMapping.FromStorage(TestLayerId, storage);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2730
Closes #2741
Related to #2729

## Summary
Fixes two provider-level spatial predicate defects found by the geodesy audit (#2729): the MySQL provider evaluated `esriSpatialRelWithin`/`Contains` with inverted operands relative to the canonical Esri query-geometry convention (the one #2068 established for the other six providers), silently swapping result sets on MySQL/MariaDB-backed layers; and the SQL Server provider passed client polygon filter WKB to `geography::STGeomFromWKB` without ring-orientation normalization, so clockwise-exterior polygons (common from Esri clients) selected the complement of the intended region under the left-hand rule or raised error 24205.

## Changes Made
- Lead with the filter geometry for `SpatialRelationship.Within`/`Contains` in `MySqlFeatureQueryBuilder.Spatial.cs`, matching the PostGIS reference, with explanatory comments
- Correct the canonical `SpatialRelationship` enum XML docs in `FeatureQuery.cs`, which documented the opposite (layer-perspective) convention — the likely root cause of the divergence; both members now state the query-geometry semantics with a `<remarks>` pointing at #2068
- Add `SqlServerGeographyWinding` normalizing polygon/multipolygon filter geometry to CCW-exterior/CW-holes before WKB serialization on the geography path only (planar geometry path unchanged, orientation-insensitive)
- Regression tests: MySQL SQL-shape tests locking filter-first operand order; SqlServer winding tests including byte-identical output for CW vs CCW input of the same region

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Honua.MySql.Tests: 171 passed / 0 failed. Honua.SqlServer.Tests: 45 passed / 0 failed. Affected projects built Release with `TreatWarningsAsErrors=true`, 0 warnings; touched files formatted. (Full-solution build deferred to batch CI due to shared-host disk constraints.)

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None (behavioral bug fix: MySQL `Within`/`Contains` results now match every other provider and Esri semantics).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
