### PR TITLE
fix: ground-distance ImageServer mensuration and GeometryService semantics

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -7616,6 +7616,8 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerEndpointsTests.Measure_AreaAndPerimeterEnvelope_ReturnsBasicMensuration",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerEndpointsTests.Measure_AreaAndPerimeter_AntimeridianPolygon_ReturnsFiniteArea",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerEndpointsTests.Measure_DistanceAndAngle_GeographicDegrees_ReturnsGroundMeters",
         "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerEndpointsTests.Measure_DistanceAndAngle_GetAndPost_ReturnsBasicMensuration",
         "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerEndpointsTests.Measure_HeightOperation_ReturnsNotImplemented",
         "Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer.ImageServerEndpointsTests.Measure_HeightOperation_WithDemMetadata_ButPointOutsideDem_ReturnsNotImplemented",
@@ -15252,6 +15254,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceEditOperationsTests.AutoComplete_ExistingParcelPlusClosingPolyline_ReturnsOnlyNewPolygon",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceEditOperationsTests.AutoComplete_PostPolylinesFormingClosedLoop_ReturnsPolygon"
       ],
       "proof_ledger_surface": "geometry-service",
@@ -15331,6 +15334,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Densify_UnknownLengthUnit_Returns400",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceMeasureAnalysisTests.Densify_PostPolyline_AddsVertices",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceMeasureAnalysisTests.Densify_ReasonableMaxSegmentLengthOverLargeExtent_StillSucceeds",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceMeasureAnalysisTests.Densify_TinyMaxSegmentLengthOverLargeExtent_Returns400WithoutOom"
@@ -15350,7 +15354,8 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Difference_MissingSpatialReference_Returns400",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Difference_NoOverlap_ReturnsOriginal",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Difference_PostEsriWrappedGeometry_ReturnsGeometry",
-        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Difference_PostValidRequest_ReturnsGeometry"
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Difference_PostValidRequest_ReturnsGeometry",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Difference_SubtractCoveringGeometry_Returns200WithEmptyGeometry"
       ],
       "proof_ledger_surface": "geometry-service",
       "maturity": "implemented"
@@ -15418,9 +15423,10 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
-        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Intersect_GeometryTypeMismatch_PointVsPolygon_Returns400",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Intersect_DisjointPolygons_Returns200WithEmptyGeometry",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Intersect_MalformedGeometry_Returns400",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Intersect_MissingSpatialReference_Returns400",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Intersect_PointDisjointFromPolygon_Returns200WithEmptyPoint",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Intersect_PostEsriWrappedGeometry_ReturnsGeometry",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceAdvancedOperationsTests.Intersect_PostValidRequest_ReturnsGeometry"
       ],
@@ -15500,6 +15506,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceMeasureAnalysisTests.Relation_CornerTouchingParcels_PointTouchMatchesLineTouchDoesNot",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceMeasureAnalysisTests.Relation_EdgeSharingParcels_LineTouchMatchesPointTouchDoesNot",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceMeasureAnalysisTests.Relation_PostIntersection_ReturnsMatchingPairs",
         "Honua.Server.Tests.Features.Protocols.GeoServices.GeometryService.GeometryServiceMeasureAnalysisTests.Relation_PostRelationPattern_UsesDe9imParam"
       ],

--- a/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceRequests.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Models/GeometryServiceRequests.cs
@@ -155,6 +155,12 @@ internal sealed class TrimExtendParameters
     public required string[] PolylineJsonStrings { get; init; }
     public required string TrimExtendToJson { get; init; }
     public int SR { get; init; }
+
+    /// <summary>
+    /// The Esri <c>extendHow</c> bit flag (e.g. keep end segment, keep relationships). It is
+    /// parsed and carried for request fidelity but is <b>not</b> yet honored: trimExtend always
+    /// applies the default extend behavior. Implementing the flag semantics is deferred (#2742).
+    /// </summary>
     public string? ExtendHow { get; init; }
 }
 
@@ -230,8 +236,18 @@ internal sealed class FromGeoCoordinateStringParameters
 /// </summary>
 internal enum MeasurementCalculationType
 {
+    /// <summary>Planar (Cartesian) measurement in the geometry's own spatial reference.</summary>
     Planar,
+
+    /// <summary>Geodesic (ellipsoidal ground) measurement.</summary>
     Geodesic,
+
+    /// <summary>
+    /// Esri <c>preserveShape</c>. Honua treats this as equivalent to <see cref="Geodesic"/>:
+    /// both route through the geography measurement pipeline, so preserveShape produces a true
+    /// ground measure rather than a distinct shape-preserving projection. Documented divergence
+    /// (#2742).
+    /// </summary>
     PreserveShape
 }
 

--- a/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceHandler.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceHandler.cs
@@ -2221,6 +2221,8 @@ internal sealed class GeometryServiceHandler(
 
     private IResult ExecuteTrimExtend(TrimExtendParameters parameters, HonuaTelemetryScope scope)
     {
+        // parameters.ExtendHow is parsed but intentionally not honored here (#2742): trimExtend
+        // applies the default trim/extend behavior regardless of the extendHow bit flags.
         var trimLine = ReadGeometry(parameters.TrimExtendToJson);
         var results = new List<byte[]>(parameters.PolylineJsonStrings.Length);
         var writer = new WKBWriter();
@@ -2359,10 +2361,13 @@ internal sealed class GeometryServiceHandler(
     {
         var factory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
         var edges = new List<Geometry>();
+        var inputPolygons = new List<Geometry>();
 
         foreach (var polygonJson in parameters.PolygonJsonStrings)
         {
-            edges.Add(ReadGeometry(polygonJson).Boundary);
+            var polygon = ReadGeometry(polygonJson);
+            inputPolygons.Add(polygon);
+            edges.Add(polygon.Boundary);
         }
 
         foreach (var polylineJson in parameters.PolylineJsonStrings)
@@ -2377,11 +2382,25 @@ internal sealed class GeometryServiceHandler(
         var polygonizer = new NetTopologySuite.Operation.Polygonize.Polygonizer();
         polygonizer.Add(noded);
 
-        var newPolygons = polygonizer.GetPolygons().Cast<Geometry>().ToArray();
-        var writer = new WKBWriter();
-        var results = new List<byte[]>(newPolygons.Length);
-        foreach (var polygon in newPolygons)
+        // Polygonization returns every closed face, which includes faces coincident with the
+        // existing input polygons. autoComplete must return ONLY the new gap-filling polygons,
+        // so drop faces whose interior falls inside the union of the input polygons (#2742).
+        Geometry? inputUnion = null;
+        if (inputPolygons.Count > 0)
         {
+            Geometry inputCollection = factory.CreateGeometryCollection(inputPolygons.ToArray());
+            inputUnion = NetTopologySuite.Operation.Union.UnaryUnionOp.Union(inputCollection);
+        }
+
+        var writer = new WKBWriter();
+        var results = new List<byte[]>();
+        foreach (var polygon in polygonizer.GetPolygons().Cast<Geometry>())
+        {
+            if (inputUnion is not null && inputUnion.Covers(polygon.InteriorPoint))
+            {
+                continue;
+            }
+
             results.Add(writer.Write(polygon));
         }
 
@@ -2710,8 +2729,14 @@ internal sealed class GeometryServiceHandler(
             "esrigeometryrelationintersection" => geometry1.Intersects(geometry2),
             "esrigeometryrelationoverlap" => geometry1.Overlaps(geometry2),
             "esrigeometryrelationtouch" => geometry1.Touches(geometry2),
-            "esrigeometryrelationlinetouch" => geometry1.Relate(geometry2, "F***T****"),
-            "esrigeometryrelationpointtouch" => geometry1.Relate(geometry2, "FT*******"),
+            // lineTouch: interiors disjoint and boundaries meet in a 1-dimensional (line) set.
+            // "F***T****" also matched 0-dimensional corner-point boundary touches; "F***1****"
+            // requires boundary∩boundary to be a curve (#2742).
+            "esrigeometryrelationlinetouch" => geometry1.Relate(geometry2, "F***1****"),
+            // pointTouch: interiors disjoint and boundaries meet in a 0-dimensional (point) set.
+            // "FT*******" only constrained interior∩interior and interior∩boundary, matching edge
+            // touches too; "F***0****" requires a point-dimensional boundary touch (#2742).
+            "esrigeometryrelationpointtouch" => geometry1.Relate(geometry2, "F***0****"),
             "esrigeometryrelationrelation" => geometry1.Relate(geometry2, relationParam!),
             _ => false
         };
@@ -3112,7 +3137,7 @@ internal sealed class GeometryServiceHandler(
 
         for (var i = 0; i < wkbs.Count; i++)
         {
-            geometryElements[i] = _geometryConverter.ConvertWkbToGeoServicesGeometry(wkbs[i], srid);
+            geometryElements[i] = ConvertResultWkbToElement(wkbs[i], srid, geometryType);
         }
 
         return new GeometryServiceResponse
@@ -3121,6 +3146,153 @@ internal sealed class GeometryServiceHandler(
             SpatialReference = new GeometryServiceSpatialReference { Wkid = srid, LatestWkid = srid },
             Geometries = geometryElements
         };
+    }
+
+    /// <summary>
+    /// Converts a result geometry WKB to a GeoServices JSON element, translating the two result
+    /// shapes the underlying converter reports as <see langword="null"/> into faithful Esri output
+    /// instead of a 400 (#2742):
+    /// <list type="bullet">
+    ///   <item><description>
+    ///   <b>Empty geometry</b> (PostGIS returns <c>GEOMETRYCOLLECTION EMPTY</c> for a disjoint
+    ///   intersect or a full difference) becomes an empty Esri geometry of the request's
+    ///   <paramref name="geometryType"/> (<c>{"rings":[]}</c>, <c>{"paths":[]}</c>,
+    ///   <c>{"points":[]}</c>, or an empty point <c>{"x":null,"y":null}</c>).
+    ///   </description></item>
+    ///   <item><description>
+    ///   <b>Mixed GeometryCollection</b> (e.g. an intersection that yields both an area and a
+    ///   boundary touch) is reduced to its highest-dimension components — filtered to the target
+    ///   <paramref name="geometryType"/> when one is supplied — matching Esri's behavior of
+    ///   returning a single geometry of the operator type.
+    ///   </description></item>
+    /// </list>
+    /// Genuinely invalid/unreadable WKB still surfaces as a 400 through the converter.
+    /// </summary>
+    private JsonElement ConvertResultWkbToElement(byte[] wkb, int srid, string? geometryType)
+    {
+        Geometry? geometry = null;
+        if (wkb is { Length: > 0 })
+        {
+            try
+            {
+                geometry = new WKBReader().Read(wkb);
+            }
+            catch (Exception ex) when (ex is ParseException or FormatException)
+            {
+                // Fall through to the converter, which maps unreadable WKB to a 400.
+                geometry = null;
+            }
+        }
+
+        if (geometry is null || geometry.IsEmpty)
+        {
+            return CreateEmptyGeometryElement(geometryType, srid);
+        }
+
+        if (geometry is GeometryCollection and not (MultiPoint or MultiLineString or MultiPolygon))
+        {
+            var reduced = ReduceMixedCollection(geometry, geometryType);
+            if (reduced is null || reduced.IsEmpty)
+            {
+                return CreateEmptyGeometryElement(geometryType, srid);
+            }
+
+            var reducedWkb = new WKBWriter().Write(reduced);
+            return _geometryConverter.ConvertWkbToGeoServicesGeometry(reducedWkb, srid);
+        }
+
+        return _geometryConverter.ConvertWkbToGeoServicesGeometry(wkb, srid);
+    }
+
+    /// <summary>
+    /// Reduces a heterogeneous <see cref="GeometryCollection"/> to a homogeneous geometry of the
+    /// target dimension: the dimension implied by <paramref name="geometryType"/> when supplied,
+    /// otherwise the highest dimension present. Returns <see langword="null"/> when no component
+    /// matches.
+    /// </summary>
+    private static Geometry? ReduceMixedCollection(Geometry collection, string? geometryType)
+    {
+        var components = new List<Geometry>();
+        FlattenInto(collection, components);
+        if (components.Count == 0)
+        {
+            return null;
+        }
+
+        var targetDimension = TargetDimensionFor(geometryType);
+        if (targetDimension < 0)
+        {
+            targetDimension = components.Max(static c => (int)c.Dimension);
+        }
+
+        var matching = components.Where(c => (int)c.Dimension == targetDimension).ToList();
+        if (matching.Count == 0)
+        {
+            return null;
+        }
+
+        return matching.Count == 1
+            ? matching[0]
+            : collection.Factory.BuildGeometry(matching);
+    }
+
+    private static void FlattenInto(Geometry geometry, List<Geometry> sink)
+    {
+        if (geometry.IsEmpty)
+        {
+            return;
+        }
+
+        if (geometry is GeometryCollection and not (MultiPoint or MultiLineString or MultiPolygon))
+        {
+            for (var i = 0; i < geometry.NumGeometries; i++)
+            {
+                FlattenInto(geometry.GetGeometryN(i), sink);
+            }
+
+            return;
+        }
+
+        sink.Add(geometry);
+    }
+
+    private static int TargetDimensionFor(string? geometryType)
+        => NormalizeGeometryType(geometryType) switch
+        {
+            "esriGeometryPoint" or "esriGeometryMultipoint" => 0,
+            "esriGeometryPolyline" => 1,
+            "esriGeometryPolygon" or "esriGeometryEnvelope" => 2,
+            _ => -1
+        };
+
+    private static string? NormalizeGeometryType(string? geometryType)
+        => geometryType?.ToLowerInvariant() switch
+        {
+            "esrigeometrypoint" => "esriGeometryPoint",
+            "esrigeometrymultipoint" => "esriGeometryMultipoint",
+            "esrigeometrypolyline" => "esriGeometryPolyline",
+            "esrigeometrypolygon" => "esriGeometryPolygon",
+            "esrigeometryenvelope" => "esriGeometryEnvelope",
+            _ => null
+        };
+
+    /// <summary>
+    /// Builds an empty Esri geometry element matching the request's geometry type, defaulting to
+    /// an empty polygon (<c>{"rings":[]}</c>) when the type is unknown.
+    /// </summary>
+    private static JsonElement CreateEmptyGeometryElement(string? geometryType, int srid)
+    {
+        var spatialReference = $"\"spatialReference\":{{\"wkid\":{srid.ToString(System.Globalization.CultureInfo.InvariantCulture)},\"latestWkid\":{srid.ToString(System.Globalization.CultureInfo.InvariantCulture)}}}";
+        var json = NormalizeGeometryType(geometryType) switch
+        {
+            "esriGeometryPoint" => $"{{\"x\":null,\"y\":null,{spatialReference}}}",
+            "esriGeometryMultipoint" => $"{{\"points\":[],{spatialReference}}}",
+            "esriGeometryPolyline" => $"{{\"paths\":[],{spatialReference}}}",
+            _ => $"{{\"rings\":[],{spatialReference}}}"
+        };
+
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
     }
 
     // Planar (calculationType=planar / geodesic=false) measures on a geographic CRS scale

--- a/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceRequestParser.cs
+++ b/src/Honua.Protocols.GeoServices/GeometryService/Services/GeometryServiceRequestParser.cs
@@ -346,6 +346,11 @@ internal static class GeometryServiceRequestParser
     /// Returns the unit multiplier for converting to meters.
     /// Supports string names (esriMeters) and numeric codes (9001).
     /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="unit"/> is a non-empty token that is not a recognized linear
+    /// unit name or code. GeometryService operation handlers catch this and return a 400 rather
+    /// than silently defaulting an unknown token to a meters multiplier of 1.0 (#2742).
+    /// </exception>
     public static double GetUnitMultiplier(string? unit)
     {
         if (string.IsNullOrEmpty(unit))
@@ -353,7 +358,12 @@ internal static class GeometryServiceRequestParser
             return 1.0;
         }
 
-        return _unitMultipliers.GetValueOrDefault(unit, 1.0);
+        if (_unitMultipliers.TryGetValue(unit, out var multiplier))
+        {
+            return multiplier;
+        }
+
+        throw new ArgumentException($"Unsupported unit '{unit}'.", nameof(unit));
     }
 
     /// <summary>

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCoordinateMetadataHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerCoordinateMetadataHandler.cs
@@ -13,6 +13,9 @@ using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using SpatialConstants = Honua.Core.Features.Shared.Models.SpatialConstants;
+using SpatialReferenceExtensions = Honua.Core.Features.Shared.Models.SpatialReferenceExtensions;
+using WebMercatorMath = Honua.Core.Features.Shared.Models.WebMercatorMath;
 
 namespace Honua.Protocols.GeoServices.ImageServer.Handlers;
 
@@ -522,16 +525,41 @@ internal sealed class ImageServerCoordinateMetadataHandler
 
     private static double CalculateApproximateArea(RasterExtent extent)
     {
-        if (extent.Srid is 4326 or 4269)
+        // Web Mercator (EPSG:3857) is conformal: an axis-aligned extent inverse-projects to an
+        // axis-aligned lon/lat quadrangle, so inverse-project the corners and use the same
+        // spherical-cap area formula as geographic extents (#2734).
+        if (extent.Srid is int srid && SpatialReferenceExtensions.NormalizeWebMercatorSrid(srid) == 3857)
         {
-            var minLat = Math.Clamp(Math.Min(extent.YMin, extent.YMax), -90d, 90d) * Math.PI / 180d;
-            var maxLat = Math.Clamp(Math.Max(extent.YMin, extent.YMax), -90d, 90d) * Math.PI / 180d;
-            var lonSpan = Math.Abs(extent.XMax - extent.XMin) * Math.PI / 180d;
-            return WebMercatorEarthRadius * WebMercatorEarthRadius * lonSpan *
-                   Math.Abs(Math.Sin(maxLat) - Math.Sin(minLat));
+            var (minLon, minLat) = WebMercatorMath.WebMercatorToLonLat(extent.XMin, extent.YMin);
+            var (maxLon, maxLat) = WebMercatorMath.WebMercatorToLonLat(extent.XMax, extent.YMax);
+            return SphericalQuadrangleArea(minLon, minLat, maxLon, maxLat);
         }
 
+        // Geographic extents (WGS 84, NAD83, and the other shared geographic SRIDs plus the
+        // EPSG 4000–4999 geographic range) are already lon/lat degrees. #2732 tracks unifying
+        // this ad hoc classification with the shared SRID classifier.
+        if (extent.Srid is int geoSrid && IsGeographicSrid(geoSrid))
+        {
+            return SphericalQuadrangleArea(extent.XMin, extent.YMin, extent.XMax, extent.YMax);
+        }
+
+        // Other projected SRIDs: coordinates are assumed to be meters. Planar area is only
+        // correct when the map units are truly meters; documented fallback rather than a claim
+        // of ground area for degree/foot units.
         return Math.Abs((extent.XMax - extent.XMin) * (extent.YMax - extent.YMin));
+    }
+
+    private static bool IsGeographicSrid(int srid)
+        => Array.IndexOf(SpatialConstants.GeographicSrids, srid) >= 0
+           || srid is >= 4000 and <= 4999;
+
+    private static double SphericalQuadrangleArea(double minLon, double minLat, double maxLon, double maxLat)
+    {
+        var lowLat = Math.Clamp(Math.Min(minLat, maxLat), -90d, 90d) * Math.PI / 180d;
+        var highLat = Math.Clamp(Math.Max(minLat, maxLat), -90d, 90d) * Math.PI / 180d;
+        var lonSpan = Math.Abs(maxLon - minLon) * Math.PI / 180d;
+        return WebMercatorEarthRadius * WebMercatorEarthRadius * lonSpan *
+               Math.Abs(Math.Sin(highLat) - Math.Sin(lowLat));
     }
 
     private static string NormalizeGeometryInput(string geometry)

--- a/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMeasureHandler.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Handlers/ImageServerMeasureHandler.cs
@@ -4,25 +4,32 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
+using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Services;
 using Honua.Protocols.GeoServices.ImageServer.Models;
+using Honua.Protocols.GeoServices.ImageServer.Services;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using MeasureSpace = Honua.Protocols.GeoServices.ImageServer.Services.ImageServerMensurationMath.MeasureSpace;
 
 namespace Honua.Protocols.GeoServices.ImageServer.Handlers;
 
 /// <summary>
-/// Handler for Basic ImageServer mensuration.
+/// Handler for Basic ImageServer mensuration. Distance, perimeter, area, and azimuth are
+/// returned as ground quantities: coordinates are normalized to lon/lat (exact inverse Web
+/// Mercator for EPSG:3857 and its aliases, identity for geographic SRIDs, or an authoritative
+/// PostGIS transform for other projected SRIDs when a transform service is available) and then
+/// measured geodesically. Projected SRIDs without an in-process inverse or reachable transform
+/// service fall back to honest planar-meter math, which is only correct when the map units are
+/// already meters (#2734).
 /// </summary>
 internal sealed class ImageServerMeasureHandler
 {
-    private const double EarthRadiusMeters = 6378137d;
-
     private readonly record struct MeasurePoint(double X, double Y, double? Z, int? Srid);
 
     private readonly record struct MeasureGeometry(
@@ -33,15 +40,18 @@ internal sealed class ImageServerMeasureHandler
     private readonly IRasterStore _rasterStore;
     private readonly ILogger<ImageServerMeasureHandler> _logger;
     private readonly IElevationService? _elevationService;
+    private readonly ICoordinateTransformService? _transformService;
 
     public ImageServerMeasureHandler(
         IRasterStore rasterStore,
         ILogger<ImageServerMeasureHandler> logger,
-        IElevationService? elevationService = null)
+        IElevationService? elevationService = null,
+        ICoordinateTransformService? transformService = null)
     {
         _rasterStore = rasterStore ?? throw new ArgumentNullException(nameof(rasterStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _elevationService = elevationService;
+        _transformService = transformService;
     }
 
     /// <summary>
@@ -104,8 +114,10 @@ internal sealed class ImageServerMeasureHandler
             var response = operation.ToLowerInvariant() switch
             {
                 "esrimensurationpoint" => BuildPointResponse(raster.Name, fromGeometry.Points[0]),
-                "esrimensurationdistanceandangle" => BuildDistanceResponse(raster.Name, fromGeometry.Points[0], toGeometry!.Value.Points[0], linearUnit, angularUnit),
-                "esrimensurationareaandperimeter" => BuildAreaResponse(raster.Name, fromGeometry, linearUnit, areaUnit),
+                "esrimensurationdistanceandangle" => await BuildDistanceResponseAsync(
+                    raster.Name, fromGeometry.Points[0], toGeometry!.Value.Points[0], linearUnit, angularUnit, cancellationToken).ConfigureAwait(false),
+                "esrimensurationareaandperimeter" => await BuildAreaResponseAsync(
+                    raster.Name, fromGeometry, linearUnit, areaUnit, cancellationToken).ConfigureAwait(false),
                 "esrimensurationcentroid" => BuildPointResponse(raster.Name, CalculateCentroid(fromGeometry)),
                 _ => null
             };
@@ -339,15 +351,35 @@ internal sealed class ImageServerMeasureHandler
             Point = new ImageServerMeasurePointResult { Value = ToResponsePoint(point) }
         };
 
-    private static ImageServerMeasureResponse BuildDistanceResponse(
+    private async ValueTask<ImageServerMeasureResponse> BuildDistanceResponseAsync(
         string name,
         MeasurePoint from,
         MeasurePoint to,
         string linearUnit,
-        string angularUnit)
+        string angularUnit,
+        CancellationToken cancellationToken)
     {
-        var distanceMeters = CalculateDistanceMeters(from, to);
-        var azimuthDegrees = CalculateAzimuthDegrees(from, to);
+        var fromNormalized = await NormalizePointAsync(from, cancellationToken).ConfigureAwait(false);
+        var toNormalized = await NormalizePointAsync(to, cancellationToken).ConfigureAwait(false);
+
+        double distanceMeters;
+        double azimuthDegrees;
+        if (fromNormalized.Space == MeasureSpace.Geodesic && toNormalized.Space == MeasureSpace.Geodesic)
+        {
+            distanceMeters = ImageServerMensurationMath.GeodesicDistanceMeters(
+                fromNormalized.X, fromNormalized.Y, toNormalized.X, toNormalized.Y);
+            azimuthDegrees = ImageServerMensurationMath.InitialBearingDegrees(
+                fromNormalized.X, fromNormalized.Y, toNormalized.X, toNormalized.Y);
+        }
+        else
+        {
+            // Projected map units already in meters (or unknown SRID): planar fallback on the
+            // original coordinates. Both operands share the request's geometryType/SRID, so a
+            // space mismatch is a corner case handled conservatively as planar.
+            distanceMeters = ImageServerMensurationMath.PlanarDistanceMeters(from.X, from.Y, to.X, to.Y);
+            azimuthDegrees = ImageServerMensurationMath.PlanarBearingDegrees(from.X, from.Y, to.X, to.Y);
+        }
+
         var (distance, distanceUnit) = ConvertLinear(distanceMeters, linearUnit);
         var (angle, angleUnit) = ConvertAngular(azimuthDegrees, angularUnit);
         return new ImageServerMeasureResponse
@@ -358,14 +390,28 @@ internal sealed class ImageServerMeasureHandler
         };
     }
 
-    private static ImageServerMeasureResponse BuildAreaResponse(
+    private async ValueTask<ImageServerMeasureResponse> BuildAreaResponseAsync(
         string name,
         MeasureGeometry geometry,
         string linearUnit,
-        string areaUnit)
+        string areaUnit,
+        CancellationToken cancellationToken)
     {
-        var areaSquareMeters = CalculateAreaSquareMeters(geometry.Points, geometry.Srid);
-        var perimeterMeters = CalculatePerimeterMeters(geometry.Points);
+        var (coordinates, space) = await NormalizeRingAsync(geometry, cancellationToken).ConfigureAwait(false);
+
+        double areaSquareMeters;
+        double perimeterMeters;
+        if (space == MeasureSpace.Geodesic)
+        {
+            areaSquareMeters = ImageServerMensurationMath.GeodesicRingAreaSquareMeters(coordinates);
+            perimeterMeters = GeodesicPerimeterMeters(coordinates);
+        }
+        else
+        {
+            areaSquareMeters = ImageServerMensurationMath.PlanarRingAreaSquareMeters(coordinates);
+            perimeterMeters = PlanarPerimeterMeters(coordinates);
+        }
+
         var (area, responseAreaUnit) = ConvertArea(areaSquareMeters, areaUnit);
         var (perimeter, responseLinearUnit) = ConvertLinear(perimeterMeters, linearUnit);
         return new ImageServerMeasureResponse
@@ -461,81 +507,131 @@ internal sealed class ImageServerMeasureHandler
     private static MeasurePoint CalculateCentroid(MeasureGeometry geometry)
     {
         var points = geometry.Points;
-        var count = points.Length > 1 && SamePoint(points[0], points[^1]) ? points.Length - 1 : points.Length;
-        var x = 0d;
-        var y = 0d;
-        for (var i = 0; i < count; i++)
+        var ring = new (double X, double Y)[points.Length];
+        for (var i = 0; i < points.Length; i++)
         {
-            x += points[i].X;
-            y += points[i].Y;
+            ring[i] = (points[i].X, points[i].Y);
         }
 
-        return new MeasurePoint(x / count, y / count, null, geometry.Srid);
+        // Centroid is returned in the request's spatial reference, so it is computed directly
+        // in the input coordinate space (the signed-area / shoelace centroid, not a vertex mean).
+        // Geographic inputs unwrap longitudes so antimeridian-crossing rings do not skew the result.
+        var unwrapLongitudes = geometry.Srid is int srid && ImageServerMensurationMath.IsGeographicSrid(srid);
+        var (centroidX, centroidY) = ImageServerMensurationMath.SignedAreaCentroid(ring, unwrapLongitudes);
+        return new MeasurePoint(centroidX, centroidY, null, geometry.Srid);
     }
 
-    private static double CalculateDistanceMeters(MeasurePoint from, MeasurePoint to)
-    {
-        if ((from.Srid ?? to.Srid) == 4326)
-        {
-            var lat1 = DegreesToRadians(from.Y);
-            var lat2 = DegreesToRadians(to.Y);
-            var dLat = DegreesToRadians(to.Y - from.Y);
-            var dLon = DegreesToRadians(to.X - from.X);
-            var a = Math.Sin(dLat / 2d) * Math.Sin(dLat / 2d) +
-                    Math.Cos(lat1) * Math.Cos(lat2) *
-                    Math.Sin(dLon / 2d) * Math.Sin(dLon / 2d);
-            return 2d * EarthRadiusMeters * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1d - a));
-        }
-
-        var dx = to.X - from.X;
-        var dy = to.Y - from.Y;
-        return Math.Sqrt((dx * dx) + (dy * dy));
-    }
-
-    private static double CalculatePerimeterMeters(IReadOnlyList<MeasurePoint> points)
+    private static double GeodesicPerimeterMeters((double X, double Y)[] ring)
     {
         var total = 0d;
-        for (var i = 1; i < points.Count; i++)
+        for (var i = 1; i < ring.Length; i++)
         {
-            total += CalculateDistanceMeters(points[i - 1], points[i]);
+            total += ImageServerMensurationMath.GeodesicDistanceMeters(
+                ring[i - 1].X, ring[i - 1].Y, ring[i].X, ring[i].Y);
         }
 
         return total;
     }
 
-    private static double CalculateAreaSquareMeters(IReadOnlyList<MeasurePoint> points, int? srid)
+    private static double PlanarPerimeterMeters((double X, double Y)[] ring)
     {
-        var transformed = srid == 4326
-            ? ProjectGeographicRingToMeters(points)
-            : points.Select(static point => (point.X, point.Y)).ToArray();
-
-        var area = 0d;
-        for (var i = 0; i < transformed.Length; i++)
+        var total = 0d;
+        for (var i = 1; i < ring.Length; i++)
         {
-            var j = (i + 1) % transformed.Length;
-            area += transformed[i].X * transformed[j].Y;
-            area -= transformed[j].X * transformed[i].Y;
+            total += ImageServerMensurationMath.PlanarDistanceMeters(
+                ring[i - 1].X, ring[i - 1].Y, ring[i].X, ring[i].Y);
         }
 
-        return Math.Abs(area) / 2d;
+        return total;
     }
 
-    private static (double X, double Y)[] ProjectGeographicRingToMeters(IReadOnlyList<MeasurePoint> points)
+    /// <summary>
+    /// Normalizes a single measure point to a measurement coordinate: lon/lat degrees with
+    /// <see cref="MeasureSpace.Geodesic"/> when the SRID is Web Mercator, geographic, or
+    /// transformable to WGS 84; otherwise the original projected meters with
+    /// <see cref="MeasureSpace.PlanarMeters"/>.
+    /// </summary>
+    private async ValueTask<(double X, double Y, MeasureSpace Space)> NormalizePointAsync(
+        MeasurePoint point,
+        CancellationToken cancellationToken)
     {
-        var lat0 = points.Average(static point => point.Y);
-        var cosLat0 = Math.Cos(DegreesToRadians(lat0));
-        return points
-            .Select(point => (
-                X: EarthRadiusMeters * DegreesToRadians(point.X) * cosLat0,
-                Y: EarthRadiusMeters * DegreesToRadians(point.Y)))
-            .ToArray();
+        if (point.Srid is int srid)
+        {
+            if (ImageServerMensurationMath.TryConvertToLonLat(point.X, point.Y, srid, out var lon, out var lat))
+            {
+                return (lon, lat, MeasureSpace.Geodesic);
+            }
+
+            if (_transformService is not null)
+            {
+                var transformed = await _transformService
+                    .TransformPointAsync(point.X, point.Y, srid, 4326, cancellationToken)
+                    .ConfigureAwait(false);
+                if (transformed.HasValue)
+                {
+                    return (transformed.Value.X, transformed.Value.Y, MeasureSpace.Geodesic);
+                }
+            }
+        }
+
+        return (point.X, point.Y, MeasureSpace.PlanarMeters);
     }
 
-    private static double CalculateAzimuthDegrees(MeasurePoint from, MeasurePoint to)
+    /// <summary>
+    /// Normalizes a ring to measurement coordinates, preferring the exact in-process lon/lat
+    /// conversion, then an authoritative batch transform to WGS 84 when a transform service is
+    /// available, and finally the honest planar-meter fallback for other projected SRIDs.
+    /// </summary>
+    private async ValueTask<((double X, double Y)[] Coordinates, MeasureSpace Space)> NormalizeRingAsync(
+        MeasureGeometry geometry,
+        CancellationToken cancellationToken)
     {
-        var radians = Math.Atan2(to.X - from.X, to.Y - from.Y);
-        var degrees = RadiansToDegrees(radians);
-        return degrees < 0 ? degrees + 360d : degrees;
+        var points = geometry.Points;
+        if (geometry.Srid is int srid)
+        {
+            if (points.Length > 0 &&
+                ImageServerMensurationMath.TryConvertToLonLat(points[0].X, points[0].Y, srid, out _, out _))
+            {
+                var coordinates = new (double X, double Y)[points.Length];
+                for (var i = 0; i < points.Length; i++)
+                {
+                    ImageServerMensurationMath.TryConvertToLonLat(points[i].X, points[i].Y, srid, out var lon, out var lat);
+                    coordinates[i] = (lon, lat);
+                }
+
+                return (coordinates, MeasureSpace.Geodesic);
+            }
+
+            if (_transformService is not null && points.Length > 0)
+            {
+                var xs = new double[points.Length];
+                var ys = new double[points.Length];
+                for (var i = 0; i < points.Length; i++)
+                {
+                    xs[i] = points[i].X;
+                    ys[i] = points[i].Y;
+                }
+
+                if (await _transformService.TransformPointsAsync(xs, ys, srid, 4326, cancellationToken).ConfigureAwait(false))
+                {
+                    var coordinates = new (double X, double Y)[points.Length];
+                    for (var i = 0; i < points.Length; i++)
+                    {
+                        coordinates[i] = (xs[i], ys[i]);
+                    }
+
+                    return (coordinates, MeasureSpace.Geodesic);
+                }
+            }
+        }
+
+        var planar = new (double X, double Y)[points.Length];
+        for (var i = 0; i < points.Length; i++)
+        {
+            planar[i] = (points[i].X, points[i].Y);
+        }
+
+        return (planar, MeasureSpace.PlanarMeters);
     }
 
     private static ImageServerMeasureValue CreateValue(double value, string unit)
@@ -645,14 +741,8 @@ internal sealed class ImageServerMeasureHandler
                property.TryGetDouble(out value);
     }
 
-    private static bool SamePoint(MeasurePoint left, MeasurePoint right)
-        => left.X.Equals(right.X) && left.Y.Equals(right.Y);
-
     private static double DegreesToRadians(double degrees)
         => degrees * Math.PI / 180d;
-
-    private static double RadiansToDegrees(double radians)
-        => radians * 180d / Math.PI;
 
     private static string? GetString(IReadOnlyDictionary<string, StringValues> values, string key)
         => values.TryGetValue(key, out var raw) ? raw.ToString() : null;

--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerMensurationMath.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerMensurationMath.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Protocols.GeoServices.ImageServer.Services;
+
+/// <summary>
+/// Pure ground-mensuration math for Basic ImageServer measure operations (#2734).
+/// <para>
+/// Basic mensuration must return <em>ground</em> quantities (meters, square meters, true
+/// bearing), not raw map-unit deltas. Web Mercator (EPSG:3857) overstates ground distance
+/// by <c>1/cos(latitude)</c>, and geographic map units are degrees, so planar
+/// <c>sqrt(dx²+dy²)</c> on those coordinates is wrong by a factor that grows to ~10^5 for
+/// degree inputs. These helpers normalize coordinates to lon/lat and measure geodesically,
+/// falling back to honest planar meters only for projected coordinate systems whose
+/// coordinates are already in meters.
+/// </para>
+/// </summary>
+internal static class ImageServerMensurationMath
+{
+    /// <summary>
+    /// IUGG mean Earth radius R1 = (2a + b) / 3 ≈ 6371008.8 m. The spherical
+    /// haversine/bearing approximation uses the mean radius (rather than the Web Mercator
+    /// sphere's semi-major axis 6378137 m) because it minimizes global RMS error across all
+    /// latitudes for a single-radius sphere; the ~0.11% difference is far below the accuracy
+    /// clients expect from Basic mensuration.
+    /// </summary>
+    internal const double MeanEarthRadiusMeters = 6371008.8;
+
+    /// <summary>
+    /// Coordinate space a normalized measurement is expressed in.
+    /// </summary>
+    internal enum MeasureSpace
+    {
+        /// <summary>Coordinates are geographic lon/lat degrees; use spherical geodesic math.</summary>
+        Geodesic,
+
+        /// <summary>Coordinates are projected easting/northing meters; use planar Euclidean math.</summary>
+        PlanarMeters,
+    }
+
+    /// <summary>
+    /// Determines whether the SRID denotes a geographic (lon/lat degree) coordinate system.
+    /// </summary>
+    /// <remarks>
+    /// Uses the shared <see cref="SpatialConstants.GeographicSrids"/> list plus an EPSG
+    /// geographic-2D range heuristic (4000–4999). Unifying this ad hoc classification with
+    /// the shared SRID classifier is tracked by #2732; until then this local heuristic keeps
+    /// the measure path self-contained.
+    /// </remarks>
+    internal static bool IsGeographicSrid(int srid)
+        => Array.IndexOf(SpatialConstants.GeographicSrids, srid) >= 0
+           || srid is >= 4000 and <= 4999;
+
+    /// <summary>
+    /// Attempts an in-process conversion of a projected/geographic coordinate to lon/lat
+    /// degrees without any external transform service. Handles Web Mercator (and its aliases)
+    /// via the exact inverse Mercator projection and treats geographic SRIDs as already lon/lat.
+    /// Returns <see langword="false"/> for other projected SRIDs, where an authoritative
+    /// transform service is required.
+    /// </summary>
+    internal static bool TryConvertToLonLat(double x, double y, int srid, out double lon, out double lat)
+    {
+        if (SpatialReferenceExtensions.NormalizeWebMercatorSrid(srid) == 3857)
+        {
+            (lon, lat) = WebMercatorMath.WebMercatorToLonLat(x, y);
+            return true;
+        }
+
+        if (IsGeographicSrid(srid))
+        {
+            lon = x;
+            lat = y;
+            return true;
+        }
+
+        lon = 0d;
+        lat = 0d;
+        return false;
+    }
+
+    /// <summary>
+    /// Great-circle (haversine) distance in meters between two lon/lat points.
+    /// </summary>
+    internal static double GeodesicDistanceMeters(double lon1, double lat1, double lon2, double lat2)
+    {
+        var phi1 = DegreesToRadians(lat1);
+        var phi2 = DegreesToRadians(lat2);
+        var dPhi = DegreesToRadians(lat2 - lat1);
+        var dLambda = DegreesToRadians(lon2 - lon1);
+        var a = (Math.Sin(dPhi / 2d) * Math.Sin(dPhi / 2d)) +
+                (Math.Cos(phi1) * Math.Cos(phi2) * Math.Sin(dLambda / 2d) * Math.Sin(dLambda / 2d));
+        return 2d * MeanEarthRadiusMeters * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1d - a));
+    }
+
+    /// <summary>
+    /// Planar Euclidean distance between two projected-meter points.
+    /// </summary>
+    internal static double PlanarDistanceMeters(double x1, double y1, double x2, double y2)
+    {
+        var dx = x2 - x1;
+        var dy = y2 - y1;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    /// <summary>
+    /// True initial bearing (forward azimuth) in degrees clockwise from north, computed on
+    /// the sphere from lon/lat. Consistent with the geodesic distance model.
+    /// </summary>
+    internal static double InitialBearingDegrees(double lon1, double lat1, double lon2, double lat2)
+    {
+        var phi1 = DegreesToRadians(lat1);
+        var phi2 = DegreesToRadians(lat2);
+        var dLambda = DegreesToRadians(lon2 - lon1);
+        var yComponent = Math.Sin(dLambda) * Math.Cos(phi2);
+        var xComponent = (Math.Cos(phi1) * Math.Sin(phi2)) -
+                         (Math.Sin(phi1) * Math.Cos(phi2) * Math.Cos(dLambda));
+        var degrees = RadiansToDegrees(Math.Atan2(yComponent, xComponent));
+        return NormalizeBearing(degrees);
+    }
+
+    /// <summary>
+    /// Grid bearing in degrees clockwise from the projected +Y axis for projected-meter
+    /// coordinates (used only where no in-process lon/lat conversion is available).
+    /// </summary>
+    internal static double PlanarBearingDegrees(double x1, double y1, double x2, double y2)
+    {
+        var degrees = RadiansToDegrees(Math.Atan2(x2 - x1, y2 - y1));
+        return NormalizeBearing(degrees);
+    }
+
+    /// <summary>
+    /// Ground area in square meters of a geographic (lon/lat) ring using an equirectangular
+    /// projection about the ring's mean latitude. Longitudes are unwrapped first so rings that
+    /// cross the antimeridian project to a continuous polygon rather than wrapping through 360°.
+    /// </summary>
+    internal static double GeodesicRingAreaSquareMeters(IReadOnlyList<(double Lon, double Lat)> ring)
+    {
+        if (ring.Count < 3)
+        {
+            return 0d;
+        }
+
+        var lons = new double[ring.Count];
+        var lats = new double[ring.Count];
+        for (var i = 0; i < ring.Count; i++)
+        {
+            lons[i] = ring[i].Lon;
+            lats[i] = ring[i].Lat;
+        }
+
+        UnwrapLongitudesInPlace(lons);
+        var lat0 = 0d;
+        for (var i = 0; i < lats.Length; i++)
+        {
+            lat0 += lats[i];
+        }
+
+        lat0 /= lats.Length;
+        var cosLat0 = Math.Cos(DegreesToRadians(lat0));
+
+        var projected = new (double X, double Y)[ring.Count];
+        for (var i = 0; i < ring.Count; i++)
+        {
+            projected[i] = (
+                MeanEarthRadiusMeters * DegreesToRadians(lons[i]) * cosLat0,
+                MeanEarthRadiusMeters * DegreesToRadians(lats[i]));
+        }
+
+        return PlanarRingAreaSquareMeters(projected);
+    }
+
+    /// <summary>
+    /// Planar (shoelace) area in square meters of a projected-meter ring. The ring may be open
+    /// or closed; the closing segment is handled by wrap-around indexing.
+    /// </summary>
+    internal static double PlanarRingAreaSquareMeters(IReadOnlyList<(double X, double Y)> ring)
+    {
+        if (ring.Count < 3)
+        {
+            return 0d;
+        }
+
+        var area = 0d;
+        for (var i = 0; i < ring.Count; i++)
+        {
+            var j = (i + 1) % ring.Count;
+            area += ring[i].X * ring[j].Y;
+            area -= ring[j].X * ring[i].Y;
+        }
+
+        return Math.Abs(area) / 2d;
+    }
+
+    /// <summary>
+    /// Signed-area (shoelace) centroid of a ring expressed in its own coordinate space. When
+    /// <paramref name="unwrapLongitudes"/> is set the X ordinates are treated as longitudes and
+    /// unwrapped around the antimeridian before the computation, then the resulting X is wrapped
+    /// back into [-180, 180). Falls back to the vertex mean for degenerate (near-zero-area) rings.
+    /// </summary>
+    internal static (double X, double Y) SignedAreaCentroid(
+        IReadOnlyList<(double X, double Y)> ring,
+        bool unwrapLongitudes)
+    {
+        var count = ring.Count > 1 && ring[0].X.Equals(ring[^1].X) && ring[0].Y.Equals(ring[^1].Y)
+            ? ring.Count - 1
+            : ring.Count;
+        if (count < 3)
+        {
+            return VertexMean(ring, count);
+        }
+
+        var xs = new double[count];
+        var ys = new double[count];
+        for (var i = 0; i < count; i++)
+        {
+            xs[i] = ring[i].X;
+            ys[i] = ring[i].Y;
+        }
+
+        if (unwrapLongitudes)
+        {
+            UnwrapLongitudesInPlace(xs);
+        }
+
+        var signedArea = 0d;
+        var cx = 0d;
+        var cy = 0d;
+        for (var i = 0; i < count; i++)
+        {
+            var j = (i + 1) % count;
+            var cross = (xs[i] * ys[j]) - (xs[j] * ys[i]);
+            signedArea += cross;
+            cx += (xs[i] + xs[j]) * cross;
+            cy += (ys[i] + ys[j]) * cross;
+        }
+
+        signedArea /= 2d;
+        if (Math.Abs(signedArea) < 1e-12)
+        {
+            return VertexMean(ring, count);
+        }
+
+        var centroidX = cx / (6d * signedArea);
+        var centroidY = cy / (6d * signedArea);
+        if (unwrapLongitudes)
+        {
+            centroidX = WrapLongitude(centroidX);
+        }
+
+        return (centroidX, centroidY);
+    }
+
+    private static (double X, double Y) VertexMean(IReadOnlyList<(double X, double Y)> ring, int count)
+    {
+        if (count <= 0)
+        {
+            count = ring.Count;
+        }
+
+        var x = 0d;
+        var y = 0d;
+        for (var i = 0; i < count; i++)
+        {
+            x += ring[i].X;
+            y += ring[i].Y;
+        }
+
+        return (x / count, y / count);
+    }
+
+    private static void UnwrapLongitudesInPlace(double[] lons)
+    {
+        for (var i = 1; i < lons.Length; i++)
+        {
+            var delta = NormalizeLongitudeDelta(lons[i] - lons[i - 1]);
+            lons[i] = lons[i - 1] + delta;
+        }
+    }
+
+    private static double NormalizeLongitudeDelta(double delta)
+    {
+        delta %= 360d;
+        if (delta >= 180d)
+        {
+            delta -= 360d;
+        }
+        else if (delta < -180d)
+        {
+            delta += 360d;
+        }
+
+        return delta;
+    }
+
+    private static double WrapLongitude(double lon)
+    {
+        lon %= 360d;
+        if (lon >= 180d)
+        {
+            lon -= 360d;
+        }
+        else if (lon < -180d)
+        {
+            lon += 360d;
+        }
+
+        return lon;
+    }
+
+    private static double NormalizeBearing(double degrees)
+        => degrees < 0d ? degrees + 360d : degrees;
+
+    private static double DegreesToRadians(double degrees)
+        => degrees * Math.PI / 180d;
+
+    private static double RadiansToDegrees(double radians)
+        => radians * 180d / Math.PI;
+}

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
@@ -897,4 +897,105 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
         result.Error.Details.Should().NotBeNull();
         result.Error.Details!.Should().Contain(detail => detail.Contains("calculationType", StringComparison.Ordinal));
     }
+
+    // --- Empty results (#2742): disjoint intersect / full difference must be 200 + empty geometry ---
+
+    [IntegrationTest]
+    [Operation(Operations.Intersect)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/intersect")]
+    public async Task Intersect_DisjointPolygons_Returns200WithEmptyGeometry()
+    {
+        // PostGIS returns GEOMETRYCOLLECTION EMPTY for a disjoint intersection. That must render
+        // as an empty Esri polygon ({"rings":[]}), not a 400.
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [
+                    {"rings": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]}
+                ]
+            },
+            "geometry": {
+                "rings": [[[10,10],[11,10],[11,11],[10,11],[10,10]]]
+            },
+            "sr": "4326"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/intersect",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+        result.Geometries![0].TryGetProperty("rings", out var rings).Should().BeTrue();
+        rings.GetArrayLength().Should().Be(0);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Difference)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/difference")]
+    public async Task Difference_SubtractCoveringGeometry_Returns200WithEmptyGeometry()
+    {
+        // Subtracting a geometry that fully covers the input yields an empty result. That must be
+        // 200 + empty Esri polygon rather than a 400.
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [
+                    {"rings": [[[1,1],[2,1],[2,2],[1,2],[1,1]]]}
+                ]
+            },
+            "geometry": {
+                "rings": [[[0,0],[3,0],[3,3],[0,3],[0,0]]]
+            },
+            "sr": "4326"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/difference",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+        result.Geometries![0].TryGetProperty("rings", out var rings).Should().BeTrue();
+        rings.GetArrayLength().Should().Be(0);
+    }
+
+    // --- Unknown unit token (#2742): must be 400, not silently defaulted to a meters multiplier ---
+
+    [IntegrationTest]
+    [Operation(Operations.Densify)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/densify")]
+    public async Task Densify_UnknownLengthUnit_Returns400()
+    {
+        var body = """
+        {
+            "geometries": {
+                "geometryType": "esriGeometryPolyline",
+                "geometries": [
+                    {"paths": [[[0,0],[10,0]]]}
+                ]
+            },
+            "sr": "4326",
+            "maxSegmentLength": 1,
+            "geodesic": true,
+            "lengthUnit": "esriBananas"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/densify",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        await response.AssertGeoServicesErrorAsync(400);
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceAdvancedOperationsTests.cs
@@ -550,8 +550,12 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
     [IntegrationTest]
     [Operation(Operations.Intersect)]
     [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/intersect")]
-    public async Task Intersect_GeometryTypeMismatch_PointVsPolygon_Returns400()
+    public async Task Intersect_PointDisjointFromPolygon_Returns200WithEmptyPoint()
     {
+        // Point-vs-polygon is a legal Esri intersect input combination (the "geometry" operand's
+        // dimension must be >= the "geometries" elements' dimension), and this point is disjoint
+        // from the polygon, so the result is an empty point of the request type — Esri serializes
+        // empty points with null ordinates ({"x":null,"y":null}) — not a 400 (#2742).
         var body = """
         {
             "geometries": {
@@ -571,7 +575,16 @@ public sealed class GeometryServiceAdvancedOperationsTests : IClassFixture<WebAp
             "/rest/services/Utilities/Geometry/GeometryServer/intersect",
             new StringContent(body, Encoding.UTF8, "application/json"));
 
-        await response.AssertGeoServicesErrorAsync(400);
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.GeometryType.Should().Be("esriGeometryPoint");
+        result.Geometries.Should().HaveCount(1);
+        result.Geometries![0].TryGetProperty("x", out var x).Should().BeTrue();
+        x.ValueKind.Should().Be(JsonValueKind.Null);
+        result.Geometries[0].TryGetProperty("y", out var y).Should().BeTrue();
+        y.ValueKind.Should().Be(JsonValueKind.Null);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceEditOperationsTests.cs
@@ -312,6 +312,50 @@ public sealed class GeometryServiceEditOperationsTests : IClassFixture<WebAppFix
 
     [IntegrationTest]
     [Operation(Operations.AutoComplete)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/autoComplete")]
+    public async Task AutoComplete_ExistingParcelPlusClosingPolyline_ReturnsOnlyNewPolygon()
+    {
+        // Existing left square [0,0]-[1,1] plus a polyline tracing the three open sides of the
+        // adjacent right square. Polygonization yields both faces; autoComplete must return ONLY
+        // the new right square, not the pre-existing input polygon (#2742).
+        var body = """
+        {
+            "polygons": [
+                {"rings": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]}
+            ],
+            "polylines": [
+                {"paths": [[[1,0],[2,0],[2,1],[1,1]]]}
+            ],
+            "sr": "4326"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/autoComplete",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceResponse);
+        result.Should().NotBeNull();
+        result!.Geometries.Should().HaveCount(1);
+
+        // The single returned face must be the NEW right square (max x = 2), not the input square.
+        result.Geometries![0].TryGetProperty("rings", out var rings).Should().BeTrue();
+        var maxX = double.MinValue;
+        foreach (var ring in rings.EnumerateArray())
+        {
+            foreach (var point in ring.EnumerateArray())
+            {
+                maxX = Math.Max(maxX, point[0].GetDouble());
+            }
+        }
+
+        maxX.Should().BeApproximately(2d, 1e-9);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.AutoComplete)]
     [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/autoComplete")]
     public async Task AutoComplete_GetMissingPolylines_Returns400()
     {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/GeometryService/GeometryServiceMeasureAnalysisTests.cs
@@ -190,6 +190,64 @@ public sealed class GeometryServiceMeasureAnalysisTests : IClassFixture<WebAppFi
 
     [IntegrationTest]
     [Operation(Operations.Relation)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/relation")]
+    public async Task Relation_CornerTouchingParcels_PointTouchMatchesLineTouchDoesNot()
+    {
+        // Two squares meeting only at the corner (1,1): boundary∩boundary is a single point (#2742).
+        const string square1 = """{"rings": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]}""";
+        const string square2 = """{"rings": [[[1,1],[2,1],[2,2],[1,2],[1,1]]]}""";
+
+        (await RelationMatchCountAsync(square1, square2, "esriGeometryRelationPointTouch"))
+            .Should().Be(1, "corner contact is a 0-dimensional boundary touch");
+        (await RelationMatchCountAsync(square1, square2, "esriGeometryRelationLineTouch"))
+            .Should().Be(0, "a corner touch is not a 1-dimensional (line) boundary touch");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Relation)]
+    [Endpoint("POST /rest/services/Utilities/Geometry/GeometryServer/relation")]
+    public async Task Relation_EdgeSharingParcels_LineTouchMatchesPointTouchDoesNot()
+    {
+        // Two squares sharing the full edge x=1 from y=0 to y=1: boundary∩boundary is a line (#2742).
+        const string square1 = """{"rings": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]}""";
+        const string square2 = """{"rings": [[[1,0],[2,0],[2,1],[1,1],[1,0]]]}""";
+
+        (await RelationMatchCountAsync(square1, square2, "esriGeometryRelationLineTouch"))
+            .Should().Be(1, "a shared edge is a 1-dimensional boundary touch");
+        (await RelationMatchCountAsync(square1, square2, "esriGeometryRelationPointTouch"))
+            .Should().Be(0, "a shared edge is not a 0-dimensional (point) boundary touch");
+    }
+
+    private async Task<int> RelationMatchCountAsync(string ring1, string ring2, string relation)
+    {
+        var body = $$"""
+        {
+            "geometries1": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [ {{ring1}} ]
+            },
+            "geometries2": {
+                "geometryType": "esriGeometryPolygon",
+                "geometries": [ {{ring2}} ]
+            },
+            "sr": "4326",
+            "relation": "{{relation}}"
+        }
+        """;
+
+        var response = await _fixture.Client.PostAsync(
+            "/rest/services/Utilities/Geometry/GeometryServer/relation",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, GeometryServiceJsonContext.Default.GeometryServiceRelationResponse);
+        result.Should().NotBeNull();
+        return result!.Relations?.Length ?? 0;
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Relation)]
     [Endpoint("GET /rest/services/Utilities/Geometry/GeometryServer/relation")]
     public async Task Relation_GetMissingRelation_Returns400()
     {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -1236,11 +1236,73 @@ public class ImageServerEndpointsTests
 
             measure.Should().NotBeNull();
             measure!.Area.Should().NotBeNull();
-            measure.Area!.Value.Should().BeApproximately(50d, 1e-9);
+            // 10x5 EPSG:3857 envelope near the equator: ground area/perimeter ≈ the map-unit
+            // values (Web Mercator scale ≈ 1 at the equator), now measured geodesically (#2734).
+            measure.Area!.Value.Should().BeApproximately(50d, 0.2d);
             measure.Area.Unit.Should().Be("esriSquareMeters");
             measure.Perimeter.Should().NotBeNull();
-            measure.Perimeter!.Value.Should().BeApproximately(30d, 1e-9);
+            measure.Perimeter!.Value.Should().BeApproximately(30d, 0.1d);
             measure.Perimeter.Unit.Should().Be("esriMeters");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer/measure")]
+    [Operation(Operations.Distance)]
+    public async Task Measure_DistanceAndAngle_GeographicDegrees_ReturnsGroundMeters()
+    {
+        // EPSG:4269 (NAD83) 1° of longitude at 40°N. The pre-fix planar path returned the raw
+        // degree delta (~1.0) as "meters"; the ground distance is ~85 km (#2734).
+        var fixture = await CreateFixtureAsync(CreateRasterStoreSubstitute());
+        try
+        {
+            const string fromGeometry = """{"x":0,"y":40,"spatialReference":{"wkid":4269}}""";
+            const string toGeometry = """{"x":1,"y":40,"spatialReference":{"wkid":4269}}""";
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{TestLayerId}/ImageServer/measure?f=json&measureOperation=esriMensurationDistanceAndAngle&geometryType=esriGeometryPoint&fromGeometry={Uri.EscapeDataString(fromGeometry)}&toGeometry={Uri.EscapeDataString(toGeometry)}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var measure = JsonSerializer.Deserialize(
+                await response.Content.ReadAsStringAsync(),
+                ImageServerJsonContext.Default.ImageServerMeasureResponse);
+
+            measure.Should().NotBeNull();
+            measure!.Distance.Should().NotBeNull();
+            measure.Distance!.Value.Should().BeInRange(84_500d, 85_500d);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /rest/services/{id}/ImageServer/measure")]
+    [Operation(Operations.Distance)]
+    public async Task Measure_AreaAndPerimeter_AntimeridianPolygon_ReturnsFiniteArea()
+    {
+        // A ~2°x1° polygon straddling the antimeridian (179°E .. -179°E) in WGS 84. Without
+        // longitude unwrapping this projects to a ~358°-wide polygon (area ~1e14 m²); unwrapping
+        // keeps it a small finite quadrangle of a few 1e10 m² (#2734).
+        var fixture = await CreateFixtureAsync(CreateRasterStoreSubstitute());
+        try
+        {
+            const string polygon = """{"rings":[[[179,0],[-179,0],[-179,1],[179,1],[179,0]]],"spatialReference":{"wkid":4326}}""";
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{TestLayerId}/ImageServer/measure?f=json&measureOperation=esriMensurationAreaAndPerimeter&geometryType=esriGeometryPolygon&fromGeometry={Uri.EscapeDataString(polygon)}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var measure = JsonSerializer.Deserialize(
+                await response.Content.ReadAsStringAsync(),
+                ImageServerJsonContext.Default.ImageServerMeasureResponse);
+
+            measure.Should().NotBeNull();
+            measure!.Area.Should().NotBeNull();
+            measure.Area!.Value.Should().BeInRange(1e10, 1e12);
         }
         finally
         {
@@ -2714,10 +2776,13 @@ public class ImageServerEndpointsTests
         measure!.Name.Should().Be("test-raster");
         measure.SensorName.Should().Be("Unknown");
         measure.Distance.Should().NotBeNull();
-        measure.Distance!.Value.Should().BeApproximately(5d, 1e-9);
+        // (0,0)->(3,4) in EPSG:3857 near the equator: the ground distance is ~5 m (Web Mercator
+        // scale ≈ 1 at the equator), computed geodesically on the mean-radius sphere (#2734).
+        measure.Distance!.Value.Should().BeApproximately(5d, 0.05d);
         measure.Distance.Unit.Should().Be("esriMeters");
         measure.AzimuthAngle.Should().NotBeNull();
-        measure.AzimuthAngle!.Value.Should().BeApproximately(36.86989764584402d, 1e-9);
+        // 3-east / 4-north near the equator still gives atan(3/4) ≈ 36.87° true bearing.
+        measure.AzimuthAngle!.Value.Should().BeApproximately(36.86989764584402d, 1e-4);
         measure.AzimuthAngle.Unit.Should().Be("esriDUDecimalDegrees");
     }
 

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMensurationMathTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerMensurationMathTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Shared.Models;
+using Honua.Protocols.GeoServices.ImageServer.Services;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.GeoServices.ImageServer;
+
+/// <summary>
+/// Unit coverage for the ground-mensuration math backing Basic ImageServer measure (#2734).
+/// Verifies that Web Mercator distances are corrected by 1/cos(latitude), that geographic
+/// (degree) inputs are measured geodesically rather than as degrees-as-meters, that bearings
+/// carry the meridian-convergence correction, and that area handles the antimeridian and uses
+/// the signed-area centroid.
+/// </summary>
+public sealed class ImageServerMensurationMathTests
+{
+    private const double MeanRadius = 6371008.8;
+
+    [UnitTest]
+    public void GeodesicDistanceMeters_OneDegreeLatitude_IsAboutOneEleventhOfADegreeArc()
+    {
+        // 1° of latitude on the mean-radius sphere is R * pi / 180 ≈ 111194.9 m.
+        var distance = ImageServerMensurationMath.GeodesicDistanceMeters(0, 0, 0, 1);
+        distance.Should().BeApproximately(MeanRadius * Math.PI / 180d, 1e-3);
+    }
+
+    [UnitTest]
+    public void GeodesicDistanceMeters_OneDegreeLongitudeAt40N_IsAbout85Km_NotOne()
+    {
+        // EPSG:4269 (NAD83) 1° of longitude at 40°N. The pre-fix planar path returned the raw
+        // degree delta (1.0) as "meters"; the ground distance is ~85 km.
+        var distance = ImageServerMensurationMath.GeodesicDistanceMeters(0, 40, 1, 40);
+        distance.Should().BeInRange(84_500d, 85_500d);
+    }
+
+    [UnitTest]
+    public void TryConvertToLonLat_WebMercator1000mAt60N_MeasuresAbout1000GroundMeters()
+    {
+        // Two points 1000 ground-meters apart (north-south) at 60°N. In Web Mercator the
+        // northing delta is ~2000 m (scale = 1/cos(60°) = 2), so the pre-fix planar path
+        // reported ~2000 m. After inverse-Mercator normalization the ground distance is ~1000 m.
+        const double lat0 = 60d;
+        const double lon0 = 10d;
+        var groundMeters = 1000d;
+        var dLat = groundMeters / (MeanRadius * Math.PI / 180d);
+
+        var (ax, ay) = WebMercatorMath.LonLatToWebMercator(lon0, lat0);
+        var (bx, by) = WebMercatorMath.LonLatToWebMercator(lon0, lat0 + dLat);
+
+        // The raw Web Mercator northing delta overstates the ground distance ~2x.
+        ImageServerMensurationMath.PlanarDistanceMeters(ax, ay, bx, by)
+            .Should().BeApproximately(2000d, 30d);
+
+        ImageServerMensurationMath.TryConvertToLonLat(ax, ay, 3857, out var alon, out var alat).Should().BeTrue();
+        ImageServerMensurationMath.TryConvertToLonLat(bx, by, 3857, out var blon, out var blat).Should().BeTrue();
+
+        ImageServerMensurationMath.GeodesicDistanceMeters(alon, alat, blon, blat)
+            .Should().BeApproximately(1000d, 1d);
+    }
+
+    [UnitTest]
+    public void TryConvertToLonLat_WebMercatorAlias102100_ConvertsLikeCanonical3857()
+    {
+        var (x, y) = WebMercatorMath.LonLatToWebMercator(-73.5, 45.2);
+        ImageServerMensurationMath.TryConvertToLonLat(x, y, 102100, out var lon, out var lat).Should().BeTrue();
+        lon.Should().BeApproximately(-73.5, 1e-6);
+        lat.Should().BeApproximately(45.2, 1e-6);
+    }
+
+    [UnitTest]
+    public void TryConvertToLonLat_ProjectedUtmSrid_ReturnsFalse()
+    {
+        // UTM zone 18N (EPSG:32618) has no in-process inverse; the caller must use a transform
+        // service or fall back to planar meters.
+        ImageServerMensurationMath.TryConvertToLonLat(500000, 5000000, 32618, out _, out _).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void IsGeographicSrid_ClassifiesKnownAndRangeCodes()
+    {
+        ImageServerMensurationMath.IsGeographicSrid(4326).Should().BeTrue();
+        ImageServerMensurationMath.IsGeographicSrid(4269).Should().BeTrue();
+        ImageServerMensurationMath.IsGeographicSrid(4258).Should().BeTrue();
+        ImageServerMensurationMath.IsGeographicSrid(3857).Should().BeFalse();
+        ImageServerMensurationMath.IsGeographicSrid(32618).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void InitialBearingDegrees_DiagonalAt60N_IsCorrectedBelow45Degrees()
+    {
+        // From (0,60) to (1,61): the pre-fix planar azimuth atan2(dx,dy) was exactly 45°. The
+        // true initial bearing folds in meridian convergence and is well below 45°.
+        var bearing = ImageServerMensurationMath.InitialBearingDegrees(0, 60, 1, 61);
+        bearing.Should().BeInRange(24d, 28d);
+        bearing.Should().BeLessThan(45d);
+    }
+
+    [UnitTest]
+    public void InitialBearingDegrees_DueEast_IsNinetyDegrees()
+    {
+        var bearing = ImageServerMensurationMath.InitialBearingDegrees(0, 0, 1, 0);
+        bearing.Should().BeApproximately(90d, 1e-6);
+    }
+
+    [UnitTest]
+    public void GeodesicRingAreaSquareMeters_OneDegreeSquareAtEquator_IsAboutExpected()
+    {
+        // A 1°×1° cell at the equator ≈ (111194.9 m)² ≈ 1.236e10 m².
+        var ring = new (double Lon, double Lat)[]
+        {
+            (0, 0), (1, 0), (1, 1), (0, 1), (0, 0)
+        };
+        var area = ImageServerMensurationMath.GeodesicRingAreaSquareMeters(ring);
+        var expected = Math.Pow(MeanRadius * Math.PI / 180d, 2);
+        area.Should().BeApproximately(expected, expected * 0.01);
+    }
+
+    [UnitTest]
+    public void GeodesicRingAreaSquareMeters_AntimeridianCrossingRing_IsFiniteAndSmall()
+    {
+        // A ~2°×1° cell straddling the antimeridian (179°E .. -179°E). Raw longitude deltas would
+        // project a ~358°-wide polygon; longitude unwrapping keeps it a small finite area.
+        var ring = new (double Lon, double Lat)[]
+        {
+            (179, 0), (-179, 0), (-179, 1), (179, 1), (179, 0)
+        };
+        var area = ImageServerMensurationMath.GeodesicRingAreaSquareMeters(ring);
+
+        var reference = new (double Lon, double Lat)[]
+        {
+            (0, 0), (2, 0), (2, 1), (0, 1), (0, 0)
+        };
+        var referenceArea = ImageServerMensurationMath.GeodesicRingAreaSquareMeters(reference);
+
+        area.Should().BeApproximately(referenceArea, referenceArea * 0.01);
+    }
+
+    [UnitTest]
+    public void SignedAreaCentroid_LShapedPolygon_DiffersFromVertexMean()
+    {
+        // An L-shaped polygon: the true area centroid is not the mean of the vertices.
+        var ring = new (double X, double Y)[]
+        {
+            (0, 0), (4, 0), (4, 1), (1, 1), (1, 4), (0, 4), (0, 0)
+        };
+        var (cx, cy) = ImageServerMensurationMath.SignedAreaCentroid(ring, unwrapLongitudes: false);
+
+        // Area centroid = ([0,4]x[0,1] arm @ (2,0.5), area 4) + ([0,1]x[1,4] arm @ (0.5,2.5),
+        // area 3) → (9.5/7, 9.5/7) = (1.35714, 1.35714), distinct from the vertex mean (1.6667).
+        cx.Should().BeApproximately(1.3571429, 1e-4);
+        cy.Should().BeApproximately(1.3571429, 1e-4);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2734
Closes #2742
Related to #2729

## Summary
Fixes two GeoServices semantic clusters from the geodesy audit (#2729). ImageServer `measure` returned planar map-unit values labeled as meters — 2x off on Web Mercator at 60°N and ~10^5x off for non-4326 geographic services; it now normalizes coordinates to lon/lat (exact inverse Web Mercator in-process, PostGIS transform service for other projected CRSs) and measures geodesically, with a true initial-bearing azimuth, antimeridian-safe area, and a signed-area centroid. GeometryService returned HTTP 400 for legitimately empty operation results (disjoint `intersect`, fully-erased `difference`), used dimension-unconstrained DE-9IM patterns for `lineTouch`/`pointTouch` (corner touches misclassified), and `autoComplete` echoed pre-existing parcels back as new polygons.

## Changes Made
- New `ImageServerMensurationMath` (pure, unit-tested): haversine distance/bearing on IUGG mean radius 6371008.8 m, longitude-unwrapped equirectangular ring area, shoelace centroid; Web Mercator aliases normalized via the shared helper; geographic SRIDs classified via `SpatialConstants.GeographicSrids` + EPSG 4000-4999 heuristic (commented, unification tracked by #2732)
- `ImageServerMeasureHandler` normalizes to lon/lat before measuring; other projected SRIDs go through `ICoordinateTransformService` (PostGIS) with an honest documented planar fallback when unavailable
- GeometryService: empty results serialize as empty Esri geometries of the request type (`{"rings":[]}`, `{"paths":[]}`, `{"points":[]}`, null-ordinate point) instead of 400; mixed collections reduce to highest-dimension/target-type components
- DE-9IM: `lineTouch` `F***T****`→`F***1****`, `pointTouch` `FT*******`→`F***0****`
- `autoComplete` excludes faces covered by the union of input polygons — only new gap-filling polygons are returned
- Unknown `unit`/`lengthUnit` tokens now reject with 400 (previously silently treated as meters); `extendHow` and `preserveShape` limitations documented in code
- Two equatorial-tolerance test expectations updated for the mean-radius change (~0.11%), with explanatory comments

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

`ImageServerMensurationMathTests` 11/11 passed (incl. 3857\@60°N 1000 m ground distance, 4269 degrees-as-meters case, bearing, antimeridian area, centroid). Integration tests 11/11 passed (Testcontainers/PostGIS): measure updates plus disjoint-intersect/covering-difference 200-empty, corner/edge touch truth table, autoComplete, unknown-unit 400. Affected projects built Release `TreatWarningsAsErrors=true`, 0 warnings. (Full-solution build deferred to batch CI due to shared-host disk constraints.)

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None (mensuration values change on non-4326 SRIDs because they were previously wrong; empty GeometryService results now return 200 with an empty geometry instead of 400).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
