### PR TITLE
test(imageserver): align catalog fixtures with pushdown (#2760)

### DIFF
--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerClientCompatibilityTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerClientCompatibilityTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.Services;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.DependencyInjection;
@@ -153,6 +154,12 @@ public sealed class ImageServerClientCompatibilityTests
             .Returns(rasterInfo);
         store.ListRastersAsync(TestLayerId, Arg.Any<CancellationToken>())
             .Returns([rasterInfo]);
+        store.QueryCatalogAsync(TestLayerId, Arg.Any<RasterCatalogQuery>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => RasterCatalogQueryEvaluator.EvaluateAsync(
+                [rasterInfo],
+                callInfo.ArgAt<RasterCatalogQuery>(1),
+                transformService: null,
+                callInfo.ArgAt<CancellationToken>(2)));
         store.QueryRastersAsync(TestLayerId, Arg.Any<RasterSelectionQuery>(), Arg.Any<CancellationToken>())
             .Returns([rasterInfo]);
         store.GetExtentAsync(TestLayerId, 100, Arg.Any<CancellationToken>())

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerEndpointsTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
+using Honua.Core.Features.Raster.Services;
 using Honua.Protocols.GeoServices.ImageServer.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
@@ -57,6 +58,12 @@ public class ImageServerEndpointsTests
             .Returns(rasterInfo);
         store.ListRastersAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([rasterInfo]);
+        store.QueryCatalogAsync(Arg.Any<int>(), Arg.Any<RasterCatalogQuery>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => RasterCatalogQueryEvaluator.EvaluateAsync(
+                [rasterInfo],
+                callInfo.ArgAt<RasterCatalogQuery>(1),
+                transformService: null,
+                callInfo.ArgAt<CancellationToken>(2)));
         store.GetSensorMetadataAsync(Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<long, RasterSensorMetadata>());
         store.GetStatisticsAsync(Arg.Any<int>(), Arg.Any<long>(), Arg.Any<int[]?>(), Arg.Any<RasterIdentifyRendering?>(), Arg.Any<CancellationToken>())
@@ -185,6 +192,12 @@ public class ImageServerEndpointsTests
         var rasters = new[] { Build(200, "b"), Build(100, "a"), Build(300, "c") };
         store.ListRastersAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(rasters);
         store.QueryRastersAsync(default, default, default).ReturnsForAnyArgs(rasters);
+        store.QueryCatalogAsync(Arg.Any<int>(), Arg.Any<RasterCatalogQuery>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => RasterCatalogQueryEvaluator.EvaluateAsync(
+                rasters,
+                callInfo.ArgAt<RasterCatalogQuery>(1),
+                transformService: null,
+                callInfo.ArgAt<CancellationToken>(2)));
         store.GetSensorMetadataAsync(Arg.Any<IReadOnlyCollection<long>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<long, RasterSensorMetadata>());
         return store;


### PR DESCRIPTION
## Issue Link

Fixes #2760

## Summary

Fixes the GeoServices ImageServer endpoint-test regression exposed by post-merge run 29169427811. The production reader now calls the neutral raster catalog query contract, but the endpoint substitutes still configured only the former list methods and returned a null page.

## Changes Made

- Configure the single-raster endpoint fixture to evaluate `RasterCatalogQuery` through the shared reference evaluator.
- Configure the multi-raster fixture through the same canonical evaluator.
- Preserve storage pushdown in production; this changes test fixtures only.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Targeted hosted validation run 29172097700 passed on this exact head: build/format, foundation (including architecture), package and Postgres compatibility, and the GeoServices ImageServer shard. The 12 regressions from run 29169427811 are repaired.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract (not applicable)
- [x] If breaking admin/control-plane API changes: updated migration guide (not applicable)
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review (not applicable)