### PR TITLE
fix(wmts): honor declared CRS axis order (#2738)

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -88,6 +88,15 @@
       ]
     },
     {
+      "prefix": "src/Honua.Protocols.Ogc.Shared/Common/WmtsTileMatrixFormatting.cs",
+      "reason": "shared_wmts_tile_matrix_formatting",
+      "shards": [
+        "OGC Classic WMTS",
+        "OGC API Tiles Coverages and Processes",
+        "GeoServices ImageServer"
+      ]
+    },
+    {
       "prefix": "src/Honua.Hosting/Features/Authentication/",
       "reason": "shared_auth_feature_area",
       "shards": [

--- a/docs/reference/protocols/wms-wfs-wcs-wmts.md
+++ b/docs/reference/protocols/wms-wfs-wcs-wmts.md
@@ -74,7 +74,7 @@ curl -o coverage.tif "https://server.example.com/rest/services/0/ImageServer/WCS
 
 | Operation | Notes |
 | --- | --- |
-| `GetCapabilities` | KVP and RESTful (`.../WMTS/1.0.0/WMTSCapabilities.xml` style paths via `{**restPath}`). Advertises the reserved built-in gridsets (`WebMercatorQuad`, `WorldCRS84Quad`, byte-identical to before) plus any operator-defined custom gridsets from the `TileMatrixSets` configuration section, with per-layer links. |
+| `GetCapabilities` | KVP and RESTful (`.../WMTS/1.0.0/WMTSCapabilities.xml` style paths via `{**restPath}`). Advertises the reserved built-in gridsets (`WebMercatorQuad`, `WorldCRS84Quad`) plus any operator-defined custom gridsets from the `TileMatrixSets` configuration section, with per-layer links. `TopLeftCorner` follows the advertised CRS axis order (CRS84 is longitude/latitude; geographic EPSG identifiers are latitude/longitude) and preserves configured origin precision. |
 | `GetTile` | `LAYER`, `STYLE`, `TILEMATRIXSET`, `TILEMATRIX`, `TILEROW`, `TILECOL`, `FORMAT`, optional `TIME` (temporal layers) and `ELEVATION` (elevation-aware layers); serves built-in and custom gridsets. RESTful tile paths also supported. |
 | `GetFeatureInfo` | Tile-coordinate identify with `I`/`J` and `INFOFORMAT`; resolves the requested gridset through the same `ITileMatrixSetRegistry` as `GetTile`, so the built-in `WebMercatorQuad`/`WorldCRS84Quad` gridsets and operator-defined custom gridsets are supported. The clicked pixel is mapped to a world coordinate using the gridset's own origin, cell size and matrix dimensions (WebMercatorQuad stays byte-identical to before); unsupported gridsets are rejected with `InvalidParameterValue`. |
 

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -614,6 +614,14 @@ assert_descriptor \
   "false" \
   "OData Core"
 
+# The shared WMTS TopLeftCorner formatter has three bounded consumers. Keep a
+# change to that exact file on the classic WMTS, OGC API Tiles, and ImageServer
+# owners instead of tripping the unmapped shared-protocol run_all safety net.
+assert_exact_shards \
+  "shared-wmts-formatter-bounded-owners" \
+  "src/Honua.Protocols.Ogc.Shared/Common/WmtsTileMatrixFormatting.cs" \
+  '["OGC Classic WMTS","OGC API Tiles Coverages and Processes","GeoServices ImageServer"]'
+
 # An endpoint-ADDING feature PR touches the registration plumbing AND a feature
 # dir under a shard's paths: it runs the smoke subset PLUS that feature's owning
 # shard (here GeoServices ImageServer), and is targeted, not run_all.

--- a/src/Honua.Protocols.Ogc.Shared/Common/WmtsTileMatrixFormatting.cs
+++ b/src/Honua.Protocols.Ogc.Shared/Common/WmtsTileMatrixFormatting.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Shared.Models;
+using Honua.Infrastructure.Services;
+
+namespace Honua.Protocols.Ogc.Common;
+
+/// <summary>
+/// Canonical WMTS coordinate formatting shared by every adapter that emits a tile matrix set.
+/// </summary>
+internal static class WmtsTileMatrixFormatting
+{
+    /// <summary>
+    /// Formats an internal XY top-left origin in the axis order declared by the advertised CRS.
+    /// </summary>
+    /// <remarks>
+    /// CRS84 is EastNorth (longitude, latitude), while geographic EPSG identifiers such as
+    /// EPSG:4326 are NorthEast (latitude, longitude). Geographic classification alone cannot
+    /// distinguish those contracts. Coordinates use the round-trip format so configured grid
+    /// origins do not lose precision in capabilities documents.
+    /// </remarks>
+    internal static string FormatTopLeftCorner(string crs, bool isGeographic, double x, double y)
+    {
+        var axisOrder = SpatialReferenceHelpers.TryParseCrsDefinition(crs, out var definition)
+            ? definition.AxisOrder
+            : isGeographic
+                ? AxisOrder.NorthEast
+                : AxisOrder.EastNorth;
+        var first = axisOrder == AxisOrder.NorthEast ? y : x;
+        var second = axisOrder == AxisOrder.NorthEast ? x : y;
+
+        return string.Concat(FormatOrdinate(first), " ", FormatOrdinate(second));
+    }
+
+    private static string FormatOrdinate(double value)
+        => value.ToString("R", CultureInfo.InvariantCulture);
+}

--- a/src/Honua.Protocols.OgcClassic/Wmts/WmtsRequestHandlers.cs
+++ b/src/Honua.Protocols.OgcClassic/Wmts/WmtsRequestHandlers.cs
@@ -2450,7 +2450,13 @@ internal static class WmtsRequestHandlers
             sb.AppendLine("      <TileMatrix>");
             sb.Append("        <ows:Identifier>").Append(z.ToString(CultureInfo.InvariantCulture)).AppendLine("</ows:Identifier>");
             sb.Append("        <ScaleDenominator>").Append(FormatWmtsScaleDenominator(scaleDenominator)).AppendLine("</ScaleDenominator>");
-            sb.Append("        <TopLeftCorner>").Append((-WebMercatorOrigin).ToString("F6", CultureInfo.InvariantCulture)).Append(' ').Append(WebMercatorOrigin.ToString("F6", CultureInfo.InvariantCulture)).AppendLine("</TopLeftCorner>");
+            sb.Append("        <TopLeftCorner>")
+                .Append(WmtsTileMatrixFormatting.FormatTopLeftCorner(
+                    "urn:ogc:def:crs:EPSG:6.18:3:3857",
+                    isGeographic: false,
+                    -WebMercatorOrigin,
+                    WebMercatorOrigin))
+                .AppendLine("</TopLeftCorner>");
             sb.Append("        <TileWidth>").Append(TileSize.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileWidth>");
             sb.Append("        <TileHeight>").Append(TileSize.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileHeight>");
             sb.Append("        <MatrixWidth>").Append(matrixSize.ToString(CultureInfo.InvariantCulture)).AppendLine("</MatrixWidth>");
@@ -2463,8 +2469,8 @@ internal static class WmtsRequestHandlers
 
     /// <summary>
     /// Emits the WorldCRS84Quad <c>TileMatrixSet</c> definition (CRS84/EPSG:4326). The grid is
-    /// two tiles wide by one tile tall at level 0; the top-left corner is in latitude/longitude
-    /// (axis order Lat Lon for CRS84 in the WMTS TopLeftCorner element).
+    /// two tiles wide by one tile tall at level 0; the top-left corner follows the declared CRS84
+    /// EastNorth axis order (longitude, latitude) in the WMTS <c>TopLeftCorner</c> element.
     /// </summary>
     private static void AppendWmtsWorldCrs84QuadTileMatrixSet(StringBuilder sb, int wmtsMaxZoom)
     {
@@ -2488,7 +2494,13 @@ internal static class WmtsRequestHandlers
             sb.AppendLine("      <TileMatrix>");
             sb.Append("        <ows:Identifier>").Append(z.ToString(CultureInfo.InvariantCulture)).AppendLine("</ows:Identifier>");
             sb.Append("        <ScaleDenominator>").Append(FormatWmtsScaleDenominator(scaleDenominator)).AppendLine("</ScaleDenominator>");
-            sb.Append("        <TopLeftCorner>").Append(Crs84OriginLat.ToString("F6", CultureInfo.InvariantCulture)).Append(' ').Append(Crs84OriginLon.ToString("F6", CultureInfo.InvariantCulture)).AppendLine("</TopLeftCorner>");
+            sb.Append("        <TopLeftCorner>")
+                .Append(WmtsTileMatrixFormatting.FormatTopLeftCorner(
+                    "urn:ogc:def:crs:OGC:1.3:CRS84",
+                    isGeographic: true,
+                    Crs84OriginLon,
+                    Crs84OriginLat))
+                .AppendLine("</TopLeftCorner>");
             sb.Append("        <TileWidth>").Append(TileSize.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileWidth>");
             sb.Append("        <TileHeight>").Append(TileSize.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileHeight>");
             sb.Append("        <MatrixWidth>").Append(matrixWidth.ToString(CultureInfo.InvariantCulture)).AppendLine("</MatrixWidth>");
@@ -2542,8 +2554,9 @@ internal static class WmtsRequestHandlers
 
     /// <summary>
     /// Emits the <c>TileMatrixSet</c> definition for every operator-defined custom gridset in the
-    /// registry. The geographic-CRS axis order in <c>TopLeftCorner</c> matches the built-in CRS84
-    /// path (latitude then longitude); projected CRSes use easting then northing.
+    /// registry. The <c>TopLeftCorner</c> axis order follows each declared CRS identifier: CRS84
+    /// uses longitude/latitude, EPSG geographic CRSes use latitude/longitude, and projected CRSes
+    /// use easting/northing.
     /// </summary>
     internal static void AppendWmtsCustomTileMatrixSets(
         StringBuilder sb,
@@ -2568,15 +2581,16 @@ internal static class WmtsRequestHandlers
 
             foreach (var level in geometry.Levels)
             {
-                // WMTS TopLeftCorner axis order follows the CRS: latitude/longitude for geographic
-                // CRSes (matching the built-in CRS84 grid), easting/northing for projected CRSes.
-                var firstAxis = geometry.IsGeographic ? geometry.TopLeftY : geometry.TopLeftX;
-                var secondAxis = geometry.IsGeographic ? geometry.TopLeftX : geometry.TopLeftY;
-
                 sb.AppendLine("      <TileMatrix>");
                 sb.Append("        <ows:Identifier>").Append(level.Level.ToString(CultureInfo.InvariantCulture)).AppendLine("</ows:Identifier>");
                 sb.Append("        <ScaleDenominator>").Append(FormatWmtsScaleDenominator(level.ScaleDenominator)).AppendLine("</ScaleDenominator>");
-                sb.Append("        <TopLeftCorner>").Append(firstAxis.ToString("F6", CultureInfo.InvariantCulture)).Append(' ').Append(secondAxis.ToString("F6", CultureInfo.InvariantCulture)).AppendLine("</TopLeftCorner>");
+                sb.Append("        <TopLeftCorner>")
+                    .Append(WmtsTileMatrixFormatting.FormatTopLeftCorner(
+                        entry.Crs,
+                        geometry.IsGeographic,
+                        geometry.TopLeftX,
+                        geometry.TopLeftY))
+                    .AppendLine("</TopLeftCorner>");
                 sb.Append("        <TileWidth>").Append(geometry.TileWidth.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileWidth>");
                 sb.Append("        <TileHeight>").Append(geometry.TileHeight.ToString(CultureInfo.InvariantCulture)).AppendLine("</TileHeight>");
                 sb.Append("        <MatrixWidth>").Append(level.MatrixWidth.ToString(CultureInfo.InvariantCulture)).AppendLine("</MatrixWidth>");

--- a/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Tiles/TileMatrixSetDefinitionSnapshotTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcApi.Tests/Source/Tiles/TileMatrixSetDefinitionSnapshotTests.cs
@@ -51,6 +51,7 @@ public class TileMatrixSetDefinitionSnapshotTests
 
         fromRegistry.Should().BeEquivalentTo(legacy, options => options.WithStrictOrdering());
         Serialize(fromRegistry).Should().Be(Serialize(legacy));
+        fromRegistry.TileMatrices[0].PointOfOrigin.Should().Equal(-180, 90);
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/OgcClassicWmtsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/OgcClassicWmtsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Text.Json;
+using System.Xml.Linq;
 using FluentAssertions;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -294,6 +295,18 @@ public sealed class OgcClassicWmtsTests : IAsyncLifetime
         content.Should().Contain("<ows:Identifier>WorldCRS84Quad</ows:Identifier>");
         content.Should().Contain("<ows:SupportedCRS>urn:ogc:def:crs:OGC:1.3:CRS84</ows:SupportedCRS>");
         content.Should().Contain("<TileMatrixSet>WorldCRS84Quad</TileMatrixSet>");
+
+        var document = XDocument.Parse(content);
+        var worldCrs84Quad = document
+            .Descendants()
+            .Where(static element => element.Name.LocalName == "TileMatrixSet")
+            .Single(element => element.Elements().Any(child =>
+                child.Name.LocalName == "Identifier" && child.Value == "WorldCRS84Quad"));
+        var topLeftCorners = worldCrs84Quad
+            .Descendants()
+            .Where(static element => element.Name.LocalName == "TopLeftCorner")
+            .Select(static element => element.Value);
+        topLeftCorners.Should().NotBeEmpty().And.OnlyContain(static value => value == "-180 90");
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/WmtsCustomTileMatrixSetXmlTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/WmtsCustomTileMatrixSetXmlTests.cs
@@ -36,18 +36,18 @@ public class WmtsCustomTileMatrixSetXmlTests
         string crs = "urn:ogc:def:crs:OGC:1.3:CRS84",
         double topLeftX = -180.0,
         double topLeftY = 90.0) => new()
-    {
-        Id = "DemoGeographic",
-        Crs = crs,
-        Srid = 4326,
-        TopLeftCorner = [topLeftX, topLeftY],
-        TileWidth = 256,
-        TileHeight = 256,
-        Levels =
-        [
-            new TileMatrixLevel { Id = 0, ScaleDenominator = 279541132.0143589, CellSize = 0.703125, MatrixWidth = 2, MatrixHeight = 1 }
-        ]
-    };
+        {
+            Id = "DemoGeographic",
+            Crs = crs,
+            Srid = 4326,
+            TopLeftCorner = [topLeftX, topLeftY],
+            TileWidth = 256,
+            TileHeight = 256,
+            Levels =
+            [
+                new TileMatrixLevel { Id = 0, ScaleDenominator = 279541132.0143589, CellSize = 0.703125, MatrixWidth = 2, MatrixHeight = 1 }
+            ]
+        };
 
     [Fact]
     public void AppendCustomTileMatrixSets_NullRegistry_EmitsNothing()

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/WmtsCustomTileMatrixSetXmlTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/WmtsCustomTileMatrixSetXmlTests.cs
@@ -10,10 +10,8 @@ namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts;
 
 /// <summary>
 /// Unit coverage for the operator-defined custom tile matrix set emission in WMTS
-/// GetCapabilities. The built-in WebMercatorQuad / WorldCRS84Quad XML is emitted by separate,
-/// untouched methods so it stays byte-identical (the CITE WMTS 60/60 guard); these tests pin the
-/// shape of the additive custom-grid XML, including the geographic-CRS lat/lon TopLeftCorner axis
-/// order.
+/// GetCapabilities. These tests pin the shape of the additive custom-grid XML, including
+/// CRS-identifier-specific TopLeftCorner axis order and round-trip coordinate precision.
 /// </summary>
 public class WmtsCustomTileMatrixSetXmlTests
 {
@@ -34,12 +32,15 @@ public class WmtsCustomTileMatrixSetXmlTests
         ]
     };
 
-    private static CustomTileMatrixSet GeographicGrid() => new()
+    private static CustomTileMatrixSet GeographicGrid(
+        string crs = "urn:ogc:def:crs:OGC:1.3:CRS84",
+        double topLeftX = -180.0,
+        double topLeftY = 90.0) => new()
     {
         Id = "DemoGeographic",
-        Crs = "urn:ogc:def:crs:OGC:1.3:CRS84",
+        Crs = crs,
         Srid = 4326,
-        TopLeftCorner = [-180.0, 90.0],
+        TopLeftCorner = [topLeftX, topLeftY],
         TileWidth = 256,
         TileHeight = 256,
         Levels =
@@ -73,23 +74,48 @@ public class WmtsCustomTileMatrixSetXmlTests
 
         xml.Should().Contain("<ows:Identifier>DemoProjected</ows:Identifier>");
         xml.Should().Contain("<ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18:3:3857</ows:SupportedCRS>");
-        // Projected: easting then northing.
-        xml.Should().Contain("<TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>");
+        xml.Should().Contain("<TopLeftCorner>-20037508.342789244 20037508.342789244</TopLeftCorner>");
         xml.Should().Contain("<MatrixWidth>1</MatrixWidth>");
     }
 
     [Fact]
-    public void AppendCustomTileMatrixSets_GeographicGrid_EmitsLatLonTopLeftCorner()
+    public void AppendCustomTileMatrixSets_Crs84Grid_EmitsLongitudeLatitudeTopLeftCorner()
     {
         var sb = new StringBuilder();
         WmtsRequestHandlers.AppendWmtsCustomTileMatrixSets(sb, RegistryWith(GeographicGrid()), 18);
         var xml = sb.ToString();
 
         xml.Should().Contain("<ows:Identifier>DemoGeographic</ows:Identifier>");
-        // Geographic CRS: latitude (90) then longitude (-180), matching the built-in CRS84 grid.
-        xml.Should().Contain("<TopLeftCorner>90.000000 -180.000000</TopLeftCorner>");
+        xml.Should().Contain("<TopLeftCorner>-180 90</TopLeftCorner>");
         xml.Should().Contain("<MatrixWidth>2</MatrixWidth>");
         xml.Should().Contain("<MatrixHeight>1</MatrixHeight>");
+    }
+
+    [Fact]
+    public void AppendCustomTileMatrixSets_Epsg4326Grid_EmitsLatitudeLongitudeTopLeftCorner()
+    {
+        var sb = new StringBuilder();
+        WmtsRequestHandlers.AppendWmtsCustomTileMatrixSets(
+            sb,
+            RegistryWith(GeographicGrid("urn:ogc:def:crs:EPSG::4326")),
+            18);
+
+        sb.ToString().Should().Contain("<TopLeftCorner>90 -180</TopLeftCorner>");
+    }
+
+    [Fact]
+    public void AppendCustomTileMatrixSets_CustomOrigin_PreservesRoundTripPrecision()
+    {
+        var sb = new StringBuilder();
+        WmtsRequestHandlers.AppendWmtsCustomTileMatrixSets(
+            sb,
+            RegistryWith(GeographicGrid(
+                topLeftX: -157.85833333333332,
+                topLeftY: 21.306944444444447)),
+            18);
+
+        sb.ToString().Should().Contain(
+            "<TopLeftCorner>-157.85833333333332 21.306944444444447</TopLeftCorner>");
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2738

## Summary
WMTS capabilities declared WorldCRS84Quad as CRS84 but emitted its `TopLeftCorner` in latitude/longitude order. CRS84 is EastNorth, so axis-order-aware clients derived a displaced grid. Custom geographic gridsets also chose axis order from `IsGeographic` alone, which cannot distinguish CRS84 from EPSG:4326, and six-decimal formatting truncated configured origins.

This change makes capabilities follow the advertised CRS identifier and preserves origin coordinates with round-trip formatting.

## Changes Made
- Add one shared WMTS tile-matrix formatter that resolves the declared CRS through the canonical CRS parser and formats coordinates without precision loss.
- Emit WorldCRS84Quad as `-180 90`, retain latitude/longitude for geographic EPSG identifiers, and retain easting/northing for projected gridsets.
- Pin classic WMTS capabilities/custom-grid behavior and the already-correct OGC API Tiles WorldCRS84Quad origin; document the client-visible contract.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Focused evidence:
- `WmtsCustomTileMatrixSetXmlTests`: 7/7 passed in the combined focused run (CRS84, EPSG:4326, projected, and precision cases).
- `TileMatrixSetDefinitionSnapshotTests.BuildWorldCrs84QuadDefinition_RegistryDriven_MatchesLegacy`: 1/1 passed.
- Release compilation completed for the shared OGC, classic WMTS, OGC API, server, and test-host dependency path with no compiler errors.
- Scoped `dotnet format` completed successfully.
- Targeted hosted run 29173376430 passed on exact head 5059a79d5: build/format, foundation (including architecture), compatibility, and all three bounded consumers (`OGC Classic WMTS`, `OGC API Tiles Coverages and Processes`, `GeoServices ImageServer`).
- WMTS CITE was not run locally; the existing 60/60 suite remains the required conformance gate.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

Release note: WMTS GetCapabilities now emits CRS84 `TopLeftCorner` coordinates in longitude/latitude order and preserves custom grid-origin precision. This is a client-visible correction for capabilities-derived grids; no runtime tile coordinates or deployment configuration change.

## Breaking Changes
None. The corrected capabilities XML can change grid placement for clients that previously compensated for the invalid CRS84 axis order.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

<!-- Targeted equivalent pre-PR validation was used to conserve shared build capacity; the local GetCapabilities host-start blocker is disclosed above. Hosted PR gates remain authoritative. -->