### PR TITLE
fix(mcp): widen every tool error schema (#2749)

### DIFF
--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Models/McpWireModels.cs
@@ -262,6 +262,8 @@ internal sealed class McpToolsListResult
 
 internal sealed class McpToolDescriptor
 {
+    private JsonElement? _outputSchema;
+
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
@@ -289,7 +291,13 @@ internal sealed class McpToolDescriptor
     /// ignore this field harmlessly.
     /// </summary>
     [JsonPropertyName("outputSchema")]
-    public JsonElement? OutputSchema { get; set; }
+    public JsonElement? OutputSchema
+    {
+        get => _outputSchema;
+        set => _outputSchema = value is null
+            ? null
+            : Tools.McpToolOutputSchemas.IncludeErrorEnvelope(value.Value);
+    }
 
     /// <summary>
     /// MCP 2025-03-26 tool behavior hints. Lets a client LLM distinguish

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Honua.Core.Features.Geoprocessing.Domain;
 
 namespace Honua.Ai.Protocols.Mcp.Tools;
@@ -68,6 +69,107 @@ internal static class McpToolOutputSchemas
               }
             }
         """;
+
+    /// <summary>
+    /// Widens a tool's success schema with the shared structured error envelope.
+    /// MCP clients validate <c>structuredContent</c> against <c>outputSchema</c>
+    /// for both successful and failed tool calls, so every advertised schema must
+    /// accept the result produced by <see cref="McpToolHelpers.ErrorResult(Exception)"/>.
+    /// </summary>
+    /// <remarks>
+    /// The merge keeps the success schema's root properties intact for client
+    /// introspection and adds only an alternative required-property branch. It
+    /// uses the JSON DOM rather than reflection-based serialization, preserving
+    /// Native AOT compatibility. Schemas already carrying the error branch are
+    /// returned unchanged.
+    /// </remarks>
+    internal static JsonElement IncludeErrorEnvelope(JsonElement successSchema)
+    {
+        if (AcceptsErrorEnvelope(successSchema))
+        {
+            return successSchema;
+        }
+
+        var root = JsonNode.Parse(successSchema.GetRawText())?.AsObject()
+            ?? throw new InvalidOperationException("MCP tool output schemas must be JSON objects.");
+        var errorRoot = JsonNode.Parse(ToolErrorBranch)!.AsObject();
+        var errorRequired = errorRoot["required"]!.DeepClone();
+        if (root["properties"] is not JsonObject successProperties)
+        {
+            throw new InvalidOperationException("MCP tool output schemas must declare object properties.");
+        }
+
+        var closedSuccessSchema = root["additionalProperties"]?.GetValue<bool>() is false;
+        root.Remove("additionalProperties");
+        var successRequired = root["required"]?.DeepClone();
+        root.Remove("required");
+        JsonObject successBranch;
+        if (successRequired is not null)
+        {
+            successBranch = new JsonObject
+            {
+                ["required"] = successRequired,
+                ["not"] = new JsonObject { ["required"] = errorRequired.DeepClone() }
+            };
+        }
+        else
+        {
+            successBranch = new JsonObject
+            {
+                ["not"] = new JsonObject { ["required"] = errorRequired.DeepClone() }
+            };
+        }
+
+        // Preserve a closed success schema without applying its
+        // additionalProperties:false constraint to the alternative error shape.
+        // Empty property schemas in this branch only declare the allowed names;
+        // their actual types remain governed by the unchanged root properties.
+        if (closedSuccessSchema)
+        {
+            var allowedSuccessProperties = new JsonObject();
+            foreach (var property in successProperties)
+            {
+                allowedSuccessProperties.Add(property.Key, new JsonObject());
+            }
+
+            successBranch["properties"] = allowedSuccessProperties;
+            successBranch["additionalProperties"] = false;
+        }
+
+        root["oneOf"] = new JsonArray(
+            successBranch,
+            new JsonObject { ["required"] = errorRequired });
+
+        return Parse(root.ToJsonString());
+    }
+
+    private static bool AcceptsErrorEnvelope(JsonElement schema)
+    {
+        if (!schema.TryGetProperty("oneOf", out var branches)
+            || branches.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var branch in branches.EnumerateArray())
+        {
+            if (!branch.TryGetProperty("required", out var required)
+                || required.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            var names = required.EnumerateArray()
+                .Select(value => value.GetString())
+                .ToHashSet(StringComparer.Ordinal);
+            if (names.IsSupersetOf(["status", "code", "message", "error"]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>Schema for <see cref="Models.McpValidatePlanOutput"/>.</summary>
     public static readonly JsonElement ValidatePlanOutputSchema = Parse(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/McpToolOutputSchemas.cs
@@ -42,6 +42,23 @@ internal static class McpToolOutputSchemas
         }
         """;
 
+    private const string ToolErrorRequiredProperties = """
+            "status": { "type": "string", "const": "error" },
+            "code": { "type": "string" },
+            "message": { "type": "string" },
+            "error": { "type": "object" }
+        """;
+
+    private static string ToolErrorSchema => $$"""
+        {
+          "type": "object",
+          "required": ["status", "code", "message", "error"],
+          "properties": {
+            {{ToolErrorRequiredProperties}}
+          }
+        }
+        """;
+
     private static string ToolErrorProperties => $$"""
             "status": { "type": "string", "const": "error" },
             "code": { "type": "string" },
@@ -77,8 +94,10 @@ internal static class McpToolOutputSchemas
     /// accept the result produced by <see cref="McpToolHelpers.ErrorResult(Exception)"/>.
     /// </summary>
     /// <remarks>
-    /// The merge keeps the success schema's root properties intact for client
-    /// introspection and adds only an alternative required-property branch. It
+    /// The wrapper retains every success constraint at the root or in the success
+    /// branch and adds a separately typed error branch. Properties shared by both
+    /// shapes are constrained in their respective branches, preventing the union
+    /// from relaxing successful results without duplicating the full schema. It
     /// uses the JSON DOM rather than reflection-based serialization, preserving
     /// Native AOT compatibility. Schemas already carrying the error branch are
     /// returned unchanged.
@@ -92,53 +111,67 @@ internal static class McpToolOutputSchemas
 
         var root = JsonNode.Parse(successSchema.GetRawText())?.AsObject()
             ?? throw new InvalidOperationException("MCP tool output schemas must be JSON objects.");
-        var errorRoot = JsonNode.Parse(ToolErrorBranch)!.AsObject();
+        var errorRoot = JsonNode.Parse(ToolErrorSchema)!.AsObject();
         var errorRequired = errorRoot["required"]!.DeepClone();
         if (root["properties"] is not JsonObject successProperties)
         {
             throw new InvalidOperationException("MCP tool output schemas must declare object properties.");
         }
 
+        var errorProperties = errorRoot["properties"]!.AsObject();
+        var successPropertyNames = successProperties.Select(property => property.Key).ToArray();
+        var successOverlapProperties = new JsonObject();
+        var errorOverlapProperties = new JsonObject();
+        foreach (var errorProperty in errorProperties)
+        {
+            if (successProperties[errorProperty.Key] is JsonNode successProperty)
+            {
+                successOverlapProperties[errorProperty.Key] = successProperty.DeepClone();
+                errorOverlapProperties[errorProperty.Key] = errorProperty.Value?.DeepClone();
+                successProperties[errorProperty.Key] = new JsonObject();
+                continue;
+            }
+
+            successProperties[errorProperty.Key] = errorProperty.Value?.DeepClone();
+        }
+
         var closedSuccessSchema = root["additionalProperties"]?.GetValue<bool>() is false;
         root.Remove("additionalProperties");
         var successRequired = root["required"]?.DeepClone();
         root.Remove("required");
-        JsonObject successBranch;
+        var successBranch = new JsonObject
+        {
+            ["not"] = new JsonObject { ["required"] = errorRequired.DeepClone() }
+        };
         if (successRequired is not null)
         {
-            successBranch = new JsonObject
-            {
-                ["required"] = successRequired,
-                ["not"] = new JsonObject { ["required"] = errorRequired.DeepClone() }
-            };
-        }
-        else
-        {
-            successBranch = new JsonObject
-            {
-                ["not"] = new JsonObject { ["required"] = errorRequired.DeepClone() }
-            };
+            successBranch["required"] = successRequired;
         }
 
-        // Preserve a closed success schema without applying its
-        // additionalProperties:false constraint to the alternative error shape.
-        // Empty property schemas in this branch only declare the allowed names;
-        // their actual types remain governed by the unchanged root properties.
         if (closedSuccessSchema)
         {
             var allowedSuccessProperties = new JsonObject();
-            foreach (var property in successProperties)
+            foreach (var propertyName in successPropertyNames)
             {
-                allowedSuccessProperties.Add(property.Key, new JsonObject());
+                allowedSuccessProperties[propertyName] =
+                    successOverlapProperties[propertyName]?.DeepClone() ?? new JsonObject();
             }
 
             successBranch["properties"] = allowedSuccessProperties;
             successBranch["additionalProperties"] = false;
         }
+        else if (successOverlapProperties.Count > 0)
+        {
+            successBranch["properties"] = successOverlapProperties;
+        }
 
-        root["oneOf"] = new JsonArray(
-            successBranch,
-            new JsonObject { ["required"] = errorRequired });
+        var errorBranch = new JsonObject { ["required"] = errorRequired };
+        if (errorOverlapProperties.Count > 0)
+        {
+            errorBranch["properties"] = errorOverlapProperties;
+        }
+
+        root["oneOf"] = new JsonArray(successBranch, errorBranch);
 
         return Parse(root.ToJsonString());
     }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpTaxonomyAlignmentTests.cs
@@ -14,6 +14,8 @@ using Honua.Ai.Protocols.Mcp.Tools;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
 using NSubstitute;
 using Honua.Core.Features.Reporting.Abstractions;
 
@@ -408,6 +410,34 @@ public sealed partial class McpTaxonomyAlignmentTests
             properties.ValueKind.Should().Be(JsonValueKind.Object);
             properties.EnumerateObject().Should().NotBeEmpty(
                 $"'{tool.Name}' output schema must describe at least one property");
+        }
+    }
+
+    [UnitTest]
+    public void StructuredTools_ErrorEnvelopeMatchesEveryAdvertisedOutputSchema()
+    {
+        var errorEnvelope = JObject.Parse(
+            """
+            {
+              "status": "error",
+              "code": "validation_failed",
+              "message": "The request is invalid.",
+              "error": {
+                "kind": "ValidationFailed",
+                "message": "The request is invalid."
+              }
+            }
+            """);
+
+        foreach (var tool in BuildTools())
+        {
+            var descriptor = tool.Describe();
+            descriptor.OutputSchema.Should().NotBeNull(
+                $"tool '{tool.Name}' must advertise an output schema before its shared error envelope can be validated");
+
+            var schema = JSchema.Parse(descriptor.OutputSchema!.Value.GetRawText());
+            errorEnvelope.IsValid(schema, out IList<string> errors).Should().BeTrue(
+                $"the shared MCP error envelope must validate against '{tool.Name}' outputSchema; errors: {string.Join("; ", errors)}");
         }
     }
 

--- a/tests/js/mcp/output-schema.test.ts
+++ b/tests/js/mcp/output-schema.test.ts
@@ -1,0 +1,141 @@
+import Ajv2020, { type AnySchema } from 'ajv/dist/2020.js';
+import { config } from '../shared/client.js';
+
+interface McpTool {
+  name: string;
+  outputSchema?: AnySchema;
+}
+
+interface JsonRpcResponse {
+  result?: {
+    tools?: McpTool[];
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+const errorEnvelope = {
+  status: 'error',
+  code: 'validation_failed',
+  message: 'The request is invalid.',
+  requiresReauthentication: false,
+  approvalRequired: false,
+  policyRef: 'policy:test',
+  conflictingJobId: 'job-test',
+  retryable: false,
+  violations: [
+    {
+      code: 'required',
+      message: 'layerId is required.',
+      fieldPath: 'layerId',
+    },
+  ],
+  error: {
+    kind: 'ValidationFailed',
+    message: 'The request is invalid.',
+    stepId: 'query',
+    violations: [
+      {
+        code: 'required',
+        message: 'layerId is required.',
+        fieldPath: 'layerId',
+      },
+    ],
+  },
+};
+
+describe('MCP output schemas', () => {
+  it('validate the shared typed error envelope with the SDK Ajv configuration', async () => {
+    const tools = await listTools();
+    const toolsWithOutputSchemas = tools.filter(
+      (tool): tool is McpTool & { outputSchema: AnySchema } => tool.outputSchema !== undefined,
+    );
+
+    expect(toolsWithOutputSchemas.length).toBeGreaterThan(0);
+
+    for (const tool of toolsWithOutputSchemas) {
+      // Match the MCP TypeScript SDK validator: JSON Schema draft 2020-12
+      // with strict mode disabled for interoperable advertised schemas.
+      const ajv = new Ajv2020({ strict: false });
+      const validate = ajv.compile(tool.outputSchema);
+
+      expect(validate(errorEnvelope), `${tool.name}: ${ajv.errorsText(validate.errors)}`).toBe(true);
+
+      const invalidRequiredFields: Array<[string, unknown]> = [
+        ['status', 'failed'],
+        ['code', 400],
+        ['message', false],
+        ['error', 'ValidationFailed'],
+      ];
+      for (const [field, invalidValue] of invalidRequiredFields) {
+        const invalidEnvelope = structuredClone(errorEnvelope) as Record<string, unknown>;
+        invalidEnvelope[field] = invalidValue;
+        expect(
+          validate(invalidEnvelope),
+          `${tool.name} must retain the shared error type for ${field}`,
+        ).toBe(false);
+      }
+    }
+  });
+});
+
+async function listTools(): Promise<McpTool[]> {
+  const initialize = await mcpRequest({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'honua-ajv-contract-tests', version: '1.0.0' },
+    },
+  });
+  const sessionId = initialize.response.headers.get('mcp-session-id');
+  expect(sessionId).toBeTruthy();
+
+  await mcpRequest(
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    sessionId ?? undefined,
+    false,
+  );
+  const list = await mcpRequest(
+    { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+    sessionId ?? undefined,
+  );
+
+  expect(list.body.error).toBeUndefined();
+  expect(list.body.result?.tools).toBeDefined();
+  return list.body.result?.tools ?? [];
+}
+
+async function mcpRequest(
+  body: object,
+  sessionId?: string,
+  expectJson = true,
+): Promise<{ response: Response; body: JsonRpcResponse }> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  if (config.apiKey) {
+    headers['X-API-Key'] = config.apiKey;
+  }
+  if (sessionId) {
+    headers['Mcp-Session-Id'] = sessionId;
+  }
+
+  const response = await fetch(`${config.baseUrl}/mcp`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  expect(response.ok).toBe(true);
+
+  if (!expectJson) {
+    return { response, body: {} };
+  }
+
+  return { response, body: (await response.json()) as JsonRpcResponse };
+}

--- a/tests/js/package-lock.json
+++ b/tests/js/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^20.10.0",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/ui": "^4.1.8",
+        "ajv": "^8.20.0",
         "jsdom": "^26.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.3.0",
@@ -3353,6 +3354,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3596,6 +3614,23 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3871,6 +3906,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsts": {
       "version": "2.7.1",
@@ -4514,6 +4556,16 @@
       "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
       "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^20.10.0",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
+    "ajv": "^8.20.0",
     "jsdom": "^26.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.3.0",


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2749

## Summary
Makes the shared MCP structured error envelope valid against every tool's advertised `outputSchema`, instead of only query, geocode, and render. The widening is centralized on the descriptor contract so static and runtime-published tools cannot drift.

## Changes Made
- Add a shared AOT-safe schema transformer that preserves every success constraint and adds a typed common error branch.
- Preserve closed success-schema semantics and reassert overlapping success/error property types in their respective branches.
- Leave the three schemas already corrected by #1956 unchanged.
- Add a live roster-wide contract test using Ajv draft 2020-12 with `strict: false`, matching the MCP SDK validator configuration.
- Assert the representative full error envelope validates and invalid required error-field types are rejected for every advertised output schema.
- Keep the `tools/list` token-density guard green.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Validation:
- `dotnet test tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj --no-restore --configuration Release --filter '<error-envelope and token-density tests>'` — 2 passed.
- `npm run typecheck` in `tests/js` — passed.
- `dotnet format Honua.sln --no-restore --verify-no-changes` — passed.
- `dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj --no-restore --configuration Release /p:TreatWarningsAsErrors=true` — 127 passed on the original PR revision.

The new live JavaScript integration test runs in the existing `js-integration-tests` job, which starts Honua and validates every schema returned by `tools/list` with the exact Ajv configuration.
- Targeted hosted run 29178827984 passed on exact head `174c56c99`: build/format, foundation, JavaScript integration/typecheck, MCP, Operator Eval, and compatibility gates.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

The advertised MCP output schemas are widened additively; success payloads, success constraints, and serialized outputs remain unchanged.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review