### PR TITLE
fix: DuckDB axis order and distance guards; Postgres geography distance predicates

### DIFF
--- a/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
+++ b/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
@@ -674,11 +674,17 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
     /// Returns a geometry SQL expression with ST_Transform applied when the requested
     /// output SRID differs from the layer's source SRID.
     /// </summary>
+    /// <remarks>
+    /// <c>always_xy := true</c> is required on every ST_Transform call: DuckDB's spatial
+    /// extension honours the authority axis order (latitude/longitude for EPSG:4326), while
+    /// Honua's canonical WKB contract stores coordinates X=longitude, Y=latitude. Without
+    /// this flag DuckDB would swap axes for geographic CRSs and emit transposed coordinates.
+    /// </remarks>
     private static string BuildTransformedGeometryExpression(DuckDBLayerMapping mapping, FeatureQuery query)
     {
         if (query.OutputSrid.HasValue && query.OutputSrid.Value != mapping.Srid)
         {
-            return $"ST_Transform({mapping.QuotedGeometryColumn}, 'EPSG:{mapping.Srid}', 'EPSG:{query.OutputSrid.Value}')";
+            return $"ST_Transform({mapping.QuotedGeometryColumn}, 'EPSG:{mapping.Srid}', 'EPSG:{query.OutputSrid.Value}', always_xy := true)";
         }
 
         return mapping.QuotedGeometryColumn;
@@ -1243,7 +1249,10 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
 
         if (filter.Srid.HasValue && filter.Srid.Value > 0 && filter.Srid.Value != mapping.Srid)
         {
-            return $"ST_Transform({baseGeometry}, 'EPSG:{filter.Srid.Value}', 'EPSG:{mapping.Srid}')";
+            // always_xy := true keeps DuckDB in X=lon/Y=lat order to match Honua's canonical WKB
+            // contract; without it DuckDB applies the authority axis order (lat/lon for EPSG:4326)
+            // and the transformed filter geometry would be transposed relative to the stored column.
+            return $"ST_Transform({baseGeometry}, 'EPSG:{filter.Srid.Value}', 'EPSG:{mapping.Srid}', always_xy := true)";
         }
 
         return baseGeometry;
@@ -1255,18 +1264,54 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
         ref int paramIndex, List<object> parameters)
     {
         var distanceInMeters = ConvertDistanceToMeters(filter.Distance!.Value, filter.DistanceUnit);
-        parameters.Add(distanceInMeters);
 
-        // DuckDB ST_DWithin operates in CRS units. For geographic CRS (degrees),
-        // passing meters would be wildly incorrect. Use ST_Distance_Spheroid for
-        // geodesic distance in meters on the WGS84 spheroid instead.
+        // DuckDB ST_DWithin operates in the CRS's native units. Distance filters carry the client
+        // distance in meters, so the branch selection has to match the storage CRS's unit:
+        //   * Known geographic (degree) CRSs  -> ST_Distance_Spheroid (geodesic, metres).
+        //   * Projected metre-unit CRSs       -> planar ST_DWithin with the metre distance.
+        //   * Plausibly-geographic-but-unlisted CRSs (EPSG 4000-4999 outside the allowlist)
+        //     -> reject, because running planar ST_DWithin would compare metres to degrees and
+        //        match the entire planet. See distance policy note below.
         if (IsGeographicSrid(mapping.Srid))
         {
-            return $"ST_Distance_Spheroid({geomCol}, {filterGeomParam}) <= ${paramIndex++}";
+            parameters.Add(distanceInMeters);
+
+            // Axis contract: DuckDB's *_Spheroid functions document their inputs as EPSG:4326 in
+            // latitude/longitude order, but Honua stores coordinates X=longitude, Y=latitude.
+            // ST_FlipCoordinates swaps to the lat/lon order the spheroid model expects so the
+            // geodesic distance is computed on the correct axes.
+            return $"ST_Distance_Spheroid(ST_FlipCoordinates({geomCol}), ST_FlipCoordinates({filterGeomParam})) <= ${paramIndex++}";
         }
 
+        // Safety net (#2731, pending classifier unification in #2732): the geodesic allowlist in
+        // SpatialConstants.GeographicSrids only covers seven well-known codes. Any other SRID in
+        // the EPSG geographic 2D range (4000-4999) is almost certainly a lat/lon degree CRS
+        // (e.g. 4674 SIRGAS 2000, 4490 CGCS2000, 4230 ED50) whose geodesy we cannot establish from
+        // the static list. Running planar ST_DWithin(metres) against degrees would silently match
+        // the whole planet, so reject distance filters on those SRIDs rather than return wrong
+        // results. Projected metre-unit CRSs (outside 4000-4999) keep the correct planar path.
+        if (IsUnlistedGeographicSridRange(mapping.Srid))
+        {
+            throw new NotSupportedException(
+                $"Distance spatial filters are not supported for layer SRID {mapping.Srid} in the DuckDB provider. " +
+                $"This SRID falls in the EPSG geographic range (4000-4999) but is not in the geodesic allowlist, " +
+                $"so its distance semantics cannot be established without projecting. " +
+                $"Pre-project the layer to EPSG:4326 or a projected metre-unit CRS before issuing distance filters.");
+        }
+
+        // Projected metre-unit CRS: planar ST_DWithin in the layer's native (metre) units is correct.
+        parameters.Add(distanceInMeters);
         return $"ST_DWithin({geomCol}, {filterGeomParam}, ${paramIndex++})";
     }
+
+    /// <summary>
+    /// Returns <c>true</c> when the SRID lies in the EPSG geographic 2D code range (4000-4999)
+    /// but is not one of the codes explicitly recognised as geographic by
+    /// <see cref="DistanceConversions.IsGeographicSrid"/>. Such SRIDs are treated as
+    /// "geodesy-unestablished" for distance filters to avoid comparing metres against degrees.
+    /// </summary>
+    private static bool IsUnlistedGeographicSridRange(int srid)
+        => srid is >= 4000 and <= 4999 && !IsGeographicSrid(srid);
 
     /// <summary>
     /// Returns <c>true</c> for SRIDs known to be geographic (lat/lon degree-based) CRSs.

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Knn.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Knn.cs
@@ -49,9 +49,13 @@ internal sealed partial class FeatureQueryBuilder
             return false;
         }
 
-        // Use the curated canonical geographic-SRID list (single source of truth) rather
-        // than a loose 4000-4999 range, which swept in projected/geocentric CRS in that band
-        // (e.g. EPSG:4978 geocentric) and missed geographic CRS outside it.
-        return DistanceConversions.IsGeographicSrid(query.SpatialReferenceSrid.Value);
+        // The curated canonical geographic-SRID list is the primary source of truth. Until the
+        // classifier unification (#2732) replaces this heuristic, add a safety net: an SRID in the
+        // EPSG geographic 2D range (4000-4999) that is not on the allowlist is still a lat/lon
+        // degree CRS (e.g. 4674 SIRGAS 2000, 4490 CGCS2000). Planar degree KNN on those would
+        // produce meaningless distances, so route them through the same geodesic path as 4326.
+        // The narrow 4xxx geocentric/3D codes (4978/4979) are out of scope for 2D KNN.
+        var srid = query.SpatialReferenceSrid.Value;
+        return DistanceConversions.IsGeographicSrid(srid) || IsUnlistedGeographicSridRange(srid);
     }
 }

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Spatial.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Spatial.cs
@@ -253,7 +253,6 @@ internal sealed partial class FeatureQueryBuilder
         var isGeographicStorage =
             DistanceConversions.IsGeographicSrid(storageSrid) || IsUnlistedGeographicSridRange(storageSrid);
 
-        string expansion;
         if (isGeographicStorage)
         {
             // Geographic storage measures the envelope in degrees: ~111320 m per degree of
@@ -265,17 +264,26 @@ internal sealed partial class FeatureQueryBuilder
             var degrees = (distanceInMeters / 111320.0).ToString("R", CultureInfo.InvariantCulture);
             var latExtent =
                 $"LEAST(89.9, GREATEST(abs(ST_YMin({storageFilterGeometry})), abs(ST_YMax({storageFilterGeometry}))))";
-            expansion = $"({degrees} / cos(radians({latExtent})))";
-        }
-        else
-        {
-            // Projected storage is assumed to use metre units (the dominant case and consistent
-            // with the geography exact predicate, which always yields metres). Non-metre projected
-            // CRSs are out of scope for this minimal fix (#2732).
-            expansion = distanceInMeters.ToString("R", CultureInfo.InvariantCulture);
+            var expansion = $"({degrees} / cos(radians({latExtent})))";
+
+            // Longitude is periodic: a planar && envelope near the antimeridian cannot see a
+            // geodesic match on the other side (a query at lon 179.9 expanded by 30 km spans
+            // roughly [179.63, 180.17], while a true match at lon -179.9 sits ~359.8 planar
+            // degrees away and would be wrongly pruned). Probe the envelope shifted by +/-360
+            // degrees as well; each && stays index-usable (bitmap OR over the GiST index) and
+            // the exact geography ST_DWithin still decides membership, so the extra probes only
+            // cost selectivity for data normalized to [-180, 180].
+            var envelope = $"ST_Expand({storageFilterGeometry}, {expansion})";
+            return $"({geometryOperand} && {envelope}" +
+                   $" OR {geometryOperand} && ST_Translate({envelope}, 360, 0)" +
+                   $" OR {geometryOperand} && ST_Translate({envelope}, -360, 0))";
         }
 
-        return $"{geometryOperand} && ST_Expand({storageFilterGeometry}, {expansion})";
+        // Projected storage is assumed to use metre units (the dominant case and consistent
+        // with the geography exact predicate, which always yields metres). Non-metre projected
+        // CRSs are out of scope for this minimal fix (#2732).
+        var metres = distanceInMeters.ToString("R", CultureInfo.InvariantCulture);
+        return $"{geometryOperand} && ST_Expand({storageFilterGeometry}, {metres})";
     }
 
     private static bool IsUnlistedGeographicSridRange(int srid)

--- a/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Spatial.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/FeatureQueryBuilder.Spatial.cs
@@ -126,15 +126,19 @@ internal sealed partial class FeatureQueryBuilder
                 break;
 
             case SpatialRelationship.WithinDistance:
-                // Use ST_DWithin with geography type for accurate geodesic distance calculations
+                // Use ST_DWithin with geography type for accurate geodesic distance calculations.
+                // The geography operands wrap the column in ST_Transform(col,4326)::geography, which
+                // is not GiST-index-usable and forces a full scan. Pair it with an && envelope
+                // pre-filter in the STORED CRS (mirroring the Intersects family) so the spatial
+                // index prunes candidates before the exact geodesic check runs. (#2740)
+                var withinDistanceMeters = _geometryProcessor.ConvertDistanceToMeters(filter.Distance ?? 0, filter.DistanceUnit);
+                var storageFilterGeometry = BuildSpatialFilterGeometryExpression(filter, query, ref paramIndex, parameters);
+                var distancePrefilter = BuildDistanceEnvelopePrefilter(
+                    geometryOperand, storageFilterGeometry, withinDistanceMeters, query.SpatialReferenceSrid);
                 var geographyFilter = BuildGeographyFilterExpression(filter, query, ref paramIndex);
                 parameters?.Add(filter.Geometry);
-                clause = $"ST_DWithin({geographyOperand}, {geographyFilter}, ${paramIndex++})";
-                if (parameters != null)
-                {
-                    var distanceInMeters = _geometryProcessor.ConvertDistanceToMeters(filter.Distance ?? 0, filter.DistanceUnit);
-                    parameters.Add(distanceInMeters);
-                }
+                clause = $"{distancePrefilter} AND ST_DWithin({geographyOperand}, {geographyFilter}, ${paramIndex++})";
+                parameters?.Add(withinDistanceMeters);
                 break;
 
             case SpatialRelationship.BeyondDistance:
@@ -223,4 +227,57 @@ internal sealed partial class FeatureQueryBuilder
                $"ST_Y({geometryOperand}) <= ${maxYParam} " +
                $"ELSE ST_Intersects({geometryOperand}, {filterGeometry}) END";
     }
+
+    /// <summary>
+    /// Builds an index-usable <c>&amp;&amp;</c> bounding-box pre-filter for a WithinDistance predicate.
+    /// The envelope is the filter geometry (already in the stored column's CRS) expanded by the
+    /// search distance converted to the storage CRS's units, so the GiST index on the geometry
+    /// column can prune candidates before the exact geodesic <c>ST_DWithin(...::geography)</c> runs.
+    /// The pre-filter is deliberately conservative (over-expanding rather than under-expanding); the
+    /// exact geography predicate still decides membership, so the envelope can never exclude a real
+    /// match. Only WithinDistance uses this — BeyondDistance selects features outside the envelope,
+    /// where a bounding-box window would incorrectly drop the desired far features.
+    /// </summary>
+    private static string BuildDistanceEnvelopePrefilter(
+        string geometryOperand,
+        string storageFilterGeometry,
+        double distanceInMeters,
+        int? spatialReferenceSrid)
+    {
+        var storageSrid = spatialReferenceSrid ?? SpatialReference.WGS84.Wkid;
+
+        // Bias classification toward "geographic" only for the curated list plus the unlisted
+        // EPSG geographic 2D range (4000-4999). Misclassifying projected-metre storage as
+        // geographic would under-expand (degrees << metres) and drop matches, so everything else
+        // is treated as metre-unit projected storage. Full CRS-unit resolution is deferred to #2732.
+        var isGeographicStorage =
+            DistanceConversions.IsGeographicSrid(storageSrid) || IsUnlistedGeographicSridRange(storageSrid);
+
+        string expansion;
+        if (isGeographicStorage)
+        {
+            // Geographic storage measures the envelope in degrees: ~111320 m per degree of
+            // latitude, and ~111320*cos(lat) m per degree of longitude. Expanding by only
+            // metres/111320 would under-cover east/west at high latitudes and could drop true
+            // matches, so divide by cos(lat) using the filter geometry's own latitude extent,
+            // clamped to 89.9deg to bound the blow-up near the poles. Over-expansion only costs
+            // index selectivity; correctness is preserved by the exact geography ST_DWithin.
+            var degrees = (distanceInMeters / 111320.0).ToString("R", CultureInfo.InvariantCulture);
+            var latExtent =
+                $"LEAST(89.9, GREATEST(abs(ST_YMin({storageFilterGeometry})), abs(ST_YMax({storageFilterGeometry}))))";
+            expansion = $"({degrees} / cos(radians({latExtent})))";
+        }
+        else
+        {
+            // Projected storage is assumed to use metre units (the dominant case and consistent
+            // with the geography exact predicate, which always yields metres). Non-metre projected
+            // CRSs are out of scope for this minimal fix (#2732).
+            expansion = distanceInMeters.ToString("R", CultureInfo.InvariantCulture);
+        }
+
+        return $"{geometryOperand} && ST_Expand({storageFilterGeometry}, {expansion})";
+    }
+
+    private static bool IsUnlistedGeographicSridRange(int srid)
+        => srid is >= 4000 and <= 4999 && !DistanceConversions.IsGeographicSrid(srid);
 }

--- a/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/PostgresStorageMappedFeatureReader.cs
@@ -824,7 +824,7 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
             : $"ST_Transform({geometryExpression}, {targetSrid})";
     }
 
-    private static string BuildDistancePredicate(
+    private string BuildDistancePredicate(
         string geometryColumn,
         string filterGeometry,
         SpatialFilter filter,
@@ -832,8 +832,29 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
         bool beyond)
     {
         var distance = ConvertDistanceToMeters(filter.Distance ?? 0d, filter.DistanceUnit);
+        return BuildDistancePredicateSql(geometryColumn, filterGeometry, _storageSrid, distance, beyond, sql.AddParameter);
+    }
+
+    /// <summary>
+    /// Builds the ST_Distance distance/beyond predicate for a storage-mapped layer. Both operands
+    /// arrive in the storage SRID (the column natively, the filter after
+    /// <see cref="TransformFilterGeometryIfNeeded"/>). A bare <c>::geography</c> cast requires
+    /// lon/lat input and throws for projected-storage layers (a 500), so both operands are
+    /// reprojected to WGS84 geography via <see cref="ToWgs84Geography"/> (the same path KNN uses)
+    /// so <c>ST_Distance</c> returns metres regardless of the storage CRS. (#2740)
+    /// </summary>
+    internal static string BuildDistancePredicateSql(
+        string geometryColumn,
+        string filterGeometry,
+        int storageSrid,
+        double distanceInMeters,
+        bool beyond,
+        Func<object?, string> addParameter)
+    {
         var operatorText = beyond ? ">" : "<=";
-        return $"ST_Distance({geometryColumn}::geography, {filterGeometry}::geography) {operatorText} {sql.AddParameter(distance)}";
+        var geographyColumn = ToWgs84Geography(geometryColumn, storageSrid);
+        var geographyFilter = ToWgs84Geography(filterGeometry, storageSrid);
+        return $"ST_Distance({geographyColumn}, {geographyFilter}) {operatorText} {addParameter(distanceInMeters)}";
     }
 
     private static double ConvertDistanceToMeters(double distance, DistanceUnit unit)
@@ -1432,12 +1453,18 @@ internal sealed partial class PostgresStorageMappedFeatureReader : IFeatureReade
 
     private bool ShouldUseGeodesicNearestNeighbor()
     {
-        // Use the curated canonical geographic-SRID list (single source of truth) rather
-        // than a loose 4000-4999 range, which swept in projected/geocentric CRS in that band
-        // (e.g. EPSG:4978 geocentric) and missed geographic CRS outside it. The classification
-        // gates both the geodesic ordering and the returned NearestNeighbor distance units.
-        return DistanceConversions.IsGeographicSrid(_storageSrid);
+        // The curated canonical geographic-SRID list is the primary source of truth. Until the
+        // classifier unification (#2732) replaces this heuristic, add a safety net: any SRID in
+        // the EPSG geographic 2D range (4000-4999) that is not already on the allowlist is still a
+        // lat/lon degree CRS (e.g. 4674 SIRGAS 2000, 4490 CGCS2000), so planar degree KNN would
+        // silently produce meaningless "distances". Route those through the same geodesic path as
+        // 4326. The narrow 4xxx-3D/geocentric exceptions (4978/4979) are out of scope for 2D KNN.
+        return DistanceConversions.IsGeographicSrid(_storageSrid)
+            || IsUnlistedGeographicSridRange(_storageSrid);
     }
+
+    private static bool IsUnlistedGeographicSridRange(int srid)
+        => srid is >= 4000 and <= 4999 && !DistanceConversions.IsGeographicSrid(srid);
 
     private static string ToWgs84Geography(string geometryExpression, int srid)
         => srid == SpatialReference.WGS84.Wkid

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureQueryBuilderTests.cs
@@ -247,9 +247,25 @@ public class DuckDBFeatureQueryBuilderTests
         var result = _builder.BuildSelectQuery(TestLayerId, query);
 
         Assert.Contains("ST_Transform(ST_GeomFromWKB($", result.Sql);
-        Assert.Contains("'EPSG:3857', 'EPSG:4326'", result.Sql);
+        Assert.Contains("'EPSG:3857', 'EPSG:4326', always_xy := true", result.Sql);
         Assert.Contains("ST_Intersects(\"geom\", ST_Transform(ST_GeomFromWKB($", result.Sql);
         Assert.Contains(wkb, result.WhereParameters);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_OutputSrid_ReprojectsWithAlwaysXy()
+    {
+        // Layer is 4326; client requests Web Mercator (3857) output. The output geometry
+        // expression must reproject with always_xy := true so DuckDB keeps X=lon/Y=lat order
+        // and does not transpose axes for the geographic source CRS.
+        var query = new FeatureQuery
+        {
+            OutputSrid = 3857
+        };
+
+        var result = _builder.BuildSelectQuery(TestLayerId, query);
+
+        Assert.Contains("ST_Transform(\"geom\", 'EPSG:4326', 'EPSG:3857', always_xy := true)", result.Sql);
     }
 
     [Fact]
@@ -426,8 +442,38 @@ public class DuckDBFeatureQueryBuilderTests
         var result = _builder.BuildSelectQuery(TestLayerId, query);
 
         Assert.Contains("ST_Distance_Spheroid(", result.Sql);
+        // DuckDB spheroid functions expect lat/lon axis order; the stored WKB is lon/lat, so both
+        // operands are flipped before the geodesic distance is computed.
+        Assert.Contains("ST_Distance_Spheroid(ST_FlipCoordinates(\"geom\"), ST_FlipCoordinates(", result.Sql);
         Assert.DoesNotContain("ST_DWithin(", result.Sql);
         Assert.Contains(1000.0, result.WhereParameters.OfType<double>());
+    }
+
+    [Fact]
+    public void BuildSelectQuery_WithinDistance_UnlistedGeographicSrid_Throws()
+    {
+        // EPSG:4674 (SIRGAS 2000) is a geographic degree CRS but is not in the geodesic allowlist.
+        // Running planar ST_DWithin(metres) against degrees would match the whole planet, so the
+        // builder must reject the distance filter rather than emit silently-wrong SQL (#2731).
+        var geographicMapping = new DuckDBLayerMapping
+        {
+            LayerId = 1,
+            TableName = "parcels_sirgas",
+            GeometryColumn = "geom",
+            ObjectIdColumn = "id",
+            Srid = 4674,
+            AttributeColumns = ["name"]
+        };
+        var registry = new DuckDBLayerRegistry([geographicMapping]);
+        var builder = new DuckDBFeatureQueryBuilder(registry);
+
+        var wkb = new byte[] { 1, 2, 3, 4 };
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.CreateDistanceFilter(wkb, 1000.0, DistanceUnit.Meters)
+        };
+
+        Assert.Throws<NotSupportedException>(() => builder.BuildSelectQuery(1, query));
     }
 
     [Fact]

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBSpatialBootstrapTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBSpatialBootstrapTests.cs
@@ -55,6 +55,36 @@ public sealed class DuckDBSpatialBootstrapTests
     }
 
     [Fact]
+    public async Task StTransform_WithAlwaysXy_TreatsCoordinatesAsLonLat()
+    {
+        // Round-trip proof for the always_xy fix (#2731): Honua stores X=lon, Y=lat, so a WGS84
+        // point ST_Point(lon, lat) must reproject to Web Mercator without axis transposition.
+        // Helsinki (24.94 E, 60.17 N) -> EPSG:3857 x ≈ 2,776,000 m, y ≈ 8,437,000 m.
+        var bootstrap = new DuckDBSpatialBootstrap(
+            extensionPath: null,
+            logger: NullLogger<DuckDBSpatialBootstrap>.Instance);
+
+        await using var connection = new DuckDBConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        await bootstrap.EnsureSpatialExtensionAsync(connection, CancellationToken.None);
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            "SELECT ST_X(pt) AS x, ST_Y(pt) AS y FROM (" +
+            "SELECT ST_Transform(ST_Point(24.94, 60.17), 'EPSG:4326', 'EPSG:3857', always_xy := true) AS pt)";
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        var x = reader.GetDouble(0);
+        var y = reader.GetDouble(1);
+
+        // Web Mercator easting is a direct scaling of longitude (never near the latitude value),
+        // which is the discriminating check that axes were not swapped.
+        Assert.InRange(x, 2_770_000.0, 2_782_000.0);
+        Assert.InRange(y, 8_430_000.0, 8_444_000.0);
+    }
+
+    [Fact]
     public async Task EnsureSpatialExtensionAsync_WithExternalSources_LoadsExtensionsAndCreatesViewsPerConnection()
     {
         var options = new DuckDBOptions

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderKnnTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderKnnTests.cs
@@ -31,4 +31,29 @@ public sealed class FeatureQueryBuilderKnnTests
         result.Sql.Should().Contain("ST_Transform(");
         result.Sql.Should().NotContain("<->");
     }
+
+    [Fact]
+    public void BuildSelectQuery_WithUnlistedGeographic4xxxKnn_UsesGeodesicOrdering()
+    {
+        // #2740/#2731: EPSG:4674 (SIRGAS 2000) is a geographic degree CRS but is not on the curated
+        // allowlist. Planar degree KNN (the <-> operator) would produce meaningless distances, so
+        // the 4000-4999 safety net must route it through the same geodesic path as 4326 (#2732).
+        var poolProvider = new DefaultObjectPoolProvider();
+        var stringBuilderPool = poolProvider.Create(new FeatureStoreStringBuilderPooledObjectPolicy());
+        var geometryProcessor = new GeometryProcessor();
+        var queryBuilder = new FeatureQueryBuilder(stringBuilderPool, geometryProcessor);
+
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 4674,
+            SpatialFilter = SpatialFilter.CreateKnnFilter(new byte[] { 1, 2, 3 }, count: 5, srid: 4674)
+        };
+
+        var result = queryBuilder.BuildSelectQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("ORDER BY ST_Distance(");
+        result.Sql.Should().Contain("::geography");
+        result.Sql.Should().Contain("ST_Transform(");
+        result.Sql.Should().NotContain("<->");
+    }
 }

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSpatialFilterParameterTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/FeatureQueryBuilderSpatialFilterParameterTests.cs
@@ -223,9 +223,76 @@ public sealed class FeatureQueryBuilderSpatialFilterParameterTests
 
         var distanceInMeters = geometryProcessor.ConvertDistanceToMeters(5, DistanceUnit.Miles);
 
-        result.WhereParameters.OfType<byte[]>().Should().ContainSingle(value => value.SequenceEqual(geometry));
+        // The WithinDistance predicate now emits an && envelope pre-filter (ST_Expand) alongside the
+        // exact ST_DWithin geography check (#2740), so the filter geometry is bound twice — once for
+        // the pre-filter geometry and once for the geography operand.
+        result.WhereParameters.OfType<byte[]>()
+            .Where(value => value.SequenceEqual(geometry)).Should().HaveCount(2);
         result.WhereParameters.Should().Contain(distanceInMeters);
         result.Sql.Should().Contain("ST_DWithin");
+        result.Sql.Should().Contain("&& ST_Expand(");
+    }
+
+    [Fact]
+    public void BuildSelectQuery_WithinDistanceGeographicStorage_EmitsEnvelopePrefilterAndExactGeography()
+    {
+        // #2740: the geodesic ST_DWithin(...::geography) predicate is not GiST-index-usable and
+        // forces a full scan. It must be paired with an && envelope pre-filter (ST_Expand) in the
+        // stored CRS. For geographic (degree) storage the expansion applies a cos(lat) correction
+        // so the east/west window never under-covers at high latitudes.
+        var poolProvider = new DefaultObjectPoolProvider();
+        var stringBuilderPool = poolProvider.Create(new FeatureStoreStringBuilderPooledObjectPolicy());
+        var geometryProcessor = new GeometryProcessor();
+        var queryBuilder = new FeatureQueryBuilder(stringBuilderPool, geometryProcessor);
+
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 4326,
+            SpatialFilter = SpatialFilter.CreateDistanceFilter(
+                [1, 2, 3, 4],
+                distance: 1000,
+                unit: DistanceUnit.Meters,
+                withinDistance: true,
+                srid: 4326)
+        };
+
+        var result = queryBuilder.BuildSelectQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("geometry && ST_Expand(");
+        result.Sql.Should().Contain("cos(radians(");
+        result.Sql.Should().Contain("ST_DWithin(");
+        result.Sql.Should().Contain("::geography");
+    }
+
+    [Fact]
+    public void BuildSelectQuery_WithinDistanceProjectedStorage_ExpandsInMetresAndReprojectsExactCheck()
+    {
+        // #2740: projected (metre) storage expands the envelope by the metre distance directly (no
+        // cos(lat) correction), while the exact geography predicate still reprojects the column to
+        // WGS84 (ST_Transform(...,4326)::geography).
+        var poolProvider = new DefaultObjectPoolProvider();
+        var stringBuilderPool = poolProvider.Create(new FeatureStoreStringBuilderPooledObjectPolicy());
+        var geometryProcessor = new GeometryProcessor();
+        var queryBuilder = new FeatureQueryBuilder(stringBuilderPool, geometryProcessor);
+
+        var query = new FeatureQuery
+        {
+            SpatialReferenceSrid = 3857,
+            SpatialFilter = SpatialFilter.CreateDistanceFilter(
+                [1, 2, 3, 4],
+                distance: 1000,
+                unit: DistanceUnit.Meters,
+                withinDistance: true,
+                srid: 3857)
+        };
+
+        var result = queryBuilder.BuildSelectQuery(layerId: 1, query);
+
+        result.Sql.Should().Contain("geometry && ST_Expand(");
+        result.Sql.Should().NotContain("cos(radians(");
+        result.Sql.Should().Contain("ST_DWithin(");
+        result.Sql.Should().Contain("ST_Transform(");
+        result.Sql.Should().Contain("::geography");
     }
 
     [Fact]

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderSqlTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/PostgresStorageMappedFeatureReaderSqlTests.cs
@@ -59,6 +59,58 @@ public sealed class PostgresStorageMappedFeatureReaderSqlTests
     }
 
     [Fact]
+    public void BuildDistancePredicateSql_WithProjectedStorage_ReprojectsBothOperandsToWgs84Geography()
+    {
+        // Projected-storage layer (EPSG:3857). A bare ::geography cast requires lon/lat and would
+        // throw at execution (500); the predicate must reproject both operands to WGS84 geography
+        // via ST_Transform(...,4326)::geography so ST_Distance returns metres (#2740).
+        // Seed the filter-geometry parameter ($1) so the distance parameter realistically becomes $2.
+        var parameters = new List<object?> { new byte[] { 1, 2, 3, 4 } };
+
+        var predicate = PostgresStorageMappedFeatureReader.BuildDistancePredicateSql(
+            geometryColumn: "\"geom\"::geometry",
+            filterGeometry: "$1",
+            storageSrid: 3857,
+            distanceInMeters: 1000d,
+            beyond: false,
+            addParameter: value =>
+            {
+                parameters.Add(value);
+                return "$" + parameters.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            });
+
+        predicate.Should().Contain("ST_Transform(\"geom\"::geometry, 4326)::geography");
+        predicate.Should().Contain("ST_Transform($1, 4326)::geography");
+        predicate.Should().StartWith("ST_Distance(");
+        predicate.Should().Contain("<= $2");
+        parameters.Last().Should().Be(1000d);
+    }
+
+    [Fact]
+    public void BuildDistancePredicateSql_WithWgs84Storage_CastsDirectlyToGeography()
+    {
+        // Geographic (EPSG:4326) storage is already lon/lat, so no ST_Transform is required —
+        // a direct ::geography cast is correct and cheaper.
+        var parameters = new List<object?>();
+
+        var predicate = PostgresStorageMappedFeatureReader.BuildDistancePredicateSql(
+            geometryColumn: "\"geom\"::geometry",
+            filterGeometry: "$1",
+            storageSrid: 4326,
+            distanceInMeters: 500d,
+            beyond: true,
+            addParameter: value =>
+            {
+                parameters.Add(value);
+                return "$" + parameters.Count.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            });
+
+        predicate.Should().Contain("\"geom\"::geometry::geography");
+        predicate.Should().NotContain("ST_Transform");
+        predicate.Should().Contain("> $1");
+    }
+
+    [Fact]
     public void BuildStatisticsAggregateExpression_WithNumericAggregate_CastsMappedSourceColumn()
     {
         var expression = PostgresStorageMappedFeatureReader.BuildStatisticsAggregateExpression(


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2731
Closes #2740
Related to #2729

## Summary
Fixes the silent distance-unit and axis-order defects in the DuckDB provider and the Postgres distance-predicate defects from the geodesy audit (#2729). DuckDB `ST_Transform` was called without `always_xy`, letting the extension apply authority axis order (lat/lon for EPSG:4326) against Honua's X=lon WKB contract; distance filters on geographic SRIDs outside the 7-code allowlist ran planar `ST_DWithin` comparing meters to degrees (whole-planet matches). On Postgres, storage-mapped distance queries cast projected-storage geometry straight to `::geography` (a 500 on every request), geodesic DWithin had no index-usable pre-filter (full scan per query), and KNN ordered unlisted geographic SRIDs by planar degrees.

## Changes Made
- DuckDB: `always_xy := true` on all `ST_Transform` calls, with axis-contract remarks; `ST_Distance_Spheroid` operands wrapped in `ST_FlipCoordinates` (DuckDB documents spheroid inputs as lat/lon-ordered)
- DuckDB distance policy: geodesic spheroid path for allowlisted geographic SRIDs; typed `NotSupportedException` for EPSG 4000-4999 SRIDs outside the allowlist (previously silent meters-as-degrees); planar path unchanged for projected metre CRSs
- Postgres storage-mapped `WithinDistance`/`BeyondDistance`: both operands through the existing `ToWgs84Geography` helper (same path KNN uses) instead of bare `::geography` casts that threw for projected storage
- Postgres `WithinDistance` adds a conservative `&&` `ST_Expand` envelope pre-filter in the stored CRS (cos-latitude corrected for geographic storage, clamped near poles; over-expansion only costs selectivity — the exact geodesic predicate decides membership). `BeyondDistance` deliberately gets no pre-filter
- Postgres KNN: unlisted EPSG 4000-4999 geographic SRIDs route through the geodesic path instead of planar degree ordering; classifier unification remains tracked by #2732
- SQL-shape regression tests for all of the above (DuckDB always_xy/flip/rejection; Postgres storage-mapped geography, pre-filter shape, KNN gate)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Honua.DuckDB.Tests: 95 passed / 0 failed. Honua.Postgres.Tests: 855 passed / 0 failed. Affected projects built Release `TreatWarningsAsErrors=true`, 0 warnings. (Full-solution validation deferred to batch CI.) Note: `always_xy` behavior is asserted at the SQL-shape level; a live DuckDB round-trip integration test is recommended follow-up per #2731.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
- DuckDB layers with EPSG 4000-4999 SRIDs outside the geodesic allowlist now reject distance filters with a clear error (previously returned silently wrong results)
- DuckDB reprojection output for geographic CRSs changes where the axis swap previously produced transposed coordinates (that output was wrong)

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
