### PR TITLE
fix(geoservices): normalize Web Mercator query aliases (#2736)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -8505,6 +8505,8 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.Query_WithReturnCentroidOnPolygonLayer_ReturnsCentroidWithoutGeometry",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.Query_WithUnknownDatumTransformationWkid_ReturnsExplicitError",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.Query_WithVerticalCoordinateSystemOutSr_ReturnsExplicitError",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.Query_WithWebMercatorAliasInSr_FiltersCanonicalWebMercatorLayer",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerSpatialReferenceTests.Query_WithWebMercatorAliasOutSr_ReturnsAliasAndCanonicalLatestWkid",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerTemporalExtentEndpointTests.Query_NonTimeAwareLayer_WithTimeNullPair_ReturnsOk",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerTemporalExtentEndpointTests.Query_NonTimeAwareLayer_WithTime_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerTemporalTests.GeoServicesQuery_CombinedTemporalAndSpatialFilter_ReturnsCorrectFeatures",

--- a/src/Honua.Core/Features/Query/QueryProcessor.cs
+++ b/src/Honua.Core/Features/Query/QueryProcessor.cs
@@ -559,8 +559,18 @@ public sealed class QueryProcessor : IQueryProcessor
         }
 
         // Convert output CRS
-        var outputSrid = query.OutputCrs?.Srid;
+        int? outputSrid = query.OutputCrs?.Srid is { } requestedOutputSrid
+            ? SpatialReferenceExtensions.NormalizeWebMercatorSrid(requestedOutputSrid)
+            : null;
         var outputAxisOrder = query.OutputCrs?.AxisOrder;
+        var spatialFilter = query.SpatialFilter;
+        if (spatialFilter is { Srid: { } filterSrid })
+        {
+            spatialFilter = spatialFilter.Value with
+            {
+                Srid = SpatialReferenceExtensions.NormalizeWebMercatorSrid(filterSrid)
+            };
+        }
 
         // Convert to FeatureQuery
         var featureQuery = new FeatureQuery
@@ -576,7 +586,7 @@ public sealed class QueryProcessor : IQueryProcessor
             PublicIdAttributeName = ResolvePublicIdAttributeName(resource),
             OutputSrid = outputSrid,
             OutputAxisOrder = outputAxisOrder,
-            SpatialFilter = query.SpatialFilter,
+            SpatialFilter = spatialFilter,
             TemporalFilter = query.TemporalFilter,
             Distinct = query.Aggregation?.Distinct ?? false
         };

--- a/src/Honua.Core/Features/Shared/Models/SpatialReferenceExtensions.cs
+++ b/src/Honua.Core/Features/Shared/Models/SpatialReferenceExtensions.cs
@@ -152,7 +152,7 @@ public static class SpatialReferenceExtensions
     /// <param name="to">Target spatial reference</param>
     /// <returns>True if transformation is needed, false if they are the same</returns>
     public static bool RequiresTransformation(this SpatialReference from, SpatialReference to)
-        => from.Wkid != to.Wkid;
+        => NormalizeWebMercatorSrid(from.Wkid) != NormalizeWebMercatorSrid(to.Wkid);
 
     /// <summary>
     /// Normalizes well-known WGS 84 / Web Mercator SRID aliases

--- a/src/Honua.Postgres/Features/FeatureStore/Services/DatumTransformSql.cs
+++ b/src/Honua.Postgres/Features/FeatureStore/Services/DatumTransformSql.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.Infrastructure.Crs;
+using Honua.Core.Features.Shared.Models;
 
 namespace Honua.Postgres.Features.FeatureStore.Services;
 
@@ -29,6 +30,8 @@ internal static class DatumTransformSql
     /// <returns>The reprojection SQL expression.</returns>
     public static string BuildTransformExpression(string operand, int toSrid, DatumTransformationSelection? selection)
     {
+        toSrid = SpatialReferenceExtensions.NormalizeWebMercatorSrid(toSrid);
+
         if (selection?.ProjPipeline is { Length: > 0 } pipeline)
         {
             // A PROJ pipeline is direction-sensitive (a +proj=hgridshift NADCON/NTv2 step

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerQueryHandler.cs
@@ -1392,6 +1392,17 @@ internal sealed partial class FeatureServerQueryHandler(
                 [CreateSpatialReferenceErrorMessage("outSR", validatedParams.OutSr)]));
         }
 
+        // Execute with the canonical SRID resolved above, but retain the client's
+        // Esri Web Mercator alias for the response envelope. ArcGIS clients expect
+        // {wkid:102100, latestWkid:3857}; providers must only see EPSG:3857.
+        int? requestedResponseOutputSrid = null;
+        if (outputSrid.HasValue
+            && SpatialReferenceHelpers.TryParseSrid(validatedParams.OutSr) is { } requestedOutputSrid
+            && SpatialReferenceExtensions.NormalizeWebMercatorSrid(requestedOutputSrid) == outputSrid.Value)
+        {
+            requestedResponseOutputSrid = requestedOutputSrid;
+        }
+
         // Vertical (geoid/ellipsoidal) datum transformations are not yet supported. When
         // outSR carries a vertical CS (vcsWkid), fail explicitly rather than silently
         // ignoring the vertical component and returning horizontally-only reprojected Z.
@@ -1602,7 +1613,7 @@ internal sealed partial class FeatureServerQueryHandler(
             query = query with { OutputDatumTransformation = datumSelection };
         }
 
-        return (query, outputSrid, null);
+        return (query, requestedResponseOutputSrid ?? outputSrid, null);
     }
 
     /// <summary>

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Models/GeoServicesSpatialReference.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Models/GeoServicesSpatialReference.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Shared.Models;
+
 namespace Honua.Protocols.GeoServices.FeatureServer.Models;
 
 /// <summary>
@@ -32,4 +34,24 @@ public sealed class GeoServicesSpatialReference
     /// Well-Known Text representation
     /// </summary>
     public string? Wkt { get; init; }
+}
+
+/// <summary>
+/// Creates GeoServices spatial-reference envelopes while retaining a requested
+/// Esri WKID and pairing it with its current canonical WKID.
+/// </summary>
+internal static class GeoServicesSpatialReferenceFactory
+{
+    /// <summary>
+    /// Creates a spatial reference for a positive requested SRID, or
+    /// <c>null</c> when no valid SRID was supplied.
+    /// </summary>
+    internal static GeoServicesSpatialReference? Create(int? requestedSrid)
+        => requestedSrid is > 0
+            ? new GeoServicesSpatialReference
+            {
+                Wkid = requestedSrid.Value,
+                LatestWkid = SpatialReferenceExtensions.NormalizeWebMercatorSrid(requestedSrid.Value)
+            }
+            : null;
 }

--- a/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/Services/QueryFormatters.cs
@@ -220,7 +220,7 @@ internal sealed class QueryFormatter : IQueryFormatter
 
         var srid = outputSrid ?? resource.ReadSrid() ?? SpatialReference.WGS84.Wkid;
         var spatialReference = hasGeometry
-            ? new GeoServicesSpatialReference { Wkid = srid, LatestWkid = srid }
+            ? GeoServicesSpatialReferenceFactory.Create(srid)
             : null;
 
         var response = new QueryResponse

--- a/src/Honua.Protocols.GeoServices/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Protocols.GeoServices/GeoServicesGeometryConverter.cs
@@ -796,9 +796,7 @@ internal static class GeoServicesGeometryConverter
     }
 
     private static GeoServicesSpatialReference? CreateSpatialReference(int? srid)
-        => srid.HasValue && srid.Value > 0
-            ? new GeoServicesSpatialReference { Wkid = srid.Value, LatestWkid = srid.Value }
-            : null;
+        => GeoServicesSpatialReferenceFactory.Create(srid);
 
     private static int ReadInt32(ReadOnlySpan<byte> span, bool littleEndian)
         => littleEndian

--- a/src/Honua.Protocols.GeoServices/Geometry/SpatialReferenceResolver.cs
+++ b/src/Honua.Protocols.GeoServices/Geometry/SpatialReferenceResolver.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
 using Honua.Protocols.GeoServices.FeatureServer.Models;
 
 namespace Honua.Infrastructure.Services;
@@ -54,9 +55,10 @@ internal class SpatialReferenceResolver
             return null;
         }
 
-        return await _crsRegistry.IsSridSupportedAsync(srid.Value, cancellationToken)
+        var canonicalSrid = SpatialReferenceExtensions.NormalizeWebMercatorSrid(srid.Value);
+        return await _crsRegistry.IsSridSupportedAsync(canonicalSrid, cancellationToken)
             .ConfigureAwait(false)
-            ? srid
+            ? canonicalSrid
             : null;
     }
 

--- a/tests/dotnet/Honua.Core.Tests/Features/Query/QueryProcessorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Query/QueryProcessorTests.cs
@@ -191,4 +191,25 @@ public sealed class QueryProcessorTests
 
         featureQuery.IncludeNullGeometry.Should().BeTrue();
     }
+
+    [Fact]
+    public void ToFeatureQuery_WebMercatorAliases_NormalizesProviderSrids()
+    {
+        var query = new UnifiedQuery
+        {
+            OutputCrs = QueryCrs.Create(102100),
+            SpatialFilter = new SpatialFilter
+            {
+                Geometry = [1, 2, 3],
+                Srid = 900913,
+                SpatialRelationship = SpatialRelationship.Intersects
+            }
+        };
+
+        var featureQuery = _processor.ToFeatureQuery(query, _resource);
+
+        featureQuery.OutputSrid.Should().Be(3857);
+        featureQuery.SpatialFilter.Should().NotBeNull();
+        featureQuery.SpatialFilter!.Value.Srid.Should().Be(3857);
+    }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/SharedModels/SpatialReferenceExtensionsTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/SharedModels/SpatialReferenceExtensionsTests.cs
@@ -35,6 +35,18 @@ public sealed class SpatialReferenceExtensionsTests
         SpatialReferenceExtensions.NormalizeWebMercatorSrid(srid).Should().Be(srid);
     }
 
+    [Theory]
+    [InlineData(102100, 3857)]
+    [InlineData(900913, 102113)]
+    [InlineData(3785, 3857)]
+    public void RequiresTransformation_WebMercatorAliasPair_ReturnsFalse(int fromSrid, int toSrid)
+    {
+        var from = SpatialReference.Create(fromSrid);
+        var to = SpatialReference.Create(toSrid);
+
+        from.RequiresTransformation(to).Should().BeFalse();
+    }
+
     // PA-024: GetAuthorityName and GetAuthorityCode must return the OGC-defined values for WKID 4326
     // (CRS84) so that WFS 2.0 / OGC API conformance URNs are formed correctly.
 

--- a/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/DatumTransformSqlTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/FeatureStore/DatumTransformSqlTests.cs
@@ -22,6 +22,18 @@ public sealed class DatumTransformSqlTests
         sql.Should().Be("ST_Transform(geom, 4326)");
     }
 
+    [Theory]
+    [InlineData(102100)]
+    [InlineData(102113)]
+    [InlineData(900913)]
+    [InlineData(3785)]
+    public void BuildTransformExpression_WebMercatorAlias_EmitsCanonicalSrid(int alias)
+    {
+        var sql = DatumTransformSql.BuildTransformExpression("geom", alias, selection: null);
+
+        sql.Should().Be("ST_Transform(geom, 3857)");
+    }
+
     [UnitTest]
     public void BuildTransformExpression_SelectionWithoutPipeline_EmitsTwoArgumentForm()
     {

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerSpatialReferenceTests.cs
@@ -81,6 +81,51 @@ public sealed class FeatureServerSpatialReferenceTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithWebMercatorAliasOutSr_ReturnsAliasAndCanonicalLatestWkid()
+    {
+        var requestUri = $"/rest/services/{SpatialReferenceTestLayerCatalog.ServiceId}/FeatureServer/{SpatialReferenceTestLayerCatalog.PointLayerId}/query" +
+                         $"?where=objectid%20%3D%20{_pointObjectId}&outSR=102100&f=json";
+
+        var response = await _fixture.Client.GetAsync(requestUri);
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, FeatureServerJsonContext.Default.QueryResponse);
+
+        result.Should().NotBeNull();
+        result!.SpatialReference.Should().NotBeNull();
+        result.SpatialReference!.Wkid.Should().Be(102100);
+        result.SpatialReference.LatestWkid.Should().Be(3857);
+        result.Features.Should().ContainSingle();
+        result.Features[0].Geometry.Should().NotBeNull();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
+    public async Task Query_WithWebMercatorAliasInSr_FiltersCanonicalWebMercatorLayer()
+    {
+        // San Francisco viewport in Web Mercator metres. ESRI:102100 is coordinate-
+        // equivalent to EPSG:3857, the storage CRS of the seeded point layer.
+        const string geometry = "-13627700,4547600,-13627600,4547750";
+        var requestUri = $"/rest/services/{SpatialReferenceTestLayerCatalog.ServiceId}/FeatureServer/{SpatialReferenceTestLayerCatalog.PointLayerId}/query" +
+                         $"?geometry={Uri.EscapeDataString(geometry)}&geometryType=esriGeometryEnvelope&inSR=102100&f=json";
+
+        var response = await _fixture.Client.GetAsync(requestUri);
+
+        response.Be200Ok();
+        var content = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize(content, FeatureServerJsonContext.Default.QueryResponse);
+
+        result.Should().NotBeNull();
+        result!.Features.Should().ContainSingle();
+        result.Features[0].Attributes.Should().ContainKey("name");
+        result.Features[0].Attributes["name"]!.ToString().Should().Be("San Francisco");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
     public async Task Query_WithGeoJsonFormat_OnProjectedLayer_ReturnsWgs84Coordinates()
     {
         var requestUri = $"/rest/services/{SpatialReferenceTestLayerCatalog.ServiceId}/FeatureServer/{SpatialReferenceTestLayerCatalog.PointLayerId}/query" +


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2736

## Summary
Accepts Esri Web Mercator WKID aliases such as `102100` throughout FeatureServer query input/output handling while keeping providers and transform SQL on canonical EPSG:3857. GeoServices responses retain the requested Esri WKID and emit the conventional `latestWkid:3857` pairing.

## Changes Made
- Normalize Web Mercator aliases before CRS registry validation.
- Canonicalize unified-query output and spatial-filter SRIDs before provider execution.
- Treat Web Mercator alias pairs as the same CRS and normalize the shared PostGIS transform target.
- Centralize GeoServices requested/canonical spatial-reference envelope creation.
- Preserve the requested `outSR` alias only at response formatting; providers receive 3857.
- Add endpoint coverage for `inSR=102100` and `outSR=102100`, plus shared Core/Postgres regression tests.
- Regenerate the evidence-based feature catalog for the new endpoint proofs.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

Validation:
- FeatureServer alias endpoint tests, Release: 2 passed.
- Core canonical-query and same-CRS tests, Release: 4 passed.
- Postgres canonical transform-SQL tests, Release: 4 passed.
- Architecture suite: 126 unaffected checks passed; after regenerating the feature catalog, the drift check passed.
- Targeted `dotnet format` completed cleanly.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

The generated feature catalog now records the two additional endpoint proofs.

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None. This is additive alias compatibility; canonical CRS behavior is unchanged.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Equivalent affected Release builds/tests, formatting, architecture checks, and generated-catalog validation were run under the shared build lock.
