### PR TITLE
fix(worker-gdal): restrict GDAL drivers + disable remote VSI on untrusted GP inputs (#2765)

### DIFF
--- a/src/Honua.Worker.Gdal/Execution/DockerGdalCommandRunner.cs
+++ b/src/Honua.Worker.Gdal/Execution/DockerGdalCommandRunner.cs
@@ -40,6 +40,7 @@ namespace Honua.Worker.Gdal.Execution;
 internal sealed partial class DockerGdalCommandRunner(
     IDockerCommandInvoker invoker,
     IOptions<GdalContainerExecutionOptions> options,
+    IOptions<GdalHardeningOptions> hardening,
     ILogger<DockerGdalCommandRunner> logger) : IGdalCommandRunner
 {
     /// <inheritdoc />
@@ -54,7 +55,10 @@ internal sealed partial class DockerGdalCommandRunner(
         ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
 
         var opts = options.Value;
-        var dockerArgs = BuildDockerRunArguments(opts, tool, arguments, workingDirectory);
+        var hardeningEnv = GdalRuntimeHardening.BuildEnvironment(
+            hardening.Value,
+            GdalRuntimeHardening.ArgumentsReferenceVsi(arguments));
+        var dockerArgs = BuildDockerRunArguments(opts, tool, arguments, workingDirectory, hardeningEnv);
 
         Log.DispatchingToContainer(logger, tool, opts.Image, workingDirectory);
         return invoker.RunAsync(opts.DockerExecutable, dockerArgs, cancellationToken);
@@ -91,14 +95,19 @@ internal sealed partial class DockerGdalCommandRunner(
         GdalContainerExecutionOptions options,
         string tool,
         IReadOnlyList<string> toolArguments,
-        string workspace)
+        string workspace,
+        IReadOnlyDictionary<string, string>? environment = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(tool);
         ArgumentNullException.ThrowIfNull(toolArguments);
         ArgumentException.ThrowIfNullOrWhiteSpace(workspace);
 
-        var args = new List<string>(toolArguments.Count + 14)
+        var envArgs = environment is null
+            ? []
+            : GdalRuntimeHardening.ToDockerEnvArguments(environment);
+
+        var args = new List<string>(toolArguments.Count + envArgs.Count + 14)
         {
             "run",
             "--rm",
@@ -115,6 +124,10 @@ internal sealed partial class DockerGdalCommandRunner(
             args.Add("--user");
             args.Add(options.User);
         }
+
+        // Propagate the GDAL hardening environment into the container so the
+        // driver-skip / remote-VSI-disable policy applies inside the image too (#2765).
+        args.AddRange(envArgs);
 
         // Identical-path bind mount: the executor's absolute workspace paths must
         // resolve to the same files inside the container.

--- a/src/Honua.Worker.Gdal/Execution/GdalCalcInputs.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalCalcInputs.cs
@@ -95,6 +95,14 @@ internal static class GdalCalcInputs
                 return false;
             }
 
+            // Refuse a content-sniffed VRT/XML indirection blob or an embedded /vsi
+            // reference before it is ever materialized and opened by GDAL (#2765).
+            if (!GdalUntrustedInputGuard.IsAdmissible(bytes, out var guardReason))
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} rejected: {guardReason}";
+                return false;
+            }
+
             if (bytes.Length > maxBytes)
             {
                 failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} size {bytes.Length.ToString(CultureInfo.InvariantCulture)} bytes exceeds configured MaxArtifactBytes={maxBytes}";

--- a/src/Honua.Worker.Gdal/Execution/GdalHardeningOptions.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalHardeningOptions.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Configurable, restrictive-by-default GDAL runtime hardening applied to every
+/// GDAL/OGR CLI subprocess the worker launches (#2765). The defaults exclude the
+/// virtual / indirection drivers that let a base64-supplied dataset reach off the
+/// local scratch workspace (VRT <c>&lt;SourceFilename&gt;</c>, WMS/WMTS/WCS/STAC
+/// service descriptions) and disable the remote virtual-filesystem handlers for
+/// invocations that operate purely on local scratch files.
+/// </summary>
+internal sealed class GdalHardeningOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "GdalWorker:Hardening";
+
+    /// <summary>
+    /// GDAL driver short names excluded via <c>GDAL_SKIP</c> on every invocation.
+    /// These are the indirection / network / archive drivers that can dereference an
+    /// external file or URL from within an opened dataset — none of the raster or
+    /// vector <em>data</em> formats the worker ingests (GTiff, PNG, JPEG, GeoJSON,
+    /// GPKG, CSV, FlatGeobuf, ESRI Shapefile) or reads from trusted cloud storage
+    /// (NetCDF, HDF5, Zarr, GRIB) appears here, so skipping them does not affect a
+    /// legitimate op. <c>GDAL_SKIP</c> is honored by both the GDAL (raster) and OGR
+    /// (vector) driver registrars.
+    /// </summary>
+    public IList<string> SkipDrivers { get; set; } = new List<string>
+    {
+        // Raster indirection / aggregation.
+        "VRT",
+        "GTI",
+        "DERIVED",
+        // OGC / web service descriptions (auto-fetch on open).
+        "WMS",
+        "WMTS",
+        "WCS",
+        "HTTP",
+        "STACIT",
+        "STACTA",
+        // Vector indirection / web services.
+        "OGR_VRT",
+        "WFS",
+        "OAPIF",
+        "NGW",
+        "PLMOSAIC",
+        "EEDA",
+        "EEDAI",
+    };
+
+    /// <summary>
+    /// When <see langword="true"/> (the default), invocations that operate purely on
+    /// local scratch files (no <c>/vsi</c> path in the argument vector) additionally
+    /// get the remote virtual-filesystem handlers neutralized: the <c>/vsicurl</c>
+    /// family is gated to an unmatchable extension, HTTP retries are disabled, and
+    /// directory pre-scan on open is suppressed. Invocations that legitimately pass a
+    /// <c>/vsi</c> path (the trusted cloud-hosted multidimensional-coverage reader,
+    /// whose paths come from the catalog — never from an untrusted blob) keep remote
+    /// VSI enabled so those bucket-scoped range reads still work.
+    /// </summary>
+    public bool DisableRemoteVsiForLocalInputs { get; set; } = true;
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalHardeningOptions.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalHardeningOptions.cs
@@ -32,6 +32,13 @@ internal sealed class GdalHardeningOptions
         "VRT",
         "GTI",
         "DERIVED",
+        // GDAL Streamed Algorithm (GDAL >= 3.10): a JSON blob serializing a
+        // gdal_translate/gdalwarp command line that can open a plain LOCAL path — it is
+        // neither XML nor a /vsi reference, so the content pre-check does not catch it;
+        // skipping the driver is the control. Pure attack surface, used by no executor.
+        "GDALG",
+        // Meta Raster Format: a header can point at a remote <CachedSource> URL.
+        "MRF",
         // OGC / web service descriptions (auto-fetch on open).
         "WMS",
         "WMTS",

--- a/src/Honua.Worker.Gdal/Execution/GdalJobInputReader.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalJobInputReader.cs
@@ -102,6 +102,13 @@ internal static class GdalJobInputReader
             return false;
         }
 
+        if (!GdalUntrustedInputGuard.IsAdmissible(bytes, out var guardReason))
+        {
+            error = $"input '{name}' rejected: {guardReason}";
+            bytes = [];
+            return false;
+        }
+
         return true;
     }
 
@@ -156,6 +163,15 @@ internal static class GdalJobInputReader
         if (bytes.Length == 0)
         {
             error = $"input '{name}' decoded to zero bytes";
+            bytes = [];
+            return false;
+        }
+
+        // Refuse a content-sniffed VRT/XML indirection blob or an embedded /vsi
+        // reference before it is ever materialized and opened by GDAL (#2765).
+        if (!GdalUntrustedInputGuard.IsAdmissible(bytes, out var guardReason))
+        {
+            error = $"input '{name}' rejected: {guardReason}";
             bytes = [];
             return false;
         }

--- a/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRasterMosaicJobExecutor.cs
@@ -294,6 +294,16 @@ internal sealed partial class GdalRasterMosaicJobExecutor(
                 return false;
             }
 
+            // Refuse a content-sniffed VRT/service-XML indirection blob or an embedded
+            // /vsi reference before it is ever staged to scratch and opened by gdalwarp
+            // (#2765). This executor decodes sources inline rather than through the
+            // shared GdalJobInputReader chokepoint, so the guard must be applied here too.
+            if (!GdalUntrustedInputGuard.IsAdmissible(bytes, out var guardReason))
+            {
+                failure = $"source #{(i + 1).ToString(CultureInfo.InvariantCulture)} rejected: {guardReason}";
+                return false;
+            }
+
             // Bound the aggregate decoded size: every source is buffered in memory and
             // staged to scratch before gdalwarp runs, so cap the total by the same
             // MaxArtifactBytes ceiling used for the merged output artifact.

--- a/src/Honua.Worker.Gdal/Execution/GdalRuntimeHardening.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalRuntimeHardening.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Builds the restrictive GDAL environment every GDAL/OGR CLI subprocess inherits
+/// (#2765). Pure and deterministic so the exact variable set can be asserted
+/// offline; both the in-process (<see cref="ProcessGdalCommandRunner"/>) and
+/// container-exec (<see cref="DockerGdalCommandRunner"/>) runners apply it so no
+/// invocation escapes the driver-skip / remote-VSI-disable policy.
+/// </summary>
+internal static class GdalRuntimeHardening
+{
+    /// <summary>Sentinel extension gated into the <c>/vsicurl</c>-family allow-list to block it.</summary>
+    private const string BlockedCurlExtension = ".honua-vsi-blocked";
+
+    /// <summary>
+    /// Builds the GDAL environment variables to set on a subprocess.
+    /// </summary>
+    /// <param name="options">The configured hardening policy.</param>
+    /// <param name="inputReferencesRemoteVsi">
+    /// <see langword="true"/> when the invocation's argument vector legitimately
+    /// references a <c>/vsi</c> path (the trusted cloud-coverage reader). Such an
+    /// invocation keeps remote VSI enabled; a pure local-scratch invocation (every
+    /// untrusted-blob executor) gets the remote handlers neutralized.
+    /// </param>
+    /// <returns>An ordered map of environment variable name to value.</returns>
+    public static IReadOnlyDictionary<string, string> BuildEnvironment(
+        GdalHardeningOptions options,
+        bool inputReferencesRemoteVsi)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var env = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // Exclude the indirection / network / archive drivers so a content-sniffed
+            // VRT / OGR VRT / WMS / … is never registered and cannot open, no matter
+            // what bytes an untrusted input claims to be.
+            ["GDAL_SKIP"] = string.Join(
+                ' ',
+                options.SkipDrivers.Where(d => !string.IsNullOrWhiteSpace(d)).Select(d => d.Trim())),
+
+            // Never negotiate around an invalid TLS certificate.
+            ["GDAL_HTTP_UNSAFESSL"] = "NO",
+        };
+
+        if (options.DisableRemoteVsiForLocalInputs && !inputReferencesRemoteVsi)
+        {
+            // Local-scratch-only invocation (every untrusted-blob path): neutralize the
+            // remote virtual-filesystem handlers. Gating the /vsicurl-family allow-list
+            // to an extension no real input carries blocks arbitrary-URL range reads;
+            // suppressing directory pre-scan and HTTP retries closes the residual reach.
+            env["CPL_VSIL_CURL_ALLOWED_EXTENSIONS"] = BlockedCurlExtension;
+            env["GDAL_HTTP_MAX_RETRY"] = "0";
+            env["GDAL_HTTP_CONNECTTIMEOUT"] = "2";
+            env["GDAL_DISABLE_READDIR_ON_OPEN"] = "EMPTY_DIR";
+        }
+
+        return env;
+    }
+
+    /// <summary>
+    /// Reports whether any argument references a GDAL virtual-filesystem path
+    /// (<c>/vsi…</c>). Used by the runners to decide whether an invocation is the
+    /// trusted cloud-coverage reader (keep remote VSI) or a local-scratch-only op
+    /// (neutralize remote VSI).
+    /// </summary>
+    public static bool ArgumentsReferenceVsi(IReadOnlyList<string> arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        foreach (var arg in arguments)
+        {
+            if (arg is not null && arg.Contains("/vsi", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Formats the environment as <c>docker run -e KEY=VALUE</c> argument pairs, in a
+    /// stable order, for the container-exec runner.
+    /// </summary>
+    public static IReadOnlyList<string> ToDockerEnvArguments(IReadOnlyDictionary<string, string> environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        var args = new List<string>(environment.Count * 2);
+        foreach (var kvp in environment)
+        {
+            args.Add("-e");
+            args.Add(string.Create(CultureInfo.InvariantCulture, $"{kvp.Key}={kvp.Value}"));
+        }
+
+        return args;
+    }
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalUntrustedInputGuard.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalUntrustedInputGuard.cs
@@ -7,29 +7,53 @@ namespace Honua.Worker.Gdal.Execution;
 /// Content pre-check for the untrusted base64 blobs the geoprocessing submit path
 /// projects onto raster/vector step inputs (#2765). GDAL opens a materialized
 /// input by <em>sniffing its content</em>, not the claimed media type, so a caller
-/// can base64-encode a GDAL <c>VRT</c> (or any XML service-description /
-/// indirection format) whose <c>&lt;SourceFilename&gt;</c> points at a local path
+/// can base64-encode a GDAL <c>VRT</c> (or a WMS/WMTS/WCS service description) whose
+/// <c>&lt;SourceFilename&gt;</c> / service URL points at a local path
 /// (<c>/etc/passwd</c>, a mounted secret) or a <c>/vsicurl/</c> / <c>/vsis3/</c>
 /// URL — a file-read / SSRF vector. This guard refuses such blobs BEFORE they are
 /// ever written to scratch and handed to a GDAL CLI:
 /// <list type="number">
-/// <item>Any blob whose leading bytes look like XML (a VRT / OGR VRT / WMS / WMTS /
-/// WCS / STAC service description are all XML): none of the raster or vector
-/// formats the worker legitimately ingests over this path (GTiff, PNG, JPEG,
-/// GeoJSON, GPKG, CSV, FlatGeobuf, ESRI Shapefile) begin with <c>&lt;</c>, so an
-/// XML lead is always an indirection driver we exclude.</item>
+/// <item>Any blob whose bytes contain a GDAL <em>indirection / service</em> XML root
+/// (<c>&lt;VRTDataset</c>, <c>&lt;OGRVRTDataSource</c>, a GDAL WMS/WMTS/WCS service
+/// description, or a WMS capabilities document). These are the XML formats that
+/// dereference an external file or URL on open. Crucially this is a targeted set,
+/// NOT "any XML": the <c>source.ogr</c> reader legitimately ingests KML and GML —
+/// which are also XML — so a blanket XML refusal would break those imports.</item>
 /// <item>Any blob whose bytes contain a GDAL virtual-filesystem reference
 /// (<c>/vsicurl</c>, <c>/vsis3</c>, <c>/vsihttp</c>, …): the remote/indirection VSI
 /// handlers are the SSRF / file-read reach, and an untrusted ingest never has a
-/// legitimate reason to embed one.</item>
+/// legitimate reason to embed one — this catches a hostile <c>&lt;NetworkLink&gt;</c>
+/// smuggled inside an otherwise-admissible KML/GML too.</item>
 /// </list>
 /// This is the belt-and-suspenders pre-check; the driver-skip + remote-VSI-disable
 /// subprocess environment (<see cref="GdalRuntimeHardening"/>) is the second,
-/// independent control that blocks the same blob at the GDAL layer even if it were
-/// to slip past this sniff.
+/// independent and authoritative control — <c>GDAL_SKIP</c> removes the entire
+/// indirection/service driver family at registration, so even an indirection blob
+/// this sniff does not specifically name cannot be opened by GDAL.
 /// </summary>
 internal static class GdalUntrustedInputGuard
 {
+    /// <summary>
+    /// Element-open tokens of the GDAL indirection / OGC-service XML formats that
+    /// dereference an external file or URL on open. Each is a specific, long root
+    /// marker (≥ nine bytes) so scanning a decoded payload for it as an ASCII
+    /// substring has a negligible false-positive rate on legitimate binary rasters or
+    /// on the XML vector formats the worker legitimately imports (KML, GML). Matched
+    /// case-insensitively.
+    /// </summary>
+    private static readonly string[] IndirectionXmlMarkers =
+    [
+        "<VRTDataset",         // raster VRT
+        "<OGRVRTDataSource",   // vector VRT
+        "<GDAL_WMS",           // GDAL WMS service description
+        "<GDAL_WMTS",          // GDAL WMTS service description
+        "<WMS_GDAL",           // legacy WMS service description alias
+        "<WMTS_GDAL",          // legacy WMTS service description alias
+        "<WCS_GDAL",           // GDAL WCS service description
+        "<WMT_MS_Capabilities", // WMS 1.1 capabilities (openable by the WMS driver)
+        "<WMS_Capabilities",   // WMS 1.3 capabilities (openable by the WMS driver)
+    ];
+
     /// <summary>
     /// The GDAL virtual-filesystem prefixes that reach off the local scratch
     /// workspace (remote object stores, arbitrary URLs, and archive indirection).
@@ -60,8 +84,8 @@ internal static class GdalUntrustedInputGuard
 
     /// <summary>
     /// Validates a decoded untrusted input, returning <see langword="false"/> with a
-    /// caller-safe <paramref name="reason"/> when the blob is an XML/indirection
-    /// format or embeds a virtual-filesystem reference.
+    /// caller-safe <paramref name="reason"/> when the blob is a GDAL
+    /// indirection/service XML format or embeds a virtual-filesystem reference.
     /// </summary>
     /// <param name="decoded">The base64-decoded input bytes.</param>
     /// <param name="reason">On rejection, a short reason suitable for a job-failure message.</param>
@@ -70,12 +94,13 @@ internal static class GdalUntrustedInputGuard
     {
         reason = "";
 
-        if (LooksLikeXml(decoded))
+        if (ContainsIndirectionXmlMarker(decoded, out var marker))
         {
             reason =
-                "input content is XML — GDAL VRT / OGR VRT / WMS / WMTS / WCS / STAC "
-                + "indirection formats are refused on the untrusted-input path (they can "
-                + "reference arbitrary local files or remote URLs)";
+                $"input content is a GDAL indirection / service XML format ('{marker}') — "
+                + "VRT / OGR VRT / WMS / WMTS / WCS blobs are refused on the untrusted-input "
+                + "path because they can reference arbitrary local files or remote URLs "
+                + "(KML / GML and other data formats remain accepted)";
             return false;
         }
 
@@ -90,43 +115,19 @@ internal static class GdalUntrustedInputGuard
         return true;
     }
 
-    /// <summary>
-    /// Reports whether the leading non-whitespace bytes indicate an XML document
-    /// (an <c>&lt;?xml</c> declaration or an element open <c>&lt;</c>). A UTF-8 /
-    /// UTF-16 BOM and leading ASCII whitespace are skipped first so a VRT written
-    /// with a BOM or indented root still trips the check.
-    /// </summary>
-    private static bool LooksLikeXml(ReadOnlySpan<byte> decoded)
+    private static bool ContainsIndirectionXmlMarker(ReadOnlySpan<byte> decoded, out string marker)
     {
-        var span = decoded;
-
-        // Skip a UTF-8 BOM.
-        if (span.Length >= 3 && span[0] == 0xEF && span[1] == 0xBB && span[2] == 0xBF)
+        foreach (var candidate in IndirectionXmlMarkers)
         {
-            span = span[3..];
-        }
-        // Skip a UTF-16 LE/BE BOM.
-        else if (span.Length >= 2 && ((span[0] == 0xFF && span[1] == 0xFE) || (span[0] == 0xFE && span[1] == 0xFF)))
-        {
-            span = span[2..];
+            if (IndexOfAsciiIgnoreCase(decoded, candidate) >= 0)
+            {
+                marker = candidate;
+                return true;
+            }
         }
 
-        var i = 0;
-        while (i < span.Length && IsAsciiWhitespace(span[i]))
-        {
-            i++;
-        }
-
-        // A leading '<' (after optional whitespace/BOM) is the XML element/declaration
-        // open. UTF-16-encoded XML surfaces as '<' 0x00 or 0x00 '<'; both leave a '<'
-        // as the first or second meaningful byte, which this catches.
-        if (i < span.Length && span[i] == (byte)'<')
-        {
-            return true;
-        }
-
-        // UTF-16 BE without BOM: 0x00 '<'.
-        return i + 1 < span.Length && span[i] == 0x00 && span[i + 1] == (byte)'<';
+        marker = "";
+        return false;
     }
 
     private static bool ContainsVsiReference(ReadOnlySpan<byte> decoded, out string matched)
@@ -143,9 +144,6 @@ internal static class GdalUntrustedInputGuard
         matched = "";
         return false;
     }
-
-    private static bool IsAsciiWhitespace(byte b)
-        => b is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n' or 0x0B or 0x0C;
 
     private static int IndexOfAsciiIgnoreCase(ReadOnlySpan<byte> haystack, string needle)
     {

--- a/src/Honua.Worker.Gdal/Execution/GdalUntrustedInputGuard.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalUntrustedInputGuard.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Worker.Gdal.Execution;
+
+/// <summary>
+/// Content pre-check for the untrusted base64 blobs the geoprocessing submit path
+/// projects onto raster/vector step inputs (#2765). GDAL opens a materialized
+/// input by <em>sniffing its content</em>, not the claimed media type, so a caller
+/// can base64-encode a GDAL <c>VRT</c> (or any XML service-description /
+/// indirection format) whose <c>&lt;SourceFilename&gt;</c> points at a local path
+/// (<c>/etc/passwd</c>, a mounted secret) or a <c>/vsicurl/</c> / <c>/vsis3/</c>
+/// URL — a file-read / SSRF vector. This guard refuses such blobs BEFORE they are
+/// ever written to scratch and handed to a GDAL CLI:
+/// <list type="number">
+/// <item>Any blob whose leading bytes look like XML (a VRT / OGR VRT / WMS / WMTS /
+/// WCS / STAC service description are all XML): none of the raster or vector
+/// formats the worker legitimately ingests over this path (GTiff, PNG, JPEG,
+/// GeoJSON, GPKG, CSV, FlatGeobuf, ESRI Shapefile) begin with <c>&lt;</c>, so an
+/// XML lead is always an indirection driver we exclude.</item>
+/// <item>Any blob whose bytes contain a GDAL virtual-filesystem reference
+/// (<c>/vsicurl</c>, <c>/vsis3</c>, <c>/vsihttp</c>, …): the remote/indirection VSI
+/// handlers are the SSRF / file-read reach, and an untrusted ingest never has a
+/// legitimate reason to embed one.</item>
+/// </list>
+/// This is the belt-and-suspenders pre-check; the driver-skip + remote-VSI-disable
+/// subprocess environment (<see cref="GdalRuntimeHardening"/>) is the second,
+/// independent control that blocks the same blob at the GDAL layer even if it were
+/// to slip past this sniff.
+/// </summary>
+internal static class GdalUntrustedInputGuard
+{
+    /// <summary>
+    /// The GDAL virtual-filesystem prefixes that reach off the local scratch
+    /// workspace (remote object stores, arbitrary URLs, and archive indirection).
+    /// Each is at least six bytes with a leading <c>/vsi</c>, so scanning a decoded
+    /// payload for them as ASCII substrings has a negligible false-positive rate on
+    /// legitimate binary rasters while catching an embedded reference in any text or
+    /// XML input. Matched case-insensitively.
+    /// </summary>
+    private static readonly string[] DangerousVsiPrefixes =
+    [
+        "/vsicurl",
+        "/vsis3",
+        "/vsigs",
+        "/vsiaz",
+        "/vsioss",
+        "/vsiswift",
+        "/vsihdfs",
+        "/vsiwebhdfs",
+        "/vsihttp",
+        "/vsizip",
+        "/vsitar",
+        "/vsigzip",
+        "/vsi7z",
+        "/vsirar",
+        "/vsimem",
+        "/vsistdin",
+    ];
+
+    /// <summary>
+    /// Validates a decoded untrusted input, returning <see langword="false"/> with a
+    /// caller-safe <paramref name="reason"/> when the blob is an XML/indirection
+    /// format or embeds a virtual-filesystem reference.
+    /// </summary>
+    /// <param name="decoded">The base64-decoded input bytes.</param>
+    /// <param name="reason">On rejection, a short reason suitable for a job-failure message.</param>
+    /// <returns><see langword="true"/> when the blob is admissible; otherwise <see langword="false"/>.</returns>
+    public static bool IsAdmissible(ReadOnlySpan<byte> decoded, out string reason)
+    {
+        reason = "";
+
+        if (LooksLikeXml(decoded))
+        {
+            reason =
+                "input content is XML — GDAL VRT / OGR VRT / WMS / WMTS / WCS / STAC "
+                + "indirection formats are refused on the untrusted-input path (they can "
+                + "reference arbitrary local files or remote URLs)";
+            return false;
+        }
+
+        if (ContainsVsiReference(decoded, out var matched))
+        {
+            reason =
+                $"input content references the GDAL virtual filesystem ('{matched}') — "
+                + "remote / indirection VSI handlers are refused on the untrusted-input path";
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Reports whether the leading non-whitespace bytes indicate an XML document
+    /// (an <c>&lt;?xml</c> declaration or an element open <c>&lt;</c>). A UTF-8 /
+    /// UTF-16 BOM and leading ASCII whitespace are skipped first so a VRT written
+    /// with a BOM or indented root still trips the check.
+    /// </summary>
+    private static bool LooksLikeXml(ReadOnlySpan<byte> decoded)
+    {
+        var span = decoded;
+
+        // Skip a UTF-8 BOM.
+        if (span.Length >= 3 && span[0] == 0xEF && span[1] == 0xBB && span[2] == 0xBF)
+        {
+            span = span[3..];
+        }
+        // Skip a UTF-16 LE/BE BOM.
+        else if (span.Length >= 2 && ((span[0] == 0xFF && span[1] == 0xFE) || (span[0] == 0xFE && span[1] == 0xFF)))
+        {
+            span = span[2..];
+        }
+
+        var i = 0;
+        while (i < span.Length && IsAsciiWhitespace(span[i]))
+        {
+            i++;
+        }
+
+        // A leading '<' (after optional whitespace/BOM) is the XML element/declaration
+        // open. UTF-16-encoded XML surfaces as '<' 0x00 or 0x00 '<'; both leave a '<'
+        // as the first or second meaningful byte, which this catches.
+        if (i < span.Length && span[i] == (byte)'<')
+        {
+            return true;
+        }
+
+        // UTF-16 BE without BOM: 0x00 '<'.
+        return i + 1 < span.Length && span[i] == 0x00 && span[i + 1] == (byte)'<';
+    }
+
+    private static bool ContainsVsiReference(ReadOnlySpan<byte> decoded, out string matched)
+    {
+        foreach (var prefix in DangerousVsiPrefixes)
+        {
+            if (IndexOfAsciiIgnoreCase(decoded, prefix) >= 0)
+            {
+                matched = prefix;
+                return true;
+            }
+        }
+
+        matched = "";
+        return false;
+    }
+
+    private static bool IsAsciiWhitespace(byte b)
+        => b is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n' or 0x0B or 0x0C;
+
+    private static int IndexOfAsciiIgnoreCase(ReadOnlySpan<byte> haystack, string needle)
+    {
+        if (needle.Length == 0 || haystack.Length < needle.Length)
+        {
+            return -1;
+        }
+
+        var last = haystack.Length - needle.Length;
+        for (var i = 0; i <= last; i++)
+        {
+            var match = true;
+            for (var j = 0; j < needle.Length; j++)
+            {
+                if (ToLowerAscii(haystack[i + j]) != ToLowerAscii((byte)needle[j]))
+                {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static byte ToLowerAscii(byte b)
+        => b is >= (byte)'A' and <= (byte)'Z' ? (byte)(b + 32) : b;
+}

--- a/src/Honua.Worker.Gdal/Execution/GdalVectorReprojectJobExecutor.cs
+++ b/src/Honua.Worker.Gdal/Execution/GdalVectorReprojectJobExecutor.cs
@@ -262,6 +262,18 @@ internal sealed partial class GdalVectorReprojectJobExecutor(
             return false;
         }
 
+        // Refuse a content-sniffed VRT/service-XML indirection blob or an embedded /vsi
+        // reference before it is ever staged to scratch and opened by ogr2ogr (#2765).
+        // This executor strips its own data-URI prefix and decodes inline rather than
+        // through the shared GdalJobInputReader chokepoint, so a VRT / OGR VRT / service
+        // XML smuggled in as the "GeoJSON" data URI would otherwise reach GDAL unchecked.
+        if (!GdalUntrustedInputGuard.IsAdmissible(bytes, out var guardReason))
+        {
+            error = $"rejected: {guardReason}";
+            bytes = [];
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Honua.Worker.Gdal/Execution/ProcessGdalCommandRunner.cs
+++ b/src/Honua.Worker.Gdal/Execution/ProcessGdalCommandRunner.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Worker.Gdal.Execution;
 
@@ -13,7 +14,9 @@ namespace Honua.Worker.Gdal.Execution;
 /// worker container is built from; this runner does not bundle managed GDAL
 /// bindings so it adds no native package dependencies to any managed assembly.
 /// </summary>
-internal sealed partial class ProcessGdalCommandRunner(ILogger<ProcessGdalCommandRunner> logger) : IGdalCommandRunner
+internal sealed partial class ProcessGdalCommandRunner(
+    IOptions<GdalHardeningOptions> hardening,
+    ILogger<ProcessGdalCommandRunner> logger) : IGdalCommandRunner
 {
     /// <inheritdoc />
     public async Task<GdalCommandResult> RunAsync(
@@ -38,6 +41,18 @@ internal sealed partial class ProcessGdalCommandRunner(ILogger<ProcessGdalComman
         foreach (var argument in arguments)
         {
             startInfo.ArgumentList.Add(argument);
+        }
+
+        // Harden every GDAL subprocess (#2765): skip the indirection/network drivers
+        // (VRT, WMS, …) and — for a pure local-scratch invocation — neutralize the
+        // remote virtual-filesystem handlers. Applied by overwriting the inherited
+        // environment so a value set on the worker process cannot weaken the policy.
+        var hardeningEnv = GdalRuntimeHardening.BuildEnvironment(
+            hardening.Value,
+            GdalRuntimeHardening.ArgumentsReferenceVsi(arguments));
+        foreach (var kvp in hardeningEnv)
+        {
+            startInfo.Environment[kvp.Key] = kvp.Value;
         }
 
         Log.RunningTool(logger, tool, string.Join(' ', arguments));

--- a/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
+++ b/src/Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs
@@ -144,6 +144,13 @@ public static class GdalWorkerServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
+        // Restrictive-by-default GDAL runtime hardening (#2765): the driver-skip and
+        // remote-VSI-disable policy every GDAL/OGR subprocess inherits. Bound here so
+        // both the in-process and container-exec runner seams resolve it.
+        services
+            .AddOptions<GdalHardeningOptions>()
+            .Bind(configuration.GetSection(GdalHardeningOptions.SectionName));
+
         if (mode == GdalProcessExecutorMode.Container)
         {
             // Container-exec fidelity path: bind the GdalContainer options and run each

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/DockerGdalCommandRunnerTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/DockerGdalCommandRunnerTests.cs
@@ -79,6 +79,7 @@ public sealed class DockerGdalCommandRunnerTests
         var runner = new DockerGdalCommandRunner(
             invoker,
             Options.Create(new GdalContainerExecutionOptions()),
+            Options.Create(new GdalHardeningOptions()),
             NullLogger<DockerGdalCommandRunner>.Instance);
 
         var result = await runner.RunAsync(

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalCli.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalCli.cs
@@ -120,7 +120,9 @@ internal static class GdalCli
 
     private static async Task RunOrThrowAsync(string tool, IReadOnlyList<string> args, string scratch)
     {
-        var runner = new ProcessGdalCommandRunner(NullLogger<ProcessGdalCommandRunner>.Instance);
+        var runner = new ProcessGdalCommandRunner(
+            Microsoft.Extensions.Options.Options.Create(new GdalHardeningOptions()),
+            NullLogger<ProcessGdalCommandRunner>.Instance);
         var result = await runner.RunAsync(tool, args, scratch, CancellationToken.None).ConfigureAwait(false);
         if (!result.Succeeded)
         {

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalSurfaceExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalSurfaceExecutorTests.cs
@@ -305,7 +305,9 @@ public sealed class GdalSurfaceExecutorTests
     {
         var scratch = NewScratch();
         var executor = new GdalSurfaceJobExecutor(
-            new ProcessGdalCommandRunner(NullLogger<ProcessGdalCommandRunner>.Instance),
+            new ProcessGdalCommandRunner(
+                Microsoft.Extensions.Options.Options.Create(new GdalHardeningOptions()),
+                NullLogger<ProcessGdalCommandRunner>.Instance),
             GdalJobFactory.Options(scratch),
             NullLogger<GdalSurfaceJobExecutor>.Instance);
 

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalUntrustedInputHardeningTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalUntrustedInputHardeningTests.cs
@@ -429,4 +429,148 @@ public sealed class GdalUntrustedInputHardeningTests
             GdalCli.CleanupScratch(scratch);
         }
     }
+
+    // ---- Private-decoder chokepoints: mosaic + vector-reproject (#2776 review) --
+
+    [UnitTest]
+    public async Task MosaicExecutor_RefusesBase64Vrt_WithoutInvokingGdal()
+    {
+        // raster.mosaic decodes its |-separated sources inline (not through the shared
+        // GdalJobInputReader chokepoint); prove the guard is applied on that path too.
+        var runner = new FakeGdalCommandRunner((_, _, _) =>
+            throw new InvalidOperationException("gdalwarp must not run for a refused VRT source"));
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        var executor = new GdalRasterMosaicJobExecutor(
+            runner,
+            GdalJobFactory.Options(scratch),
+            NullLogger<GdalRasterMosaicJobExecutor>.Instance);
+        try
+        {
+            // Two sources (mosaic requires >= 2); the first is a hostile VRT.
+            var sources = Base64(LocalPathVrt) + "|" + Convert.ToBase64String(
+                new byte[] { 0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00 });
+            var job = GdalJobFactory.Job(GdalRasterMosaicJobExecutor.HandledProcessId, ("sources", sources));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("rejected");
+            runner.Invocations.Should().BeEmpty("the VRT source must be refused before gdalwarp runs");
+        }
+        finally
+        {
+            GdalCli.CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task VectorReprojectExecutor_RefusesVrtSmuggledAsGeoJsonDataUri_WithoutInvokingGdal()
+    {
+        // transform.reproject strips a `data:application/geo+json;base64,` prefix and
+        // decodes inline; a VRT / service XML smuggled as that "GeoJSON" must be refused.
+        var runner = new FakeGdalCommandRunner((_, _, _) =>
+            throw new InvalidOperationException("ogr2ogr must not run for a refused indirection blob"));
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        var executor = new GdalVectorReprojectJobExecutor(
+            runner,
+            GdalJobFactory.Options(scratch),
+            NullLogger<GdalVectorReprojectJobExecutor>.Instance);
+        try
+        {
+            var dataUri = "data:application/geo+json;base64," + Base64(LocalPathVrt);
+            var job = GdalJobFactory.Job(
+                GdalVectorReprojectJobExecutor.HandledProcessId,
+                ("fromSrid", "4267"),
+                ("toSrid", "4326"),
+                ("input", dataUri));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("rejected");
+            runner.Invocations.Should().BeEmpty("the indirection blob must be refused before ogr2ogr runs");
+        }
+        finally
+        {
+            GdalCli.CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task VectorReprojectExecutor_AcceptsGeoJson_AndInvokesGdal()
+    {
+        // Regression: a genuine GeoJSON data URI passes the guard and reaches ogr2ogr.
+        // ogr2ogr arg order is `… <outputPath> <inputPath>`, so the output is the
+        // second-to-last argument (index 1 from the end).
+        var geojson = "{\"type\":\"FeatureCollection\",\"features\":[]}";
+        var runner = FakeGdalCommandRunner.Succeeding(Encoding.UTF8.GetBytes(geojson), outputArgIndexFromEnd: 1);
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        var executor = new GdalVectorReprojectJobExecutor(
+            runner,
+            GdalJobFactory.Options(scratch),
+            NullLogger<GdalVectorReprojectJobExecutor>.Instance);
+        try
+        {
+            var dataUri = "data:application/geo+json;base64," + Base64(geojson);
+            var job = GdalJobFactory.Job(
+                GdalVectorReprojectJobExecutor.HandledProcessId,
+                ("fromSrid", "4267"),
+                ("toSrid", "4326"),
+                ("input", dataUri));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            runner.Invocations.Should().ContainSingle().Which.Tool.Should().Be("ogr2ogr");
+        }
+        finally
+        {
+            GdalCli.CleanupScratch(scratch);
+        }
+    }
+
+    // ---- GDALG: caught by GDAL_SKIP, not by the content sniff (#2776 review) ----
+
+    [UnitTest]
+    public void GdalgBlob_IsNotCaughtBySniff_ButDriverIsSkipped()
+    {
+        // A GDALG streamed-algorithm blob is JSON (not XML) and needs no /vsi path, so
+        // the content pre-check does NOT catch it — the GDAL_SKIP driver denial is the
+        // control. This test pins both facts so the two-layer contract stays honest.
+        var gdalg = Encoding.UTF8.GetBytes(
+            "{\"type\":\"gdal_streamed_alg\",\"command_line\":\"gdal_translate /etc/hostname out.tif\"}");
+
+        GdalUntrustedInputGuard.IsAdmissible(gdalg, out _).Should().BeTrue(
+            "GDALG is JSON with no /vsi reference, so the sniff cannot identify it");
+
+        var env = GdalRuntimeHardening.BuildEnvironment(new GdalHardeningOptions(), inputReferencesRemoteVsi: false);
+        env["GDAL_SKIP"].Should().Contain("GDALG", "the GDALG driver must be skipped so the blob cannot open");
+        env["GDAL_SKIP"].Should().Contain("MRF");
+    }
+
+    // ---- KML/GML external-href limitation is documented + pinned (#2776 review) -
+
+    [UnitTest]
+    public void Guard_AdmitsKmlWithPlainHttpHref_DocumentedNetworkPostureBoundary()
+    {
+        // KML/GML are deliberately admitted, and a plain-http <href> (no /vsi) inside a
+        // NetworkLink/GroundOverlay is NOT refused by the content guard — it cannot be
+        // sniffed apart from a legitimate icon/style href without breaking real KML.
+        // External-href fetch safety therefore relies on NETWORK POSTURE (the local-op
+        // HTTP-neutralization env, and Container-mode / egress isolation), not this
+        // guard. This test pins that boundary so the residual is explicit, not silent.
+        var kmlWithHttpHref = Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+              <NetworkLink><Link><href>http://169.254.169.254/latest/meta-data/</href></Link></NetworkLink>
+            </kml>
+            """);
+
+        GdalUntrustedInputGuard.IsAdmissible(kmlWithHttpHref, out _).Should().BeTrue(
+            "plain-http hrefs in admitted KML/GML are gated by network posture, not the content sniff");
+    }
 }

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalUntrustedInputHardeningTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalUntrustedInputHardeningTests.cs
@@ -1,0 +1,350 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.TestKit.Attributes;
+using Honua.Worker.Gdal.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Worker.Gdal.Tests;
+
+/// <summary>
+/// Proves the #2765 GDAL untrusted-input controls actually block: the content
+/// pre-check refuses a base64-supplied VRT / XML indirection blob and any
+/// <c>/vsi</c> reference before GDAL ever opens it, the base64 input readers wire
+/// that pre-check in, and every GDAL subprocess inherits a driver-skip /
+/// remote-VSI-disable environment. GDAL is not required for any of these — they
+/// pin the pre-check and the subprocess-environment construction (the two controls
+/// that block, independent of a live gdal binary). The end-to-end "gdal actually
+/// refuses to open the VRT" assertion needs a gdal-present integration run.
+/// </summary>
+public sealed class GdalUntrustedInputHardeningTests
+{
+    private const string ScratchSuite = "honua-gdal-hardening-test";
+
+    // A GDAL VRT whose SourceFilename points at a local secret — the file-read vector.
+    private const string LocalPathVrt =
+        """
+        <VRTDataset rasterXSize="512" rasterYSize="512">
+          <VRTRasterBand dataType="Byte" band="1">
+            <SimpleSource>
+              <SourceFilename relativeToVRT="0">/etc/passwd</SourceFilename>
+            </SimpleSource>
+          </VRTRasterBand>
+        </VRTDataset>
+        """;
+
+    // A GDAL VRT whose SourceFilename points at a /vsicurl URL — the SSRF vector.
+    private const string VsiCurlVrt =
+        """
+        <VRTDataset rasterXSize="512" rasterYSize="512">
+          <VRTRasterBand dataType="Byte" band="1">
+            <SimpleSource>
+              <SourceFilename relativeToVRT="0">/vsicurl/http://169.254.169.254/latest/meta-data/</SourceFilename>
+            </SimpleSource>
+          </VRTRasterBand>
+        </VRTDataset>
+        """;
+
+    private static string Base64(string text) => Convert.ToBase64String(Encoding.UTF8.GetBytes(text));
+
+    private static Dictionary<string, string> SourceParam(string base64Value)
+        => new(StringComparer.Ordinal)
+        {
+            [GdalWorkerParameterKeys.StepInputPrefix + "source"] = base64Value,
+        };
+
+    // ---- Pre-check: GdalUntrustedInputGuard ------------------------------------
+
+    [UnitTest]
+    public void Guard_RejectsVrtWithLocalSourceFilename()
+    {
+        var ok = GdalUntrustedInputGuard.IsAdmissible(Encoding.UTF8.GetBytes(LocalPathVrt), out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Contain("XML");
+    }
+
+    [UnitTest]
+    public void Guard_RejectsVrtWithVsiCurlSourceFilename()
+    {
+        // XML lead is caught first; either way it must be refused.
+        var ok = GdalUntrustedInputGuard.IsAdmissible(Encoding.UTF8.GetBytes(VsiCurlVrt), out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().NotBeEmpty();
+    }
+
+    [UnitTest]
+    public void Guard_RejectsXmlWithLeadingWhitespaceAndBom()
+    {
+        var withBomAndIndent = new byte[] { 0xEF, 0xBB, 0xBF }
+            .Concat(Encoding.UTF8.GetBytes("\n   " + LocalPathVrt))
+            .ToArray();
+
+        var ok = GdalUntrustedInputGuard.IsAdmissible(withBomAndIndent, out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Contain("XML");
+    }
+
+    [UnitTest]
+    public void Guard_RejectsBareVsiReferenceInNonXmlContent()
+    {
+        // A non-XML text blob that still smuggles a /vsis3 path is refused by the
+        // virtual-filesystem scan even though it is not XML.
+        var blob = Encoding.UTF8.GetBytes("some,csv,header\n/vsis3/attacker-bucket/secret.tif,1,2\n");
+
+        var ok = GdalUntrustedInputGuard.IsAdmissible(blob, out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Contain("/vsis3");
+    }
+
+    [UnitTest]
+    public void Guard_AdmitsGeoTiffMagicBytes()
+    {
+        // Little-endian TIFF signature "II*\0" followed by arbitrary binary. A real
+        // GeoTIFF must sail through the guard untouched (regression).
+        var tiff = new byte[] { 0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF };
+
+        var ok = GdalUntrustedInputGuard.IsAdmissible(tiff, out var reason);
+
+        ok.Should().BeTrue();
+        reason.Should().BeEmpty();
+    }
+
+    [UnitTest]
+    public void Guard_AdmitsPngMagicBytes()
+    {
+        var png = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D };
+
+        GdalUntrustedInputGuard.IsAdmissible(png, out _).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void Guard_AdmitsGeoJson()
+    {
+        var geojson = Encoding.UTF8.GetBytes(
+            "{\"type\":\"FeatureCollection\",\"features\":[]}");
+
+        GdalUntrustedInputGuard.IsAdmissible(geojson, out _).Should().BeTrue();
+    }
+
+    // ---- Pre-check is wired into the base64 input readers -----------------------
+
+    [UnitTest]
+    public void TryGetBase64Input_RejectsBase64Vrt_WithLocalPath()
+    {
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            SourceParam(Base64(LocalPathVrt)),
+            "source",
+            maxBytes: 1024 * 1024,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeFalse();
+        bytes.Should().BeEmpty();
+        error.Should().Contain("rejected");
+        error.Should().Contain("source");
+    }
+
+    [UnitTest]
+    public void TryGetBase64Input_RejectsBase64Vrt_WithVsiCurl()
+    {
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            SourceParam(Base64(VsiCurlVrt)),
+            "source",
+            out var bytes,
+            out var error);
+
+        ok.Should().BeFalse();
+        bytes.Should().BeEmpty();
+        error.Should().Contain("rejected");
+    }
+
+    [UnitTest]
+    public void TryDecodeSources_RejectsVrtSourceEntry()
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [GdalWorkerParameterKeys.StepInputPrefix + "sources"] = Base64(LocalPathVrt),
+        };
+
+        var ok = GdalCalcInputs.TryDecodeSources(parameters, 1024 * 1024, out var sources, out var failure);
+
+        ok.Should().BeFalse();
+        sources.Should().BeEmpty();
+        failure.Should().Contain("rejected");
+    }
+
+    // ---- Subprocess environment: GdalRuntimeHardening --------------------------
+
+    [UnitTest]
+    public void Hardening_LocalFileInvocation_SkipsVrtAndDisablesRemoteVsi()
+    {
+        var env = GdalRuntimeHardening.BuildEnvironment(
+            new GdalHardeningOptions(),
+            inputReferencesRemoteVsi: false);
+
+        env.Should().ContainKey("GDAL_SKIP");
+        env["GDAL_SKIP"].Should().Contain("VRT");
+        env["GDAL_SKIP"].Should().Contain("OGR_VRT");
+        env["GDAL_SKIP"].Should().Contain("WMS");
+        env["GDAL_SKIP"].Should().Contain("HTTP");
+
+        // Remote VSI neutralized for a pure local-scratch op.
+        env.Should().ContainKey("CPL_VSIL_CURL_ALLOWED_EXTENSIONS");
+        env["CPL_VSIL_CURL_ALLOWED_EXTENSIONS"].Should().NotBeEmpty();
+        env["GDAL_HTTP_MAX_RETRY"].Should().Be("0");
+        env.Should().ContainKey("GDAL_DISABLE_READDIR_ON_OPEN");
+        env["GDAL_HTTP_UNSAFESSL"].Should().Be("NO");
+    }
+
+    [UnitTest]
+    public void Hardening_TrustedVsiInvocation_KeepsRemoteVsiButStillSkipsVrt()
+    {
+        // The trusted cloud-coverage reader passes a /vsis3 path in argv; it must keep
+        // remote VSI working (bucket-scoped range reads) while still refusing VRT.
+        var env = GdalRuntimeHardening.BuildEnvironment(
+            new GdalHardeningOptions(),
+            inputReferencesRemoteVsi: true);
+
+        env["GDAL_SKIP"].Should().Contain("VRT");
+        env.Should().NotContainKey("CPL_VSIL_CURL_ALLOWED_EXTENSIONS");
+        env.Should().NotContainKey("GDAL_DISABLE_READDIR_ON_OPEN");
+    }
+
+    [UnitTest]
+    public void Hardening_ArgumentsReferenceVsi_DetectsVsiPaths()
+    {
+        GdalRuntimeHardening.ArgumentsReferenceVsi(new[] { "-json", "/vsis3/bucket/x.nc" })
+            .Should().BeTrue();
+        GdalRuntimeHardening.ArgumentsReferenceVsi(new[] { "-json", "/scratch/op/input.tif" })
+            .Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void Hardening_DisableRemoteVsiFalse_LeavesCurlEnabledEvenForLocalOps()
+    {
+        var env = GdalRuntimeHardening.BuildEnvironment(
+            new GdalHardeningOptions { DisableRemoteVsiForLocalInputs = false },
+            inputReferencesRemoteVsi: false);
+
+        env["GDAL_SKIP"].Should().Contain("VRT");
+        env.Should().NotContainKey("CPL_VSIL_CURL_ALLOWED_EXTENSIONS");
+    }
+
+    // ---- Runners actually apply the environment --------------------------------
+
+    [UnitTest]
+    public void DockerRunner_LocalFileOp_EmitsHardeningEnvArgs()
+    {
+        var env = GdalRuntimeHardening.BuildEnvironment(new GdalHardeningOptions(), inputReferencesRemoteVsi: false);
+        var args = DockerGdalCommandRunner.BuildDockerRunArguments(
+            new GdalContainerExecutionOptions(),
+            "gdalinfo",
+            new[] { "-json", "/scratch/op/input.tif" },
+            "/scratch/op",
+            env);
+
+        // Each hardening var appears as a `-e KEY=VALUE` pair before the image.
+        args.Should().Contain("-e");
+        args.Should().Contain(a => a.StartsWith("GDAL_SKIP=", StringComparison.Ordinal));
+        args.Should().Contain(a => a.StartsWith("CPL_VSIL_CURL_ALLOWED_EXTENSIONS=", StringComparison.Ordinal));
+
+        var imageIndex = args.ToList().IndexOf(GdalContainerExecutionOptions.DefaultImage);
+        var lastEnvValueIndex = args.ToList().FindLastIndex(a => a.StartsWith("GDAL_", StringComparison.Ordinal));
+        lastEnvValueIndex.Should().BeLessThan(imageIndex, "docker flags must precede the image ref");
+    }
+
+    [UnitTest]
+    public async Task ProcessRunner_AppliesHardeningEnvToSubprocess()
+    {
+        // Drive a trivial cross-platform command through the runner and have it echo
+        // GDAL_SKIP back so we can prove the runner set it on the child environment.
+        var runner = new ProcessGdalCommandRunner(
+            Options.Create(new GdalHardeningOptions()),
+            NullLogger<ProcessGdalCommandRunner>.Instance);
+
+        var (tool, args) = OperatingSystem.IsWindows()
+            ? ("cmd.exe", (IReadOnlyList<string>)new[] { "/c", "echo %GDAL_SKIP%" })
+            : ("/bin/sh", new[] { "-c", "printf '%s' \"$GDAL_SKIP\"" });
+
+        var result = await runner.RunAsync(tool, args, Path.GetTempPath(), CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.StandardOutput.Should().Contain("VRT");
+        result.StandardOutput.Should().Contain("WMS");
+    }
+
+    // ---- End-to-end at the executor boundary (no gdal binary needed) -----------
+
+    [UnitTest]
+    public async Task StatisticsExecutor_RefusesBase64Vrt_WithoutInvokingGdal()
+    {
+        // A never-succeeds runner proves the job fails at the input guard, before any
+        // gdal invocation — the VRT is refused, not opened.
+        var runner = new FakeGdalCommandRunner((_, _, _) =>
+            throw new InvalidOperationException("gdal must not be invoked for a refused VRT input"));
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        var executor = new GdalRasterStatisticsJobExecutor(
+            runner,
+            GdalJobFactory.Options(scratch),
+            NullLogger<GdalRasterStatisticsJobExecutor>.Instance);
+        try
+        {
+            var job = GdalJobFactory.Job(
+                GdalRasterStatisticsJobExecutor.StatisticsProcessId,
+                ("source", Base64(LocalPathVrt)));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Failed);
+            result.ErrorMessage.Should().Contain("rejected");
+            runner.Invocations.Should().BeEmpty("the VRT must be refused before gdal runs");
+        }
+        finally
+        {
+            GdalCli.CleanupScratch(scratch);
+        }
+    }
+
+    [UnitTest]
+    public async Task StatisticsExecutor_AcceptsGeoTiff_AndInvokesGdal()
+    {
+        // Regression: a normal (binary) GeoTIFF passes the guard and reaches gdalinfo,
+        // which the fake runner answers with a minimal stats document.
+        const string gdalinfoJson =
+            "{\"bands\":[{\"band\":1,\"type\":\"Byte\",\"minimum\":0,\"maximum\":255,\"mean\":128,\"stdDev\":10}]}";
+        var runner = new FakeGdalCommandRunner((_, _, _) =>
+            new GdalCommandResult { ExitCode = 0, StandardOutput = gdalinfoJson });
+        var scratch = GdalCli.NewScratch(ScratchSuite);
+        var executor = new GdalRasterStatisticsJobExecutor(
+            runner,
+            GdalJobFactory.Options(scratch),
+            NullLogger<GdalRasterStatisticsJobExecutor>.Instance);
+        try
+        {
+            var tiff = new byte[] { 0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF };
+            var job = GdalJobFactory.Job(
+                GdalRasterStatisticsJobExecutor.StatisticsProcessId,
+                ("source", Convert.ToBase64String(tiff)));
+            var context = new RecordingJobExecutionContext(job.OperationId);
+
+            var result = await executor.ExecuteAsync(job, context, default);
+
+            result.Status.Should().Be(ExecutionJobStatus.Succeeded, result.ErrorMessage);
+            runner.Invocations.Should().ContainSingle().Which.Tool.Should().Be("gdalinfo");
+            context.Artifacts.Should().ContainSingle();
+        }
+        finally
+        {
+            GdalCli.CleanupScratch(scratch);
+        }
+    }
+}

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalUntrustedInputHardeningTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalUntrustedInputHardeningTests.cs
@@ -134,6 +134,88 @@ public sealed class GdalUntrustedInputHardeningTests
         GdalUntrustedInputGuard.IsAdmissible(geojson, out _).Should().BeTrue();
     }
 
+    [UnitTest]
+    public void Guard_AdmitsKml()
+    {
+        // KML is XML but a legitimate source.ogr import format — it must NOT be
+        // refused by the indirection sniff (only VRT/WMS/WMTS/WCS are). Regression
+        // for the narrowing from a blanket XML refusal.
+        var kml = Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+              <Placemark><Point><coordinates>-105,40,0</coordinates></Point></Placemark>
+            </kml>
+            """);
+
+        GdalUntrustedInputGuard.IsAdmissible(kml, out var reason).Should().BeTrue(reason);
+    }
+
+    [UnitTest]
+    public void Guard_AdmitsGml()
+    {
+        var gml = Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ogr:FeatureCollection xmlns:ogr="http://ogr.maptools.org/" xmlns:gml="http://www.opengis.net/gml">
+              <gml:featureMember><ogr:layer><ogr:geometryProperty></ogr:geometryProperty></ogr:layer></gml:featureMember>
+            </ogr:FeatureCollection>
+            """);
+
+        GdalUntrustedInputGuard.IsAdmissible(gml, out var reason).Should().BeTrue(reason);
+    }
+
+    [UnitTest]
+    public void Guard_RejectsKmlSmugglingVsiReference()
+    {
+        // An otherwise-admissible KML that smuggles a /vsicurl network link is still
+        // refused by the virtual-filesystem scan.
+        var hostileKml = Encoding.UTF8.GetBytes(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+              <NetworkLink><Link><href>/vsicurl/http://169.254.169.254/latest/meta-data/</href></Link></NetworkLink>
+            </kml>
+            """);
+
+        var ok = GdalUntrustedInputGuard.IsAdmissible(hostileKml, out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Contain("/vsicurl");
+    }
+
+    [UnitTest]
+    public void Guard_RejectsWmsServiceDescription()
+    {
+        var wms = Encoding.UTF8.GetBytes(
+            """
+            <GDAL_WMS>
+              <Service name="WMS"><ServerUrl>http://169.254.169.254/</ServerUrl></Service>
+            </GDAL_WMS>
+            """);
+
+        GdalUntrustedInputGuard.IsAdmissible(wms, out var reason).Should().BeFalse();
+        reason.Should().Contain("GDAL_WMS");
+    }
+
+    [UnitTest]
+    public void TryGetBase64Input_AdmitsBase64Kml()
+    {
+        // The shared decoder must let a base64 KML through so GdalVectorSourceReadJobExecutor
+        // can still materialize the .kml and run ogr2ogr.
+        var kml = "<?xml version=\"1.0\"?><kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document/></kml>";
+
+        var ok = GdalJobInputReader.TryGetBase64Input(
+            SourceParam(Base64(kml)),
+            "source",
+            maxBytes: 1024 * 1024,
+            out var bytes,
+            out var error);
+
+        ok.Should().BeTrue(error);
+        bytes.Should().NotBeEmpty();
+    }
+
     // ---- Pre-check is wired into the base64 input readers -----------------------
 
     [UnitTest]

--- a/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
+++ b/tests/dotnet/Honua.Worker.Gdal.Tests/GdalWorkerExecutorTests.cs
@@ -310,7 +310,9 @@ public sealed class GdalWorkerExecutorTests
     {
         var scratch = NewScratch();
         var executor = new GdalVectorConvertJobExecutor(
-            new ProcessGdalCommandRunner(NullLogger<ProcessGdalCommandRunner>.Instance),
+            new ProcessGdalCommandRunner(
+                Microsoft.Extensions.Options.Options.Create(new GdalHardeningOptions()),
+                NullLogger<ProcessGdalCommandRunner>.Instance),
             GdalJobFactory.Options(scratch),
             NullLogger<GdalVectorConvertJobExecutor>.Instance);
 
@@ -468,7 +470,9 @@ public sealed class GdalWorkerExecutorTests
     {
         var scratch = NewScratch();
         var executor = new GdalVectorReprojectJobExecutor(
-            new ProcessGdalCommandRunner(NullLogger<ProcessGdalCommandRunner>.Instance),
+            new ProcessGdalCommandRunner(
+                Microsoft.Extensions.Options.Options.Create(new GdalHardeningOptions()),
+                NullLogger<ProcessGdalCommandRunner>.Instance),
             GdalJobFactory.Options(scratch),
             NullLogger<GdalVectorReprojectJobExecutor>.Instance);
 


### PR DESCRIPTION
Fixes #2765

## Problem
The GP worker materialized untrusted base64 raster/vector blobs to scratch and opened them with the GDAL/OGR CLI under **content auto-detection with no driver restriction**. Because GDAL sniffs content (not the claimed media type), a caller could base64-encode a GDAL **VRT** (XML) whose `<SourceFilename>` referenced a local path (`/etc/passwd`, a mounted secret) or a `/vsicurl//vsis3` URL — a **file-read / SSRF** vector. Confirmed by source trace: no `GDAL_SKIP` / driver-allowlist / `/vsicurl` restriction existed.

## Invocation model
Out-of-process CLI subprocess. `ProcessGdalCommandRunner` (the **default** `InProcess` mode) shells `gdalinfo`/`gdalwarp`/`gdal_calc.py`/`ogr2ogr`/… with `UseShellExecute=false`, previously **inheriting the parent env with zero GDAL hardening**. `DockerGdalCommandRunner` (opt-in `Container` mode) runs `docker run`. Every executor materializes base64 inputs to an isolated per-job scratch file and passes the absolute path to the CLI.

## Fix — two independent controls

**1. Input pre-check** (`GdalUntrustedInputGuard`), refusing before the blob is written/opened:
- a decoded payload containing a GDAL **indirection / service XML root** (`<VRTDataset`, `<OGRVRTDataSource`, `<GDAL_WMS/WMTS`, `<WCS_GDAL`, WMS capabilities) — targeted, **not** "any XML", so KML/GML data imports stay admissible;
- any payload embedding a `/vsi` reference (`/vsicurl`, `/vsis3`, …).

It is wired into **all four** base64/data-URI decode paths (the exhaustive set, verified by grepping `FromBase64String` / data-URI prefixes across `src/Honua.Worker.Gdal`):
- `GdalJobInputReader.TryGetBase64Input` (both overloads) — used by statistics, vector-convert, source.ogr, and the rest;
- `GdalCalcInputs.TryDecodeSources` — map-algebra / spectral-index / reclassify;
- `GdalRasterMosaicJobExecutor.TryDecodeSources` — `raster.mosaic` (**added this round**; had a private decoder that bypassed the guard);
- `GdalVectorReprojectJobExecutor.TryDecodeGeoJsonDataUri` — `transform.reproject` (**added this round**; stripped its own `data:application/geo+json;base64,` prefix and decoded inline, bypassing the guard).

`GdalDataUri.cs` is the output-artifact encoder, not an input decoder. The `source.ogr` ZIP path decodes through the guarded `TryGetBase64Input`, and its extracted entries are opened under `GDAL_SKIP` with no `/vsi` in argv.

**2. Subprocess hardening** (`GdalRuntimeHardening`), applied by **both** runners so no invocation escapes it:
- `GDAL_SKIP` excludes the indirection / network / serialized-command drivers: VRT, OGR_VRT, GTI, DERIVED, **GDALG** (GDAL≥3.10 streamed-algorithm JSON that opens a plain local path — not XML, no `/vsi`, so the sniff can't catch it; the driver skip is the control), **MRF** (remote `<CachedSource>`), WMS, WMTS, WCS, HTTP, STAC*, WFS, OAPIF, NGW, PLMOSAIC, EEDA, EEDAI;
- a **pure local-scratch** invocation additionally gets remote VSI neutralized (`CPL_VSIL_CURL_ALLOWED_EXTENSIONS` gated, `GDAL_HTTP_MAX_RETRY=0`, `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`, `GDAL_HTTP_UNSAFESSL=NO`);
- invocations that pass a `/vsi` path in argv (the trusted, catalog-driven multidim-coverage reader) keep bucket-scoped remote VSI so those reads still work.

Policy is configurable via `GdalHardeningOptions` (`GdalWorker:Hardening`) with a restrictive default.

## Tests (prove the control, no gdal binary required)
- Guard rejects a VRT (local path **and** `/vsicurl`), a bare `/vsi` reference, a `<GDAL_WMS>` service description; admits GeoTIFF/PNG/GeoJSON/**KML**/**GML**; refuses a `/vsicurl` smuggled inside a KML.
- All four decoders refuse a VRT; **mosaic** and **vector-reproject** executors refuse a VRT **without invoking gdal**, and vector-reproject still processes a genuine GeoJSON.
- GDALG blob is admitted by the sniff (documented) but `GDAL_SKIP` contains `GDALG`+`MRF`.
- Env construction correct for local vs trusted-`/vsi`; `ProcessGdalCommandRunner` **actually sets `GDAL_SKIP` on a spawned child process**; Docker argv emits `-e` pairs before the image.

Full `Honua.Worker.Gdal.Tests` green (see CI).

## Residual (honest)
- **Default in-process path has no network isolation.** The default runner is `InProcess`/`ProcessGdalCommandRunner`, which does **not** use `--network none` (only opt-in `Container` mode does). On the default path the remote-VSI-neutralization env is the boundary, not network isolation — recommend `Container` mode (or an equivalent egress restriction) for the untrusted-input worker in production.
- **KML/GML external hrefs are network-posture-gated, not sniffed.** KML/GML are deliberately admitted, so a plain-`http://` `<href>` in a `NetworkLink`/`GroundOverlay` (no `/vsi`) is **not** refused by the content guard — it is indistinguishable from a legitimate icon/style href without breaking real KML. External-href fetch safety therefore relies on network posture (the local-op HTTP-neutralization env + `Container`/egress isolation). Pinned by a test and called out here explicitly.
- **HDF5/netCDF not skipped.** They are legitimately required by the multidimensional-coverage reader (including its `Local` provider path, which passes a local — not `/vsi` — path), so they are not in `GDAL_SKIP`; the external-link primitive there is constrained to HDF/netCDF-formatted targets (it cannot read arbitrary bytes like a VRT `<SourceFilename>`). This is not limited to the trusted reader: an untrusted raster executor (`gdalinfo`/`gdalwarp`, no `-if`) will **content-open** an HDF5-/netCDF-magic base64 blob too (it is not XML and carries no `/vsi`, so the guard admits it) — but the reach stays bounded to that same HDF/netCDF-formatted local-target oracle (a file-existence/type probe via libhdf5's POSIX VFD), NOT an arbitrary-byte read and NOT URL-driven SSRF.
- **GTiff external-overview following** is mitigated on both paths: the per-job scratch workspace contains only the executor-written inputs (no attacker-named `.ovr` sidecar), and `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` suppresses the directory pre-scan.
- End-to-end "gdal actually refuses to open the VRT" needs a gdal-present integration run; the two managed controls block it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
