### PR TITLE
fix(ci): keep gh workflow run URL out of the captured train gate value

### DIFF
--- a/scripts/ci/merge-train/smart-ci.sh
+++ b/scripts/ci/merge-train/smart-ci.sh
@@ -43,9 +43,13 @@ train_smart_ci_run() {
     return 0
   fi
 
-  # Live: push the branch and dispatch CI.
+  # Live: push the branch and dispatch CI. This function's stdout IS the gate
+  # value the caller captures (`gate="$(train_smart_ci_run ...)"`), and newer
+  # gh releases print the created run's URL on stdout — route it to stderr or
+  # the gate becomes "<url>\nSUCCESS", which matches neither SUCCESS nor
+  # FAILURE and fail-closes every live batch.
   git -C "${TRAIN_REPO_ROOT}" push "${TRAIN_REMOTE}" "${batch}:${batch}"
-  gh workflow run ci.yml --ref "${batch}"
+  gh workflow run ci.yml --ref "${batch}" 1>&2
 
   # Find the dispatched run id (most recent ci.yml run on this ref).
   local run_id=""


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2755

## Summary
Every live merge-train dispatch fails closed with "CI Gate/run is <url>\nSUCCESS with incomplete or unusable jobs" — even when the batch CI is fully green (e.g. run 29187420422: 66 success / 10 skipped jobs, all 54 selected shards succeeded exactly once). Root cause: newer `gh` releases print the created run's URL on stdout for `gh workflow run`, and `train_smart_ci_run`'s stdout is captured as the gate value, so the gate becomes `"<url>\nSUCCESS"` and string-matches neither `SUCCESS` nor `FAILURE`. The train then takes the incomplete/unusable fail-closed branch on every batch, which is why the PR queue stopped draining (three consecutive live dispatches on 2026-07-12 all stopped this way).

## Changes Made
- Redirect `gh workflow run ci.yml --ref <batch>` stdout to stderr inside `train_smart_ci_run` so the dispatch URL stays visible in the job log but out of the captured gate value.
- Document the capture hazard at the call site.

## Breaking Changes
None

## Gate Impact
- [x] No gate-tier changes (fixes the existing gate evaluation; no new jobs or checks)

## Testing
- [x] Ran scripts/ci/merge-train/fixtures/validate-merge-train.sh — 151 passed, 0 failed
- [x] Verified against live evidence: train runs 29181971623 / 29186144514 / 29187397643 all logged `CI Gate/run is <url>\n<CONCLUSION> with incomplete or unusable jobs`, and batch CI 29187420422 is green with all selected shards classifiable — only the polluted capture explains the fail-closed outcome.
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed (shell-only change; validated via the merge-train fixture suite above — no .NET surface touched)
