### PR TITLE
docs: scope README CI badge to trunk runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Honua Server
 
-[![CI](https://github.com/honua-io/honua-server/actions/workflows/ci.yml/badge.svg)](https://github.com/honua-io/honua-server/actions/workflows/ci.yml)
+[![CI](https://github.com/honua-io/honua-server/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-server/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/honua-io/honua-server/actions/workflows/codeql.yml/badge.svg)](https://github.com/honua-io/honua-server/actions/workflows/codeql.yml)
 [![Security Nightly](https://github.com/honua-io/honua-server/actions/workflows/security-nightly.yml/badge.svg)](https://github.com/honua-io/honua-server/actions/workflows/security-nightly.yml)
 [![License](https://img.shields.io/badge/License-Elastic_License_2.0-blue.svg)](https://github.com/honua-io/honua-server/blob/trunk/LICENSE)


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2755

## Summary
The README CI chip shows "failing" whenever the newest ci.yml run is a merge-train batch (train/batch/* branches fail by design during attribution); the badge had no branch filter. Scope it to trunk.

## Changes Made
- Add `?branch=trunk` to the CI workflow badge URL in README.md

## Breaking Changes
None

## Gate Impact
- [x] No gate-tier changes (docs-only)

## Testing
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed (docs-only change; no runtime surface)
