### PR TITLE
test(python): align GPServer env-control and computeClassStatistics smoke tests

### DIFF
--- a/tests/python/feature_server/test_auxiliary_services.py
+++ b/tests/python/feature_server/test_auxiliary_services.py
@@ -99,7 +99,7 @@ class TestImageServer:
         assert isinstance(data["histograms"], list)
 
     @pytest.mark.integration
-    def test_compute_class_statistics_valid_request_returns_not_implemented(
+    def test_compute_class_statistics_missing_training_geometry_returns_validation_error(
         self, http_client: httpx.Client, test_layer_id: int
     ):
         response = http_client.get(
@@ -112,8 +112,7 @@ class TestImageServer:
             },
         )
 
-        # PA-070/PA-117 (#2418): the not-implemented signal is now HTTP 200 +
-        # an {"error"} envelope rather than a bare 501 status. The envelope maps
-        # 501 to body code 500 (GeoServicesErrorCodes.FromHttpStatusCode has no
-        # 501 entry), so accept both.
-        assert_geoservices_error(response, body_codes={501, 500})
+        # #2662: computeClassStatistics is implemented; a class without a training
+        # geometry is rejected at validation. PA-070/PA-117 (#2418): the error is
+        # HTTP 200 + an {"error"} envelope with the code in the body.
+        assert_geoservices_error(response, body_codes={400})

--- a/tests/python/feature_server/test_gpserver_smoke.py
+++ b/tests/python/feature_server/test_gpserver_smoke.py
@@ -66,6 +66,9 @@ class TestGPServerSmoke:
     def test_gpserver_submit_job_rejects_unsupported_env_controls(
         self, http_client: httpx.Client, test_service_id: str
     ):
+        # #2787: env:outSR/env:processSR/env:workspace/env:overwriteOutput are now
+        # honored on submitJob, so an unrecognized control (env:extent) exercises
+        # the rejection path instead.
         response = http_client.post(
             f"/rest/services/{test_service_id}/GPServer/geometry.buffer/submitJob",
             data={
@@ -73,7 +76,7 @@ class TestGPServerSmoke:
                 "wkb": POINT_WKB_BASE64,
                 "srid": "4326",
                 "distance": "10",
-                "env:outSR": "4326",
+                "env:extent": "-180,-90,180,90",
             },
         )
 
@@ -87,7 +90,7 @@ class TestGPServerSmoke:
 
         details = " ".join(data["error"].get("details") or [])
         assert "GP environment controls are not yet supported" in details
-        assert "env:outSR" in details
+        assert "env:extent" in details
 
     @pytest.mark.integration
     @pytest.mark.featureserver


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2787

## Summary
The trunk nightly full-matrix CI fails only in the Python Integration Tests lane: two smoke tests pin behavior that today's landings deliberately changed. env:outSR is now honored on GPServer submitJob (env-controls feature), and computeClassStatistics is implemented (its 501-stub expectation is obsolete).

## Changes Made
- `test_gpserver_submit_job_rejects_unsupported_env_controls`: use `env:extent` (still unsupported) instead of the now-honored `env:outSR`
- `test_compute_class_statistics_valid_request_returns_not_implemented` -> `test_compute_class_statistics_missing_training_geometry_returns_validation_error`: assert the implemented endpoint's validation contract (body code 400, training geometry required) instead of 501/500

## Breaking Changes
None

## Gate Impact
- [x] No gate-tier changes (test-only)

## Testing
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed (python test-only change: py_compile clean; behavior verified against the live nightly failure output — the CI Python lane is the executable proof)
