### PR TITLE
test: deflake streaming active-session gauge assertion

### DIFF
--- a/tests/dotnet/Honua.Server.Tests/Features/Streaming/FeatureStreamMetricsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Streaming/FeatureStreamMetricsTests.cs
@@ -135,13 +135,27 @@ public sealed class FeatureStreamMetricsTests
         using var session = manager.CreateSession("WebSocket", null);
 
         manager.DisconnectSession(session.SessionId).Should().BeTrue();
-        listener.RecordObservableInstruments();
 
         closed.Should().Contain(m =>
             m.Value == 1 &&
             m.Tags.Any(t => t.Key == "transport" && (string?)t.Value == "WebSocket") &&
             m.Tags.Any(t => t.Key == "reason" && (string?)t.Value == "AdminDisconnect"));
-        active.Should().Contain(0);
+
+        // The active-session gauge is process-global (FeatureStreamMetrics is a
+        // static class), so parallel tests that hold their own sessions can be
+        // observed at the instant of a single poll. Poll with a deadline until the
+        // refresh from this manager's disconnect (count 0) is observed, instead of
+        // asserting one instantaneous snapshot.
+        var deadline = TimeSpan.FromSeconds(10);
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        listener.RecordObservableInstruments();
+        while (!active.Contains(0) && watch.Elapsed < deadline)
+        {
+            Thread.Sleep(25);
+            listener.RecordObservableInstruments();
+        }
+
+        active.Should().Contain(0, "DisconnectSession must refresh the active-session gauge to this manager's count");
     }
 
     private static List<(long Value, IReadOnlyList<KeyValuePair<string, object?>> Tags)> CaptureLongMeasurements(


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #1568

## Summary
`FeatureStreamMetricsTests.DisconnectSession_RecordsAdminCloseAndRefreshesActiveGauge` intermittently fails under parallel test load ("Expected collection {1L} to contain 0L") because the active-session gauge is process-global static state and the test asserted a single instantaneous observable-instrument poll. It failed roughly 1 in 3 merge-train batches on 2026-07-12; Foundation-lane failures escalate whole batches, so this flake was expensive.

## Changes Made
- Poll `RecordObservableInstruments` with a 10s deadline until the disconnect refresh (count 0) is observed, instead of asserting one snapshot
- Document the process-global gauge race at the assertion site

## Breaking Changes
None

## Gate Impact
- [x] No gate-tier changes (test-only)

## Testing
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed (Release warnings-as-errors build of Honua.Server.Tests clean; FeatureStreamMetricsTests 8/8 passed on three consecutive runs; dotnet format verify clean on the touched file)
