### PR TITLE
fix(rendering): interpolate colors instead of coercing stops to 0f (#2867)

### DIFF
--- a/src/Honua.Hosting/Features/Rendering/ExpressionEvaluator.cs
+++ b/src/Honua.Hosting/Features/Rendering/ExpressionEvaluator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using SkiaSharp;
 
@@ -366,12 +367,74 @@ internal static class ExpressionEvaluator
         return prevOutput;
     }
 
-    private static object? InterpolateValues(object? from, object? to, float t)
+    [SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "Returns a boxed double for numeric stops and an SKColor for color stops; the caller dispatches on the runtime type.")]
+    private static object InterpolateValues(object? from, object? to, float t)
     {
-        var fromF = ConvertToFloat(from, 0f);
-        var toF = ConvertToFloat(to, 0f);
-        return (double)(fromF + (toF - fromF) * t);
+        if (TryConvertToFloat(from, out var fromF) && TryConvertToFloat(to, out var toF))
+        {
+            return (double)(fromF + (toF - fromF) * t);
+        }
+
+        if (TryParseColor(from, out var fromColor) && TryParseColor(to, out var toColor))
+        {
+            return InterpolateColors(fromColor, toColor, t);
+        }
+
+        throw new StyleExpressionEvaluationException(
+            $"Cannot interpolate between stop outputs of type '{DescribeStopType(from)}' and "
+            + $"'{DescribeStopType(to)}'. MapLibre 'interpolate' requires every stop output to be "
+            + "the same interpolatable type (all numbers or all colors).");
     }
+
+    /// <summary>
+    /// Interpolates two colors the way MapLibre GL JS does for the default <c>rgb</c>
+    /// interpolation space: a straight (non-premultiplied) per-channel lerp over
+    /// gamma-encoded sRGB, including alpha. Mirrors <c>Color.interpolate</c> in
+    /// <c>maplibre-style-spec/src/expression/types/color.ts</c>, which reads the
+    /// un-premultiplied <c>rgb</c> getter and applies <c>interpolateNumber</c>
+    /// (<c>from + t * (to - from)</c>) to each channel. Deliberately not a linear-light
+    /// blend — MapLibre reserves perceptual spaces for 'interpolate-hcl'/'interpolate-lab'.
+    /// </summary>
+    private static SKColor InterpolateColors(SKColor from, SKColor to, float t) =>
+        new(
+            InterpolateChannel(from.Red, to.Red, t),
+            InterpolateChannel(from.Green, to.Green, t),
+            InterpolateChannel(from.Blue, to.Blue, t),
+            InterpolateChannel(from.Alpha, to.Alpha, t));
+
+    /// <summary>
+    /// Lerps a single 8-bit channel. The arithmetic runs in normalized 0..1 double
+    /// precision — rather than directly over the byte values — because MapLibre holds
+    /// channels as 0..1 float64 and only quantizes to 8 bits at raster time. The two
+    /// disagree by one step wherever byte-space math lands exactly on .5 but the
+    /// normalized math does not: interpolating 251 and 48 at t=0.5 is exactly 149.5
+    /// over bytes (rounding to 150), yet 149.4999... over 0..1 (rounding to 149, which
+    /// is what MapLibre emits).
+    /// </summary>
+    private static byte InterpolateChannel(byte from, byte to, float t)
+    {
+        var fromN = from / 255.0;
+        var toN = to / 255.0;
+        var value = (fromN + t * (toN - fromN)) * 255.0;
+
+        // Channels stay within 0..255 for t in [0,1]; clamp guards against a caller
+        // extrapolating outside the stop range.
+        return (byte)Math.Clamp(Math.Round(value, MidpointRounding.AwayFromZero), 0.0, 255.0);
+    }
+
+    private static string DescribeStopType(object? value) =>
+        value switch
+        {
+            null => "null",
+            bool => "boolean",
+            int or long or float or double or decimal => "number",
+            SKColor => "color",
+            string s => TryParseColor(s, out _) ? "color" : "string",
+            _ => "object"
+        };
 
     private static string EvaluateToString(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
     {
@@ -544,76 +607,117 @@ internal static class ExpressionEvaluator
     }
 
     /// <summary>
-    /// Parses a color from various formats (hex, rgb, rgba, named colors).
+    /// Parses a color from various formats (hex, rgb, rgba, named colors),
+    /// falling back to transparent for absent values and black for unrecognized ones.
     /// </summary>
     internal static SKColor ParseColor(object? value)
     {
-        if (value == null)
+        if (TryParseColor(value, out var color))
         {
-            return SKColors.Transparent;
+            return color;
         }
 
-        var str = value.ToString();
+        return string.IsNullOrEmpty(value?.ToString()) ? SKColors.Transparent : SKColors.Black;
+    }
+
+    /// <summary>
+    /// Attempts to parse a color from various formats (hex, rgb, rgba, hsl, named colors),
+    /// reporting failure instead of substituting a fallback. Callers that must distinguish
+    /// "not a color" from "black" — such as interpolation stop typing — use this overload.
+    /// </summary>
+    internal static bool TryParseColor(object? value, out SKColor color)
+    {
+        color = default;
+        if (value is SKColor already)
+        {
+            color = already;
+            return true;
+        }
+
+        var str = value?.ToString();
         if (string.IsNullOrEmpty(str))
         {
-            return SKColors.Transparent;
+            return false;
         }
 
         // Handle hex colors
-        if (str.StartsWith('#') && SKColor.TryParse(str, out var hex))
+        if (str.StartsWith('#'))
         {
-            return hex;
+            return SKColor.TryParse(str, out color);
         }
 
         // Handle rgb(r,g,b) and rgba(r,g,b,a)
         if (str.StartsWith("rgb", StringComparison.OrdinalIgnoreCase))
         {
-            return ParseRgbColor(str);
+            return TryParseRgbColor(str, out color);
         }
 
         // Handle hsl(h,s,l) and hsla(h,s,l,a)
         if (str.StartsWith("hsl", StringComparison.OrdinalIgnoreCase))
         {
-            return ParseHslColor(str);
+            return TryParseHslColor(str, out color);
         }
 
         // Named colors
-        return str.ToLowerInvariant() switch
+        switch (str.ToLowerInvariant())
         {
-            "transparent" => SKColors.Transparent,
-            "black" => SKColors.Black,
-            "white" => SKColors.White,
-            "red" => SKColors.Red,
-            "green" => new SKColor(0, 128, 0),
-            "blue" => SKColors.Blue,
-            "yellow" => SKColors.Yellow,
-            "orange" => new SKColor(255, 165, 0),
-            "purple" => new SKColor(128, 0, 128),
-            "gray" or "grey" => SKColors.Gray,
-            _ => SKColor.TryParse(str, out var parsed) ? parsed : SKColors.Black
-        };
+            case "transparent":
+                color = SKColors.Transparent;
+                return true;
+            case "black":
+                color = SKColors.Black;
+                return true;
+            case "white":
+                color = SKColors.White;
+                return true;
+            case "red":
+                color = SKColors.Red;
+                return true;
+            case "green":
+                color = new SKColor(0, 128, 0);
+                return true;
+            case "blue":
+                color = SKColors.Blue;
+                return true;
+            case "yellow":
+                color = SKColors.Yellow;
+                return true;
+            case "orange":
+                color = new SKColor(255, 165, 0);
+                return true;
+            case "purple":
+                color = new SKColor(128, 0, 128);
+                return true;
+            case "gray":
+            case "grey":
+                color = SKColors.Gray;
+                return true;
+            default:
+                return SKColor.TryParse(str, out color);
+        }
     }
 
-    private static SKColor ParseRgbColor(string value)
+    private static bool TryParseRgbColor(string value, out SKColor color)
     {
+        color = default;
         var start = value.IndexOf('(');
         var end = value.LastIndexOf(')');
         if (start < 0 || end < 0)
         {
-            return SKColors.Black;
+            return false;
         }
 
         var parts = value[(start + 1)..end].Split(',', StringSplitOptions.TrimEntries);
         if (parts.Length < 3)
         {
-            return SKColors.Black;
+            return false;
         }
 
         if (!byte.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var r) ||
             !byte.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var g) ||
             !byte.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var b))
         {
-            return SKColors.Black;
+            return false;
         }
 
         byte a = 255;
@@ -623,29 +727,31 @@ internal static class ExpressionEvaluator
             a = (byte)Math.Clamp(alpha * 255f, 0f, 255f);
         }
 
-        return new SKColor(r, g, b, a);
+        color = new SKColor(r, g, b, a);
+        return true;
     }
 
-    private static SKColor ParseHslColor(string value)
+    private static bool TryParseHslColor(string value, out SKColor color)
     {
+        color = default;
         var start = value.IndexOf('(');
         var end = value.LastIndexOf(')');
         if (start < 0 || end < 0)
         {
-            return SKColors.Black;
+            return false;
         }
 
         var parts = value[(start + 1)..end].Split(',', StringSplitOptions.TrimEntries);
         if (parts.Length < 3)
         {
-            return SKColors.Black;
+            return false;
         }
 
         if (!float.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var h) ||
             !float.TryParse(parts[1].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out var s) ||
             !float.TryParse(parts[2].TrimEnd('%'), NumberStyles.Float, CultureInfo.InvariantCulture, out var l))
         {
-            return SKColors.Black;
+            return false;
         }
 
         byte a = 255;
@@ -659,7 +765,8 @@ internal static class ExpressionEvaluator
         s /= 100f;
         l /= 100f;
         var (r, g, b) = HslToRgb(h, s, l);
-        return new SKColor((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), a);
+        color = new SKColor((byte)(r * 255), (byte)(g * 255), (byte)(b * 255), a);
+        return true;
     }
 
     private static (float R, float G, float B) HslToRgb(float h, float s, float l)
@@ -705,17 +812,34 @@ internal static class ExpressionEvaluator
         return p;
     }
 
-    internal static float ConvertToFloat(object? value, float defaultValue)
+    internal static float ConvertToFloat(object? value, float defaultValue) =>
+        TryConvertToFloat(value, out var result) ? result : defaultValue;
+
+    private static bool TryConvertToFloat(object? value, out float result)
     {
-        return value switch
+        switch (value)
         {
-            double d => (float)d,
-            float f => f,
-            int i => i,
-            long lng => lng,
-            decimal dec => (float)dec,
-            string s when float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) => parsed,
-            _ => defaultValue
-        };
+            case double d:
+                result = (float)d;
+                return true;
+            case float f:
+                result = f;
+                return true;
+            case int i:
+                result = i;
+                return true;
+            case long lng:
+                result = lng;
+                return true;
+            case decimal dec:
+                result = (float)dec;
+                return true;
+            case string s when float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed):
+                result = parsed;
+                return true;
+            default:
+                result = 0f;
+                return false;
+        }
     }
 }

--- a/src/Honua.Hosting/Features/Rendering/StyleExpressionEvaluationException.cs
+++ b/src/Honua.Hosting/Features/Rendering/StyleExpressionEvaluationException.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Infrastructure.Rendering;
+
+/// <summary>
+/// Thrown when a MapLibre style expression is well-formed enough to parse but cannot be
+/// evaluated to a usable value — for example an <c>interpolate</c> whose stop outputs mix
+/// types, or whose outputs are neither numbers nor colors.
+/// </summary>
+/// <remarks>
+/// MapLibre GL JS rejects these expressions at style-validation time; because this
+/// evaluator parses styles lazily at render time, the equivalent failure surfaces here.
+/// The evaluator raises this rather than substituting a default so an unevaluatable style
+/// cannot render as a confident, plausible-looking image — the silent <c>0f</c> coercion it
+/// replaces turned every color <c>interpolate</c> into black with no throw, warning, or log
+/// (honua-server#2867). The message describes the offending stop types only; it carries no
+/// server internals and is safe to log, though protocol adapters map it through the shared
+/// problem helpers rather than returning it verbatim.
+/// </remarks>
+public sealed class StyleExpressionEvaluationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance with a description of the unevaluatable expression.
+    /// </summary>
+    /// <param name="message">A description of why the expression could not be evaluated.</param>
+    public StyleExpressionEvaluationException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance with a description of the unevaluatable expression
+    /// and the underlying cause.
+    /// </summary>
+    /// <param name="message">A description of why the expression could not be evaluated.</param>
+    /// <param name="innerException">The underlying cause.</param>
+    public StyleExpressionEvaluationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/ExpressionEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/ExpressionEvaluatorTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Honua.Infrastructure.Rendering;
 using Honua.TestKit.Attributes;
 using SkiaSharp;
+using Xunit;
 
 namespace Honua.Server.Tests.Features.Infrastructure.Rendering;
 
@@ -349,5 +350,243 @@ public class ExpressionEvaluatorTests
         var result = ExpressionEvaluator.ConvertToFloat("abc", 99f);
 
         result.Should().Be(99f);
+    }
+
+    private const string ChoroplethRamp =
+        """["interpolate", ["linear"], ["get", "value"], 0, "#f7fbff", 100, "#08306b"]""";
+
+    private const string MultiStopRamp =
+        """["interpolate", ["linear"], ["get", "value"], 0, "#ff0000", 50, "#00ff00", 100, "#0000ff"]""";
+
+    private static SKColor EvaluateRamp(string expression, object? value) =>
+        ExpressionEvaluator.EvaluateColor(MapLibreExpressionParser.Parse(expression), Props(("value", value)));
+
+    /// <summary>
+    /// Expected colors are the output of MapLibre GL JS's own reference implementation
+    /// (<c>@maplibre/maplibre-gl-style-spec</c>, <c>createExpression(expr, 'fill-color',
+    /// latest.paint_fill['fill-color'])</c>) evaluated over the same expression and inputs.
+    /// They are not derived from this implementation.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(-10, 247, 251, 255)]
+    [InlineData(0, 247, 251, 255)]
+    [InlineData(25, 187, 200, 218)]
+    [InlineData(50, 128, 149, 181)]
+    [InlineData(75, 68, 99, 144)]
+    [InlineData(100, 8, 48, 107)]
+    [InlineData(150, 8, 48, 107)]
+    public void EvaluateColor_TwoStopColorRamp_MatchesMapLibreOutput(double value, byte r, byte g, byte b)
+    {
+        var result = EvaluateRamp(ChoroplethRamp, value);
+
+        result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(-5, 255, 0, 0)]
+    [InlineData(0, 255, 0, 0)]
+    [InlineData(25, 128, 128, 0)]
+    [InlineData(50, 0, 255, 0)]
+    [InlineData(75, 0, 128, 128)]
+    [InlineData(100, 0, 0, 255)]
+    [InlineData(120, 0, 0, 255)]
+    public void EvaluateColor_MultiStopColorRamp_MatchesMapLibreOutput(double value, byte r, byte g, byte b)
+    {
+        var result = EvaluateRamp(MultiStopRamp, value);
+
+        result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(0, 255, 0, 0, 255)]
+    [InlineData(25, 191, 0, 64, 191)]
+    [InlineData(50, 128, 0, 128, 128)]
+    [InlineData(100, 0, 0, 255, 0)]
+    public void EvaluateColor_RgbaStopsWithAlpha_InterpolatesAlphaLikeMapLibre(
+        double value, byte r, byte g, byte b, byte a)
+    {
+        var expression =
+            """["interpolate", ["linear"], ["get", "value"], 0, "rgba(255,0,0,1)", 100, "rgba(0,0,255,0)"]""";
+
+        var result = EvaluateRamp(expression, value);
+
+        result.Should().Be(new SKColor(r, g, b, a));
+    }
+
+    /// <summary>
+    /// A fully transparent stop keeps its RGB channels rather than collapsing to zero:
+    /// MapLibre stores colors premultiplied but preserves the original channels for a
+    /// zero-alpha color, so the midpoint here is purple, not blue. Straight (non-premultiplied)
+    /// interpolation over <see cref="SKColor"/> reproduces that. MapLibre emits rgba(128,0,128,0.5).
+    /// </summary>
+    [UnitTest]
+    public void EvaluateColor_ZeroAlphaStop_PreservesRgbChannelsLikeMapLibre()
+    {
+        var expression =
+            """["interpolate", ["linear"], ["get", "value"], 0, "rgba(255,0,0,0)", 100, "rgba(0,0,255,1)"]""";
+
+        var result = EvaluateRamp(expression, 50.0);
+
+        result.Should().Be(new SKColor(128, 0, 128, 128));
+    }
+
+    /// <summary>
+    /// The decisive check that interpolation happens in gamma-encoded sRGB rather than
+    /// linear-light: MapLibre's midpoint of black and white is 128, where a linear-light
+    /// blend would produce roughly 188.
+    /// </summary>
+    [UnitTest]
+    public void EvaluateColor_BlackToWhite_InterpolatesInGammaEncodedSrgbNotLinearLight()
+    {
+        var expression =
+            """["interpolate", ["linear"], ["get", "value"], 0, "#000000", 100, "#ffffff"]""";
+
+        var result = EvaluateRamp(expression, 50.0);
+
+        result.Should().Be(new SKColor(128, 128, 128, 255));
+    }
+
+    [UnitTest]
+    public void EvaluateColor_NamedColorStops_InterpolatesLikeMapLibre()
+    {
+        var expression = """["interpolate", ["linear"], ["get", "value"], 0, "red", 100, "blue"]""";
+
+        var result = EvaluateRamp(expression, 50.0);
+
+        result.Should().Be(new SKColor(128, 0, 128, 255));
+    }
+
+    [UnitTest]
+    public void EvaluateColor_ColorRamp_DoesNotReturnBlack()
+    {
+        var result = EvaluateRamp(ChoroplethRamp, 50.0);
+
+        result.Should().NotBe(SKColors.Black);
+    }
+
+    /// <summary>
+    /// Numeric interpolation must be a pure widening: these expectations are MapLibre's
+    /// output for the same expression and are also the values the pre-fix evaluator produced.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(-10, 0.0)]
+    [InlineData(0, 0.0)]
+    [InlineData(25, 2.5)]
+    [InlineData(50, 5.0)]
+    [InlineData(100, 10.0)]
+    [InlineData(150, 10.0)]
+    public void Evaluate_NumericInterpolate_IsUnchangedByColorSupport(double value, double expected)
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["interpolate", ["linear"], ["get", "value"], 0, 0, 100, 10]""");
+
+        var result = ExpressionEvaluator.Evaluate(expr, Props(("value", value)));
+
+        result.Should().BeOfType<double>().Which.Should().BeApproximately(expected, 1e-9);
+    }
+
+    [UnitTest]
+    public void Evaluate_NumericInterpolate_NumericStringStopsStayNumeric()
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["interpolate", ["linear"], ["get", "value"], 0, "0", 100, "10"]""");
+
+        var result = ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+
+        result.Should().BeOfType<double>().Which.Should().BeApproximately(5.0, 1e-9);
+    }
+
+    /// <summary>
+    /// MapLibre rejects mixed-type stops when the style is validated
+    /// ("Expected color but found number instead."); this evaluator parses styles lazily at
+    /// render time, so the equivalent failure has to surface here rather than silently
+    /// coercing both stops to 0 and rendering black (honua-server#2867).
+    /// </summary>
+    [UnitTest]
+    public void Evaluate_InterpolateWithMixedColorAndNumberStops_Throws()
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["interpolate", ["linear"], ["get", "value"], 0, "#ff0000", 100, 42]""");
+
+        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+
+        act.Should().Throw<StyleExpressionEvaluationException>()
+            .WithMessage("*color*number*");
+    }
+
+    /// <summary>
+    /// MapLibre rejects this at validation time with
+    /// "Could not parse color from value 'not-a-color'".
+    /// </summary>
+    [UnitTest]
+    public void Evaluate_InterpolateWithUnparseableColorStop_Throws()
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["interpolate", ["linear"], ["get", "value"], 0, "not-a-color", 100, "#08306b"]""");
+
+        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+
+        act.Should().Throw<StyleExpressionEvaluationException>();
+    }
+
+    [UnitTest]
+    public void Evaluate_InterpolateWithNullStopOutput_Throws()
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["interpolate", ["linear"], ["get", "value"], 0, ["get", "missing"], 100, 10]""");
+
+        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+
+        act.Should().Throw<StyleExpressionEvaluationException>();
+    }
+
+    /// <summary>
+    /// Landing exactly on a stop must yield that stop's own color rather than a rounded
+    /// neighbour, at the first stop, an interior stop, and the last stop.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(0, 255, 0, 0)]
+    [InlineData(50, 0, 255, 0)]
+    [InlineData(100, 0, 0, 255)]
+    public void EvaluateColor_ExactStopBoundary_ReturnsStopColorExactly(double value, byte r, byte g, byte b)
+    {
+        var result = EvaluateRamp(MultiStopRamp, value);
+
+        result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    [UnitTest]
+    public void TryParseColor_UnrecognizedValue_ReturnsFalseInsteadOfBlack()
+    {
+        ExpressionEvaluator.TryParseColor("not-a-color", out _).Should().BeFalse();
+        ExpressionEvaluator.TryParseColor(null, out _).Should().BeFalse();
+        ExpressionEvaluator.TryParseColor("#08306b", out var parsed).Should().BeTrue();
+        parsed.Should().Be(new SKColor(8, 48, 107, 255));
+    }
+
+    /// <summary>
+    /// <see cref="ExpressionEvaluator.ParseColor"/> keeps its existing fallbacks — transparent
+    /// for absent values, black for unrecognized ones — now that it delegates to the
+    /// failure-reporting parser.
+    /// </summary>
+    [UnitTest]
+    public void ParseColor_FallbackBehaviour_IsUnchanged()
+    {
+        ExpressionEvaluator.ParseColor(null).Should().Be(SKColors.Transparent);
+        ExpressionEvaluator.ParseColor("").Should().Be(SKColors.Transparent);
+        ExpressionEvaluator.ParseColor("not-a-color").Should().Be(SKColors.Black);
+        ExpressionEvaluator.ParseColor("#ff0000").Should().Be(SKColors.Red);
+        ExpressionEvaluator.ParseColor("rgb(1,2,3)").Should().Be(new SKColor(1, 2, 3, 255));
+        ExpressionEvaluator.ParseColor("rgb(bad)").Should().Be(SKColors.Black);
     }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2867

## Summary

`interpolate` over colors rendered black. Color stops are strings (`"#f7fbff"`, `"rgba(255,0,0,1)"`), but `InterpolateValues` ran every stop through `ConvertToFloat`, which cannot parse them — so both endpoints collapsed to the `0f` default and the function returned a *number* where the renderer expected a *color*. The renderer parsed that number back as a color, failed, and fell back to black. Silently: no throw, no warning, no log. `["interpolate", ["linear"], ["get", "value"], 0, "#f7fbff", 100, "#08306b"]` — the standard MapLibre choropleth ramp — was broken in **WMS `GetMap`** and **Esri `MapServer/export`** alike, since both adapt to the shared `RasterMapRenderingPipeline` / `StyleTranslator` / `SkiaMapRenderer` path.

`InterpolateValues` now types its stops: numeric stops keep the existing lerp expression verbatim, color stops parse to `SKColor` and interpolate per channel including alpha, and anything we cannot evaluate throws instead of defaulting to `0f`.

### What MapLibre actually does, and how that was confirmed

The risk here was replacing "black" with "subtly wrong". Rather than reason from expectations, I installed MapLibre GL JS's own reference implementation (`@maplibre/maplibre-gl-style-spec`) and ran the real expressions through `createExpression(expr, 'fill-color', latest.paint_fill['fill-color'])`, then used its output as the expected values in the tests. They are **not** derived from this implementation.

MapLibre's default `interpolate` (`rgb` space) is a **straight, non-premultiplied per-channel lerp in gamma-encoded sRGB**, including alpha — `Color.interpolate` reads the un-premultiplied `rgb` getter and applies `interpolateNumber` (`from + t * (to - from)`) per channel. Three findings that would each have made a plausible implementation wrong:

| Check | MapLibre output | Rules out |
|---|---|---|
| `#000000` → `#ffffff` @ t=0.5 | `(128,128,128)` | **linear-light** blending (would give ~188) |
| `rgba(255,0,0,1)` → `rgba(0,0,255,0)` @ t=0.5 | `rgba(128,0,128,0.5)` | **premultiplied** lerp (would give `rgba(255,0,0,0.5)`) |
| `#f7fbff` → `#08306b` @ t=0.5, green | `149` (not `150`) | **byte-space** math |

That last one is subtle: MapLibre holds channels as 0..1 float64 and only quantizes at raster time, so `149.5` in byte space is `149.4999…` normalized and rounds down. Channel math therefore runs in normalized 0..1 double precision to match. Perceptual spaces are deliberately not used — MapLibre reserves those for `interpolate-hcl` / `interpolate-lab`, which are separate operators.

Zero-alpha stops also keep their RGB channels (MapLibre preserves the original channels for a zero-alpha color); straight interpolation over `SKColor` reproduces that, so `rgba(255,0,0,0)` → `rgba(0,0,255,1)` @ t=0.5 is purple, not blue.

### Numeric interpolation is unchanged

The numeric branch is the original expression, character for character, and `ConvertToFloat` was refactored into a `TryConvertToFloat` core with identical switch arms in identical order — so `ConvertToFloat(x, 0f)` is by construction `TryConvertToFloat(x, out r) ? r : 0f`. Proven empirically: reverting **only** the `InterpolateValues` body to the pre-fix implementation fails all 20 color/throw tests while **all 7 numeric-interpolate cases still pass**, and those numeric expectations are themselves MapLibre's output (`0, 2.5, 5, 10`).

### Unparseable / mixed stops now fail loudly

Previously they silently became `0f` → black. They now throw `StyleExpressionEvaluationException` naming both offending stop types. This matches MapLibre, which rejects the same expressions at style-validation time (`"Expected color but found number instead."`, `"Could not parse color from value 'not-a-color'"`); because this evaluator parses styles lazily at render time, the equivalent failure has to surface at evaluation. A style we cannot evaluate must not render as a confident black polygon. The message describes stop types only — no server internals.

`ParseColor` keeps its existing transparent/black fallbacks but delegates to a new `TryParseColor` core, so interpolation can distinguish "not a color" from "black" **without a second color parser**.

## Changes Made
- `ExpressionEvaluator.InterpolateValues` — dispatch on stop type: numeric lerp (verbatim), color lerp, or throw. Replaces the unconditional `ConvertToFloat(..., 0f)` coercion that returned a number for color stops.
- `ExpressionEvaluator.InterpolateColors` / `InterpolateChannel` — straight non-premultiplied per-channel sRGB lerp including alpha, in normalized 0..1 double precision to match MapLibre's quantization.
- `ExpressionEvaluator.ParseColor` — refactored onto a new `TryParseColor` core that reports failure instead of substituting black; existing fallbacks preserved and covered by a test. No second color parser.
- `ExpressionEvaluator.ConvertToFloat` — refactored onto `TryConvertToFloat` with identical arms; behavior bit-identical for all existing callers.
- New `StyleExpressionEvaluationException` for lazily-evaluated styles MapLibre would reject at validation time.
- 37 new tests in `ExpressionEvaluatorTests`, with MapLibre-derived expected values.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Covers two-stop ramp, multi-stop ramp, below-first/above-last stop, `rgba()` with alpha, zero-alpha endpoints, exact-stop boundaries (first/interior/last), named colors, gamma-vs-linear-light, numeric unchanged, numeric-string stops, and the mixed/unparseable/null throw paths.

- `ExpressionEvaluatorTests` — 69/69 pass (Release).
- Full `Features.Infrastructure.Rendering` suite — 168/168 pass (Release), no regressions in `StyleTranslator` / `SkiaMapRenderer` / `StyledVectorMapRender`.
- `Honua.Architecture.Tests` — 132/132 pass (Release).
- `dotnet build --configuration Release -p:TreatWarningsAsErrors=true` clean; `dotnet format --verify-no-changes` clean.

**No visual baselines changed** — the repo has no golden-image/visual-regression baselines for map rendering (`RenderGoldenTests` covers Markdown/HTML reporting templates; `tests/baselines/client-compat` are protocol-conformance `.cert.json`). This change does move pixels: areas that rendered black now render their correct ramp color. That is the fix.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

Internal rendering logic only — no new routes, so no `EndpointRegistry` / `public-interface-proof.json` / catalog changes.

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None for valid styles. Two intentional behavior changes:
- Styles using color `interpolate` now render correct colors instead of black (the fix — it moves pixels).
- An `interpolate` with mixed-type, unparseable, or null stop outputs now throws rather than silently rendering black. These are styles MapLibre itself rejects at validation time; the previous silent `0f` default is the root cause this PR removes.

## Coordination

- **#2866 (WMS `GetLegendGraphic`) — not touched by this PR.** It reports `interpolate`-over-colors as unrepresentable via a `Warning` header *because `GetMap` could not render it either*. That was the correct call at the time. Now that colors interpolate, that `Warning` may be stale — the legend could represent these as discrete sampled entries. Worth revisiting **after both land**; deliberately left to #2866's owner rather than edited here. Noted on #2867.
- **#2868 (WMS `GetMap` never passes zoom)** is a sibling defect from the same investigation and is explicitly out of scope here.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

> **Note on `pre-pr-check.sh`:** the script currently fails on Windows before it runs anything, for reasons unrelated to this change — it generates the temporary `.slnf` with forward-slash project paths while `Honua.sln` stores backslashes, so `dotnet restore` aborts with `MSB5028: ... includes project ... that is not in the solution file`. Verified pre-existing: it fails identically on a clean `origin/trunk` checkout with only a whitespace touch (it named a different project, `Honua.Architecture.Tests`). The equivalent checks were run individually instead and all passed — Release build with `TreatWarningsAsErrors=true`, `dotnet format --verify-no-changes`, the affected rendering test suites, and the architecture tests (all listed under Testing above). Filing separately rather than fixing it in this PR.
