### PR TITLE
fix(wms): derive zoom for GetMap so minzoom/maxzoom gates apply (#2868)

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -9782,6 +9782,9 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_WithoutFilter_NoRegression",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_InvalidServiceId_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_InvalidService_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsZoomGatingTests.Wms_GetMap_MaxZoomScopedStyle_OmitsLayerAtOrAboveThreshold",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsZoomGatingTests.Wms_GetMap_MinZoomScopedStyle_OmitsLayerBelowThreshold",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsZoomGatingTests.Wms_GetMap_UnscopedStyle_RendersAtEveryScale",
         "Honua.Server.Tests.Features.Security.WmsServiceRbacTests.GetCapabilities_WithAnonymousClient_ReturnsWmsAccessDeniedException"
       ],
       "proof_ledger_surface": "map-server",

--- a/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
+++ b/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
@@ -287,7 +287,8 @@ internal static class RasterMapRenderingPipeline
                 TileSize,
                 true,
                 null,
-                MetadataV2GeometryType.None);
+                MetadataV2GeometryType.None,
+                RenderZoom.NotDerivable("the tile has no render layers"));
 
             return RasterTileRenderResult.Success(emptyImage, 0);
         }
@@ -311,6 +312,13 @@ internal static class RasterMapRenderingPipeline
         var canvas = surface.Canvas;
         canvas.Clear(SKColors.Transparent);
         var transform = SkiaMapRenderer.BuildTransform(renderExtent, TileSize, TileSize);
+
+        // The tile matrix level is not the MapLibre zoom: these tiles are TileSize (256) pixels, so
+        // a client consuming them as a 256px source sits one camera zoom below the matrix level.
+        // Deriving from the tile envelope keeps the gate aligned with that camera zoom and with the
+        // other protocols rendering the same envelope.
+        var renderZoom = RenderZoom.FromExtent(renderExtent, TileSize, TileSize, tileSrid);
+        RecordRenderZoom(renderZoom);
 
         for (var layerIndex = 0; layerIndex < renderLayers.Count; layerIndex++)
         {
@@ -343,6 +351,11 @@ internal static class RasterMapRenderingPipeline
                 styleCatalog,
                 layer.LayerId,
                 cancellationToken).ConfigureAwait(false);
+            if (!StyleTranslator.IsAnyLayerInZoomRange(stylePlan.StyleLayers, renderZoom))
+            {
+                continue;
+            }
+
             var featureQuery = CreateRasterFeatureQuery(
                 stylePlan,
                 spatialFilter,
@@ -379,7 +392,7 @@ internal static class RasterMapRenderingPipeline
             }
 
             totalFeatureCount += features.Length;
-            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, layer.GeometryType);
+            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, layer.GeometryType, renderZoom);
         }
 
         var imageBytes = SkiaMapRenderer.EncodeSurface(surface, "png");
@@ -561,6 +574,13 @@ internal static class RasterMapRenderingPipeline
         {
             var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
             var transform = SkiaMapRenderer.BuildTransform(requestExtent, imageWidth, imageHeight);
+            var renderZoom = await DeriveRenderZoomAsync(
+                context,
+                requestExtent,
+                requestSrid,
+                imageWidth,
+                imageHeight,
+                cancellationToken).ConfigureAwait(false);
             var stylePlan = BuildRasterStylePlanFromJson(mapLibreStyleJson);
             var spatialFilter = CreateBboxSpatialFilter(queryExtent, serviceSrid);
             var featureQuery = CreateRasterFeatureQuery(
@@ -594,7 +614,7 @@ internal static class RasterMapRenderingPipeline
                 if (features.Length > 0)
                 {
                     totalFeatureCount += features.Length;
-                    RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, geometryType);
+                    RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, geometryType, renderZoom);
                 }
             }
         }
@@ -652,6 +672,8 @@ internal static class RasterMapRenderingPipeline
         canvas.Clear(effectiveTransparent ? SKColors.Transparent : backgroundColor ?? SKColors.White);
 
         var transform = SkiaMapRenderer.BuildTransform(requestExtent, imageWidth, imageHeight);
+        var renderZoom = RenderZoom.FromExtent(requestExtent, imageWidth, imageHeight, requestSrid);
+        RecordRenderZoom(renderZoom);
 
         foreach (var layer in layers)
         {
@@ -698,7 +720,7 @@ internal static class RasterMapRenderingPipeline
                 continue;
             }
 
-            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, layer.GeometryType);
+            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, layer.GeometryType, renderZoom);
         }
 
         return SkiaMapRenderer.EncodeSurface(surface, format);
@@ -709,13 +731,14 @@ internal static class RasterMapRenderingPipeline
         ImmutableArray<Feature> features,
         MapLibreStyleLayer[] styleLayers,
         Func<double, double, SKPoint> transform,
-        MetadataV2GeometryType geometryType)
+        MetadataV2GeometryType geometryType,
+        RenderZoom zoom)
     {
         if (styleLayers.Length > 0)
         {
             foreach (var styleLayer in styleLayers)
             {
-                if (styleLayer.Type == null)
+                if (styleLayer.Type == null || !StyleTranslator.ShouldRenderLayer(styleLayer, zoom))
                 {
                     continue;
                 }
@@ -1339,6 +1362,55 @@ internal static class RasterMapRenderingPipeline
             DrawCircleLoop(canvas, projectedPoints, points.Length, circleStyle.Radius, strokePaint);
         }
     }
+
+    /// <summary>
+    /// Derives the MapLibre <see cref="RenderZoom"/> for a request extent, resolving CRSs that have
+    /// no in-process Web Mercator mapping through the same shared transform services the render
+    /// paths already use for reprojection. The result is recorded on the current activity, so a
+    /// render that ends up ungated is traceable rather than silently unfiltered.
+    /// </summary>
+    internal static async Task<RenderZoom> DeriveRenderZoomAsync(
+        HttpContext context,
+        SkiaMapRenderer.RenderExtent extent,
+        int srid,
+        int imageWidth,
+        int imageHeight,
+        CancellationToken cancellationToken)
+    {
+        var zoom = RenderZoom.FromExtent(extent, imageWidth, imageHeight, srid);
+
+        if (zoom.Level is null && !SpatialReferenceExtensions.IsWebMercatorSrid(srid))
+        {
+            var transformed = await TryTransformExtentAsync(context, extent, srid, TileSrid, cancellationToken)
+                .ConfigureAwait(false);
+            zoom = transformed.IsSuccess
+                ? RenderZoom.FromWebMercatorExtent(transformed.Extent, imageWidth, imageHeight)
+                : RenderZoom.NotDerivable(
+                    $"the request extent could not be transformed from EPSG:{srid.ToString(System.Globalization.CultureInfo.InvariantCulture)} to Web Mercator");
+        }
+
+        RecordRenderZoom(zoom);
+        return zoom;
+    }
+
+    internal static void RecordRenderZoom(RenderZoom zoom)
+    {
+        var activity = System.Diagnostics.Activity.Current;
+        if (activity is null)
+        {
+            return;
+        }
+
+        if (zoom.Level is { } level)
+        {
+            activity.SetTag("honua.render.zoom", level);
+        }
+        else
+        {
+            activity.SetTag("honua.render.zoom_ungated_reason", zoom.NotDerivableReason);
+        }
+    }
+
     internal static int? TryParseSrid(string? sr)
         => SpatialReferenceHelpers.TryParseSrid(sr);
 

--- a/src/Honua.Hosting/Features/Rendering/RenderZoom.cs
+++ b/src/Honua.Hosting/Features/Rendering/RenderZoom.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Infrastructure.Rendering;
+
+/// <summary>
+/// The MapLibre zoom level a render is evaluated at, used to apply style layer
+/// <c>minzoom</c>/<c>maxzoom</c> gates.
+/// </summary>
+/// <remarks>
+/// <para>A render either carries a derived zoom (<see cref="At"/>) or records why one could not be
+/// derived (<see cref="NotDerivable"/>). This is a reference type with no public constructor and no
+/// meaningful default so that "no zoom" cannot be reached by omitting an argument: every render path
+/// has to state which case it is in, and an ungated render carries a reason callers can record.</para>
+/// <para>Zoom follows MapLibre GL JS, where the mercator world spans <c>512 * 2^zoom</c> pixels
+/// (<c>Transform.tileSize</c> is a constant 512). The zoom for an image is therefore the camera zoom
+/// at which that image would be displayed 1:1. Deriving it from the rendered envelope and pixel size
+/// — rather than from a tile matrix level or a client's zoom convention — is what keeps protocols
+/// consistent: the same envelope at the same pixel size gates identically whether it arrives as a WMS
+/// <c>GetMap</c>, a raster tile, a static map, or a map export.</para>
+/// </remarks>
+internal sealed class RenderZoom
+{
+    private const double MapLibreWorldTileSize = 512.0;
+    private const double MercatorWorldSpanMeters = SpatialConstants.WebMercatorExtent * 2.0;
+    private const int WebMercatorSrid = 3857;
+
+    private RenderZoom(double? level, string? notDerivableReason)
+    {
+        Level = level;
+        NotDerivableReason = notDerivableReason;
+    }
+
+    /// <summary>
+    /// The MapLibre zoom level, or <see langword="null"/> when no zoom could be derived and
+    /// <c>minzoom</c>/<c>maxzoom</c> gates consequently do not apply.
+    /// </summary>
+    public double? Level { get; }
+
+    /// <summary>
+    /// Why no zoom is available, or <see langword="null"/> when <see cref="Level"/> has a value.
+    /// </summary>
+    public string? NotDerivableReason { get; }
+
+    /// <summary>
+    /// A render at a known MapLibre zoom level.
+    /// </summary>
+    public static RenderZoom At(double level) => new(level, null);
+
+    /// <summary>
+    /// A render with no derivable zoom. The <paramref name="reason"/> is retained so that an
+    /// ungated render is traceable rather than silent.
+    /// </summary>
+    public static RenderZoom NotDerivable(string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        return new RenderZoom(null, reason);
+    }
+
+    /// <summary>
+    /// Derives the MapLibre zoom for an extent already expressed in Web Mercator (EPSG:3857) metres
+    /// and rendered at the supplied pixel size.
+    /// </summary>
+    public static RenderZoom FromWebMercatorExtent(
+        SkiaMapRenderer.RenderExtent extent,
+        int imageWidth,
+        int imageHeight)
+    {
+        if (imageWidth <= 0 || imageHeight <= 0)
+        {
+            return NotDerivable("the render has no positive pixel dimensions");
+        }
+
+        var spanX = CoordinateTransformer.GetEffectiveWidth(extent) / MercatorWorldSpanMeters;
+        var spanY = extent.Height / MercatorWorldSpanMeters;
+        if (!(spanX > 0) || !(spanY > 0))
+        {
+            return NotDerivable("the render extent is empty or degenerate");
+        }
+
+        // Mirrors MapLibre's cameraForBoxAndBearing, which fits the more constrained axis
+        // (camera_helper.ts: `scaleZoom(tr.scale * Math.min(scaleX, scaleY))`). For a well-formed
+        // request whose envelope aspect matches the image aspect both axes agree.
+        var level = Math.Min(
+            Math.Log2(imageWidth / (MapLibreWorldTileSize * spanX)),
+            Math.Log2(imageHeight / (MapLibreWorldTileSize * spanY)));
+
+        return double.IsFinite(level)
+            ? At(level)
+            : NotDerivable("the render extent is empty or degenerate");
+    }
+
+    /// <summary>
+    /// Derives the MapLibre zoom for an extent in <paramref name="srid"/> using in-process geodesy
+    /// only. Returns a <see cref="NotDerivable"/> zoom when the CRS has no in-process Web Mercator
+    /// mapping; callers that can reach the shared coordinate transform services should prefer
+    /// <see cref="RasterMapRenderingPipeline.DeriveRenderZoomAsync"/>, which resolves those CRSs too.
+    /// </summary>
+    public static RenderZoom FromExtent(
+        SkiaMapRenderer.RenderExtent extent,
+        int imageWidth,
+        int imageHeight,
+        int srid)
+    {
+        if (SpatialReferenceExtensions.IsWebMercatorSrid(srid))
+        {
+            return FromWebMercatorExtent(extent, imageWidth, imageHeight);
+        }
+
+        try
+        {
+            return FromWebMercatorExtent(
+                CoordinateTransformer.TransformExtent(extent, srid, WebMercatorSrid),
+                imageWidth,
+                imageHeight);
+        }
+        catch (NotSupportedException)
+        {
+            return NotDerivable(
+                $"EPSG:{srid.ToString(System.Globalization.CultureInfo.InvariantCulture)} has no in-process Web Mercator transform");
+        }
+    }
+
+    /// <summary>
+    /// Derives the MapLibre zoom for a shared render extent in <paramref name="srid"/>.
+    /// </summary>
+    public static RenderZoom FromExtent(
+        RenderExtent extent,
+        int imageWidth,
+        int imageHeight,
+        int srid)
+        => FromExtent(
+            new SkiaMapRenderer.RenderExtent(extent.MinX, extent.MinY, extent.MaxX, extent.MaxY),
+            imageWidth,
+            imageHeight,
+            srid);
+}

--- a/src/Honua.Hosting/Features/Rendering/SkiaMapRenderer.cs
+++ b/src/Honua.Hosting/Features/Rendering/SkiaMapRenderer.cs
@@ -46,7 +46,7 @@ internal sealed class SkiaMapRenderer : IDisposable
     /// <param name="transparent">Whether background should be transparent</param>
     /// <param name="backgroundColor">Background color (when not transparent)</param>
     /// <param name="geometryType">Geometry type of the layer</param>
-    /// <param name="zoom">Optional MapLibre zoom level for evaluating layer minzoom/maxzoom gates</param>
+    /// <param name="zoom">MapLibre zoom level for evaluating layer minzoom/maxzoom gates</param>
     /// <returns>PNG image bytes</returns>
     internal byte[] RenderMap(
         IReadOnlyList<Feature> features,
@@ -57,7 +57,7 @@ internal sealed class SkiaMapRenderer : IDisposable
         bool transparent,
         SKColor? backgroundColor,
         MetadataV2GeometryType geometryType,
-        double? zoom = null)
+        RenderZoom zoom)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ValidatePositiveDimension(imageWidth, nameof(imageWidth));
@@ -109,7 +109,7 @@ internal sealed class SkiaMapRenderer : IDisposable
         int imageWidth,
         int imageHeight,
         MetadataV2GeometryType geometryType,
-        double? zoom = null)
+        RenderZoom zoom)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -265,7 +265,7 @@ internal sealed class SkiaMapRenderer : IDisposable
         IReadOnlyList<Feature> features,
         MapLibreStyleLayer[] styleLayers,
         Func<double, double, SKPoint> transform,
-        double? zoom = null)
+        RenderZoom zoom)
     {
         foreach (var styleLayer in styleLayers)
         {

--- a/src/Honua.Hosting/Features/Rendering/StyleTranslator.cs
+++ b/src/Honua.Hosting/Features/Rendering/StyleTranslator.cs
@@ -80,20 +80,51 @@ internal static class StyleTranslator
     }
 
     /// <summary>
-    /// Returns whether a style layer should be rendered for the supplied zoom, when zoom is known.
-    /// If zoom is not known, minzoom/maxzoom are left unapplied and layer visibility is still honored.
+    /// Returns whether a style layer should be rendered at the supplied <paramref name="zoom"/>.
+    /// Layer visibility is always honored; minzoom/maxzoom apply when the render carries a derived
+    /// zoom and are left unapplied when <see cref="RenderZoom.NotDerivable"/> states that no zoom
+    /// could be derived for the request.
     /// </summary>
     public static bool ShouldRenderLayer(
         MapLibreStyleLayer layer,
-        double? zoom = null,
+        RenderZoom zoom,
         ImmutableDictionary<string, object?>? properties = null)
     {
-        if (zoom.HasValue && !IsLayerInZoomRange(layer, zoom.Value))
+        ArgumentNullException.ThrowIfNull(zoom);
+
+        if (zoom.Level is { } level && !IsLayerInZoomRange(layer, level))
         {
             return false;
         }
 
         return IsLayerVisible(layer, properties ?? ImmutableDictionary<string, object?>.Empty);
+    }
+
+    /// <summary>
+    /// Returns whether any layer in a style document falls inside its minzoom/maxzoom range at the
+    /// supplied <paramref name="zoom"/>. Callers use this to skip querying features for a layer
+    /// whose style is entirely out of range, since none of it could be drawn. Styles with no layers
+    /// render with default paints and are always in range.
+    /// </summary>
+    public static bool IsAnyLayerInZoomRange(MapLibreStyleLayer[] styleLayers, RenderZoom zoom)
+    {
+        ArgumentNullException.ThrowIfNull(styleLayers);
+        ArgumentNullException.ThrowIfNull(zoom);
+
+        if (zoom.Level is not { } level || styleLayers.Length == 0)
+        {
+            return true;
+        }
+
+        foreach (var styleLayer in styleLayers)
+        {
+            if (IsLayerInZoomRange(styleLayer, level))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Export.cs
+++ b/src/Honua.Protocols.GeoServices/MapServer/MapServerRequestHandlers.Export.cs
@@ -303,7 +303,8 @@ internal static partial class MapServerEndpoints
                     imageHeight,
                     parameters.Transparent,
                     backgroundColor,
-                    MetadataV2GeometryType.None);
+                    MetadataV2GeometryType.None,
+                    RenderZoom.NotDerivable("the export has no render layers"));
 
                 stopwatch.Stop();
                 MapServerLog.ExportCompleted(logger, serviceId, 0, stopwatch.Elapsed.TotalMilliseconds);
@@ -324,6 +325,17 @@ internal static partial class MapServerEndpoints
             }
 
             var scaleDenominator = CoordinateTransformer.CalculateScaleDenominator(extent, imageWidth, dpi, bboxSrid.Value);
+
+            // Esri layer min/max scale gating (IsLayerVisibleAtScale) and MapLibre minzoom/maxzoom
+            // gating are independent: the former is layer metadata, the latter belongs to the bound
+            // style document. Both apply to an export.
+            var renderZoom = await DeriveRenderZoomAsync(
+                context,
+                renderExtent,
+                imageSrid.Value,
+                imageWidth,
+                imageHeight,
+                cancellationToken).ConfigureAwait(false);
 
             var featureReader = context.RequestServices.GetRequiredService<IFeatureReader>();
             var styleCatalog = context.RequestServices.GetRequiredService<ILayerStyleCatalog>();
@@ -458,7 +470,7 @@ internal static partial class MapServerEndpoints
                 }
 
                 totalFeatureCount += features.Length;
-                RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, geometryType);
+                RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transform, geometryType, renderZoom);
             }
 
             stopwatch.Stop();

--- a/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetMap.cs
+++ b/src/Honua.Protocols.OgcClassic/Wms/WmsRequestHandlers.GetMap.cs
@@ -228,6 +228,17 @@ internal static partial class WmsRequestHandlers
         canvas.Clear(effectiveTransparent ? SKColors.Transparent : backgroundColor);
         var transformFn = SkiaMapRenderer.BuildTransform(requestedExtent, imageWidth, imageHeight);
 
+        // BBOX + WIDTH/HEIGHT + CRS fix the scale the map is drawn at, which is what a style's
+        // minzoom/maxzoom is authored against.
+        var renderZoom = await DeriveRenderZoomAsync(
+            context,
+            requestedExtent,
+            requestSrid,
+            imageWidth,
+            imageHeight,
+            cancellationToken).ConfigureAwait(false);
+        activity?.SetTag("wms.render_zoom", renderZoom.Level);
+
         for (var i = 0; i < renderLayers.Length; i++)
         {
             var layer = renderLayers[i];
@@ -266,6 +277,11 @@ internal static partial class WmsRequestHandlers
                 styleCatalog,
                 layer.StorageLayerId,
                 cancellationToken).ConfigureAwait(false);
+            if (!StyleTranslator.IsAnyLayerInZoomRange(stylePlan.StyleLayers, renderZoom))
+            {
+                continue;
+            }
+
             var featureQuery = CreateRasterFeatureQuery(
                 stylePlan,
                 spatialFilter,
@@ -300,7 +316,7 @@ internal static partial class WmsRequestHandlers
             }
 
             totalFeatureCount += features.Length;
-            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transformFn, geometryType);
+            RenderLayerToCanvas(canvas, features, stylePlan.StyleLayers, transformFn, geometryType, renderZoom);
         }
 
         var imageBytes = SkiaMapRenderer.EncodeSurface(surface, imageFormat);

--- a/src/Honua.Server/Features/PrintingTools/PrintingToolsRequestHandlers.cs
+++ b/src/Honua.Server/Features/PrintingTools/PrintingToolsRequestHandlers.cs
@@ -213,6 +213,10 @@ internal static class PrintingToolsRequestHandlers
                 renderExtent, webMap.MapOptions.Scale.Value, imageWidth, imageHeight, dpi, extentSrid);
         }
 
+        // Derived from the scale-adjusted extent so a mapOptions.scale request gates its styles at
+        // the scale it actually renders at.
+        var renderZoom = RenderZoom.FromExtent(renderExtent, imageWidth, imageHeight, extentSrid);
+
         // Create a composite surface for all layers
         using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight, SKColorType.Rgba8888, SKAlphaType.Premul));
         var canvas = surface.Canvas;
@@ -245,12 +249,12 @@ internal static class PrintingToolsRequestHandlers
             {
                 using var opacityPaint = new SKPaint { Color = SKColors.White.WithAlpha((byte)(resolved.OperationalLayer.Opacity.Value * 255)) };
                 var count = canvas.SaveLayer(opacityPaint);
-                renderer.RenderFeaturesOnCanvas(canvas, queryResult.Items, styleLayers, renderExtent, imageWidth, imageHeight, renderGeometryType);
+                renderer.RenderFeaturesOnCanvas(canvas, queryResult.Items, styleLayers, renderExtent, imageWidth, imageHeight, renderGeometryType, renderZoom);
                 canvas.RestoreToCount(count);
             }
             else
             {
-                renderer.RenderFeaturesOnCanvas(canvas, queryResult.Items, styleLayers, renderExtent, imageWidth, imageHeight, renderGeometryType);
+                renderer.RenderFeaturesOnCanvas(canvas, queryResult.Items, styleLayers, renderExtent, imageWidth, imageHeight, renderGeometryType, renderZoom);
             }
         }
 

--- a/src/Honua.Server/Features/StaticMap/StaticMapRequestHandlers.cs
+++ b/src/Honua.Server/Features/StaticMap/StaticMapRequestHandlers.cs
@@ -337,6 +337,12 @@ internal static partial class StaticMapEndpoints
                 : extent;
             var transform = SkiaMapRenderer.BuildTransform(renderExtent, renderWidth, renderHeight);
 
+            // Derived from the rendered extent rather than parameters.Zoom: the static map zoom is
+            // defined against 256px tiles (see CenterZoomToExtent) while a MapLibre style's
+            // minzoom/maxzoom is against MapLibre's 512px camera zoom, so the two differ by one.
+            // Deriving also covers the bbox route, which carries no zoom at all.
+            var renderZoom = RenderZoom.FromExtent(renderExtent, renderWidth, renderHeight, renderSrid);
+
             // Overlay markers/paths are always specified in lon/lat — project to Mercator first
             // when rendering in 3857, otherwise use the same transform.
             var overlayTransform = useMercator
@@ -378,7 +384,7 @@ internal static partial class StaticMapEndpoints
                 var style = await styleCatalog.GetLayerStyleAsync(layer.StorageLayerId, context.RequestAborted);
                 var styleLayers = StyleTranslator.ParseStyleLayers(style?.MapLibreStyleJson);
 
-                RenderLayerToCanvas(canvas, queryResult.Items, styleLayers, transform, layer.GeometryType);
+                RenderLayerToCanvas(canvas, queryResult.Items, styleLayers, transform, layer.GeometryType, renderZoom);
             }
 
             // Render overlay markers
@@ -832,11 +838,12 @@ internal static partial class StaticMapEndpoints
         ImmutableArray<Feature> features,
         MapLibreStyleLayer[] styleLayers,
         Func<double, double, SKPoint> transform,
-        MetadataV2GeometryType geometryType)
+        MetadataV2GeometryType geometryType,
+        RenderZoom zoom)
     {
         if (styleLayers.Length > 0)
         {
-            SkiaMapRenderer.RenderWithStyles(canvas, features, styleLayers, transform);
+            SkiaMapRenderer.RenderWithStyles(canvas, features, styleLayers, transform, zoom);
         }
         else
         {

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsZoomGatingTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsZoomGatingTests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using FluentAssertions;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using SkiaSharp;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms;
+
+/// <summary>
+/// Integration coverage for honua-server#2868: WMS GetMap must derive a MapLibre zoom from
+/// BBOX + WIDTH/HEIGHT + CRS and apply each style layer's minzoom/maxzoom gate. Before the fix
+/// GetMap passed no zoom at all, so every layer drew at every scale.
+/// </summary>
+/// <remarks>
+/// Both requests below use the same EPSG:3857 envelope and differ only in image size, so the
+/// geographic window (and therefore the features in view) is identical and the only variable is
+/// the derived zoom. The envelope is the Web Mercator projection of -123,37 .. -122,38, which
+/// contains the seeded point features. Derived zoom is min over the two axes of
+/// log2(pixels / (512 * mercatorSpan)): 7.158 at 256px and 9.158 at 1024px, so a minzoom/maxzoom
+/// of 8 falls cleanly between them with ~0.84 of margin on either side.
+/// </remarks>
+[Collection("Database")]
+[Protocol(TestProtocols.Wms13)]
+public sealed class OgcClassicWmsZoomGatingTests : IAsyncLifetime
+{
+    private const string Bbox3857 = "-13692297.3676,4439106.7873,-13580977.8768,4579425.8129";
+    private const int ZoomedOutPixels = 256;   // derived MapLibre zoom ~7.158
+    private const int ZoomedInPixels = 1024;   // derived MapLibre zoom ~9.158
+
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    private static string CircleStyle(string? zoomScoping) =>
+        $$"""
+        {
+          "version": 8,
+          "sources": {},
+          "layers": [
+            {
+              "id": "points",
+              "type": "circle",
+              "source": "features",
+              {{zoomScoping}}
+              "paint": { "circle-color": "#ff0000", "circle-radius": 10 }
+            }
+          ]
+        }
+        """;
+
+    private async Task<byte[]> GetMapAsync(int pixels)
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMS" +
+            $"?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&BBOX={Bbox3857}" +
+            $"&WIDTH={pixels}&HEIGHT={pixels}&CRS=EPSG:3857" +
+            $"&LAYERS={WebAppFixture.TestLayerId}&STYLES=&FORMAT=image/png&TRANSPARENT=true");
+
+        var content = await response.Content.ReadAsByteArrayAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.OK, System.Text.Encoding.UTF8.GetString(content));
+        return content;
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Wms)]
+    [InterfaceOperation(TestProtocols.Wms13, "GetMap")]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms_GetMap_UnscopedStyle_RendersAtEveryScale()
+    {
+        var catalog = _fixture.GetService<ILayerStyleCatalog>();
+        await catalog.SetMapLibreStyleAsync(WebAppFixture.TestLayerId, CircleStyle(null));
+
+        // Baseline: with no minzoom/maxzoom the layer must draw at both scales. This pins the
+        // style binding and the layer mapping so a gating failure below cannot be a false positive.
+        HasStyledPixel(await GetMapAsync(ZoomedOutPixels)).Should().BeTrue();
+        HasStyledPixel(await GetMapAsync(ZoomedInPixels)).Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Wms)]
+    [InterfaceOperation(TestProtocols.Wms13, "GetMap")]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms_GetMap_MinZoomScopedStyle_OmitsLayerBelowThreshold()
+    {
+        var catalog = _fixture.GetService<ILayerStyleCatalog>();
+        await catalog.SetMapLibreStyleAsync(WebAppFixture.TestLayerId, CircleStyle("\"minzoom\": 8,"));
+
+        HasStyledPixel(await GetMapAsync(ZoomedOutPixels)).Should()
+            .BeFalse("derived zoom ~7.16 is below the layer's minzoom of 8");
+        HasStyledPixel(await GetMapAsync(ZoomedInPixels)).Should()
+            .BeTrue("derived zoom ~9.16 is at or above the layer's minzoom of 8");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Wms)]
+    [InterfaceOperation(TestProtocols.Wms13, "GetMap")]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms_GetMap_MaxZoomScopedStyle_OmitsLayerAtOrAboveThreshold()
+    {
+        var catalog = _fixture.GetService<ILayerStyleCatalog>();
+        await catalog.SetMapLibreStyleAsync(WebAppFixture.TestLayerId, CircleStyle("\"maxzoom\": 8,"));
+
+        // maxzoom is exclusive in MapLibre, so the zoomed-in request (~9.16) is gated out while
+        // the zoomed-out request (~7.16) still draws.
+        HasStyledPixel(await GetMapAsync(ZoomedOutPixels)).Should()
+            .BeTrue("derived zoom ~7.16 is below the layer's maxzoom of 8");
+        HasStyledPixel(await GetMapAsync(ZoomedInPixels)).Should()
+            .BeFalse("derived zoom ~9.16 is at or above the layer's exclusive maxzoom of 8");
+    }
+
+    private static bool HasStyledPixel(byte[] pngBytes)
+    {
+        using var bitmap = SKBitmap.Decode(pngBytes);
+        bitmap.Should().NotBeNull("the GetMap response must be a decodable PNG");
+
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                if (pixel.Alpha > 0 && pixel.Red > 150 && pixel.Green < 80 && pixel.Blue < 80)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/RenderZoomTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/RenderZoomTests.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Infrastructure.Rendering;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Rendering;
+
+/// <summary>
+/// Tests for deriving a MapLibre zoom level from a render envelope and image size.
+/// </summary>
+/// <remarks>
+/// The reference envelopes below are the bounds a MapLibre GL JS map reports for a known
+/// camera zoom, center, and viewport at bearing 0 / pitch 0. They are computed from MapLibre's
+/// own published definitions: <c>mercatorXfromLng</c>/<c>mercatorYfromLat</c>
+/// (src/geo/mercator_coordinate.ts) over a world of <c>tileSize * 2^zoom</c> pixels, where
+/// <c>Transform.tileSize</c> is the constant 512 (src/geo/transform_helper.ts). Deriving the zoom
+/// back from those bounds must return the camera zoom MapLibre started from — a derivation that is
+/// off by one silently drops or adds a layer.
+/// </remarks>
+[Trait("Component", "MapServer")]
+public class RenderZoomTests
+{
+    private const int WebMercator = 3857;
+    private const int Wgs84 = 4326;
+    private const double WorldSpanMeters = 40075016.685578488;
+
+    [Theory]
+    // center lng/lat, camera zoom, viewport px -> the EPSG:3857 bounds MapLibre covers.
+    [InlineData("SF", -13637449.2108385768, 4540337.3996251794, -13617881.3315975722, 4555013.3090559337, 1024, 768, 12.0)]
+    [InlineData("Oslo", 1195018.5032003040, 8379160.3756668363, 1198840.3546145628, 8382026.7642275300, 800, 600, 14.0)]
+    [InlineData("Sydney", 16793406.5207253322, -4050334.4057895844, 16871678.0376893505, -3972062.8888255637, 512, 512, 9.0)]
+    [InlineData("NullIsland", -20037508.3427892439, -20037508.3427892439, 20037508.3427892439, 20037508.3427892439, 512, 512, 0.0)]
+    [InlineData("Quito", -8735377.7248098571, -20421.2134459828, -8734613.3545270059, -19809.7172197014, 1280, 1024, 17.0)]
+    public void FromWebMercatorExtent_MapLibreViewport_RecoversCameraZoom(
+        string label,
+        double minX,
+        double minY,
+        double maxX,
+        double maxY,
+        int imageWidth,
+        int imageHeight,
+        double expectedZoom)
+    {
+        label.Should().NotBeNull();
+        var extent = new SkiaMapRenderer.RenderExtent(minX, minY, maxX, maxY);
+
+        var zoom = RenderZoom.FromWebMercatorExtent(extent, imageWidth, imageHeight);
+
+        zoom.Level.Should().NotBeNull();
+        zoom.Level!.Value.Should().BeApproximately(expectedZoom, 1e-9);
+        zoom.NotDerivableReason.Should().BeNull();
+    }
+
+    [UnitTest]
+    public void FromExtent_Wgs84WholeWorld_MatchesWebMercatorWholeWorld()
+    {
+        var geographic = RenderZoom.FromExtent(
+            new SkiaMapRenderer.RenderExtent(-180, -85.0511287798066, 180, 85.0511287798066),
+            512,
+            512,
+            Wgs84);
+
+        geographic.Level.Should().NotBeNull();
+        geographic.Level!.Value.Should().BeApproximately(0.0, 1e-9);
+    }
+
+    [Theory]
+    // A whole-world Web Mercator envelope is MapLibre zoom 0 at 512px, because MapLibre's world
+    // is 512 * 2^zoom pixels wide. Halving the pixels halves the detail: one zoom level down.
+    [InlineData(512, 0.0)]
+    [InlineData(256, -1.0)]
+    [InlineData(1024, 1.0)]
+    [InlineData(2048, 2.0)]
+    public void FromWebMercatorExtent_WholeWorld_ScalesWithImageSize(int imagePixels, double expectedZoom)
+    {
+        var half = WorldSpanMeters / 2.0;
+        var extent = new SkiaMapRenderer.RenderExtent(-half, -half, half, half);
+
+        var zoom = RenderZoom.FromWebMercatorExtent(extent, imagePixels, imagePixels);
+
+        zoom.Level!.Value.Should().BeApproximately(expectedZoom, 1e-9);
+    }
+
+    [Theory]
+    // A WebMercatorQuad tile matrix level is not the MapLibre camera zoom: these tiles are 256px,
+    // so a client consuming them as a 256px raster source sits one camera zoom below the level.
+    [InlineData(4, 256, 3.0)]
+    [InlineData(4, 512, 4.0)]
+    [InlineData(14, 256, 13.0)]
+    [InlineData(14, 512, 14.0)]
+    public void FromWebMercatorExtent_TileEnvelope_IsOneZoomBelowMatrixLevelAt256Px(
+        int matrixLevel,
+        int tilePixels,
+        double expectedZoom)
+    {
+        var tileSpan = WorldSpanMeters / Math.Pow(2, matrixLevel);
+        var minX = -WorldSpanMeters / 2.0;
+        var extent = new SkiaMapRenderer.RenderExtent(minX, 0, minX + tileSpan, tileSpan);
+
+        var zoom = RenderZoom.FromWebMercatorExtent(extent, tilePixels, tilePixels);
+
+        zoom.Level!.Value.Should().BeApproximately(expectedZoom, 1e-9);
+    }
+
+    [UnitTest]
+    public void FromWebMercatorExtent_MismatchedAspect_FitsTheMoreConstrainedAxis()
+    {
+        // MapLibre's cameraForBoxAndBearing takes Math.min(scaleX, scaleY), so the axis that needs
+        // to zoom out furthest wins.
+        var quarterWorld = WorldSpanMeters / 4.0;
+        var extent = new SkiaMapRenderer.RenderExtent(0, 0, quarterWorld, quarterWorld / 2.0);
+
+        var zoom = RenderZoom.FromWebMercatorExtent(extent, 512, 512);
+
+        // x: log2(512 / (512 * 1/4)) = 2 ; y: log2(512 / (512 * 1/8)) = 3 -> min = 2
+        zoom.Level!.Value.Should().BeApproximately(2.0, 1e-9);
+    }
+
+    [UnitTest]
+    public void FromExtent_UnsupportedCrs_IsNotDerivableWithAReason()
+    {
+        var zoom = RenderZoom.FromExtent(
+            new SkiaMapRenderer.RenderExtent(400000, 5000000, 410000, 5010000),
+            512,
+            512,
+            25832);
+
+        zoom.Level.Should().BeNull();
+        zoom.NotDerivableReason.Should().Contain("25832");
+    }
+
+    [Theory]
+    [InlineData(0, 512)]
+    [InlineData(512, 0)]
+    [InlineData(-1, 512)]
+    public void FromWebMercatorExtent_NonPositiveDimensions_IsNotDerivable(int imageWidth, int imageHeight)
+    {
+        var extent = new SkiaMapRenderer.RenderExtent(0, 0, 1000, 1000);
+
+        var zoom = RenderZoom.FromWebMercatorExtent(extent, imageWidth, imageHeight);
+
+        zoom.Level.Should().BeNull();
+        zoom.NotDerivableReason.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [UnitTest]
+    public void FromWebMercatorExtent_DegenerateExtent_IsNotDerivable()
+    {
+        var extent = new SkiaMapRenderer.RenderExtent(0, 0, 0, 0);
+
+        var zoom = RenderZoom.FromWebMercatorExtent(extent, 512, 512);
+
+        zoom.Level.Should().BeNull();
+        zoom.NotDerivableReason.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [UnitTest]
+    public void NotDerivable_WithoutReason_Throws()
+    {
+        var act = () => RenderZoom.NotDerivable("  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [UnitTest]
+    public void FromExtent_WebMercatorAlias_DerivesSameZoomAsEpsg3857()
+    {
+        var half = WorldSpanMeters / 2.0;
+        var extent = new SkiaMapRenderer.RenderExtent(-half, -half, half, half);
+
+        var canonical = RenderZoom.FromExtent(extent, 512, 512, WebMercator);
+        var alias = RenderZoom.FromExtent(extent, 512, 512, 900913);
+
+        alias.Level.Should().NotBeNull();
+        alias.Level!.Value.Should().BeApproximately(canonical.Level!.Value, 1e-9);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/SkiaMapRendererTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/SkiaMapRendererTests.cs
@@ -32,7 +32,8 @@ public class SkiaMapRendererTests
             256,
             transparent: true,
             backgroundColor: null,
-            MetadataV2GeometryType.Point);
+            MetadataV2GeometryType.Point,
+            RenderZoom.NotDerivable("unit test"));
 
         result.Should().NotBeEmpty();
         // PNG magic bytes
@@ -65,7 +66,8 @@ public class SkiaMapRendererTests
             256,
             transparent: true,
             backgroundColor: null,
-            MetadataV2GeometryType.Point);
+            MetadataV2GeometryType.Point,
+            RenderZoom.NotDerivable("unit test"));
 
         result.Should().NotBeEmpty();
         result[0].Should().Be(0x89); // PNG header
@@ -85,7 +87,8 @@ public class SkiaMapRendererTests
             100,
             transparent: false,
             backgroundColor: SKColors.White,
-            MetadataV2GeometryType.None);
+            MetadataV2GeometryType.None,
+            RenderZoom.NotDerivable("unit test"));
 
         result.Should().NotBeEmpty();
     }
@@ -115,7 +118,8 @@ public class SkiaMapRendererTests
             256,
             transparent: true,
             backgroundColor: null,
-            MetadataV2GeometryType.Point);
+            MetadataV2GeometryType.Point,
+            RenderZoom.NotDerivable("unit test"));
 
         result.Should().NotBeEmpty();
     }
@@ -142,7 +146,8 @@ public class SkiaMapRendererTests
             64,
             transparent: true,
             backgroundColor: null,
-            MetadataV2GeometryType.Point);
+            MetadataV2GeometryType.Point,
+            RenderZoom.NotDerivable("unit test"));
 
         HasNonTransparentPixel(result).Should().BeFalse();
     }
@@ -170,7 +175,7 @@ public class SkiaMapRendererTests
             transparent: true,
             backgroundColor: null,
             MetadataV2GeometryType.Point,
-            zoom: 4);
+            RenderZoom.At(4));
         var visible = renderer.RenderMap(
             [feature],
             styleLayers,
@@ -180,7 +185,7 @@ public class SkiaMapRendererTests
             transparent: true,
             backgroundColor: null,
             MetadataV2GeometryType.Point,
-            zoom: 6);
+            RenderZoom.At(6));
 
         HasNonTransparentPixel(hidden).Should().BeFalse();
         HasNonTransparentPixel(visible).Should().BeTrue();
@@ -237,7 +242,7 @@ public class SkiaMapRendererTests
         using var renderer = new SkiaMapRenderer();
         var extent = new SkiaMapRenderer.RenderExtent(0, 0, 1, 1);
 
-        var act = () => renderer.RenderMap([], [], extent, width, 10, true, null, MetadataV2GeometryType.None);
+        var act = () => renderer.RenderMap([], [], extent, width, 10, true, null, MetadataV2GeometryType.None, RenderZoom.NotDerivable("unit test"));
 
         act.Should().Throw<ArgumentOutOfRangeException>()
             .Which.ParamName.Should().Be("imageWidth");
@@ -386,7 +391,7 @@ public class SkiaMapRendererTests
         renderer.Dispose();
 
         var extent = new SkiaMapRenderer.RenderExtent(0, 0, 1, 1);
-        var act = () => renderer.RenderMap([], [], extent, 10, 10, true, null, MetadataV2GeometryType.None);
+        var act = () => renderer.RenderMap([], [], extent, 10, 10, true, null, MetadataV2GeometryType.None, RenderZoom.NotDerivable("unit test"));
 
         act.Should().Throw<ObjectDisposedException>();
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyleTranslatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyleTranslatorTests.cs
@@ -221,7 +221,7 @@ public class StyleTranslatorTests
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"c","type":"circle","layout":{"visibility":"none"}}]""");
 
-        StyleTranslator.ShouldRenderLayer(layers[0]).Should().BeFalse();
+        StyleTranslator.ShouldRenderLayer(layers[0], RenderZoom.NotDerivable("unit test")).Should().BeFalse();
     }
 
     [Theory]
@@ -233,8 +233,53 @@ public class StyleTranslatorTests
     public void ShouldRenderLayer_WithZoomContext_AppliesMinInclusiveMaxExclusive(double? zoom, bool expected)
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"c","type":"circle","minzoom":5,"maxzoom":10}]""");
+        var renderZoom = zoom.HasValue ? RenderZoom.At(zoom.Value) : RenderZoom.NotDerivable("unit test");
 
-        StyleTranslator.ShouldRenderLayer(layers[0], zoom).Should().Be(expected);
+        StyleTranslator.ShouldRenderLayer(layers[0], renderZoom).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(4.99, false)]
+    [InlineData(5.0, true)]
+    [InlineData(9.99, true)]
+    [InlineData(10.0, false)]
+    public void IsAnyLayerInZoomRange_SingleScopedLayer_MatchesLayerGate(double zoom, bool expected)
+    {
+        var layers = StyleTranslator.ParseStyleLayers("""[{"id":"c","type":"circle","minzoom":5,"maxzoom":10}]""");
+
+        StyleTranslator.IsAnyLayerInZoomRange(layers, RenderZoom.At(zoom)).Should().Be(expected);
+    }
+
+    [UnitTest]
+    public void IsAnyLayerInZoomRange_OneLayerInRange_ReturnsTrue()
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"circle","minzoom":14},{"id":"b","type":"line","maxzoom":8}]""");
+
+        StyleTranslator.IsAnyLayerInZoomRange(layers, RenderZoom.At(4)).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsAnyLayerInZoomRange_AllLayersOutOfRange_ReturnsFalse()
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"circle","minzoom":14},{"id":"b","type":"line","minzoom":16}]""");
+
+        StyleTranslator.IsAnyLayerInZoomRange(layers, RenderZoom.At(4)).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void IsAnyLayerInZoomRange_NoDerivedZoom_ReturnsTrue()
+    {
+        var layers = StyleTranslator.ParseStyleLayers("""[{"id":"a","type":"circle","minzoom":14}]""");
+
+        StyleTranslator.IsAnyLayerInZoomRange(layers, RenderZoom.NotDerivable("unit test")).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void IsAnyLayerInZoomRange_EmptyStyle_ReturnsTrue()
+    {
+        StyleTranslator.IsAnyLayerInZoomRange([], RenderZoom.At(4)).Should().BeTrue();
     }
 
     [UnitTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2868

## Summary

WMS `GetMap` never supplied a zoom, so `StyleTranslator.ShouldRenderLayer`'s `zoom = null` default silently skipped every layer's `minzoom`/`maxzoom` gate — every layer drew at every scale.

The audit the ticket asked for found **WMS was not the only broken caller — every server-side render path was**. The shared draw path `RasterMapRenderingPipeline.RenderLayerToCanvas` (reached by WMS `GetMap`, Esri `MapServer/export`, the raster tile pipeline, OGC API Maps, static maps, and the bound-style vector compositor) never called `ShouldRenderLayer` at all, so it could not gate even if a zoom had been available. The one path that did call it — `SkiaMapRenderer.RenderWithStyles` — was only ever reached by callers relying on the `null` default. The gate was inert product-wide.

This derives a MapLibre zoom from the rendered envelope and pixel size, threads it through all of those paths, and closes the `null` trap so the next caller cannot silently repeat this.

**How zoom is derived.** MapLibre GL JS defines the mercator world as `Transform.tileSize * 2^zoom` pixels, with `tileSize` a constant 512 (`src/geo/transform_helper.ts`), so `zoom = log2(pixels / (512 * mercatorSpan))`, taking `min` over the two axes exactly as MapLibre's own `cameraForBoxAndBearing` does (`Math.min(scaleX, scaleY)`, `src/geo/projection/camera_helper.ts`). Verified against MapLibre's published `mercatorXfromLng`/`mercatorYfromLat` (`src/geo/mercator_coordinate.ts`): the bounds MapLibre reports for five known camera zoom/center/viewport combinations round-trip back to the original zoom to ~1e-14 (`RenderZoomTests`).

The derivation is deliberately **scale-based, not tile-level-based**: zoom is the camera zoom at which an image is displayed 1:1. This is the only self-consistent rule — the same envelope at the same pixel size now gates identically no matter which protocol asked for it. Two consequences worth naming, both correct rather than incidental:

- A 256px tile of matrix level *z* derives to camera zoom *z − 1*. That is right: a MapLibre client with a 256px raster source sits one camera zoom below the matrix level it fetches, so a style saying "labels above z14" starts drawing them exactly when the camera reaches 14.
- Static maps derive rather than reuse `parameters.Zoom`, because `CenterZoomToExtent` defines that zoom against 256px tiles while MapLibre's camera zoom is against 512px — they differ by one. Deriving also covers the bbox route, which carries no zoom at all.

**Non-WebMercator CRSs.** Gating applies to every CRS whose extent can be expressed in Web Mercator, and it is exact rather than approximate. EPSG:3857 and its aliases derive directly; geographic and other CRSs reproject through the shared transform services the render paths already use. Reprojecting to mercator *before* deriving is what makes this MapLibre-correct for projected CRSs — it naturally accounts for the `1/cos(latitude)` mercator distortion that makes a UTM ground span a different mercator span, which a ground-resolution shortcut would have got wrong by a full zoom level at 60° latitude. Only a CRS with no available transform at all is left ungated, and that path is explicit and traceable rather than silent.

**Closing the trap.** `zoom` is no longer `double? = null`. It is a required `RenderZoom` — a reference type with no public constructor and no meaningful default, so "no zoom" is unreachable by omission and every render path must state which case it is in: `RenderZoom.At(level)` or `RenderZoom.NotDerivable(reason)`. The reason is recorded on the current activity (`honua.render.zoom` / `honua.render.zoom_ungated_reason`), so an ungated render is diagnosable instead of invisible. This is not theoretical — making the parameter required caused the compiler to catch a call site that had been missed while writing this change.

## Changes Made
- Add `RenderZoom` (`src/Honua.Hosting/Features/Rendering/RenderZoom.cs`): a MapLibre zoom derived from an envelope + pixel size, or an explicit `NotDerivable` carrying a reason.
- Add `RasterMapRenderingPipeline.DeriveRenderZoomAsync`, which resolves CRSs with no in-process mercator mapping through the shared coordinate transform services and records the outcome on the current activity.
- Make `StyleTranslator.ShouldRenderLayer`'s `zoom` a required `RenderZoom` instead of `double? = null`, and require it on `SkiaMapRenderer.RenderMap` / `RenderFeaturesOnCanvas` / `RenderWithStyles`.
- Gate `RasterMapRenderingPipeline.RenderLayerToCanvas` on `ShouldRenderLayer`, which it never called — this is what makes gating actually reach WMS, MapServer export, tiles, OGC API Maps, and static maps.
- Derive and pass a zoom from WMS `GetMap` (`BBOX` + `WIDTH`/`HEIGHT` + `CRS`), Esri `MapServer/export`, the raster tile core, OGC API Maps, the bound-style vector compositor, static maps, and print.
- Add `StyleTranslator.IsAnyLayerInZoomRange` and use it in WMS `GetMap` and the tile core to skip *querying* a layer whose style is entirely out of range, not just skip drawing it (the performance tail called out in the ticket).
- Tests: `RenderZoomTests` (MapLibre reference viewports, tile-size semantics, aspect handling, unsupported CRS, degenerate input), `OgcClassicWmsZoomGatingTests` (min/max zoom gating end-to-end over WMS `GetMap`), plus `StyleTranslator`/`SkiaMapRenderer` boundary coverage.
- Regenerate `docs/gis/data/feature-catalog.json` (in Release) — the only change is the three new `[Endpoint]`-attributed proving tests joining the existing WMS route entry. No new routes, so `EndpointRegistry` and `public-interface-proof.json` are untouched.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Boundary semantics are pinned to MapLibre's asymmetric rule — `zoom < minzoom` hides, `zoom >= maxzoom` hides — at 4.99 / 5.0 / 9.99 / 10.0 for a `minzoom:5,maxzoom:10` layer, so the existing `<` / `>=` asymmetry cannot regress.

The new WMS integration tests were verified to actually catch the bug rather than pass vacuously. With the zoom derivation reverted to `NotDerivable` (reproducing trunk's behavior), `Wms_GetMap_MinZoomScopedStyle_OmitsLayerBelowThreshold` and `Wms_GetMap_MaxZoomScopedStyle_OmitsLayerAtOrAboveThreshold` both fail with the layer drawing where it should not; restoring the derivation makes them pass. The unscoped baseline test passes either way by design, so a gating assertion cannot pass merely because the style silently failed to bind.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

No new routes, so no `EndpointRegistry` / `public-interface-proof.json` / catalog changes.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

**This changes rendered output**, which is the point: layers with `minzoom`/`maxzoom` that previously drew at every scale will now disappear outside their declared range. No server-rendered golden-image baselines exist in the repo, so none needed regenerating — the only committed rendered snapshot (`tests/js-browser/esri-leaflet/rendering.spec.ts-snapshots/`) is a client-side Leaflet render of vector features from `/rest/services/.../FeatureServer` and is not produced by this pipeline.

One deliberate, disclosed side effect: routing `RenderLayerToCanvas` through the shared `ShouldRenderLayer` gate also makes it honor `layout.visibility: "none"`, which it previously ignored. That is the same latent defect in the same helper, `SkiaMapRenderer.RenderWithStyles` already honored it, and adding a second zoom-only entry point purely to preserve "draw the layer the cartographer hid" would have been worse than reusing the canonical gate.

## Coordination

Two notes for whoever lands #2866 (WMS `GetLegendGraphic`), which is open and touches `SkiaMapRenderer.cs`:

1. **It will need a one-line update after this lands.** #2866 calls `StyleTranslator.ShouldRenderLayer(styleLayer, zoom)` with a `double? zoom` that is `null` when `SCALE` is absent. That signature is now `RenderZoom`, so its no-SCALE path becomes `RenderZoom.NotDerivable("WMS SCALE parameter was not supplied")` and its SCALE path `RenderZoom.At(...)`. This is the trap-closing working as intended: the null path has to be named rather than defaulted.

2. **Its scale→zoom conversion looks off by one against MapLibre**, and is worth a look before the two ship together. #2866 uses `LegendScaleDenominatorZoom0 = 559082264.0287178` — the GoogleMapsCompatible/WMTS zoom-0 scale denominator, which is derived from **256px** tiles. MapLibre's camera zoom 0 is a **512px** world, i.e. scale denominator `279541132.0143588`. So `log2(559082264.0287178 / SCALE)` returns exactly **MapLibre camera zoom + 1**. If both land as-is, `GetLegendGraphic` and `GetMap` gate the same style at the same physical scale one zoom apart — the legend would list a layer the map does not draw. I have not touched #2866; flagging only.

## Breaking Changes
None — internal APIs only.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed<sup>*</sup>

<sup>*</sup> `scripts/ci/pre-pr-check.sh` is currently broken on a Windows host and aborts at its restore step with `MSB5028: Solution filter file ... includes project ... that is not in the solution file`. This is **pre-existing and unrelated to this PR** — it reproduces identically on a clean `origin/trunk` checkout with no changes applied. The equivalent checks were run directly instead, all green: full-solution Release build with `TreatWarningsAsErrors=true`, `dotnet format Honua.sln --verify-no-changes`, `Honua.Architecture.Tests`, the full WMS suite (65/65), and the affected rendering unit tests.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
