### PR TITLE
feat(rendering): evaluate ["zoom"] expressions against the derived RenderZoom (#2873)

### DIFF
--- a/src/Honua.Hosting/Features/Rendering/ExpressionEvaluator.cs
+++ b/src/Honua.Hosting/Features/Rendering/ExpressionEvaluator.cs
@@ -9,9 +9,17 @@ using SkiaSharp;
 namespace Honua.Infrastructure.Rendering;
 
 /// <summary>
-/// Evaluates MapLibre style expressions against feature properties.
-/// Supports common expression operators: get, case, match, interpolate, step, literal, has, !, ==, !=, &lt;, &gt;, etc.
+/// Evaluates MapLibre style expressions against feature properties and the zoom the render is
+/// being evaluated at.
+/// Supports common expression operators: get, zoom, case, match, interpolate, step, literal, has, !, ==, !=, &lt;, &gt;, etc.
 /// </summary>
+/// <remarks>
+/// Every entry point takes an explicit <see cref="RenderZoom"/> rather than defaulting to "no zoom",
+/// so a caller cannot reach the zoom-dependent operators by accident. A render that carries
+/// <see cref="RenderZoom.NotDerivable"/> and evaluates a <c>["zoom"]</c> expression raises
+/// <see cref="StyleExpressionEvaluationException"/> instead of substituting a placeholder level
+/// (honua-server#2873).
+/// </remarks>
 internal static class ExpressionEvaluator
 {
     /// <summary>
@@ -23,37 +31,55 @@ internal static class ExpressionEvaluator
     private const double NumericEpsilon = 1e-9;
 
     /// <summary>
-    /// Evaluates a MapLibre expression to a color value.
+    /// Evaluates a MapLibre expression to a color value at the supplied <paramref name="zoom"/>.
     /// </summary>
-    public static SKColor EvaluateColor(MapLibreExpression expression, ImmutableDictionary<string, object?> properties)
+    public static SKColor EvaluateColor(
+        MapLibreExpression expression,
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
-        var result = Evaluate(expression, properties);
+        var result = Evaluate(expression, properties, zoom);
         return ParseColor(result);
     }
 
     /// <summary>
-    /// Evaluates a MapLibre expression to a float value.
+    /// Evaluates a MapLibre expression to a float value at the supplied <paramref name="zoom"/>.
     /// </summary>
-    public static float EvaluateFloat(MapLibreExpression expression, ImmutableDictionary<string, object?> properties, float defaultValue = 0f)
+    public static float EvaluateFloat(
+        MapLibreExpression expression,
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom,
+        float defaultValue = 0f)
     {
-        var result = Evaluate(expression, properties);
+        var result = Evaluate(expression, properties, zoom);
         return ConvertToFloat(result, defaultValue);
     }
 
     /// <summary>
-    /// Evaluates a MapLibre expression to a string value.
+    /// Evaluates a MapLibre expression to a string value at the supplied <paramref name="zoom"/>.
     /// </summary>
-    public static string? EvaluateString(MapLibreExpression expression, ImmutableDictionary<string, object?> properties)
+    public static string? EvaluateString(
+        MapLibreExpression expression,
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
-        var result = Evaluate(expression, properties);
+        var result = Evaluate(expression, properties, zoom);
         return result?.ToString();
     }
 
     /// <summary>
     /// Core expression evaluator.
     /// </summary>
-    public static object? Evaluate(MapLibreExpression expression, ImmutableDictionary<string, object?> properties)
+    /// <exception cref="StyleExpressionEvaluationException">
+    /// The expression evaluates <c>["zoom"]</c> but <paramref name="zoom"/> carries no derived level.
+    /// </exception>
+    public static object? Evaluate(
+        MapLibreExpression expression,
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
+        ArgumentNullException.ThrowIfNull(zoom);
+
         return expression.Kind switch
         {
             MapLibreExpressionKind.String => expression.StringValue,
@@ -61,7 +87,7 @@ internal static class ExpressionEvaluator
             MapLibreExpressionKind.Boolean => expression.BoolValue,
             MapLibreExpressionKind.Null => null,
             MapLibreExpressionKind.Array => expression.Items is { Length: > 0 }
-                ? EvaluateArrayExpression(expression.Items, properties)
+                ? EvaluateArrayExpression(expression.Items, properties, zoom)
                 : null,
             _ => null
         };
@@ -102,7 +128,10 @@ internal static class ExpressionEvaluator
         return values.Length > 0;
     }
 
-    private static object? EvaluateArrayExpression(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static object? EvaluateArrayExpression(
+        MapLibreExpression[] array,
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
         if (array.Length == 0)
         {
@@ -118,31 +147,60 @@ internal static class ExpressionEvaluator
         {
             "get" => EvaluateGet(array, properties),
             "has" => EvaluateHas(array, properties),
-            "!" => EvaluateNot(array, properties),
-            "case" => EvaluateCase(array, properties),
-            "match" => EvaluateMatch(array, properties),
-            "step" => EvaluateStep(array, properties),
-            "interpolate" => EvaluateInterpolate(array, properties),
+            "zoom" => EvaluateZoom(zoom),
+            "!" => EvaluateNot(array, properties, zoom),
+            "case" => EvaluateCase(array, properties, zoom),
+            "match" => EvaluateMatch(array, properties, zoom),
+            "step" => EvaluateStep(array, properties, zoom),
+            "interpolate" => EvaluateInterpolate(array, properties, zoom),
             "literal" => array.Length > 1 ? EvaluateLiteral(array[1]) : null,
-            "to-string" => EvaluateToString(array, properties),
-            "to-number" => EvaluateToNumber(array, properties),
-            "typeof" => EvaluateTypeof(array, properties),
-            "concat" => EvaluateConcat(array, properties),
-            "==" => EvaluateComparison(array, properties, CompareEqual),
-            "!=" => EvaluateComparison(array, properties, CompareNotEqual),
-            "<" => EvaluateComparison(array, properties, CompareLessThan),
-            ">" => EvaluateComparison(array, properties, CompareGreaterThan),
-            "<=" => EvaluateComparison(array, properties, CompareLessThanOrEqual),
-            ">=" => EvaluateComparison(array, properties, CompareGreaterThanOrEqual),
-            "all" => EvaluateAll(array, properties),
-            "any" => EvaluateAny(array, properties),
-            "coalesce" => EvaluateCoalesce(array, properties),
-            "+" => EvaluateArithmetic(array, properties, (a, b) => a + b),
-            "-" => EvaluateArithmetic(array, properties, (a, b) => a - b),
-            "*" => EvaluateArithmetic(array, properties, (a, b) => a * b),
-            "/" => EvaluateArithmetic(array, properties, (a, b) => Math.Abs(b) > NumericEpsilon ? a / b : 0),
+            "to-string" => EvaluateToString(array, properties, zoom),
+            "to-number" => EvaluateToNumber(array, properties, zoom),
+            "typeof" => EvaluateTypeof(array, properties, zoom),
+            "concat" => EvaluateConcat(array, properties, zoom),
+            "==" => EvaluateComparison(array, properties, zoom, CompareEqual),
+            "!=" => EvaluateComparison(array, properties, zoom, CompareNotEqual),
+            "<" => EvaluateComparison(array, properties, zoom, CompareLessThan),
+            ">" => EvaluateComparison(array, properties, zoom, CompareGreaterThan),
+            "<=" => EvaluateComparison(array, properties, zoom, CompareLessThanOrEqual),
+            ">=" => EvaluateComparison(array, properties, zoom, CompareGreaterThanOrEqual),
+            "all" => EvaluateAll(array, properties, zoom),
+            "any" => EvaluateAny(array, properties, zoom),
+            "coalesce" => EvaluateCoalesce(array, properties, zoom),
+            "+" => EvaluateArithmetic(array, properties, zoom, (a, b) => a + b),
+            "-" => EvaluateArithmetic(array, properties, zoom, (a, b) => a - b),
+            "*" => EvaluateArithmetic(array, properties, zoom, (a, b) => a * b),
+            "/" => EvaluateArithmetic(array, properties, zoom, (a, b) => Math.Abs(b) > NumericEpsilon ? a / b : 0),
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Evaluates the MapLibre <c>["zoom"]</c> input, which yields the zoom level the render is being
+    /// evaluated at. MapLibre GL JS reads this from the evaluation globals
+    /// (<c>expression/definitions/index.ts</c> binds <c>zoom</c> to <c>ctx.globals.zoom</c>) and
+    /// returns it as a plain number, so a fractional zoom stays fractional here too.
+    /// </summary>
+    /// <remarks>
+    /// When the render carries no derived zoom this raises rather than substituting a level. A
+    /// substituted zoom is not a degraded picture but a confidently wrong one: every zoom ramp would
+    /// silently collapse onto whichever stop the placeholder selects, with no throw, warning, or log
+    /// — the failure mode that made <c>interpolate</c> render black in honua-server#2867 and that let
+    /// <c>minzoom</c>/<c>maxzoom</c> be skipped in honua-server#2868. The
+    /// <see cref="RenderZoom.NotDerivableReason"/> recorded by the render path is carried into the
+    /// message so the cause is traceable from the failure alone.
+    /// </remarks>
+    private static double EvaluateZoom(RenderZoom zoom)
+    {
+        if (zoom.Level is { } level)
+        {
+            return level;
+        }
+
+        throw new StyleExpressionEvaluationException(
+            "Cannot evaluate a [\"zoom\"] expression: no zoom could be derived for this render because "
+            + $"{zoom.NotDerivableReason}. The style is zoom-dependent, so it cannot be rendered "
+            + "correctly at an unknown zoom.");
     }
 
     private static object? EvaluateLiteral(MapLibreExpression expression)
@@ -190,35 +248,35 @@ internal static class ExpressionEvaluator
         return properties.ContainsKey(key);
     }
 
-    private static bool EvaluateNot(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static bool EvaluateNot(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         if (array.Length < 2)
         {
             return true;
         }
 
-        var result = Evaluate(array[1], properties);
+        var result = Evaluate(array[1], properties, zoom);
         return !IsTruthy(result);
     }
 
-    private static object? EvaluateCase(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static object? EvaluateCase(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         // case, condition1, output1, condition2, output2, ..., fallback
         for (int i = 1; i < length - 1; i += 2)
         {
-            var condition = Evaluate(array[i], properties);
+            var condition = Evaluate(array[i], properties, zoom);
             if (IsTruthy(condition))
             {
-                return Evaluate(array[i + 1], properties);
+                return Evaluate(array[i + 1], properties, zoom);
             }
         }
 
         // Return fallback (last element)
-        return length > 1 ? Evaluate(array[length - 1], properties) : null;
+        return length > 1 ? Evaluate(array[length - 1], properties, zoom) : null;
     }
 
-    private static object? EvaluateMatch(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static object? EvaluateMatch(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         if (length < 4)
@@ -226,7 +284,7 @@ internal static class ExpressionEvaluator
             return null;
         }
 
-        var input = Evaluate(array[1], properties);
+        var input = Evaluate(array[1], properties, zoom);
         var inputStr = input?.ToString();
 
         // match, input, label1, output1, label2, output2, ..., fallback
@@ -241,18 +299,18 @@ internal static class ExpressionEvaluator
                 {
                     if (MatchesLabel(inputStr, input, item))
                     {
-                        return Evaluate(array[i + 1], properties);
+                        return Evaluate(array[i + 1], properties, zoom);
                     }
                 }
             }
             else if (MatchesLabel(inputStr, input, label))
             {
-                return Evaluate(array[i + 1], properties);
+                return Evaluate(array[i + 1], properties, zoom);
             }
         }
 
         // Fallback
-        return Evaluate(array[length - 1], properties);
+        return Evaluate(array[length - 1], properties, zoom);
     }
 
     private static bool MatchesLabel(string? inputStr, object? inputObj, MapLibreExpression label)
@@ -301,7 +359,7 @@ internal static class ExpressionEvaluator
         }
     }
 
-    private static object? EvaluateStep(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static object? EvaluateStep(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         if (length < 4)
@@ -309,17 +367,17 @@ internal static class ExpressionEvaluator
             return null;
         }
 
-        var input = ConvertToFloat(Evaluate(array[1], properties), 0f);
-        var defaultOutput = Evaluate(array[2], properties);
+        var input = ConvertToFloat(Evaluate(array[1], properties, zoom), 0f);
+        var defaultOutput = Evaluate(array[2], properties, zoom);
 
         // step, input, default, stop1, output1, stop2, output2, ...
         object? result = defaultOutput;
         for (int i = 3; i < length - 1; i += 2)
         {
-            var stop = ConvertToFloat(Evaluate(array[i], properties), float.MaxValue);
+            var stop = ConvertToFloat(Evaluate(array[i], properties, zoom), float.MaxValue);
             if (input >= stop)
             {
-                result = Evaluate(array[i + 1], properties);
+                result = Evaluate(array[i + 1], properties, zoom);
             }
             else
             {
@@ -330,7 +388,7 @@ internal static class ExpressionEvaluator
         return result;
     }
 
-    private static object? EvaluateInterpolate(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static object? EvaluateInterpolate(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         if (length < 5)
@@ -339,15 +397,15 @@ internal static class ExpressionEvaluator
         }
 
         // interpolate, ["linear"], input, stop1, output1, stop2, output2, ...
-        var input = ConvertToFloat(Evaluate(array[2], properties), 0f);
+        var input = ConvertToFloat(Evaluate(array[2], properties, zoom), 0f);
 
         float? prevStop = null;
         object? prevOutput = null;
 
         for (int i = 3; i < length - 1; i += 2)
         {
-            var stop = ConvertToFloat(Evaluate(array[i], properties), 0f);
-            var output = Evaluate(array[i + 1], properties);
+            var stop = ConvertToFloat(Evaluate(array[i], properties, zoom), 0f);
+            var output = Evaluate(array[i + 1], properties, zoom);
 
             if (input <= stop)
             {
@@ -436,24 +494,24 @@ internal static class ExpressionEvaluator
             _ => "object"
         };
 
-    private static string EvaluateToString(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static string EvaluateToString(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         if (array.Length < 2)
         {
             return "";
         }
 
-        return Evaluate(array[1], properties)?.ToString() ?? "";
+        return Evaluate(array[1], properties, zoom)?.ToString() ?? "";
     }
 
-    private static object? EvaluateToNumber(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static object? EvaluateToNumber(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         if (array.Length < 2)
         {
             return 0.0;
         }
 
-        var val = Evaluate(array[1], properties);
+        var val = Evaluate(array[1], properties, zoom);
         return (double)ConvertToFloat(val, 0f);
     }
 
@@ -461,14 +519,14 @@ internal static class ExpressionEvaluator
     /// Evaluates the MapLibre <c>typeof</c> expression, returning the runtime type name
     /// of the evaluated value: "number", "string", "boolean", "object", or "null".
     /// </summary>
-    private static string EvaluateTypeof(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static string EvaluateTypeof(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         if (array.Length < 2)
         {
             return "null";
         }
 
-        var val = Evaluate(array[1], properties);
+        var val = Evaluate(array[1], properties, zoom);
         return val switch
         {
             null => "null",
@@ -479,13 +537,13 @@ internal static class ExpressionEvaluator
         };
     }
 
-    private static string EvaluateConcat(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static string EvaluateConcat(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         var parts = new string[length - 1];
         for (int i = 1; i < length; i++)
         {
-            parts[i - 1] = Evaluate(array[i], properties)?.ToString() ?? "";
+            parts[i - 1] = Evaluate(array[i], properties, zoom)?.ToString() ?? "";
         }
 
         return string.Concat(parts);
@@ -494,6 +552,7 @@ internal static class ExpressionEvaluator
     private static bool EvaluateComparison(
         MapLibreExpression[] array,
         ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom,
         Func<object?, object?, bool> comparator)
     {
         if (array.Length < 3)
@@ -501,17 +560,17 @@ internal static class ExpressionEvaluator
             return false;
         }
 
-        var left = Evaluate(array[1], properties);
-        var right = Evaluate(array[2], properties);
+        var left = Evaluate(array[1], properties, zoom);
+        var right = Evaluate(array[2], properties, zoom);
         return comparator(left, right);
     }
 
-    private static bool EvaluateAll(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static bool EvaluateAll(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         for (int i = 1; i < length; i++)
         {
-            if (!IsTruthy(Evaluate(array[i], properties)))
+            if (!IsTruthy(Evaluate(array[i], properties, zoom)))
             {
                 return false;
             }
@@ -520,12 +579,12 @@ internal static class ExpressionEvaluator
         return true;
     }
 
-    private static bool EvaluateAny(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static bool EvaluateAny(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         for (int i = 1; i < length; i++)
         {
-            if (IsTruthy(Evaluate(array[i], properties)))
+            if (IsTruthy(Evaluate(array[i], properties, zoom)))
             {
                 return true;
             }
@@ -534,12 +593,12 @@ internal static class ExpressionEvaluator
         return false;
     }
 
-    private static object? EvaluateCoalesce(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties)
+    private static object? EvaluateCoalesce(MapLibreExpression[] array, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
         var length = array.Length;
         for (int i = 1; i < length; i++)
         {
-            var val = Evaluate(array[i], properties);
+            var val = Evaluate(array[i], properties, zoom);
             if (val != null)
             {
                 return val;
@@ -552,6 +611,7 @@ internal static class ExpressionEvaluator
     private static double EvaluateArithmetic(
         MapLibreExpression[] array,
         ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom,
         Func<double, double, double> op)
     {
         if (array.Length < 3)
@@ -559,8 +619,8 @@ internal static class ExpressionEvaluator
             return 0.0;
         }
 
-        var left = ConvertToFloat(Evaluate(array[1], properties), 0f);
-        var right = ConvertToFloat(Evaluate(array[2], properties), 0f);
+        var left = ConvertToFloat(Evaluate(array[1], properties, zoom), 0f);
+        var right = ConvertToFloat(Evaluate(array[2], properties, zoom), 0f);
         return op(left, right);
     }
 

--- a/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
+++ b/src/Honua.Hosting/Features/Rendering/RasterMapRenderingPipeline.cs
@@ -743,7 +743,7 @@ internal static class RasterMapRenderingPipeline
                     continue;
                 }
 
-                if (TryRenderBatchedStyleLayer(canvas, features, styleLayer, transform))
+                if (TryRenderBatchedStyleLayer(canvas, features, styleLayer, transform, zoom))
                 {
                     continue;
                 }
@@ -755,12 +755,12 @@ internal static class RasterMapRenderingPipeline
                         continue;
                     }
 
-                    if (styleLayer.Filter is { } filter && !EvaluateFilter(filter, feature.Attributes))
+                    if (styleLayer.Filter is { } filter && !EvaluateFilter(filter, feature.Attributes, zoom))
                     {
                         continue;
                     }
 
-                    RenderStyledFeature(canvas, feature, styleLayer, transform);
+                    RenderStyledFeature(canvas, feature, styleLayer, transform, zoom);
                 }
             }
         }
@@ -822,7 +822,8 @@ internal static class RasterMapRenderingPipeline
         SKCanvas canvas,
         IReadOnlyList<Feature> features,
         MapLibreStyleLayer styleLayer,
-        Func<double, double, SKPoint> transform)
+        Func<double, double, SKPoint> transform,
+        RenderZoom zoom)
     {
         if (!string.Equals(styleLayer.Type, "circle", StringComparison.Ordinal) ||
             styleLayer.Filter is not null ||
@@ -831,7 +832,7 @@ internal static class RasterMapRenderingPipeline
             return false;
         }
 
-        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, ImmutableDictionary<string, object?>.Empty);
+        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, ImmutableDictionary<string, object?>.Empty, zoom);
         RenderCirclePoints(canvas, features, transform, circleStyle);
         return true;
     }
@@ -987,7 +988,8 @@ internal static class RasterMapRenderingPipeline
         SKCanvas canvas,
         Feature feature,
         MapLibreStyleLayer styleLayer,
-        Func<double, double, SKPoint> transform)
+        Func<double, double, SKPoint> transform,
+        RenderZoom zoom)
     {
         var result = WkbToSkiaConverter.Convert(feature.Geometry!, transform);
         try
@@ -996,7 +998,7 @@ internal static class RasterMapRenderingPipeline
             {
                 case "fill":
                     {
-                        var fillStyle = StyleTranslator.ResolveFillStyle(styleLayer, feature.Attributes);
+                        var fillStyle = StyleTranslator.ResolveFillStyle(styleLayer, feature.Attributes, zoom);
                         using var fillPaint = new SKPaint
                         {
                             Style = SKPaintStyle.Fill,
@@ -1025,7 +1027,7 @@ internal static class RasterMapRenderingPipeline
                     }
                 case "line":
                     {
-                        var lineStyle = StyleTranslator.ResolveLineStyle(styleLayer, feature.Attributes);
+                        var lineStyle = StyleTranslator.ResolveLineStyle(styleLayer, feature.Attributes, zoom);
                         using var linePaint = new SKPaint
                         {
                             Style = SKPaintStyle.Stroke,
@@ -1051,7 +1053,7 @@ internal static class RasterMapRenderingPipeline
                     }
                 case "circle":
                     {
-                        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, feature.Attributes);
+                        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, feature.Attributes, zoom);
                         using var circlePaint = new SKPaint
                         {
                             Style = SKPaintStyle.Fill,
@@ -1159,6 +1161,25 @@ internal static class RasterMapRenderingPipeline
         };
     }
 
+    /// <summary>
+    /// Pre-resolves the circle style for the single-layer point fast path, or returns
+    /// <see langword="null"/> when the style is not eligible for it.
+    /// </summary>
+    /// <remarks>
+    /// <para>This runs while building a <see cref="RasterStylePlan"/>, which is cached per layer and
+    /// reused across every subsequent request for that layer — at any extent, image size, and
+    /// therefore any zoom. A zoom-dependent style must not be pre-resolved here: the first request to
+    /// build the plan would bake its own zoom into a value every later request then reuses, so a
+    /// zoom ramp would freeze at whichever zoom happened to be rendered first. Such styles are
+    /// declared ineligible and fall back to the per-render path, where
+    /// <see cref="StyleTranslator.ResolveCircleStyle"/> is called with the request's real
+    /// <see cref="RenderZoom"/>.</para>
+    /// <para>Because the zoom check above has already excluded every style that could read
+    /// <c>["zoom"]</c>, the <see cref="RenderZoom.NotDerivable"/> passed here is unreachable by
+    /// construction. It is passed rather than a placeholder level so that if that invariant is ever
+    /// broken, the result is a loud <see cref="StyleExpressionEvaluationException"/> naming this
+    /// path — not a silently stale radius.</para>
+    /// </remarks>
     private static ResolvedCircleStyle? TryResolveSimpleCircleStyle(
         MapLibreStyleLayer[] styleLayers,
         string[] referencedFields)
@@ -1166,12 +1187,16 @@ internal static class RasterMapRenderingPipeline
         if (styleLayers.Length != 1 ||
             !string.Equals(styleLayers[0].Type, "circle", StringComparison.Ordinal) ||
             styleLayers[0].Filter is not null ||
-            referencedFields.Length != 0)
+            referencedFields.Length != 0 ||
+            StyleTranslator.UsesZoomExpression(styleLayers[0]))
         {
             return null;
         }
 
-        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayers[0], ImmutableDictionary<string, object?>.Empty);
+        var circleStyle = StyleTranslator.ResolveCircleStyle(
+            styleLayers[0],
+            ImmutableDictionary<string, object?>.Empty,
+            RenderZoom.NotDerivable("a cached style plan is built without a render zoom"));
         return circleStyle.Radius > 0 ? circleStyle : null;
     }
 
@@ -1583,9 +1608,9 @@ internal static class RasterMapRenderingPipeline
     internal static SpatialFilter CreateBboxSpatialFilter(SkiaMapRenderer.RenderExtent extent, int srid)
         => SpatialFilterHelpers.CreateBboxSpatialFilter(extent.MinX, extent.MinY, extent.MaxX, extent.MaxY, srid);
 
-    private static bool EvaluateFilter(MapLibreExpression filter, System.Collections.Immutable.ImmutableDictionary<string, object?> properties)
+    private static bool EvaluateFilter(MapLibreExpression filter, System.Collections.Immutable.ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
-        var result = ExpressionEvaluator.Evaluate(filter, properties);
+        var result = ExpressionEvaluator.Evaluate(filter, properties, zoom);
         return result is bool b && b;
     }
 }

--- a/src/Honua.Hosting/Features/Rendering/SkiaMapRenderer.cs
+++ b/src/Honua.Hosting/Features/Rendering/SkiaMapRenderer.cs
@@ -171,13 +171,21 @@ internal sealed class SkiaMapRenderer : IDisposable
         ImmutableDictionary<string, object?>? properties = null)
     {
         var featureProps = properties ?? ImmutableDictionary<string, object?>.Empty;
+
+        // A swatch is drawn without a map viewport, so no render zoom exists to evaluate a
+        // zoom-dependent paint against. Passing NotDerivable rather than a placeholder level keeps
+        // a zoom-dependent legend from rendering as a confident wrong swatch (honua-server#2873);
+        // for the zoom-independent styles legends resolve today this changes nothing. A scale-driven
+        // legend zoom, when one is threaded here, comes from RenderZoom.FromScaleDenominator
+        // (honua-server#2866).
+        var swatchZoom = RenderZoom.NotDerivable("a legend swatch is drawn without a map viewport");
         var padding = 2f;
 
         switch (styleLayer.Type)
         {
             case "fill":
                 {
-                    var fillStyle = StyleTranslator.ResolveFillStyle(styleLayer, featureProps);
+                    var fillStyle = StyleTranslator.ResolveFillStyle(styleLayer, featureProps, swatchZoom);
                     using var fillPaint = new SKPaint
                     {
                         Style = SKPaintStyle.Fill,
@@ -202,7 +210,7 @@ internal sealed class SkiaMapRenderer : IDisposable
                 }
             case "line":
                 {
-                    var lineStyle = StyleTranslator.ResolveLineStyle(styleLayer, featureProps);
+                    var lineStyle = StyleTranslator.ResolveLineStyle(styleLayer, featureProps, swatchZoom);
                     using var linePaint = new SKPaint
                     {
                         Style = SKPaintStyle.Stroke,
@@ -224,7 +232,7 @@ internal sealed class SkiaMapRenderer : IDisposable
                 }
             case "circle":
                 {
-                    var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, featureProps);
+                    var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, featureProps, swatchZoom);
                     var radius = Math.Min(circleStyle.Radius, Math.Min(width, height) / 2f - padding);
                     using var circlePaint = new SKPaint
                     {
@@ -296,7 +304,7 @@ internal sealed class SkiaMapRenderer : IDisposable
                 continue;
             }
 
-            if (TryRenderBatchedStyleLayer(canvas, features, styleLayer, transform))
+            if (TryRenderBatchedStyleLayer(canvas, features, styleLayer, transform, zoom))
             {
                 continue;
             }
@@ -314,12 +322,12 @@ internal sealed class SkiaMapRenderer : IDisposable
                 }
 
                 // Check filter
-                if (styleLayer.Filter is { } filter && !EvaluateFilter(filter, feature.Attributes))
+                if (styleLayer.Filter is { } filter && !EvaluateFilter(filter, feature.Attributes, zoom))
                 {
                     continue;
                 }
 
-                RenderFeatureWithStyle(canvas, feature, styleLayer, transform);
+                RenderFeatureWithStyle(canvas, feature, styleLayer, transform, zoom);
             }
         }
     }
@@ -385,7 +393,8 @@ internal sealed class SkiaMapRenderer : IDisposable
         SKCanvas canvas,
         IReadOnlyList<Feature> features,
         MapLibreStyleLayer styleLayer,
-        Func<double, double, SKPoint> transform)
+        Func<double, double, SKPoint> transform,
+        RenderZoom zoom)
     {
         if (!string.Equals(styleLayer.Type, "circle", StringComparison.Ordinal) ||
             styleLayer.Filter is not null ||
@@ -394,7 +403,7 @@ internal sealed class SkiaMapRenderer : IDisposable
             return false;
         }
 
-        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, ImmutableDictionary<string, object?>.Empty);
+        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, ImmutableDictionary<string, object?>.Empty, zoom);
         RenderCirclePoints(canvas, features, transform, circleStyle);
         return true;
     }
@@ -550,7 +559,8 @@ internal sealed class SkiaMapRenderer : IDisposable
         SKCanvas canvas,
         Feature feature,
         MapLibreStyleLayer styleLayer,
-        Func<double, double, SKPoint> transform)
+        Func<double, double, SKPoint> transform,
+        RenderZoom zoom)
     {
         var result = WkbToSkiaConverter.Convert(feature.Geometry!, transform);
         try
@@ -559,7 +569,7 @@ internal sealed class SkiaMapRenderer : IDisposable
             {
                 case "fill":
                     {
-                        var fillStyle = StyleTranslator.ResolveFillStyle(styleLayer, feature.Attributes);
+                        var fillStyle = StyleTranslator.ResolveFillStyle(styleLayer, feature.Attributes, zoom);
                         using var fillPaint = new SKPaint
                         {
                             Style = SKPaintStyle.Fill,
@@ -588,7 +598,7 @@ internal sealed class SkiaMapRenderer : IDisposable
                     }
                 case "line":
                     {
-                        var lineStyle = StyleTranslator.ResolveLineStyle(styleLayer, feature.Attributes);
+                        var lineStyle = StyleTranslator.ResolveLineStyle(styleLayer, feature.Attributes, zoom);
                         using var linePaint = new SKPaint
                         {
                             Style = SKPaintStyle.Stroke,
@@ -614,7 +624,7 @@ internal sealed class SkiaMapRenderer : IDisposable
                     }
                 case "circle":
                     {
-                        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, feature.Attributes);
+                        var circleStyle = StyleTranslator.ResolveCircleStyle(styleLayer, feature.Attributes, zoom);
                         using var circlePaint = new SKPaint
                         {
                             Style = SKPaintStyle.Fill,
@@ -682,9 +692,9 @@ internal sealed class SkiaMapRenderer : IDisposable
         }
     }
 
-    private static bool EvaluateFilter(MapLibreExpression filter, ImmutableDictionary<string, object?> properties)
+    private static bool EvaluateFilter(MapLibreExpression filter, ImmutableDictionary<string, object?> properties, RenderZoom zoom)
     {
-        var result = ExpressionEvaluator.Evaluate(filter, properties);
+        var result = ExpressionEvaluator.Evaluate(filter, properties, zoom);
         // MapLibre spec treats non-boolean filter results as falsy (exclude).
         // Consistent with RasterMapRenderingPipeline.EvaluateFilter.
         return result is bool b && b;

--- a/src/Honua.Hosting/Features/Rendering/StyleTranslator.cs
+++ b/src/Honua.Hosting/Features/Rendering/StyleTranslator.cs
@@ -80,6 +80,72 @@ internal static class StyleTranslator
     }
 
     /// <summary>
+    /// Returns whether any of a layer's filter, paint, or layout expressions read <c>["zoom"]</c>,
+    /// and so resolve to different values at different zooms.
+    /// </summary>
+    /// <remarks>
+    /// Callers use this to keep zoom-dependent styles out of caches and precomputes that are not
+    /// keyed by zoom. Unlike feature attributes — which vary per feature and are detected by
+    /// <see cref="CollectReferencedFields(MapLibreStyleLayer[])"/> — zoom is constant across a single render but varies
+    /// between renders, so a style value resolved once and reused across requests silently freezes
+    /// at whatever zoom happened to resolve it first. The walk deliberately errs toward reporting
+    /// <see langword="true"/> (it descends into <c>literal</c> arrays as well): a false positive only
+    /// gives up a fast path, whereas a false negative reinstates the stale-value bug.
+    /// </remarks>
+    public static bool UsesZoomExpression(MapLibreStyleLayer layer)
+    {
+        ArgumentNullException.ThrowIfNull(layer);
+
+        return ContainsZoomExpression(layer.Filter) ||
+               ContainsZoomExpression(layer.Paint) ||
+               ContainsZoomExpression(layer.Layout);
+    }
+
+    private static bool ContainsZoomExpression(Dictionary<string, MapLibreExpression>? expressions)
+    {
+        if (expressions == null || expressions.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var expression in expressions.Values)
+        {
+            if (ContainsZoomExpression(expression))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsZoomExpression(MapLibreExpression? expression)
+    {
+        if (!expression.HasValue ||
+            expression.Value.Kind != MapLibreExpressionKind.Array ||
+            expression.Value.Items is not { Length: > 0 } items)
+        {
+            return false;
+        }
+
+        if (TryGetString(items[0], out var op) &&
+            string.Equals(op, "zoom", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        foreach (var item in items)
+        {
+            if (ContainsZoomExpression(item))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns whether a style layer should be rendered at the supplied <paramref name="zoom"/>.
     /// Layer visibility is always honored; minzoom/maxzoom apply when the render carries a derived
     /// zoom and are left unapplied when <see cref="RenderZoom.NotDerivable"/> states that no zoom
@@ -97,7 +163,7 @@ internal static class StyleTranslator
             return false;
         }
 
-        return IsLayerVisible(layer, properties ?? ImmutableDictionary<string, object?>.Empty);
+        return IsLayerVisible(layer, properties ?? ImmutableDictionary<string, object?>.Empty, zoom);
     }
 
     /// <summary>
@@ -128,12 +194,16 @@ internal static class StyleTranslator
     }
 
     /// <summary>
-    /// Resolves a fill style from a MapLibre layer for a specific feature.
+    /// Resolves a fill style from a MapLibre layer for a specific feature at the supplied
+    /// <paramref name="zoom"/>, which zoom-dependent paint expressions are evaluated against.
     /// </summary>
     public static ResolvedFillStyle ResolveFillStyle(
         MapLibreStyleLayer layer,
-        ImmutableDictionary<string, object?> properties)
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
+        ArgumentNullException.ThrowIfNull(zoom);
+
         var paint = layer.Paint;
         if (paint == null || paint.Count == 0)
         {
@@ -144,10 +214,10 @@ internal static class StyleTranslator
             };
         }
 
-        var fillColor = ResolveColor(paint, "fill-color", properties, new SKColor(0, 0, 0));
-        var fillOpacity = ResolveFloat(paint, "fill-opacity", properties, 1f);
-        var outlineColor = ResolveOptionalColor(paint, "fill-outline-color", properties);
-        var antialias = ResolveBool(paint, "fill-antialias", properties, true);
+        var fillColor = ResolveColor(paint, "fill-color", properties, zoom, new SKColor(0, 0, 0));
+        var fillOpacity = ResolveFloat(paint, "fill-opacity", properties, zoom, 1f);
+        var outlineColor = ResolveOptionalColor(paint, "fill-outline-color", properties, zoom);
+        var antialias = ResolveBool(paint, "fill-antialias", properties, zoom, true);
 
         fillColor = ApplyOpacity(fillColor, fillOpacity);
 
@@ -161,12 +231,16 @@ internal static class StyleTranslator
     }
 
     /// <summary>
-    /// Resolves a line style from a MapLibre layer for a specific feature.
+    /// Resolves a line style from a MapLibre layer for a specific feature at the supplied
+    /// <paramref name="zoom"/>, which zoom-dependent paint expressions are evaluated against.
     /// </summary>
     public static ResolvedLineStyle ResolveLineStyle(
         MapLibreStyleLayer layer,
-        ImmutableDictionary<string, object?> properties)
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
+        ArgumentNullException.ThrowIfNull(zoom);
+
         var paint = layer.Paint;
         if (paint == null || paint.Count == 0)
         {
@@ -177,9 +251,9 @@ internal static class StyleTranslator
             };
         }
 
-        var lineColor = ResolveColor(paint, "line-color", properties, SKColors.Black);
-        var lineWidth = ResolveFloat(paint, "line-width", properties, 1f);
-        var lineOpacity = ResolveFloat(paint, "line-opacity", properties, 1f);
+        var lineColor = ResolveColor(paint, "line-color", properties, zoom, SKColors.Black);
+        var lineWidth = ResolveFloat(paint, "line-width", properties, zoom, 1f);
+        var lineOpacity = ResolveFloat(paint, "line-opacity", properties, zoom, 1f);
 
         float[]? dashArray = ResolveFloatArray(paint, "line-dasharray");
 
@@ -189,7 +263,7 @@ internal static class StyleTranslator
         var layout = layer.Layout;
         if (layout != null && layout.Count > 0)
         {
-            var cap = ResolveString(layout, "line-cap", properties);
+            var cap = ResolveString(layout, "line-cap", properties, zoom);
             if (cap != null)
             {
                 lineCap = cap switch
@@ -200,7 +274,7 @@ internal static class StyleTranslator
                 };
             }
 
-            var join = ResolveString(layout, "line-join", properties);
+            var join = ResolveString(layout, "line-join", properties, zoom);
             if (join != null)
             {
                 lineJoin = join switch
@@ -226,12 +300,16 @@ internal static class StyleTranslator
     }
 
     /// <summary>
-    /// Resolves a circle style from a MapLibre layer for a specific feature.
+    /// Resolves a circle style from a MapLibre layer for a specific feature at the supplied
+    /// <paramref name="zoom"/>, which zoom-dependent paint expressions are evaluated against.
     /// </summary>
     public static ResolvedCircleStyle ResolveCircleStyle(
         MapLibreStyleLayer layer,
-        ImmutableDictionary<string, object?> properties)
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
+        ArgumentNullException.ThrowIfNull(zoom);
+
         var paint = layer.Paint;
         if (paint == null || paint.Count == 0)
         {
@@ -242,12 +320,12 @@ internal static class StyleTranslator
             };
         }
 
-        var radius = ResolveFloat(paint, "circle-radius", properties, 5f);
-        var fillColor = ResolveColor(paint, "circle-color", properties, SKColors.Black);
-        var fillOpacity = ResolveFloat(paint, "circle-opacity", properties, 1f);
-        var strokeColor = ResolveOptionalColor(paint, "circle-stroke-color", properties);
-        var strokeOpacity = ResolveFloat(paint, "circle-stroke-opacity", properties, 1f);
-        var strokeWidth = ResolveFloat(paint, "circle-stroke-width", properties, 0f);
+        var radius = ResolveFloat(paint, "circle-radius", properties, zoom, 5f);
+        var fillColor = ResolveColor(paint, "circle-color", properties, zoom, SKColors.Black);
+        var fillOpacity = ResolveFloat(paint, "circle-opacity", properties, zoom, 1f);
+        var strokeColor = ResolveOptionalColor(paint, "circle-stroke-color", properties, zoom);
+        var strokeOpacity = ResolveFloat(paint, "circle-stroke-opacity", properties, zoom, 1f);
+        var strokeWidth = ResolveFloat(paint, "circle-stroke-width", properties, zoom, 0f);
 
         fillColor = ApplyOpacity(fillColor, fillOpacity);
 
@@ -318,14 +396,15 @@ internal static class StyleTranslator
 
     private static bool IsLayerVisible(
         MapLibreStyleLayer layer,
-        ImmutableDictionary<string, object?> properties)
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
         if (layer.Layout == null || layer.Layout.Count == 0)
         {
             return true;
         }
 
-        var visibility = ResolveString(layer.Layout, "visibility", properties);
+        var visibility = ResolveString(layer.Layout, "visibility", properties, zoom);
         return !string.Equals(visibility, "none", StringComparison.OrdinalIgnoreCase);
     }
 
@@ -354,6 +433,7 @@ internal static class StyleTranslator
         Dictionary<string, MapLibreExpression> paint,
         string property,
         ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom,
         SKColor defaultColor)
     {
         if (!TryGetExpression(paint, property, out var expression))
@@ -364,7 +444,7 @@ internal static class StyleTranslator
         return expression.Kind switch
         {
             MapLibreExpressionKind.String => ExpressionEvaluator.ParseColor(expression.StringValue),
-            MapLibreExpressionKind.Array => ExpressionEvaluator.EvaluateColor(expression, properties),
+            MapLibreExpressionKind.Array => ExpressionEvaluator.EvaluateColor(expression, properties, zoom),
             _ => defaultColor
         };
     }
@@ -421,7 +501,8 @@ internal static class StyleTranslator
     private static SKColor? ResolveOptionalColor(
         Dictionary<string, MapLibreExpression> paint,
         string property,
-        ImmutableDictionary<string, object?> properties)
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
         if (!TryGetExpression(paint, property, out var expression))
         {
@@ -431,7 +512,7 @@ internal static class StyleTranslator
         return expression.Kind switch
         {
             MapLibreExpressionKind.String => ExpressionEvaluator.ParseColor(expression.StringValue),
-            MapLibreExpressionKind.Array => ExpressionEvaluator.EvaluateColor(expression, properties),
+            MapLibreExpressionKind.Array => ExpressionEvaluator.EvaluateColor(expression, properties, zoom),
             _ => null
         };
     }
@@ -440,6 +521,7 @@ internal static class StyleTranslator
         Dictionary<string, MapLibreExpression> paint,
         string property,
         ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom,
         float defaultValue)
     {
         if (!TryGetExpression(paint, property, out var expression))
@@ -451,7 +533,7 @@ internal static class StyleTranslator
         {
             MapLibreExpressionKind.Number => (float)expression.NumberValue,
             MapLibreExpressionKind.String => ExpressionEvaluator.ConvertToFloat(expression.StringValue, defaultValue),
-            MapLibreExpressionKind.Array => ExpressionEvaluator.EvaluateFloat(expression, properties, defaultValue),
+            MapLibreExpressionKind.Array => ExpressionEvaluator.EvaluateFloat(expression, properties, zoom, defaultValue),
             _ => defaultValue
         };
     }
@@ -460,6 +542,7 @@ internal static class StyleTranslator
         Dictionary<string, MapLibreExpression> paint,
         string property,
         ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom,
         bool defaultValue)
     {
         if (!TryGetExpression(paint, property, out var expression))
@@ -470,7 +553,7 @@ internal static class StyleTranslator
         return expression.Kind switch
         {
             MapLibreExpressionKind.Boolean => expression.BoolValue,
-            MapLibreExpressionKind.Array => ExpressionEvaluator.Evaluate(expression, properties) is bool b ? b : defaultValue,
+            MapLibreExpressionKind.Array => ExpressionEvaluator.Evaluate(expression, properties, zoom) is bool b ? b : defaultValue,
             _ => defaultValue
         };
     }
@@ -478,7 +561,8 @@ internal static class StyleTranslator
     private static string? ResolveString(
         Dictionary<string, MapLibreExpression> values,
         string property,
-        ImmutableDictionary<string, object?> properties)
+        ImmutableDictionary<string, object?> properties,
+        RenderZoom zoom)
     {
         if (!TryGetExpression(values, property, out var expression))
         {
@@ -488,7 +572,7 @@ internal static class StyleTranslator
         return expression.Kind switch
         {
             MapLibreExpressionKind.String => expression.StringValue,
-            MapLibreExpressionKind.Array => ExpressionEvaluator.Evaluate(expression, properties)?.ToString(),
+            MapLibreExpressionKind.Array => ExpressionEvaluator.Evaluate(expression, properties, zoom)?.ToString(),
             _ => null
         };
     }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/ExpressionEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/ExpressionEvaluatorTests.cs
@@ -19,6 +19,16 @@ public class ExpressionEvaluatorTests
     private static readonly ImmutableDictionary<string, object?> _emptyProps =
         ImmutableDictionary<string, object?>.Empty;
 
+    /// <summary>
+    /// The zoom passed by every test whose expression contains no <c>["zoom"]</c> input.
+    /// <see cref="RenderZoom.NotDerivable"/> makes these tests prove the non-goal guard for
+    /// honua-server#2873 rather than merely satisfy a parameter: evaluating <c>["zoom"]</c> against
+    /// it throws, so each of these tests passing unchanged is evidence that the expression never
+    /// consulted zoom and that its result is unaffected by zoom support.
+    /// </summary>
+    private static readonly RenderZoom _noZoom =
+        RenderZoom.NotDerivable("this test evaluates no zoom expression");
+
     private static ImmutableDictionary<string, object?> Props(params (string Key, object? Value)[] items) =>
         items.ToImmutableDictionary(i => i.Key, i => i.Value);
 
@@ -28,7 +38,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["get", "name"]""");
         var props = Props(("name", "Test"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("Test");
     }
@@ -38,7 +48,7 @@ public class ExpressionEvaluatorTests
     {
         var expr = MapLibreExpressionParser.Parse("""["get", "missing"]""");
 
-        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps);
+        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps, _noZoom);
 
         result.Should().BeNull();
     }
@@ -49,7 +59,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["has", "name"]""");
         var props = Props(("name", "Test"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(true);
     }
@@ -59,7 +69,7 @@ public class ExpressionEvaluatorTests
     {
         var expr = MapLibreExpressionParser.Parse("""["has", "missing"]""");
 
-        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps);
+        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps, _noZoom);
 
         result.Should().Be(false);
     }
@@ -69,7 +79,7 @@ public class ExpressionEvaluatorTests
     {
         var expr = MapLibreExpressionParser.Parse("""["!", ["has", "name"]]""");
 
-        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps);
+        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps, _noZoom);
 
         result.Should().Be(true);
     }
@@ -80,7 +90,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["==", ["get", "type"], "road"]""");
         var props = Props(("type", "road"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(true);
     }
@@ -91,7 +101,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["==", ["get", "type"], "road"]""");
         var props = Props(("type", "building"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(false);
     }
@@ -102,7 +112,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["<", ["get", "population"], 1000]""");
         var props = Props(("population", 500));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(true);
     }
@@ -113,7 +123,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse(""" [">", ["get", "population"], 1000]""");
         var props = Props(("population", 500));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(false);
     }
@@ -124,7 +134,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["all", ["has", "name"], ["has", "type"]]""");
         var props = Props(("name", "test"), ("type", "road"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(true);
     }
@@ -135,7 +145,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["all", ["has", "name"], ["has", "missing"]]""");
         var props = Props(("name", "test"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(false);
     }
@@ -146,7 +156,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["any", ["has", "missing"], ["has", "name"]]""");
         var props = Props(("name", "test"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be(true);
     }
@@ -157,7 +167,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["match", ["get", "type"], "road", "blue", "building", "red", "gray"]""");
         var props = Props(("type", "road"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("blue");
     }
@@ -168,7 +178,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["match", ["get", "type"], "road", "blue", "building", "red", "gray"]""");
         var props = Props(("type", "park"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("gray");
     }
@@ -179,7 +189,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["case", ["==", ["get", "type"], "road"], "blue", "gray"]""");
         var props = Props(("type", "road"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("blue");
     }
@@ -190,7 +200,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["case", ["==", ["get", "type"], "road"], "blue", "gray"]""");
         var props = Props(("type", "park"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("gray");
     }
@@ -200,7 +210,7 @@ public class ExpressionEvaluatorTests
     {
         var expr = MapLibreExpressionParser.Parse("""["+", 10, 20]""");
 
-        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps);
+        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps, _noZoom);
 
         result.Should().BeOfType<double>().Which.Should().Be(30.0);
     }
@@ -211,7 +221,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["coalesce", ["get", "missing"], ["get", "name"]]""");
         var props = Props(("name", "test"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("test");
     }
@@ -222,7 +232,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["typeof", ["get", "value"]]""");
         var props = Props(("value", 42.0));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("number");
     }
@@ -233,7 +243,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["typeof", ["get", "value"]]""");
         var props = Props(("value", "N/A"));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("string");
     }
@@ -243,7 +253,7 @@ public class ExpressionEvaluatorTests
     {
         var expr = MapLibreExpressionParser.Parse("""["typeof", ["get", "missing"]]""");
 
-        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps);
+        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps, _noZoom);
 
         result.Should().Be("null");
     }
@@ -254,7 +264,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse("""["typeof", ["get", "flag"]]""");
         var props = Props(("flag", true));
 
-        var result = ExpressionEvaluator.Evaluate(expr, props);
+        var result = ExpressionEvaluator.Evaluate(expr, props, _noZoom);
 
         result.Should().Be("boolean");
     }
@@ -323,7 +333,7 @@ public class ExpressionEvaluatorTests
     {
         var expr = MapLibreExpressionParser.Parse("5.0");
 
-        var result = ExpressionEvaluator.EvaluateFloat(expr, _emptyProps, 0f);
+        var result = ExpressionEvaluator.EvaluateFloat(expr, _emptyProps, _noZoom, 0f);
 
         result.Should().Be(5.0f);
     }
@@ -359,7 +369,7 @@ public class ExpressionEvaluatorTests
         """["interpolate", ["linear"], ["get", "value"], 0, "#ff0000", 50, "#00ff00", 100, "#0000ff"]""";
 
     private static SKColor EvaluateRamp(string expression, object? value) =>
-        ExpressionEvaluator.EvaluateColor(MapLibreExpressionParser.Parse(expression), Props(("value", value)));
+        ExpressionEvaluator.EvaluateColor(MapLibreExpressionParser.Parse(expression), Props(("value", value)), _noZoom);
 
     /// <summary>
     /// Expected colors are the output of MapLibre GL JS's own reference implementation
@@ -488,7 +498,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse(
             """["interpolate", ["linear"], ["get", "value"], 0, 0, 100, 10]""");
 
-        var result = ExpressionEvaluator.Evaluate(expr, Props(("value", value)));
+        var result = ExpressionEvaluator.Evaluate(expr, Props(("value", value)), _noZoom);
 
         result.Should().BeOfType<double>().Which.Should().BeApproximately(expected, 1e-9);
     }
@@ -499,7 +509,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse(
             """["interpolate", ["linear"], ["get", "value"], 0, "0", 100, "10"]""");
 
-        var result = ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+        var result = ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)), _noZoom);
 
         result.Should().BeOfType<double>().Which.Should().BeApproximately(5.0, 1e-9);
     }
@@ -516,7 +526,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse(
             """["interpolate", ["linear"], ["get", "value"], 0, "#ff0000", 100, 42]""");
 
-        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)), _noZoom);
 
         act.Should().Throw<StyleExpressionEvaluationException>()
             .WithMessage("*color*number*");
@@ -532,7 +542,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse(
             """["interpolate", ["linear"], ["get", "value"], 0, "not-a-color", 100, "#08306b"]""");
 
-        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)), _noZoom);
 
         act.Should().Throw<StyleExpressionEvaluationException>();
     }
@@ -543,7 +553,7 @@ public class ExpressionEvaluatorTests
         var expr = MapLibreExpressionParser.Parse(
             """["interpolate", ["linear"], ["get", "value"], 0, ["get", "missing"], 100, 10]""");
 
-        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)));
+        var act = () => ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)), _noZoom);
 
         act.Should().Throw<StyleExpressionEvaluationException>();
     }
@@ -588,5 +598,228 @@ public class ExpressionEvaluatorTests
         ExpressionEvaluator.ParseColor("#ff0000").Should().Be(SKColors.Red);
         ExpressionEvaluator.ParseColor("rgb(1,2,3)").Should().Be(new SKColor(1, 2, 3, 255));
         ExpressionEvaluator.ParseColor("rgb(bad)").Should().Be(SKColors.Black);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // ["zoom"] as an expression input (honua-server#2873).
+    //
+    // Every expected value below is the output of MapLibre GL JS's own reference implementation
+    // (@maplibre/maplibre-gl-style-spec v26.1.0) for the same expression at the same zoom, obtained
+    // via createExpression(expr, rootKey, propertySpec).evaluate({ zoom }, { properties }) — the
+    // method PR #2870 established. They are not derived from this implementation.
+    // ---------------------------------------------------------------------------------------
+
+    private const string ZoomWidthRamp =
+        """["interpolate", ["linear"], ["zoom"], 8, 1, 16, 6]""";
+
+    private const string ZoomColorSteps =
+        """["step", ["zoom"], "#ccc", 10, "#3a6", 14, "#083"]""";
+
+    private const string ZoomColorRamp =
+        """["interpolate", ["linear"], ["zoom"], 0, "#f7fbff", 22, "#08306b"]""";
+
+    /// <summary>
+    /// Numeric zoom ramps are compared with a tolerance rather than exactly because this evaluator
+    /// keeps the interpolation factor <c>t</c> in <see cref="float"/> while MapLibre computes it in
+    /// float64 (the caveat recorded on PR #2870). The two agree exactly wherever the zoom and the
+    /// resulting factor are representable in <see cref="float"/> — every case here except z=13.7 —
+    /// and differ only in the last few ulps otherwise, far below a pixel of stroke width.
+    /// </summary>
+    private const double ZoomRampTolerance = 1e-5;
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(0, 1)]
+    [InlineData(4, 1)]
+    [InlineData(8, 1)]
+    [InlineData(10, 2.25)]
+    [InlineData(11.5, 3.1875)]
+    [InlineData(12, 3.5)]
+    [InlineData(13.7, 4.5625)]
+    [InlineData(14, 4.75)]
+    [InlineData(16, 6)]
+    [InlineData(18, 6)]
+    [InlineData(22, 6)]
+    public void EvaluateFloat_ZoomInterpolate_MatchesMapLibreOutput(double zoom, double expected)
+    {
+        var expr = MapLibreExpressionParser.Parse(ZoomWidthRamp);
+
+        var result = ExpressionEvaluator.EvaluateFloat(expr, _emptyProps, RenderZoom.At(zoom), 0f);
+
+        result.Should().BeApproximately((float)expected, (float)ZoomRampTolerance);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(0, 204, 204, 204)]
+    [InlineData(4, 204, 204, 204)]
+    [InlineData(8, 204, 204, 204)]
+    [InlineData(10, 51, 170, 102)]
+    [InlineData(11.5, 51, 170, 102)]
+    [InlineData(12, 51, 170, 102)]
+    [InlineData(13.7, 51, 170, 102)]
+    [InlineData(14, 0, 136, 51)]
+    [InlineData(16, 0, 136, 51)]
+    [InlineData(18, 0, 136, 51)]
+    [InlineData(22, 0, 136, 51)]
+    public void EvaluateColor_ZoomStep_MatchesMapLibreOutput(double zoom, byte r, byte g, byte b)
+    {
+        var expr = MapLibreExpressionParser.Parse(ZoomColorSteps);
+
+        var result = ExpressionEvaluator.EvaluateColor(expr, _emptyProps, RenderZoom.At(zoom));
+
+        result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(0, 247, 251, 255)]
+    [InlineData(4, 204, 214, 228)]
+    [InlineData(8, 160, 177, 201)]
+    [InlineData(10, 138, 159, 188)]
+    [InlineData(11.5, 122, 145, 178)]
+    [InlineData(12, 117, 140, 174)]
+    [InlineData(13.7, 98, 125, 163)]
+    [InlineData(14, 95, 122, 161)]
+    [InlineData(16, 73, 103, 147)]
+    [InlineData(18, 51, 85, 134)]
+    [InlineData(22, 8, 48, 107)]
+    public void EvaluateColor_ZoomColorInterpolate_MatchesMapLibreOutput(double zoom, byte r, byte g, byte b)
+    {
+        var expr = MapLibreExpressionParser.Parse(ZoomColorRamp);
+
+        var result = ExpressionEvaluator.EvaluateColor(expr, _emptyProps, RenderZoom.At(zoom));
+
+        result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    /// <summary>
+    /// MapLibre's <c>step</c> selects a stop at exactly its boundary (<c>&gt;=</c>), not above it.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(9.5, 0)]
+    [InlineData(10, 100)]
+    [InlineData(13.5, 100)]
+    [InlineData(14, 200)]
+    [InlineData(20, 200)]
+    public void EvaluateFloat_ZoomStepBoundary_MatchesMapLibreOutput(double zoom, double expected)
+    {
+        var expr = MapLibreExpressionParser.Parse("""["step", ["zoom"], 0, 10, 100, 14, 200]""");
+
+        var result = ExpressionEvaluator.EvaluateFloat(expr, _emptyProps, RenderZoom.At(zoom), -1f);
+
+        result.Should().BeApproximately((float)expected, (float)ZoomRampTolerance);
+    }
+
+    /// <summary>
+    /// Zoom and feature attributes compose: the stop outputs are themselves data-driven here, so
+    /// each feature gets its own ramp evaluated at the render's zoom.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(8, 3)]
+    [InlineData(10, 5.25)]
+    [InlineData(12, 7.5)]
+    [InlineData(14, 9.75)]
+    [InlineData(16, 12)]
+    public void EvaluateFloat_ZoomCombinedWithGet_MatchesMapLibreOutput(double zoom, double expected)
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["interpolate", ["linear"], ["zoom"], 8, ["get", "w"], 16, ["*", ["get", "w"], 4]]""");
+
+        var result = ExpressionEvaluator.EvaluateFloat(expr, Props(("w", 3.0)), RenderZoom.At(zoom), 0f);
+
+        result.Should().BeApproximately((float)expected, (float)ZoomRampTolerance);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(0, 0)]
+    [InlineData(7.25, 7.25)]
+    [InlineData(14, 14)]
+    [InlineData(22, 22)]
+    public void Evaluate_BareZoomExpression_ReturnsTheRenderZoomLikeMapLibre(double zoom, double expected)
+    {
+        var expr = MapLibreExpressionParser.Parse("""["zoom"]""");
+
+        var result = ExpressionEvaluator.Evaluate(expr, _emptyProps, RenderZoom.At(zoom));
+
+        result.Should().BeOfType<double>().Which.Should().BeApproximately(expected, 1e-9);
+    }
+
+    /// <summary>
+    /// The regression witness for honua-server#2873. Before the fix, <c>["zoom"]</c> hit the
+    /// evaluator's unknown-operator arm and returned <see langword="null"/>, which
+    /// <c>ConvertToFloat(result, 0f)</c> then silently turned into <c>0f</c> — the same
+    /// permissive-default failure as #2867. Every zoom ramp therefore evaluated as if the map were
+    /// at zoom 0 and pinned to its lowest stop, at every zoom, with no throw, warning, or log. A
+    /// zoom well inside the ramp must now produce the interpolated value, not the zoom-0 one.
+    /// </summary>
+    [UnitTest]
+    public void EvaluateFloat_ZoomInterpolate_IsNotPinnedToTheLowestStop()
+    {
+        var expr = MapLibreExpressionParser.Parse(ZoomWidthRamp);
+
+        var atZoom12 = ExpressionEvaluator.EvaluateFloat(expr, _emptyProps, RenderZoom.At(12), 0f);
+        var atZoom0 = ExpressionEvaluator.EvaluateFloat(expr, _emptyProps, RenderZoom.At(0), 0f);
+
+        atZoom0.Should().BeApproximately(1f, 1e-5f);
+        atZoom12.Should().BeApproximately(3.5f, 1e-5f);
+        atZoom12.Should().NotBe(atZoom0, "a zoom ramp must vary with zoom rather than stay at its zoom-0 value");
+    }
+
+    /// <summary>
+    /// A render that could not derive a zoom must not render a zoom-dependent style as a confident
+    /// wrong picture. Substituting any level here would reinstate the shared root cause of #2867 and
+    /// #2868, so the evaluator raises and carries the render path's own reason into the message.
+    /// </summary>
+    [UnitTest]
+    public void Evaluate_ZoomExpression_WithNotDerivableZoom_ThrowsRatherThanSubstitutingALevel()
+    {
+        var expr = MapLibreExpressionParser.Parse(ZoomWidthRamp);
+        var zoom = RenderZoom.NotDerivable("the render extent is empty or degenerate");
+
+        var act = () => ExpressionEvaluator.Evaluate(expr, _emptyProps, zoom);
+
+        act.Should().Throw<StyleExpressionEvaluationException>()
+            .WithMessage("*the render extent is empty or degenerate*");
+    }
+
+    /// <summary>
+    /// The throw is scoped to expressions that actually read zoom: a style with no zoom input
+    /// evaluates normally on a render that has no derivable zoom, which is what keeps the
+    /// non-derivable case from failing renders it has no bearing on.
+    /// </summary>
+    [UnitTest]
+    public void Evaluate_NonZoomExpression_WithNotDerivableZoom_EvaluatesNormally()
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["interpolate", ["linear"], ["get", "value"], 0, 0, 100, 10]""");
+
+        var result = ExpressionEvaluator.Evaluate(expr, Props(("value", 50.0)), _noZoom);
+
+        result.Should().BeOfType<double>().Which.Should().BeApproximately(5.0, 1e-9);
+    }
+
+    /// <summary>
+    /// A zoom expression on a branch that is not taken must not fail the render: only an evaluated
+    /// <c>["zoom"]</c> needs a zoom.
+    /// </summary>
+    [UnitTest]
+    public void Evaluate_UnreachedZoomBranch_WithNotDerivableZoom_DoesNotThrow()
+    {
+        var expr = MapLibreExpressionParser.Parse(
+            """["case", ["==", ["get", "kind"], "fixed"], 5, ["zoom"]]""");
+
+        var result = ExpressionEvaluator.Evaluate(expr, Props(("kind", "fixed")), _noZoom);
+
+        result.Should().BeOfType<double>().Which.Should().Be(5.0);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/LegendClassifierTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/LegendClassifierTests.cs
@@ -17,6 +17,11 @@ public class LegendClassifierTests
     private static MapLibreStyleLayer ParseLayer(string json)
         => StyleTranslator.ParseStyleLayers(json).Single();
 
+    // A legend swatch is resolved without a map viewport, so it carries no render zoom; these
+    // classes are attribute-driven, not zoom-driven, so paint resolves identically (honua-server#2873).
+    private static readonly RenderZoom _noZoom =
+        RenderZoom.NotDerivable("legend classification resolves no zoom expression");
+
     [UnitTest]
     public void Classify_ConstantFillColor_ReturnsSingleClass()
     {
@@ -93,9 +98,9 @@ public class LegendClassifierTests
 
         // The classifier only enumerates the domain; the colour each class shows must
         // come from the same StyleTranslator path GetMap paints features with.
-        var residential = StyleTranslator.ResolveFillStyle(layer, result.Classes[0].Properties);
-        var industrial = StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties);
-        var other = StyleTranslator.ResolveFillStyle(layer, result.Classes[2].Properties);
+        var residential = StyleTranslator.ResolveFillStyle(layer, result.Classes[0].Properties, _noZoom);
+        var industrial = StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties, _noZoom);
+        var other = StyleTranslator.ResolveFillStyle(layer, result.Classes[2].Properties, _noZoom);
 
         residential.FillColor.Should().Be(new SKColor(0x00, 0xff, 0x00));
         industrial.FillColor.Should().Be(new SKColor(0xff, 0x00, 0x00));
@@ -122,11 +127,11 @@ public class LegendClassifierTests
         result.Field.Should().Be("population");
         result.Classes.Select(c => c.Label).Should().Equal("< 100", "100 - 1000", ">= 1000");
 
-        StyleTranslator.ResolveFillStyle(layer, result.Classes[0].Properties)
+        StyleTranslator.ResolveFillStyle(layer, result.Classes[0].Properties, _noZoom)
             .FillColor.Should().Be(new SKColor(0xee, 0xee, 0xee));
-        StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties)
+        StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties, _noZoom)
             .FillColor.Should().Be(new SKColor(0x88, 0xaa, 0x88));
-        StyleTranslator.ResolveFillStyle(layer, result.Classes[2].Properties)
+        StyleTranslator.ResolveFillStyle(layer, result.Classes[2].Properties, _noZoom)
             .FillColor.Should().Be(new SKColor(0x00, 0x44, 0x00));
     }
 
@@ -154,9 +159,9 @@ public class LegendClassifierTests
         result.Field.Should().Be("density");
         result.Classes.Select(c => c.Label).Should().Equal("0", "100");
 
-        StyleTranslator.ResolveFillStyle(layer, result.Classes[0].Properties)
+        StyleTranslator.ResolveFillStyle(layer, result.Classes[0].Properties, _noZoom)
             .FillColor.Should().Be(new SKColor(0xff, 0xff, 0xff));
-        StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties)
+        StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties, _noZoom)
             .FillColor.Should().Be(new SKColor(0xff, 0x00, 0x00));
     }
 
@@ -182,7 +187,7 @@ public class LegendClassifierTests
 
         result.UnrepresentableReason.Should().BeNull();
         result.Classes.Select(c => c.Label).Should().Equal("0", "50", "100");
-        StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties)
+        StyleTranslator.ResolveFillStyle(layer, result.Classes[1].Properties, _noZoom)
             .FillColor.Should().Be(new SKColor(0x00, 0xff, 0x00));
     }
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/RasterStylePlanTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/RasterStylePlanTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Infrastructure.Rendering;
+using Honua.TestKit.Attributes;
+using Xunit;
+
+namespace Honua.Server.Tests.Features.Infrastructure.Rendering;
+
+/// <summary>
+/// Covers the zoom-independence invariant of the cached raster style plan (honua-server#2873).
+/// </summary>
+/// <remarks>
+/// A <c>RasterStylePlan</c> is cached per layer and reused for every later request against that
+/// layer, at any extent and image size — and therefore at any zoom. Anything the plan pre-resolves
+/// must consequently be the same at every zoom, or the first request to build the plan silently
+/// freezes a zoom-dependent value for all the rest.
+/// </remarks>
+[Trait("Component", "MapServer")]
+public class RasterStylePlanTests
+{
+    private const string StaticCircleStyle =
+        """[{"id":"a","type":"circle","paint":{"circle-radius":6,"circle-color":"#f00"}}]""";
+
+    private const string ZoomDependentCircleStyle =
+        """[{"id":"a","type":"circle","paint":{"circle-radius":["interpolate",["linear"],["zoom"],5,2,15,20],"circle-color":"#f00"}}]""";
+
+    /// <summary>
+    /// The fast path stays available for styles that resolve identically at every zoom.
+    /// </summary>
+    [UnitTest]
+    public void BuildRasterStylePlanFromJson_StaticCircleStyle_PreResolvesTheFastPathStyle()
+    {
+        var plan = RasterMapRenderingPipeline.BuildRasterStylePlanFromJson(StaticCircleStyle);
+
+        plan.SimpleCircleStyle.Should().NotBeNull();
+        plan.SimpleCircleStyle!.Radius.Should().Be(6f);
+    }
+
+    /// <summary>
+    /// The decisive guard: a zoom-dependent circle style must not be pre-resolved into the cached
+    /// plan. Doing so would bake the zoom of whichever request built the plan into every subsequent
+    /// request for that layer, so a radius ramp would render at a stale zoom rather than the
+    /// request's own — a confident wrong picture of exactly the kind #2867/#2868 produced. Falling
+    /// back to <see langword="null"/> sends the render through the per-request path where the real
+    /// <see cref="RenderZoom"/> is known.
+    /// </summary>
+    [UnitTest]
+    public void BuildRasterStylePlanFromJson_ZoomDependentCircleStyle_DoesNotPreResolveIntoTheCachedPlan()
+    {
+        var plan = RasterMapRenderingPipeline.BuildRasterStylePlanFromJson(ZoomDependentCircleStyle);
+
+        plan.SimpleCircleStyle.Should().BeNull(
+            "a zoom-dependent style must not be pre-resolved into a plan that is cached across zooms");
+        plan.StyleLayers.Should().HaveCount(1, "the style itself still renders, just via the per-request path");
+    }
+
+    /// <summary>
+    /// Building the plan must not throw for a zoom-dependent style even though no zoom exists at
+    /// plan-build time: the style is declared ineligible for pre-resolution before any evaluation
+    /// is attempted.
+    /// </summary>
+    [UnitTest]
+    public void BuildRasterStylePlanFromJson_ZoomDependentCircleStyle_DoesNotThrow()
+    {
+        var act = () => RasterMapRenderingPipeline.BuildRasterStylePlanFromJson(ZoomDependentCircleStyle);
+
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// Zoom is not a feature attribute, so it must not widen the attribute projection the plan
+    /// queries for.
+    /// </summary>
+    [UnitTest]
+    public void BuildRasterStylePlanFromJson_ZoomDependentStyle_ReferencesNoFeatureFields()
+    {
+        var plan = RasterMapRenderingPipeline.BuildRasterStylePlanFromJson(ZoomDependentCircleStyle);
+
+        plan.ReferencedFields.Should().BeEmpty();
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyleTranslatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/StyleTranslatorTests.cs
@@ -20,6 +20,14 @@ public class StyleTranslatorTests
     private static readonly ImmutableDictionary<string, object?> _emptyProps =
         ImmutableDictionary<string, object?>.Empty;
 
+    /// <summary>
+    /// The zoom passed by every test whose style contains no <c>["zoom"]</c> input; evaluating a
+    /// zoom expression against it throws, so these tests passing unchanged shows their styles are
+    /// unaffected by zoom support (honua-server#2873).
+    /// </summary>
+    private static readonly RenderZoom _noZoom =
+        RenderZoom.NotDerivable("this test resolves no zoom expression");
+
     [UnitTest]
     public void ParseStyleLayers_NullJson_ReturnsEmpty()
     {
@@ -124,7 +132,7 @@ public class StyleTranslatorTests
     {
         var layer = new MapLibreStyleLayer { Type = "fill" };
 
-        var style = StyleTranslator.ResolveFillStyle(layer, _emptyProps);
+        var style = StyleTranslator.ResolveFillStyle(layer, _emptyProps, _noZoom);
 
         style.FillColor.Alpha.Should().BeGreaterThan(0);
     }
@@ -134,7 +142,7 @@ public class StyleTranslatorTests
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"f","type":"fill","paint":{"fill-color":"#ff0000","fill-opacity":1.0}}]""");
 
-        var style = StyleTranslator.ResolveFillStyle(layers[0], _emptyProps);
+        var style = StyleTranslator.ResolveFillStyle(layers[0], _emptyProps, _noZoom);
 
         style.FillColor.Red.Should().Be(255);
         style.FillColor.Green.Should().Be(0);
@@ -146,7 +154,7 @@ public class StyleTranslatorTests
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"f","type":"fill","paint":{"fill-color":"rgba(255,0,0,0.5)","fill-opacity":0.5}}]""");
 
-        var style = StyleTranslator.ResolveFillStyle(layers[0], _emptyProps);
+        var style = StyleTranslator.ResolveFillStyle(layers[0], _emptyProps, _noZoom);
 
         style.FillColor.Alpha.Should().BeInRange((byte)63, (byte)64);
     }
@@ -156,7 +164,7 @@ public class StyleTranslatorTests
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"f","type":"fill","paint":{"fill-color":"#ff0000","fill-outline-color":"#00ff00"}}]""");
 
-        var style = StyleTranslator.ResolveFillStyle(layers[0], _emptyProps);
+        var style = StyleTranslator.ResolveFillStyle(layers[0], _emptyProps, _noZoom);
 
         style.OutlineColor.Should().NotBeNull();
         style.OutlineColor!.Value.Green.Should().Be(255);
@@ -167,7 +175,7 @@ public class StyleTranslatorTests
     {
         var layer = new MapLibreStyleLayer { Type = "line" };
 
-        var style = StyleTranslator.ResolveLineStyle(layer, _emptyProps);
+        var style = StyleTranslator.ResolveLineStyle(layer, _emptyProps, _noZoom);
 
         style.LineWidth.Should().BeGreaterThan(0);
     }
@@ -177,7 +185,7 @@ public class StyleTranslatorTests
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"l","type":"line","paint":{"line-color":"#0000ff","line-width":3}}]""");
 
-        var style = StyleTranslator.ResolveLineStyle(layers[0], _emptyProps);
+        var style = StyleTranslator.ResolveLineStyle(layers[0], _emptyProps, _noZoom);
 
         style.LineColor.Blue.Should().Be(255);
         style.LineWidth.Should().Be(3f);
@@ -188,7 +196,7 @@ public class StyleTranslatorTests
     {
         var layer = new MapLibreStyleLayer { Type = "circle" };
 
-        var style = StyleTranslator.ResolveCircleStyle(layer, _emptyProps);
+        var style = StyleTranslator.ResolveCircleStyle(layer, _emptyProps, _noZoom);
 
         style.Radius.Should().BeGreaterThan(0);
     }
@@ -198,7 +206,7 @@ public class StyleTranslatorTests
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"c","type":"circle","paint":{"circle-radius":8,"circle-color":"#00ff00","circle-stroke-color":"#000000","circle-stroke-width":2}}]""");
 
-        var style = StyleTranslator.ResolveCircleStyle(layers[0], _emptyProps);
+        var style = StyleTranslator.ResolveCircleStyle(layers[0], _emptyProps, _noZoom);
 
         style.Radius.Should().Be(8f);
         style.FillColor.Green.Should().Be(255);
@@ -211,7 +219,7 @@ public class StyleTranslatorTests
     {
         var layers = StyleTranslator.ParseStyleLayers("""[{"id":"c","type":"circle","paint":{"circle-color":"rgba(0,255,0,0.5)","circle-opacity":0.5}}]""");
 
-        var style = StyleTranslator.ResolveCircleStyle(layers[0], _emptyProps);
+        var style = StyleTranslator.ResolveCircleStyle(layers[0], _emptyProps, _noZoom);
 
         style.FillColor.Alpha.Should().BeInRange((byte)63, (byte)64);
     }
@@ -280,6 +288,111 @@ public class StyleTranslatorTests
     public void IsAnyLayerInZoomRange_EmptyStyle_ReturnsTrue()
     {
         StyleTranslator.IsAnyLayerInZoomRange([], RenderZoom.At(4)).Should().BeTrue();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Zoom-dependent paint resolution (honua-server#2873).
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Expected widths are MapLibre GL JS's own output for this expression
+    /// (<c>@maplibre/maplibre-gl-style-spec</c>, <c>createExpression(expr, 'line-width',
+    /// latest.paint_line['line-width'])</c>) at each zoom.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(8, 1f)]
+    [InlineData(10, 2.25f)]
+    [InlineData(12, 3.5f)]
+    [InlineData(14, 4.75f)]
+    [InlineData(16, 6f)]
+    public void ResolveLineStyle_ZoomDependentWidth_ResolvesAtTheRenderZoom(double zoom, float expected)
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"line","paint":{"line-width":["interpolate",["linear"],["zoom"],8,1,16,6]}}]""");
+
+        var style = StyleTranslator.ResolveLineStyle(layers[0], _emptyProps, RenderZoom.At(zoom));
+
+        style.LineWidth.Should().BeApproximately(expected, 1e-5f);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(8, 204, 204, 204)]
+    [InlineData(10, 51, 170, 102)]
+    [InlineData(14, 0, 136, 51)]
+    public void ResolveFillStyle_ZoomDependentColor_ResolvesAtTheRenderZoom(double zoom, byte r, byte g, byte b)
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"fill","paint":{"fill-color":["step",["zoom"],"#ccc",10,"#3a6",14,"#083"]}}]""");
+
+        var style = StyleTranslator.ResolveFillStyle(layers[0], _emptyProps, RenderZoom.At(zoom));
+
+        style.FillColor.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    [UnitTest]
+    public void ResolveLineStyle_ZoomDependentWidth_WithNotDerivableZoom_Throws()
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"line","paint":{"line-width":["interpolate",["linear"],["zoom"],8,1,16,6]}}]""");
+
+        var act = () => StyleTranslator.ResolveLineStyle(layers[0], _emptyProps, _noZoom);
+
+        act.Should().Throw<StyleExpressionEvaluationException>();
+    }
+
+    [UnitTest]
+    public void UsesZoomExpression_PaintExpressionReadingZoom_ReturnsTrue()
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"circle","paint":{"circle-radius":["interpolate",["linear"],["zoom"],5,2,15,20]}}]""");
+
+        StyleTranslator.UsesZoomExpression(layers[0]).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void UsesZoomExpression_FilterReadingZoom_ReturnsTrue()
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"circle","filter":["<",["zoom"],10]}]""");
+
+        StyleTranslator.UsesZoomExpression(layers[0]).Should().BeTrue();
+    }
+
+    [UnitTest]
+    public void UsesZoomExpression_LayoutReadingZoom_ReturnsTrue()
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"line","layout":{"line-cap":["step",["zoom"],"butt",10,"round"]}}]""");
+
+        StyleTranslator.UsesZoomExpression(layers[0]).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A layer whose min/maxzoom scope it to a zoom range is not itself zoom-dependent: the gate is
+    /// applied by <see cref="StyleTranslator.ShouldRenderLayer"/>, and the paint it resolves to is
+    /// the same at every zoom it draws at. Reporting it as zoom-dependent would needlessly give up
+    /// the pre-resolved fast paths.
+    /// </summary>
+    [UnitTest]
+    public void UsesZoomExpression_DataDrivenAndZoomScopedStyles_ReturnFalse()
+    {
+        var dataDriven = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"circle","minzoom":5,"maxzoom":12,"paint":{"circle-radius":["interpolate",["linear"],["get","pop"],0,2,100,20]}}]""");
+
+        StyleTranslator.UsesZoomExpression(dataDriven[0]).Should().BeFalse();
+    }
+
+    [UnitTest]
+    public void UsesZoomExpression_StaticStyle_ReturnsFalse()
+    {
+        var layers = StyleTranslator.ParseStyleLayers(
+            """[{"id":"a","type":"circle","paint":{"circle-radius":6,"circle-color":"#f00"}}]""");
+
+        StyleTranslator.UsesZoomExpression(layers[0]).Should().BeFalse();
     }
 
     [UnitTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Styling/StyleConversionMatrixTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Styling/StyleConversionMatrixTests.cs
@@ -1372,7 +1372,7 @@ public class StyleConversionMatrixTests
         var props = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
             .Add("population", dirtyValue);
 
-        var result = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, props);
+        var result = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, props, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
 
         // Must be the gray fallback color (#CCCCCC), NOT the first bucket color (#440154)
         Assert.Equal("#CCCCCC", result?.ToString());
@@ -1437,7 +1437,7 @@ public class StyleConversionMatrixTests
         var props = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
             .Add("population", null);
 
-        var result = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, props);
+        var result = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, props, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
 
         Assert.Equal("#CCCCCC", result?.ToString());
     }
@@ -1499,13 +1499,13 @@ public class StyleConversionMatrixTests
         // Value 25.0 < break 50.0 → first bucket color
         var propsLow = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
             .Add("population", 25.0);
-        var resultLow = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsLow);
+        var resultLow = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsLow, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
         Assert.Equal("#440154", resultLow?.ToString());
 
         // Value 75.0 >= break 50.0 → second bucket color
         var propsHigh = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
             .Add("population", 75.0);
-        var resultHigh = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsHigh);
+        var resultHigh = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsHigh, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
         Assert.Equal("#FDE725", resultHigh?.ToString());
     }
 
@@ -1762,18 +1762,18 @@ public class StyleConversionMatrixTests
         // Key exists but value is null — must hit fallback, not the "" category
         var propsNull = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
             .Add("category", null);
-        var resultNull = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsNull);
+        var resultNull = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsNull, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
         Assert.Equal("#CCCCCC", resultNull?.ToString());
 
         // Key missing entirely — must also hit fallback
         var propsMissing = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty;
-        var resultMissing = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsMissing);
+        var resultMissing = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsMissing, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
         Assert.Equal("#CCCCCC", resultMissing?.ToString());
 
         // Non-null value "A" — must match category color
         var propsA = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
             .Add("category", "A");
-        var resultA = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsA);
+        var resultA = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, propsA, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
         Assert.Equal("#377EB8", resultA?.ToString());
     }
 
@@ -1979,7 +1979,7 @@ public class StyleConversionMatrixTests
         var props = System.Collections.Immutable.ImmutableDictionary<string, object?>.Empty
             .Add("population", stringValue);
 
-        var result = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, props);
+        var result = Honua.Infrastructure.Rendering.ExpressionEvaluator.Evaluate(expr, props, Honua.Infrastructure.Rendering.RenderZoom.NotDerivable("this test evaluates no zoom expression"));
 
         Assert.Equal(expectedColor, result?.ToString());
     }


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2873

## Summary

`ExpressionEvaluator` had no concept of zoom, so every zoom-driven MapLibre expression was unevaluatable. **What it did today was silent degradation, not a clean rejection** — the same failure class as #2867 (interpolate → black) and #2868 (skipped minzoom/maxzoom), not a straightforward missing feature. `["zoom"]` fell through to the evaluator's unknown-operator arm and returned `null`, which the callers' `ConvertToFloat(result, 0f)` then coerced to `0f`. Every zoom ramp therefore evaluated as if the map were at zoom 0 and pinned to its lowest stop, at every zoom, with no throw, warning, or log. `["interpolate", ["linear"], ["zoom"], 8, 1, 16, 6]` returned width `1` at *every* zoom; `["step", ["zoom"], "#ccc", 10, "#3a6", ...]` returned `#ccc` everywhere.

PR #2872 now derives a real `RenderZoom` and threads it through every server-side render path, so a zoom exists at the moment of evaluation. This PR threads that existing value into the evaluator (it does **not** re-derive one) and implements `["zoom"]` as an input matching MapLibre semantics.

Verified against MapLibre GL JS's own reference implementation (`@maplibre/maplibre-gl-style-spec` v26.1.0) via `createExpression(expr, rootKey, propertySpec).evaluate({ zoom }, { properties })` — the method PR #2870 established. Expected values in the new tests are MapLibre's output, not this implementation's.

## Changes Made
- `ExpressionEvaluator` takes an explicit `RenderZoom` on every entry point (making "no zoom" unreachable by omission); `["zoom"]` resolves to the render's level and composes with `interpolate`, `step`, filters, and data-driven (`get`) sub-expressions.
- A render carrying `RenderZoom.NotDerivable` that evaluates `["zoom"]` raises `StyleExpressionEvaluationException` carrying the `NotDerivable` reason, instead of substituting a placeholder level. Non-zoom styles evaluate unchanged on a `NotDerivable` render, and an unreached zoom branch does not throw.
- `StyleTranslator.UsesZoomExpression` keeps zoom-dependent styles out of the per-layer-cached `RasterStylePlan` pre-resolved fast path (which is reused across requests at any zoom) — pre-resolving one there would freeze a single request's zoom into every later request for that layer.
- Legend swatches (drawn without a viewport) pass `NotDerivable` explicitly; #2866 is where the WMS legend path will supply a real SCALE-derived zoom.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow. **Moves pixels** for any style using zoom expressions (the fix). No server-side visual baselines exist today.

## Breaking Changes
None. No public HTTP/gRPC/OpenAPI surface changes; internal render signatures only.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

### Verification notes
- **What `["zoom"]` did today:** silent coercion to `0f` — a correctness bug of the #2867 class, not a clean parse-time rejection. Re-prioritise upward: treat as the same silent-degradation family, not a feature gap.
- **Verified against MapLibre** (`@maplibre/maplibre-gl-style-spec` v26.1.0 `createExpression`): line-width `["interpolate",["linear"],["zoom"],8,1,16,6]` across 11 zooms; `["step",["zoom"],...]` color bands (byte-exact, incl. the `>=` boundary at z=10/z=14); a zoom color ramp; `["zoom"]` combined with `["get"]`; and bare `["zoom"]`.
- **`NotDerivable` handling:** raises `StyleExpressionEvaluationException` with the reason; verified it throws for zoom styles and does *not* throw for non-zoom styles or unreached zoom branches. Also guarded the cross-request cache-poisoning path (`RasterStylePlan.SimpleCircleStyle`).
- **Non-zoom output unchanged:** the diff changes no evaluation logic — only operator signatures/dispatch gained the parameter. The 45 pre-existing evaluator/translator/matrix tests now pass a `NotDerivable` zoom, so they would throw if any non-zoom style consulted zoom; all pass.
- **Tests run locally (Release):** Architecture 135/135; Server.Tests rendering+styling Fast 236/236; the new zoom suites (rendering namespace 193/193 incl. MapLibre-verified cases); GeoServices unit/fast 587/587; DB-backed `StyledVectorMapRenderTests` 2/2 and WMS/Maps/StaticMap render integration 30/30 (Docker up).
- **Could not run:** full Server.Tests Slow tier and the scale-stack suite. `scripts/ci/pre-pr-check.sh` is broken on Windows (MSB5028, #2871), so I ran its equivalents individually (Release warnings-as-errors build, `dotnet format`, affected tests).
- **Adjacent finding (out of scope, reported separately):** `EvaluateInterpolate` ignores the interpolation-type operand (`array[1]`), so `["exponential", base]` and `["cubic-bezier", ...]` silently behave as `["linear"]`. MapLibre honors them (base-2 at z=12 → 1.29 vs our 3.5). Affects `["get"]` ramps equally; not a zoom regression.
- Feature catalog untouched (no routes/endpoints added), so no `-c Release` regen needed.
