### PR TITLE
test(governance): validate proof-ledger evidence substantiates the claim (#2877)

### DIFF
--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -1998,12 +1998,14 @@
         },
         {
           "proofClass": "scenario-depth",
-          "proofMechanism": "Tile data (tile/{z}/{y}/{x}.pbf), style/resources (default styles + root.json, scoped-minimal sprites and glyph ranges), and tileMap routes are implemented as thin adapters over the shared vector-tile pipeline; sprite/glyphs are referenced from the composed style only when it has symbol layers.",
+          "proofMechanism": "Tile data (tile/{z}/{y}/{x}.pbf), style/resources (default styles + root.json, scoped-minimal sprites and glyph ranges), and tileMap routes are implemented as thin adapters over the shared vector-tile pipeline; sprite/glyphs are referenced from the composed style only when it has symbol layers. VectorTileServerEndpointTests exercises happy-path plus negative-path depth (bad coordinates, out-of-range zoom, unknown service, empty tile, absurd tileMap dimension) across tile, resources, and tileMap.",
           "executionLane": "ci:test-all",
           "evidenceLocations": [
             "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Tile.cs",
             "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.Resources.cs",
-            "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs"
+            "src/Honua.Protocols.GeoServices/VectorTileServer/VectorTileServerEndpoints.TileMap.cs",
+            "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs",
+            "tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileStyleComposerTests.cs"
           ],
           "ownerRepo": "honua-server",
           "status": "implemented",

--- a/docs/internal/contributor/public-interface-quality-model.md
+++ b/docs/internal/contributor/public-interface-quality-model.md
@@ -28,6 +28,26 @@ The machine-readable source of truth is [`docs/gis/data/public-interface-proof.j
 
 The ledger is intentionally allowed to overlap at the surface level. Example: `map-server` covers the broad GeoServices MapServer route family while `wms-1.3` and `wmts-1.0` describe nested standards surfaces that reuse a subset of those routes but carry their own conformance or follow-up proof obligations.
 
+## Evidence Model — Why Existence Is Not Proof
+
+The ledger used to validate every `evidenceLocations` entry with a bare `File.Exists` check. Existence is not evidence: the check passed identically for a workflow that proves the claim and a document that merely happens to exist. That is how a fabricated GeoServices route (`computeClass`, never served) rode a green architecture gate to `contract-governance: implemented` (`#2861`/`#2864`) — the ADR-0058 "fake gate that manufactures confidence", literally. `#2879` repointed those six specific proofs at a real gate; `#2877` replaced the *mechanism* with the content-aware model enforced by [`ProofEvidenceValidator`](../../../tests/dotnet/Honua.Architecture.Tests/ProofEvidenceValidator.cs) and `PublicInterfaceProofLedgerTests`.
+
+Every evidence location falls into one of two tiers:
+
+- **Gate evidence** — an artifact an *automated* lane actually executes and that exercises the claim: an architecture test (`tests/dotnet/Honua.Architecture.Tests/**`), a dotnet test (`tests/dotnet/**Tests.cs`), a python/js/js-browser test, a `.github/workflows/*.yml` governance/conformance workflow, a source-generated `JsonSerializerContext` (a wire contract the warnings-as-errors Release build gates at compile time), or the published gRPC proto schema.
+- **Corroborating evidence** — prose docs (`*.md`), published data artifacts (`*.json`), non-gate source, and support files. Necessary context; never sufficient on its own.
+
+Rules enforced by the suite:
+
+1. **Existence remains necessary** — every non-external evidence path must resolve on disk.
+2. **Every `implemented` proof on an automated lane must cite a gate its lane runs.** An `architecture` lane must cite an architecture test; a `test-all` lane a dotnet test (or, for `contract-governance`, a build-enforced source-generated contract); a `nightly:<x>` lane the like-named workflow; a `ci:<x>` lane any executed test/workflow gate; a `repo:honua-io/geospatial-grpc` lane the proto schema. A doc/data/plain-source-only proof, or a proof whose declared lane does not run the cited gate, fails red.
+3. **Manual-lane proofs are corroboration only.** A proof on `docs+review` / `release:*` is admissible only when its surface *also* carries a real automated-gate proof — manual/doc evidence can never be a surface's sole substantiation. (Today: `forms-runtime` and `wcs-2.0.1` `contract-governance`, and `odata-v4` and `ogc-api-features` `real-client-certification`, are corroborating proofs riding gated siblings — under the old `File.Exists` model these passed on documentation alone.)
+4. **Surfaces and operation keys may not over-claim.** Every surface must match at least one served `EndpointRegistry` route or registered `OperationRegistry` operation, and every declared `operationKey` must resolve to a real registered operation — the `computeClass` over-claim, generalized to the whole ledger.
+
+**What this prevents:** a document, model, or unrelated workflow that merely exists standing in for proof; a proof whose declared lane does not execute its cited gate; a surface or operation the ledger vouches for that the server does not serve.
+
+**What it still admits (stated deliberately, not silently):** the model verifies that a gate the lane runs *exists and is of the right kind*; it cannot mechanically judge that the gate's assertions are *strong enough* to cover the full claim, nor that a prose doc's sentences match runtime behaviour. A test that runs in the right lane but under-asserts, or a source-generated contract whose companion doc drifts from behaviour, still passes. Closing that residue requires a claim-specific gate (as `#2879` built for the GeoServices parity matrix), not a generic ledger check.
+
 ## Release Evidence Ledgers
 
 ### Named Client Lanes

--- a/tests/dotnet/Honua.Architecture.Tests/ProofEvidenceValidator.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ProofEvidenceValidator.cs
@@ -1,0 +1,332 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Architecture.Tests;
+
+/// <summary>
+/// The kind of substantiation an <c>evidenceLocations</c> entry in the public-interface proof
+/// ledger provides. The classification is what lets the ledger tell a gate an automated lane runs
+/// from a document that merely happens to exist (honua-server#2877).
+/// </summary>
+internal enum EvidenceKind
+{
+    /// <summary>Path does not exist on disk.</summary>
+    Missing,
+
+    /// <summary>A test under <c>tests/dotnet/Honua.Architecture.Tests/</c> — the architecture gate.</summary>
+    ArchitectureTest,
+
+    /// <summary>A <c>*Tests.cs</c> file under <c>tests/dotnet/</c> — runs in the dotnet test lanes.</summary>
+    DotnetTest,
+
+    /// <summary>A python/js/js-browser test file — runs in an integration or browser lane.</summary>
+    ForeignTest,
+
+    /// <summary>A <c>.github/workflows/*.yml</c> governance or conformance workflow.</summary>
+    Workflow,
+
+    /// <summary>
+    /// A source-generated <see cref="System.Text.Json.Serialization.JsonSerializerContext"/>: a
+    /// build-enforced wire contract. The warnings-as-errors Release build fails if the context and
+    /// its model diverge, so the shape is gated at compile time in the build/test lanes.
+    /// </summary>
+    SourceGenContract,
+
+    /// <summary>The published gRPC proto schema on <c>github.com/honua-io/geospatial-grpc</c>.</summary>
+    GrpcProtoUrl,
+
+    /// <summary>Non-gate source (compiles, but does not by itself gate the claim).</summary>
+    Source,
+
+    /// <summary>Prose documentation (<c>*.md</c>). Corroborating, never a gate.</summary>
+    Doc,
+
+    /// <summary>A published data artifact (<c>*.json</c>, cert envelopes). Corroborating, never a gate.</summary>
+    Data,
+
+    /// <summary>An external artifact URL that is not the gRPC proto schema.</summary>
+    ExternalUrl,
+
+    /// <summary>Anything else — support/config files under a test tree, scripts, etc.</summary>
+    Other,
+}
+
+/// <summary>
+/// Validates that a proof's evidence actually substantiates its claim rather than merely existing.
+/// Extracted so the guarantee can be exercised directly with synthetic proofs (see
+/// <see cref="PublicInterfaceProofLedgerTests"/>) as well as swept over the committed ledger.
+/// </summary>
+internal static class ProofEvidenceValidator
+{
+    /// <summary>
+    /// Returns the human-readable reasons <paramref name="proof"/> fails content validation, or an
+    /// empty list when the proof is substantiated. <paramref name="surface"/> supplies sibling
+    /// proofs so a manual/review-lane proof can be checked for a real automated gate elsewhere on
+    /// the surface.
+    /// </summary>
+    public static IReadOnlyList<string> Validate(
+        PublicInterfaceSurface surface,
+        PublicInterfaceProof proof,
+        string repoRoot)
+    {
+        var failures = new List<string>();
+        var classified = proof.EvidenceLocations
+            .Select(location => (Location: location, Kind: Classify(location, repoRoot)))
+            .ToArray();
+
+        // Existence is necessary (but not sufficient). Preserved from the original File.Exists check.
+        foreach (var (location, kind) in classified)
+        {
+            if (kind == EvidenceKind.Missing)
+            {
+                failures.Add(
+                    $"evidence location '{location}' for surface '{surface.SurfaceId}' " +
+                    $"({proof.ProofClass}) must exist");
+            }
+        }
+
+        // Planned / bounded-child proofs are honestly unfinished (a follow-up ticket is required
+        // elsewhere); they are not asserting a live gate, so the gate requirement does not apply.
+        if (!string.Equals(proof.Status, "implemented", StringComparison.OrdinalIgnoreCase))
+        {
+            return failures;
+        }
+
+        var laneTokens = SplitLane(proof.ExecutionLane);
+        var automatedTokens = laneTokens.Where(IsAutomatedLaneToken).ToArray();
+
+        if (automatedTokens.Length > 0)
+        {
+            if (!IsGateSatisfied(proof, classified, automatedTokens))
+            {
+                var citedKinds = string.Join(", ", classified.Select(entry => $"{entry.Location}={entry.Kind}"));
+                failures.Add(
+                    $"proof '{proof.ProofClass}' on surface '{surface.SurfaceId}' declares automated " +
+                    $"execution lane '{proof.ExecutionLane}' but cites no executable gate that lane " +
+                    $"runs — a document or model that merely exists is not proof (evidence: {citedKinds})");
+            }
+        }
+        else
+        {
+            // Purely manual/review lane: admissible only as corroboration of a surface that is
+            // gated for real elsewhere. Manual evidence can never be the sole substantiation.
+            var hasGatedSibling = surface.Proofs.Any(sibling =>
+                !ReferenceEquals(sibling, proof) &&
+                string.Equals(sibling.Status, "implemented", StringComparison.OrdinalIgnoreCase) &&
+                HasAutomatedGate(sibling, repoRoot));
+
+            if (!hasGatedSibling)
+            {
+                failures.Add(
+                    $"proof '{proof.ProofClass}' on surface '{surface.SurfaceId}' runs only on the " +
+                    $"manual lane '{proof.ExecutionLane}' and the surface carries no automated-gate " +
+                    "proof — manual/review evidence cannot be the sole substantiation of a surface");
+            }
+        }
+
+        return failures;
+    }
+
+    /// <summary>
+    /// True when <paramref name="proof"/> is implemented, declares an automated lane, and cites a
+    /// gate that lane runs. Used to decide whether a manual sibling proof is genuinely corroborated.
+    /// </summary>
+    private static bool HasAutomatedGate(PublicInterfaceProof proof, string repoRoot)
+    {
+        var automatedTokens = SplitLane(proof.ExecutionLane).Where(IsAutomatedLaneToken).ToArray();
+        if (automatedTokens.Length == 0)
+        {
+            return false;
+        }
+
+        var classified = proof.EvidenceLocations
+            .Select(location => (Location: location, Kind: Classify(location, repoRoot)))
+            .ToArray();
+
+        return IsGateSatisfied(proof, classified, automatedTokens);
+    }
+
+    private static bool IsGateSatisfied(
+        PublicInterfaceProof proof,
+        (string Location, EvidenceKind Kind)[] classified,
+        string[] automatedTokens) =>
+        automatedTokens.Any(token =>
+            classified.Any(entry => IsGateCompatible(token, entry.Kind, proof.ProofClass, entry.Location)));
+
+    /// <summary>
+    /// True when an evidence location of the given <paramref name="kind"/> is a gate the automated
+    /// lane <paramref name="laneToken"/> actually runs.
+    /// </summary>
+    private static bool IsGateCompatible(string laneToken, EvidenceKind kind, string proofClass, string location)
+    {
+        // Order matters: "ci:test-all+architecture" splits into "ci:test-all" and "architecture";
+        // the "architecture" / "test-all" checks must win over the generic "ci:" fallback.
+        if (laneToken.Contains("architecture", StringComparison.OrdinalIgnoreCase))
+        {
+            return kind == EvidenceKind.ArchitectureTest;
+        }
+
+        if (laneToken.Contains("test-all", StringComparison.OrdinalIgnoreCase))
+        {
+            // The test-all lane (ci.yml) runs the whole dotnet + python + js suite, so any of those
+            // test kinds is a gate it executes. For contract-governance, a source-generated wire
+            // contract additionally counts: the warnings-as-errors Release build gates its shape.
+            return kind is EvidenceKind.DotnetTest or EvidenceKind.ArchitectureTest or EvidenceKind.ForeignTest
+                || (kind == EvidenceKind.SourceGenContract
+                    && string.Equals(proofClass, "contract-governance", StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (laneToken.StartsWith("nightly:", StringComparison.OrdinalIgnoreCase))
+        {
+            return kind == EvidenceKind.Workflow
+                && WorkflowMatchesLane(location, laneToken["nightly:".Length..]);
+        }
+
+        if (laneToken.StartsWith("repo:honua-io/geospatial-grpc", StringComparison.OrdinalIgnoreCase))
+        {
+            return kind == EvidenceKind.GrpcProtoUrl;
+        }
+
+        if (laneToken.StartsWith("ci:", StringComparison.OrdinalIgnoreCase))
+        {
+            // Broad CI lanes run the whole test + workflow suite; any executed test or workflow gate
+            // is a valid gate for a ci: lane.
+            return kind is EvidenceKind.Workflow
+                or EvidenceKind.DotnetTest
+                or EvidenceKind.ForeignTest
+                or EvidenceKind.ArchitectureTest;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when the cited workflow file's name corresponds to the nightly lane it is claimed to run
+    /// in. Prevents a nightly proof from citing an unrelated workflow (the "workflow that answers an
+    /// unrelated question" failure).
+    /// </summary>
+    private static bool WorkflowMatchesLane(string workflowPath, string laneCore)
+    {
+        var stem = Path.GetFileNameWithoutExtension(workflowPath);
+        return stem.Contains(laneCore, StringComparison.OrdinalIgnoreCase)
+            || laneCore.Contains(stem, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsAutomatedLaneToken(string token) =>
+        token.Contains("architecture", StringComparison.OrdinalIgnoreCase)
+        || token.Contains("test-all", StringComparison.OrdinalIgnoreCase)
+        || token.StartsWith("ci:", StringComparison.OrdinalIgnoreCase)
+        || token.StartsWith("nightly:", StringComparison.OrdinalIgnoreCase)
+        || token.StartsWith("repo:", StringComparison.OrdinalIgnoreCase);
+
+    private static string[] SplitLane(string executionLane) =>
+        executionLane.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>
+    /// Classifies one evidence location by kind, reading file content only where necessary to
+    /// distinguish a build-enforced source-generated contract from ordinary source.
+    /// </summary>
+    public static EvidenceKind Classify(string evidenceLocation, string repoRoot)
+    {
+        if (Uri.TryCreate(evidenceLocation, UriKind.Absolute, out var uri)
+            && (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+        {
+            return string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase)
+                && uri.AbsolutePath.StartsWith("/honua-io/geospatial-grpc", StringComparison.OrdinalIgnoreCase)
+                    ? EvidenceKind.GrpcProtoUrl
+                    : EvidenceKind.ExternalUrl;
+        }
+
+        var normalized = evidenceLocation.Replace('\\', '/');
+
+        if (!File.Exists(ArchitectureTestHelpers.CombinePath(repoRoot, evidenceLocation)))
+        {
+            return EvidenceKind.Missing;
+        }
+
+        if (normalized.StartsWith("tests/dotnet/Honua.Architecture.Tests/", StringComparison.OrdinalIgnoreCase)
+            && normalized.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+        {
+            return EvidenceKind.ArchitectureTest;
+        }
+
+        if (normalized.StartsWith("tests/dotnet/", StringComparison.OrdinalIgnoreCase)
+            && normalized.EndsWith("Tests.cs", StringComparison.OrdinalIgnoreCase))
+        {
+            return EvidenceKind.DotnetTest;
+        }
+
+        if (IsForeignTest(normalized))
+        {
+            return EvidenceKind.ForeignTest;
+        }
+
+        if (normalized.StartsWith(".github/workflows/", StringComparison.OrdinalIgnoreCase)
+            && (normalized.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)
+                || normalized.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase)))
+        {
+            return EvidenceKind.Workflow;
+        }
+
+        if (normalized.StartsWith("src/", StringComparison.OrdinalIgnoreCase)
+            && normalized.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+        {
+            return IsSourceGeneratedContract(ArchitectureTestHelpers.CombinePath(repoRoot, evidenceLocation))
+                ? EvidenceKind.SourceGenContract
+                : EvidenceKind.Source;
+        }
+
+        if (normalized.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+        {
+            return EvidenceKind.Doc;
+        }
+
+        if (normalized.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            return EvidenceKind.Data;
+        }
+
+        return EvidenceKind.Other;
+    }
+
+    private static bool IsForeignTest(string normalizedPath)
+    {
+        if (normalizedPath.StartsWith("tests/python/", StringComparison.OrdinalIgnoreCase)
+            && normalizedPath.EndsWith(".py", StringComparison.OrdinalIgnoreCase))
+        {
+            var name = Path.GetFileName(normalizedPath);
+            return name.StartsWith("test_", StringComparison.OrdinalIgnoreCase)
+                || name.EndsWith("_test.py", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "conftest.py", StringComparison.OrdinalIgnoreCase);
+        }
+
+        if ((normalizedPath.StartsWith("tests/js/", StringComparison.OrdinalIgnoreCase)
+                || normalizedPath.StartsWith("tests/js-browser/", StringComparison.OrdinalIgnoreCase))
+            && (normalizedPath.EndsWith(".test.ts", StringComparison.OrdinalIgnoreCase)
+                || normalizedPath.EndsWith(".spec.ts", StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsSourceGeneratedContract(string absolutePath)
+    {
+        try
+        {
+            var text = File.ReadAllText(absolutePath);
+            return text.Contains("JsonSerializerContext", StringComparison.Ordinal)
+                || text.Contains("[JsonSerializable", StringComparison.Ordinal);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+}

--- a/tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.EvidenceValidation.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.EvidenceValidation.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server;
+using Xunit;
+
+namespace Honua.Architecture.Tests;
+
+/// <summary>
+/// Content-aware validation of the public-interface proof ledger's evidence.
+///
+/// <para>
+/// History: the ledger used to validate every <c>evidenceLocations</c> entry with a bare
+/// <see cref="File.Exists(string)"/> check. Existence is not evidence — the check passed
+/// identically for a workflow that proves the claim and a document that merely happens to exist,
+/// which is how a fabricated GeoServices route (<c>computeClass</c>) rode a green architecture gate
+/// to <c>contract-governance: implemented</c> (honua-server#2861/#2864). This is the ADR-0058
+/// "fake gate that manufactures confidence", literally. honua-server#2877 replaces the existence
+/// check with the gate-aware model below.
+/// </para>
+///
+/// <para>
+/// <b>What the model requires.</b> An evidence location falls into one of two tiers:
+/// <list type="bullet">
+///   <item><b>Gate evidence</b> — an artifact that an <i>automated</i> lane actually executes and
+///   that exercises the claim: a test file (architecture / dotnet / python / js), a governance or
+///   conformance workflow, a build-enforced source-generated wire contract, or the published gRPC
+///   proto schema.</item>
+///   <item><b>Corroborating evidence</b> — prose docs (<c>*.md</c>), published data artifacts
+///   (<c>*.json</c>), non-gate source, and support files. Necessary context, but never sufficient.</item>
+/// </list>
+/// Every <c>implemented</c> proof that declares an automated <c>executionLane</c> must cite at least
+/// one gate-evidence location <i>whose kind the declared lane runs</i> (an <c>architecture</c> lane
+/// must cite an architecture test; a <c>nightly:</c> lane must cite the like-named workflow; and so
+/// on). A proof on a purely manual lane (<c>docs+review</c>, <c>release:*</c>) is only admissible as
+/// <i>corroboration</i> of a surface that also carries a real automated gate — manual/doc evidence
+/// can never be the sole substantiation of a surface.
+/// </para>
+///
+/// <para>
+/// <b>False proof prevented.</b> "A document (or model) that merely exists stands in for proof":
+/// the exact <c>computeClass</c> failure. A doc/data/plain-source-only proof, or a proof whose cited
+/// gate the declared lane does not run, now fails the suite red.
+/// </para>
+///
+/// <para>
+/// <b>False proof still admitted (stated deliberately, not silently).</b> This model verifies that a
+/// gate the lane runs <i>exists and is of the right kind</i>; it cannot mechanically judge that the
+/// gate's assertions are <i>strong enough</i> to cover the full claim, nor that a prose doc's
+/// sentences are true. A test that runs in the right lane but asserts less than it should, or a
+/// source-generated contract whose companion doc drifts from runtime behaviour, would still pass.
+/// Closing that residue requires a claim-specific gate (as honua-server#2879 built for the
+/// GeoServices parity matrix), not a generic ledger check. This limitation is documented in
+/// <c>docs/internal/contributor/public-interface-quality-model.md</c>.
+/// </para>
+/// </summary>
+public sealed partial class PublicInterfaceProofLedgerTests
+{
+    [ArchitectureTest]
+    public void ProofLedger_EveryImplementedProof_ShouldCiteAGateItsLaneRuns()
+    {
+        var ledger = LoadLedger();
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+
+        var failures = ledger.Surfaces
+            .SelectMany(surface => surface.Proofs
+                .SelectMany(proof => ProofEvidenceValidator.Validate(surface, proof, repoRoot)))
+            .ToArray();
+
+        failures.Should().BeEmpty(
+            "every proof's cited evidence must actually substantiate the claim, not merely exist " +
+            "(honua-server#2877); a document that happens to exist is not proof");
+    }
+
+    [ArchitectureTest]
+    public void EveryProofLedgerSurface_ShouldMatchAtLeastOneServedRouteOrOperation()
+    {
+        var ledger = LoadLedger();
+
+        var servedRoutes = EndpointRegistry.All.Select(endpoint => endpoint.Path).ToArray();
+        var registeredOperationKeys = OperationRegistry.All
+            .Select(operation => FormatOperationKey(operation.Protocol, operation.Operation))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var phantomSurfaces = ledger.Surfaces
+            .Where(surface => !string.Equals(surface.SurfaceId, "mcp", StringComparison.OrdinalIgnoreCase))
+            .Where(surface =>
+                !servedRoutes.Any(route => MatchesEndpoint(surface, route)) &&
+                !surface.OperationKeys.Any(key => registeredOperationKeys.Contains(key)))
+            .Select(surface => surface.SurfaceId)
+            .OrderBy(value => value)
+            .ToArray();
+
+        phantomSurfaces.Should().BeEmpty(
+            "a proof-ledger surface that matches no served route and no registered operation is an " +
+            "over-claim (the 'computeClass' failure at the surface level): the ledger vouches for a " +
+            "surface the server does not serve");
+    }
+
+    [ArchitectureTest]
+    public void EveryProofLedgerOperationKey_ShouldResolveToARegisteredOperation()
+    {
+        var ledger = LoadLedger();
+
+        var registeredOperationKeys = OperationRegistry.All
+            .Select(operation => FormatOperationKey(operation.Protocol, operation.Operation))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var overClaimedOperationKeys = ledger.Surfaces
+            .SelectMany(surface => surface.OperationKeys.Select(key => new { surface.SurfaceId, Key = key }))
+            .Where(entry => !registeredOperationKeys.Contains(entry.Key))
+            .Select(entry => $"{entry.SurfaceId} -> {entry.Key}")
+            .OrderBy(value => value)
+            .ToArray();
+
+        overClaimedOperationKeys.Should().BeEmpty(
+            "every operation key a surface claims must resolve to a real OperationRegistry entry; " +
+            "an unresolved key is an operation the ledger vouches for but the server does not register");
+    }
+
+    // ---- Demonstration: the mechanism goes red for non-substantiating evidence. ----
+    // These exercise the extracted validator directly with synthetic proofs so the guarantee is
+    // provable in isolation, independent of the current (compliant) ledger contents.
+
+    [ArchitectureTest]
+    public void ProofEvidenceValidator_Rejects_ContractGovernanceProof_WhoseOnlyEvidenceIsADocThatExists()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+
+        // A document that genuinely exists on disk — the exact shape the old File.Exists check waved through.
+        var proof = MakeProof(
+            proofClass: "contract-governance",
+            executionLane: "ci:test-all",
+            status: "implemented",
+            "docs/internal/contributor/public-interface-quality-model.md");
+        var surface = MakeSurface("phantom-contract", proof);
+
+        var failures = ProofEvidenceValidator.Validate(surface, proof, repoRoot);
+
+        failures.Should().NotBeEmpty(
+            "a contract-governance proof whose only evidence is a document that exists does not " +
+            "substantiate the claim and must fail");
+        failures.Should().ContainMatch("*executable gate*");
+    }
+
+    [ArchitectureTest]
+    public void ProofEvidenceValidator_Rejects_NightlyProof_CitingAnUnrelatedWorkflow()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+
+        // Declares the WMS CITE conformance lane but cites a workflow that answers a different
+        // question — the "workflow that answers an unrelated question" failure from honua-server#2877.
+        var proof = MakeProof(
+            proofClass: "standards-conformance",
+            executionLane: "nightly:cite-wms-conformance",
+            status: "implemented",
+            ".github/workflows/sdk-server-compatibility.yml");
+        var surface = MakeSurface("mislaned-standards", proof);
+
+        var failures = ProofEvidenceValidator.Validate(surface, proof, repoRoot);
+
+        failures.Should().NotBeEmpty(
+            "a nightly conformance proof that cites a workflow the declared lane does not run must fail");
+    }
+
+    [ArchitectureTest]
+    public void ProofEvidenceValidator_Rejects_ManualLaneProof_OnASurfaceWithNoAutomatedGate()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+
+        var manualProof = MakeProof(
+            proofClass: "contract-governance",
+            executionLane: "docs+review",
+            status: "implemented",
+            "docs/internal/contributor/public-interface-quality-model.md");
+        var surface = MakeSurface("docs-only-surface", manualProof);
+
+        var failures = ProofEvidenceValidator.Validate(surface, manualProof, repoRoot);
+
+        failures.Should().NotBeEmpty(
+            "a manual-lane proof whose surface carries no automated gate is substantiated by nothing " +
+            "but documentation and must fail");
+    }
+
+    [ArchitectureTest]
+    public void ProofEvidenceValidator_Accepts_ContractGovernanceProof_CitingATestItsLaneRuns()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+
+        // Same proof shape as the rejected doc-only one, but repointed at a real architecture gate —
+        // the honua-server#2879 fix pattern.
+        var proof = MakeProof(
+            proofClass: "contract-governance",
+            executionLane: "ci:architecture",
+            status: "implemented",
+            "tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.cs");
+        var surface = MakeSurface("gated-contract", proof);
+
+        ProofEvidenceValidator.Validate(surface, proof, repoRoot)
+            .Should()
+            .BeEmpty("a proof repointed at a test its declared lane runs is substantiated");
+    }
+
+    [ArchitectureTest]
+    public void ProofEvidenceValidator_Accepts_ManualLaneProof_WhenTheSurfaceIsGatedElsewhere()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+
+        var manualProof = MakeProof(
+            proofClass: "contract-governance",
+            executionLane: "docs+review",
+            status: "implemented",
+            "docs/internal/contributor/public-interface-quality-model.md");
+        var gatedSibling = MakeProof(
+            proofClass: "route-coverage",
+            executionLane: "ci:test-all+architecture",
+            status: "implemented",
+            "tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.cs");
+        var surface = MakeSurface("corroborated-surface", manualProof, gatedSibling);
+
+        ProofEvidenceValidator.Validate(surface, manualProof, repoRoot)
+            .Should()
+            .BeEmpty("a manual-lane proof is admissible as corroboration when its surface carries a real gate");
+    }
+
+    private static PublicInterfaceProof MakeProof(
+        string proofClass,
+        string executionLane,
+        string status,
+        params string[] evidenceLocations) => new()
+        {
+            ProofClass = proofClass,
+            ProofMechanism = "synthetic proof for validator demonstration",
+            ExecutionLane = executionLane,
+            EvidenceLocations = evidenceLocations,
+            OwnerRepo = "honua-server",
+            Status = status,
+            LinkedTicket = status == "implemented" ? null : "#0",
+        };
+
+    private static PublicInterfaceSurface MakeSurface(string surfaceId, params PublicInterfaceProof[] proofs) => new()
+    {
+        SurfaceId = surfaceId,
+        DisplayName = surfaceId,
+        SurfaceKind = "http-route",
+        Protocol = "HTTP",
+        CanonicalIdentifier = "/synthetic",
+        Proofs = proofs,
+    };
+}

--- a/tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/PublicInterfaceProofLedgerTests.cs
@@ -161,7 +161,6 @@ public sealed partial class PublicInterfaceProofLedgerTests
     public void ProofLedger_ShouldDeclareRequiredMetadata_ForEveryProof()
     {
         var ledger = LoadLedger();
-        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
 
         ledger.SchemaVersion.Should().Be("1.0.0");
         ledger.Surfaces.Should().NotBeEmpty();
@@ -203,19 +202,11 @@ public sealed partial class PublicInterfaceProofLedgerTests
                 proof.ExecutionLane.Should().NotBeNullOrWhiteSpace();
                 proof.OwnerRepo.Should().NotBeNullOrWhiteSpace();
                 proof.EvidenceLocations.Should().NotBeEmpty();
+                proof.EvidenceLocations.Should().OnlyContain(location => !string.IsNullOrWhiteSpace(location));
 
-                foreach (var evidenceLocation in proof.EvidenceLocations)
-                {
-                    evidenceLocation.Should().NotBeNullOrWhiteSpace();
-                    if (IsExternalEvidenceLocation(evidenceLocation))
-                    {
-                        continue;
-                    }
-
-                    File.Exists(ArchitectureTestHelpers.CombinePath(repoRoot, evidenceLocation))
-                        .Should()
-                        .BeTrue($"evidence location '{evidenceLocation}' for surface '{surface.SurfaceId}' must exist");
-                }
+                // Content-aware evidence validation (existence + gate/lane substantiation) lives in
+                // ProofEvidenceValidator and is asserted by
+                // ProofLedger_EveryImplementedProof_ShouldCiteAGateItsLaneRuns (honua-server#2877).
 
                 if (!string.Equals(proof.Status, "implemented", StringComparison.OrdinalIgnoreCase))
                 {
@@ -601,11 +592,6 @@ public sealed partial class PublicInterfaceProofLedgerTests
 
         return ticketsByOwnerRepo.TryGetValue(ownerRepo, out linkedTicket!);
     }
-
-    private static bool IsExternalEvidenceLocation(string evidenceLocation)
-        => Uri.TryCreate(evidenceLocation, UriKind.Absolute, out var uri) &&
-           (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
 
     private static bool IsGeospatialGrpcRepositoryUrl(string evidenceLocation)
         => Uri.TryCreate(evidenceLocation, UriKind.Absolute, out var uri) &&


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2877

## Summary

The proof ledger used to validate every `evidenceLocations` entry with a bare `File.Exists` check. Existence is not evidence: the check passed identically for a workflow that proves the claim and a document that merely happens to exist. That is how a fabricated GeoServices route (`computeClass`, never served) rode a green architecture gate to `contract-governance: implemented` (#2861/#2864) — the ADR-0058 "fake gate that manufactures confidence", literally.

#2879 repointed those six specific GeoServices proofs at a real gate but deliberately deferred the *mechanism* to this ticket. This PR replaces `File.Exists` with content-aware, gate-and-lane-aware validation so that **a proof whose evidence does not actually substantiate its claim now fails the suite red.** It builds on #2879's fixes (does not re-touch them).

### The RED proof (the point of the ticket)

The mechanism is green on the real ledger and goes **red** when fed a proof whose evidence exists but does not substantiate its claim. Release run, `Honua.Architecture.Tests`:

**Green — real ledger:** `Passed! - Failed: 0, Passed: 19, Skipped: 0, Total: 19`.

**Red — inject a doc-only `contract-governance` proof** (`demo-false-proof`, evidence `docs/reference/admin-api/forms.md`, which *exists on disk* but is not a gate the declared `ci:test-all` lane runs — the exact `computeClass` / "existence stands in for proof" shape):

```
ProofLedger EveryImplementedProof ShouldCiteAGateItsLaneRuns [FAIL]
  Expected failures to be empty ... but found at least one item {"proof 'contract-governance'
  on surface 'demo-false-proof' declares automated execution lane 'ci:test-all' but cites no
  executable gate that lane runs — a document or model that merely exists is not proof
  (evidence: docs/reference/admin-api/forms.md=Doc)"}.
Failed!  - Failed: 1, Passed: 0
```

The injected surface was reverted; it is not part of this PR. Under the old `File.Exists` check this proof passed green.

## Changes Made
- Add `ProofEvidenceValidator` (`tests/dotnet/Honua.Architecture.Tests/ProofEvidenceValidator.cs`): classifies each evidence location into **gate evidence** (a test/workflow/build-enforced source-gen contract/gRPC proto an *automated* lane actually runs) vs **corroborating evidence** (docs, data, plain source), and validates that every `implemented` proof cites a gate its declared `executionLane` runs.
- Replace the `File.Exists` loop in `PublicInterfaceProofLedgerTests.ProofLedger_ShouldDeclareRequiredMetadata_ForEveryProof` with the gate-aware model, asserted by the new `ProofLedger_EveryImplementedProof_ShouldCiteAGateItsLaneRuns`.
- Add over-claim content checks: `EveryProofLedgerSurface_ShouldMatchAtLeastOneServedRouteOrOperation` and `EveryProofLedgerOperationKey_ShouldResolveToARegisteredOperation` (the `computeClass` over-claim, generalized to the whole ledger).
- Add demonstration tests proving the mechanism goes RED for non-substantiating evidence (doc-only proof, nightly proof citing an unrelated workflow, manual-lane proof on an ungated surface) and GREEN for substantiating evidence.
- Sweep finding + fix: `vector-tile-server`'s `scenario-depth` proof cited only three endpoint *source* files and no test — a proof passing purely on `File.Exists`. Repointed at the real `VectorTileServerEndpointTests` / `VectorTileStyleComposerTests` (happy + negative-path depth). No status weakened.
- Document the model, and explicitly what false proof it prevents and what it still admits, in `docs/internal/contributor/public-interface-quality-model.md`.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
