### PR TITLE
fix(ci): route pre-pr-check child validators through an executing python3 probe (#2886)

### DIFF
--- a/scripts/ci/check-kubernetes-guide.sh
+++ b/scripts/ci/check-kubernetes-guide.sh
@@ -4,7 +4,16 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 guide="${repo_root}/docs/guides/deploy/kubernetes.md"
 
-python3 - "${guide}" <<'PY'
+# Resolve a Python 3 that actually runs (see scripts/ci/lib/python-resolve.sh);
+# the Windows Store python3 alias satisfies `command -v` but does not run (#2886).
+# shellcheck source=scripts/ci/lib/python-resolve.sh
+. "${repo_root}/scripts/ci/lib/python-resolve.sh"
+if ! PYTHON_BIN="$(honua_resolve_python)"; then
+  echo "⚠️  Skipping Kubernetes guide contract check (no working Python 3: tried python3/python/py)"
+  exit 0
+fi
+
+"${PYTHON_BIN}" - "${guide}" <<'PY'
 from __future__ import annotations
 
 import re
@@ -154,7 +163,7 @@ if [[ -n "${HONUA_HELM_CHART:-}" ]]; then
     temp_dir="$(mktemp -d)"
     trap 'rm -rf "${temp_dir}"' EXIT
 
-    python3 - "${guide}" "${temp_dir}" <<'PY'
+    "${PYTHON_BIN}" - "${guide}" "${temp_dir}" <<'PY'
 import re
 import sys
 from pathlib import Path

--- a/scripts/ci/generate-cross-server-gap-report.sh
+++ b/scripts/ci/generate-cross-server-gap-report.sh
@@ -16,7 +16,16 @@ fi
 
 mkdir -p "$(dirname "$report_path")"
 
-python3 - "$trx_file" "$report_path" <<'PY'
+# Resolve a Python 3 that actually runs (see scripts/ci/lib/python-resolve.sh);
+# the Windows Store python3 alias satisfies `command -v` but does not run (#2886).
+# shellcheck source=scripts/ci/lib/python-resolve.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/python-resolve.sh"
+if ! PYTHON_BIN="$(honua_resolve_python)"; then
+  echo "⚠️  Skipping cross-server gap report (no working Python 3: tried python3/python/py)" >&2
+  exit 0
+fi
+
+"${PYTHON_BIN}" - "$trx_file" "$report_path" <<'PY'
 from __future__ import annotations
 
 import re

--- a/scripts/ci/lib/python-resolve.sh
+++ b/scripts/ci/lib/python-resolve.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+# Resolve a Python 3 interpreter that actually runs.
+#
+# `command -v python3` alone is not enough on Windows: the Microsoft Store ships
+# a python3.exe App Execution Alias stub that is present on PATH but exits
+# non-zero with "Python was not found", while the real interpreter installs as
+# `python`/`py`. A plain `command -v python3` guard therefore passes, the stub
+# then fails, and the caller blames its own logic instead of a missing
+# interpreter (#2871/#2880 for pre-pr-check.sh itself; #2886 for the child
+# validators it invokes). Probe each candidate by *executing* it, and require
+# Python 3 so a legacy `python` == python2 is not selected. On Linux/CI
+# `python3` matches first, exactly as before — a no-op there.
+#
+# This mirrors the probe #2880 added to scripts/ci/pre-pr-check.sh so every
+# scripts/ci validator resolves Python the same way instead of re-implementing
+# (or forgetting) the probe per script.
+#
+# Usage (source, then resolve or skip):
+#
+#   # shellcheck source=scripts/ci/lib/python-resolve.sh
+#   . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/python-resolve.sh"
+#   if ! PYTHON_BIN="$(honua_resolve_python)"; then
+#     echo "⚠️  Skipping <thing> (no working Python 3: tried python3/python/py)"
+#     exit 0
+#   fi
+#   "${PYTHON_BIN}" some-script.py
+#
+# honua_resolve_python prints the resolved interpreter name on stdout and
+# returns 0, or prints nothing and returns 1 when none of the candidates run.
+honua_resolve_python() {
+  local candidate
+  for candidate in python3 python py; do
+    if command -v "${candidate}" >/dev/null 2>&1 \
+      && "${candidate}" -c 'import sys; sys.exit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -15,7 +15,16 @@ require_command() {
 }
 
 require_command jq
-require_command python3
+
+# Resolve a Python 3 that actually runs (see scripts/ci/lib/python-resolve.sh).
+# `require_command python3` is not enough on Windows, where the Microsoft Store
+# python3 alias satisfies `command -v` but exits without running (#2886). When
+# no interpreter runs, skip the Python-driven checks gracefully — the jq/shell
+# validations above and below still run, and CI (where python3 is real) is
+# unaffected.
+# shellcheck source=scripts/ci/lib/python-resolve.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/python-resolve.sh"
+PYTHON_BIN="$(honua_resolve_python || true)"
 
 echo "Validating ci-shards.json structure..."
 jq -e '
@@ -81,14 +90,15 @@ scripts/ci/validate-shell-syntax.sh
 echo "Checking local pre-PR change routing..."
 scripts/ci/fixtures/validate-pre-pr-routing.sh
 
-echo "Checking Python helper syntax..."
-python3 -m py_compile scripts/ci/*.py
+if [[ -n "${PYTHON_BIN}" ]]; then
+  echo "Checking Python helper syntax..."
+  "${PYTHON_BIN}" -m py_compile scripts/ci/*.py
 
-echo "Checking Docker integration gate timeout budget..."
-python3 scripts/ci/validate-docker-gate-timeouts.py
+  echo "Checking Docker integration gate timeout budget..."
+  "${PYTHON_BIN}" scripts/ci/validate-docker-gate-timeouts.py
 
-echo "Checking workflow YAML syntax..."
-python3 - <<'PY'
+  echo "Checking workflow YAML syntax..."
+  "${PYTHON_BIN}" - <<'PY'
 from pathlib import Path
 try:
     import yaml
@@ -100,6 +110,9 @@ for path in sorted(Path(".github/workflows").glob("*.yml")):
     with path.open("r", encoding="utf-8") as handle:
         yaml.safe_load(handle)
 PY
+else
+  echo "⚠️  Skipping Python helper/timeout/YAML checks (no working Python 3: tried python3/python/py)"
+fi
 
 assert_descriptor() {
   local name="$1"
@@ -852,8 +865,9 @@ assert_descriptor \
 # the anti-regression check for the coverage hole — a new test class in an
 # unmapped namespace fails CI here instead of silently never running.
 # ---------------------------------------------------------------------------
+if [[ -n "${PYTHON_BIN}" ]]; then
 echo "Checking server-test shard coverage (no orphaned test classes)..."
-python3 scripts/ci/check-server-test-shard-coverage.py \
+"${PYTHON_BIN}" scripts/ci/check-server-test-shard-coverage.py \
   --assert-owner \
     "Honua.Server.Tests.Features.Protocols.GeoServices.Tiles.CompactTilePackageWriterTests" \
     "tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj" \
@@ -882,5 +896,8 @@ python3 scripts/ci/check-server-test-shard-coverage.py \
     "Honua.Server.Tests.Features.Protocols.Future.FutureEndpointTests" \
     "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
     "Server Features Misc"
+else
+  echo "⚠️  Skipping server-test shard coverage check (no working Python 3: tried python3/python/py)"
+fi
 
 echo "CI router validation passed."

--- a/scripts/ci/validate-openapi-contracts.sh
+++ b/scripts/ci/validate-openapi-contracts.sh
@@ -15,7 +15,16 @@ OPENAPI_ALLOW_BREAKING_CHANGES="${OPENAPI_ALLOW_BREAKING_CHANGES:-false}"
 export OPENAPI_BASE_REF
 export OPENAPI_ALLOW_BREAKING_CHANGES
 
-python3 - <<'PY'
+# Resolve a Python 3 that actually runs (see scripts/ci/lib/python-resolve.sh);
+# the Windows Store python3 alias satisfies `command -v` but does not run (#2886).
+# shellcheck source=scripts/ci/lib/python-resolve.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/python-resolve.sh"
+if ! PYTHON_BIN="$(honua_resolve_python)"; then
+  echo "⚠️  Skipping OpenAPI contract validation (no working Python 3: tried python3/python/py)" >&2
+  exit 0
+fi
+
+"${PYTHON_BIN}" - <<'PY'
 from __future__ import annotations
 
 import json

--- a/scripts/ci/validate-server-test-transfer-benchmark.sh
+++ b/scripts/ci/validate-server-test-transfer-benchmark.sh
@@ -9,6 +9,11 @@ CONFIG="${REPO_ROOT}/.github/server-test-transfer-benchmark.json"
 REGISTRY="${REPO_ROOT}/.github/server-test-artifact-projects.json"
 WORKFLOW="${REPO_ROOT}/.github/workflows/server-test-transfer-benchmark.yml"
 
+# Resolve a Python 3 that actually runs (see scripts/ci/lib/python-resolve.sh);
+# the Windows Store python3 alias satisfies `command -v` but does not run (#2886).
+# shellcheck source=scripts/ci/lib/python-resolve.sh
+. "${SCRIPT_DIR}/lib/python-resolve.sh"
+
 jq -e '
   .contract_version == 1 and
   .decision_thresholds.require_initial_time_to_first_test_improvement == true and
@@ -42,14 +47,21 @@ if grep -qE 'pull_request:|schedule:' "${WORKFLOW}"; then
 fi
 
 bash -n "${SCRIPT_DIR}/benchmark-server-test-transfer.sh"
-python3 -m py_compile "${SCRIPT_DIR}/summarize-server-test-transfer-benchmark.py"
+
+if ! PYTHON_BIN="$(honua_resolve_python)"; then
+  echo "⚠️  Skipping server-test transfer benchmark synthetic proof (no working Python 3: tried python3/python/py)"
+  echo "Server-test transfer benchmark validation passed (structural checks only)."
+  exit 0
+fi
+
+"${PYTHON_BIN}" -m py_compile "${SCRIPT_DIR}/summarize-server-test-transfer-benchmark.py"
 
 fixture="$(mktemp -d "${RUNNER_TEMP:-/tmp}/honua-transfer-summary.XXXXXX")"
 cleanup() { rm -rf "${fixture}"; }
 trap cleanup EXIT
 mkdir -p "${fixture}/metrics" "${fixture}/out"
 
-CONFIG_PATH="${CONFIG}" METRICS_PATH="${fixture}/metrics" python3 - <<'PY'
+CONFIG_PATH="${CONFIG}" METRICS_PATH="${fixture}/metrics" "${PYTHON_BIN}" - <<'PY'
 import json
 import os
 from pathlib import Path
@@ -88,7 +100,7 @@ for shard in config["shards"]:
           transfer_ms=100, total_with_transfer_ms=400)
 PY
 
-"${SCRIPT_DIR}/summarize-server-test-transfer-benchmark.py" \
+"${PYTHON_BIN}" "${SCRIPT_DIR}/summarize-server-test-transfer-benchmark.py" \
   --metrics "${fixture}/metrics" --config "${CONFIG}" \
   --output "${fixture}/out/summary.json" --markdown "${fixture}/out/summary.md" >/dev/null
 jq -e '.decision == "no-shared-producer" and all(.profiles[]; .complete == true)' \


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2886

## Summary
`pre-pr-check.sh`'s child validators shelled `python3` directly, so a **full**
local pre-PR run still broke on Windows — the primary dev platform. There,
`python3` resolves to the Microsoft Store App-Execution-Alias stub (present on
PATH, satisfies `command -v`, but exits without running), while `python`/`py`
(3.13.5) are the real interpreters. #2880 taught `pre-pr-check.sh` itself to
probe by *executing* candidates; this does the same for every `scripts/ci`
validator it invokes (and their CI-only siblings), via a single shared helper so
the next new validator isn't a fresh landmine.

## Changes Made
- Add `scripts/ci/lib/python-resolve.sh` — a sourced helper exposing
  `honua_resolve_python`, which probes `python3` -> `python` -> `py` by
  *executing* each candidate (requiring Python 3), mirroring the #2880 probe.
  Prints the working interpreter or returns non-zero when none runs.
- Route every `scripts/ci` script that invoked `python3` directly through the
  resolved `PYTHON_BIN`, skipping gracefully only when no interpreter runs:
  - `validate-ci-router.sh` (reachable from `pre-pr-check.sh`)
  - `validate-server-test-transfer-benchmark.sh` (reachable via the router)
  - `check-kubernetes-guide.sh`
  - `generate-cross-server-gap-report.sh`
  - `validate-openapi-contracts.sh`
- No behavior change on Linux/CI: the resolver returns `python3` first (it runs
  there), so every call site is byte-identical to before.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Manual proof (Windows, `python3` = broken Store alias; `python`/`py` = 3.13.5):
- Resolver picks `python` on Windows; picks `python3` first under a
  working-`python3` shim (Linux/CI no-op); returns non-zero + graceful skip when
  no interpreter is on PATH.
- Each migrated child validator runs green via the resolver:
  `check-kubernetes-guide.sh`, `validate-openapi-contracts.sh`,
  `generate-cross-server-gap-report.sh`, and all `validate-ci-router.sh` python
  blocks.
- Full `pre-pr-check.sh` (CI-only path, which invokes `validate-ci-router.sh` ->
  `validate-server-test-transfer-benchmark.sh` and its python steps) runs to
  completion **green (exit 0)** on Windows including the child validators. The
  end-to-end run additionally requires the jq-CRLF fix in #2876/#2885 (same
  class, different tool, still landing) to clear a separate pre-existing blocker
  in the transfer-benchmark child; verified green with #2885 layered on top.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
