### PR TITLE
fix(rendering): honor interpolate type operand (#2883)

### DIFF
--- a/src/Honua.Hosting/Features/Rendering/ExpressionEvaluator.cs
+++ b/src/Honua.Hosting/Features/Rendering/ExpressionEvaluator.cs
@@ -338,7 +338,9 @@ internal static class ExpressionEvaluator
             return null;
         }
 
-        // interpolate, ["linear"], input, stop1, output1, stop2, output2, ...
+        // interpolate, <interpolation>, input, stop1, output1, stop2, output2, ...
+        // <interpolation> is ["linear"], ["exponential", base], or ["cubic-bezier", x1, y1, x2, y2].
+        var interpolation = ParseInterpolation(array[1]);
         var input = ConvertToFloat(Evaluate(array[2], properties), 0f);
 
         float? prevStop = null;
@@ -356,7 +358,7 @@ internal static class ExpressionEvaluator
                     return output;
                 }
 
-                var t = (input - prevStop.Value) / (stop - prevStop.Value);
+                var t = InterpolationFactor(interpolation, input, prevStop.Value, stop);
                 return InterpolateValues(prevOutput, output, t);
             }
 
@@ -365,6 +367,196 @@ internal static class ExpressionEvaluator
         }
 
         return prevOutput;
+    }
+
+    /// <summary>
+    /// The interpolation curve declared as the second operand of a MapLibre
+    /// <c>interpolate</c> expression. Selects how the fractional position between two
+    /// consecutive stops is computed before the stop outputs are blended.
+    /// </summary>
+    private enum InterpolationKind
+    {
+        Linear,
+        Exponential,
+        CubicBezier
+    }
+
+    private readonly record struct InterpolationCurve(
+        InterpolationKind Kind,
+        double Base,
+        double X1,
+        double Y1,
+        double X2,
+        double Y2)
+    {
+        public static readonly InterpolationCurve Linear = new(InterpolationKind.Linear, 1.0, 0, 0, 0, 0);
+    }
+
+    /// <summary>
+    /// Reads the <c>interpolate</c> curve operand (<c>["linear"]</c>,
+    /// <c>["exponential", base]</c>, or <c>["cubic-bezier", x1, y1, x2, y2]</c>). Anything
+    /// unrecognized falls back to <see cref="InterpolationKind.Linear"/>, matching the
+    /// evaluator's historical behavior of treating the operand as linear.
+    /// </summary>
+    private static InterpolationCurve ParseInterpolation(MapLibreExpression operand)
+    {
+        if (operand.Kind != MapLibreExpressionKind.Array || operand.Items is not { Length: > 0 } items)
+        {
+            return InterpolationCurve.Linear;
+        }
+
+        if (!TryGetString(items[0], out var name) || name == null)
+        {
+            return InterpolationCurve.Linear;
+        }
+
+        if (string.Equals(name, "exponential", StringComparison.Ordinal))
+        {
+            if (items.Length >= 2 && items[1].Kind == MapLibreExpressionKind.Number)
+            {
+                return new InterpolationCurve(InterpolationKind.Exponential, items[1].NumberValue, 0, 0, 0, 0);
+            }
+
+            return InterpolationCurve.Linear;
+        }
+
+        if (string.Equals(name, "cubic-bezier", StringComparison.Ordinal))
+        {
+            if (items.Length >= 5 &&
+                items[1].Kind == MapLibreExpressionKind.Number &&
+                items[2].Kind == MapLibreExpressionKind.Number &&
+                items[3].Kind == MapLibreExpressionKind.Number &&
+                items[4].Kind == MapLibreExpressionKind.Number)
+            {
+                return new InterpolationCurve(
+                    InterpolationKind.CubicBezier,
+                    1.0,
+                    items[1].NumberValue,
+                    items[2].NumberValue,
+                    items[3].NumberValue,
+                    items[4].NumberValue);
+            }
+
+            return InterpolationCurve.Linear;
+        }
+
+        return InterpolationCurve.Linear;
+    }
+
+    /// <summary>
+    /// Computes the interpolation factor <c>t</c> for <paramref name="input"/> between two
+    /// adjacent stop inputs, honoring the declared curve. Mirrors MapLibre GL JS's
+    /// <c>Interpolate.interpolationFactor</c> in
+    /// <c>maplibre-style-spec/src/expression/definitions/interpolate.ts</c>. The
+    /// <see cref="InterpolationKind.Linear"/> branch is deliberately the same
+    /// single-precision expression the evaluator has always used, so existing linear ramps
+    /// stay bit-for-bit unchanged; the non-linear curves compute in double precision to
+    /// match MapLibre's <c>Math.pow</c>/unit-bezier math.
+    /// </summary>
+    private static float InterpolationFactor(in InterpolationCurve curve, float input, float lower, float upper) =>
+        curve.Kind switch
+        {
+            InterpolationKind.Exponential => (float)ExponentialInterpolation(input, curve.Base, lower, upper),
+            InterpolationKind.CubicBezier =>
+                (float)SolveCubicBezier(curve, ExponentialInterpolation(input, 1.0, lower, upper)),
+            _ => (input - lower) / (upper - lower),
+        };
+
+    /// <summary>
+    /// The ratio used to interpolate between two exponential-function stops, ported verbatim
+    /// from MapLibre's <c>exponentialInterpolation</c>. <c>base == 1</c> collapses to the
+    /// linear ratio <c>progress / difference</c> (MapLibre's own degenerate case), so an
+    /// <c>["exponential", 1]</c> curve is identical to <c>["linear"]</c>. The exponents are
+    /// the raw stop-relative progress and difference (not a pre-normalized 0..1 factor):
+    /// <c>(base^progress - 1) / (base^difference - 1)</c>.
+    /// </summary>
+    private static double ExponentialInterpolation(double input, double @base, double lower, double upper)
+    {
+        var difference = upper - lower;
+        var progress = input - lower;
+
+        if (difference == 0.0)
+        {
+            return 0.0;
+        }
+
+        if (@base == 1.0)
+        {
+            return progress / difference;
+        }
+
+        return (Math.Pow(@base, progress) - 1.0) / (Math.Pow(@base, difference) - 1.0);
+    }
+
+    /// <summary>
+    /// Solves the unit cubic Bézier <c>y</c> for a given <c>x</c> using Newton-Raphson with a
+    /// bisection fallback, a verbatim port of MapLibre's <c>UnitBezier.solve</c>
+    /// (<c>@mapbox/unitbezier</c>). The cubic-bezier curve feeds the linear stop factor in as
+    /// <c>x</c> and returns the eased factor as <c>y</c>.
+    /// </summary>
+    private static double SolveCubicBezier(in InterpolationCurve curve, double x)
+    {
+        const double epsilon = 1e-6;
+
+        var cx = 3 * curve.X1;
+        var bx = 3 * (curve.X2 - curve.X1) - cx;
+        var ax = 1 - cx - bx;
+        var cy = 3 * curve.Y1;
+        var by = 3 * (curve.Y2 - curve.Y1) - cy;
+        var ay = 1 - cy - by;
+
+        if (x <= 0)
+        {
+            return 0;
+        }
+
+        if (x >= 1)
+        {
+            return 1;
+        }
+
+        var t = x;
+        for (int i = 0; i < 8; i++)
+        {
+            var x2 = ((ax * t + bx) * t + cx) * t - x;
+            if (Math.Abs(x2) < epsilon)
+            {
+                return ((ay * t + by) * t + cy) * t;
+            }
+
+            var d2 = (3 * ax * t + 2 * bx) * t + cx;
+            if (Math.Abs(d2) < 1e-6)
+            {
+                break;
+            }
+
+            t -= x2 / d2;
+        }
+
+        double t0 = 0;
+        double t1 = 1;
+        t = x;
+        for (int i = 0; i < 20; i++)
+        {
+            var x2 = ((ax * t + bx) * t + cx) * t;
+            if (Math.Abs(x2 - x) < epsilon)
+            {
+                break;
+            }
+
+            if (x > x2)
+            {
+                t0 = t;
+            }
+            else
+            {
+                t1 = t;
+            }
+
+            t = (t0 + t1) * 0.5;
+        }
+
+        return ((ay * t + by) * t + cy) * t;
     }
 
     [SuppressMessage(

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/ExpressionEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/ExpressionEvaluatorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Collections.Immutable;
+using System.Globalization;
 using FluentAssertions;
 using Honua.Infrastructure.Rendering;
 using Honua.TestKit.Attributes;
@@ -563,6 +564,204 @@ public class ExpressionEvaluatorTests
         var result = EvaluateRamp(MultiStopRamp, value);
 
         result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    private static double EvaluateNumeric(string expression, double value) =>
+        ((double)ExpressionEvaluator.Evaluate(
+            MapLibreExpressionParser.Parse(expression), Props(("value", value)))!);
+
+    /// <summary>
+    /// Linear numeric interpolation must remain a pure widening: expectations are MapLibre
+    /// GL JS's own output for <c>["interpolate", ["linear"], ...]</c> and are byte-identical
+    /// to the pre-fix (type-ignoring) evaluator, proving the type-operand change did not move
+    /// the linear path. Captured via <c>createExpression(expr, 'line-width',
+    /// latest.paint_line['line-width'])</c>.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(-10, 0.0)]
+    [InlineData(0, 0.0)]
+    [InlineData(10, 1.0)]
+    [InlineData(25, 2.5)]
+    [InlineData(50, 5.0)]
+    [InlineData(75, 7.5)]
+    [InlineData(100, 10.0)]
+    [InlineData(150, 10.0)]
+    public void Evaluate_LinearNumericInterpolate_MatchesMapLibreAndIsBitUnchanged(double value, double expected)
+    {
+        var result = EvaluateNumeric(
+            """["interpolate", ["linear"], ["get", "value"], 0, 0, 100, 10]""", value);
+
+        result.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// <c>["exponential", 1]</c> is MapLibre's own degenerate case: it must equal
+    /// <c>["linear"]</c> exactly (its factor collapses to <c>progress / difference</c>).
+    /// Expectations are MapLibre's output and match the linear ramp above stop-for-stop.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(0, 0.0)]
+    [InlineData(10, 1.0)]
+    [InlineData(25, 2.5)]
+    [InlineData(50, 5.0)]
+    [InlineData(75, 7.5)]
+    [InlineData(100, 10.0)]
+    public void Evaluate_ExponentialBaseOne_EqualsLinear(double value, double expected)
+    {
+        var exponential = EvaluateNumeric(
+            """["interpolate", ["exponential", 1], ["get", "value"], 0, 0, 100, 10]""", value);
+        var linear = EvaluateNumeric(
+            """["interpolate", ["linear"], ["get", "value"], 0, 0, 100, 10]""", value);
+
+        exponential.Should().Be(linear);
+        exponential.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// Exponential (base 2 and base 0.5) numeric ramps over 0..100 -> 0..10. Expectations are
+    /// MapLibre GL JS's own output — the discrepancy this ticket exists for (the type-ignoring
+    /// evaluator returned the linear value here instead). Tolerance absorbs the single-precision
+    /// factor cast; the values differ from linear by orders of magnitude, so the curve is proven.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(2.0, 90, 0.009765625)]
+    [InlineData(2.0, 100, 10.0)]
+    [InlineData(0.5, 10, 9.990234375)]
+    [InlineData(0.5, 50, 9.999999999999991)]
+    public void Evaluate_ExponentialNumericInterpolate_MatchesMapLibreOutput(
+        double @base, double value, double expected)
+    {
+        var expression =
+            $$"""["interpolate", ["exponential", {{@base.ToString(CultureInfo.InvariantCulture)}}], ["get", "value"], 0, 0, 100, 10]""";
+
+        var result = EvaluateNumeric(expression, value);
+
+        result.Should().BeApproximately(expected, 1e-5);
+    }
+
+    /// <summary>
+    /// The bug's canonical shape: an exponential (base 2) ramp evaluated between two stops
+    /// returns a value that a linear ramp never would. MapLibre GL JS yields 2.0 here (stops
+    /// 10 -> 0, 14 -> 10 at input 12); the linear reading is 5.0.
+    /// </summary>
+    [UnitTest]
+    public void Evaluate_ExponentialRamp_DiffersFromLinearReading()
+    {
+        var exponential = EvaluateNumeric(
+            """["interpolate", ["exponential", 2], ["get", "value"], 10, 0, 14, 10]""", 12);
+        var linear = EvaluateNumeric(
+            """["interpolate", ["linear"], ["get", "value"], 10, 0, 14, 10]""", 12);
+
+        exponential.Should().BeApproximately(2.0, 1e-5);
+        linear.Should().Be(5.0);
+    }
+
+    /// <summary>
+    /// Multi-stop exponential selects the right interval before applying the curve.
+    /// Expectations are MapLibre GL JS's output for stops 0 -> 0, 50 -> 5, 100 -> 100.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(50, 5.0)]
+    [InlineData(90, 5.092773437499916)]
+    [InlineData(100, 100.0)]
+    public void Evaluate_MultiStopExponential_SelectsIntervalThenCurves(double value, double expected)
+    {
+        var result = EvaluateNumeric(
+            """["interpolate", ["exponential", 2], ["get", "value"], 0, 0, 50, 5, 100, 100]""", value);
+
+        result.Should().BeApproximately(expected, 1e-5);
+    }
+
+    /// <summary>
+    /// Cubic-bezier numeric easing. Expectations are MapLibre GL JS's unit-bezier solver output
+    /// for control points (0.42, 0, 0.58, 1) over stops 0 -> 0, 100 -> 10.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(10, 0.1972244726385564)]
+    [InlineData(25, 1.2916190056878776)]
+    [InlineData(50, 5.0)]
+    [InlineData(75, 8.708380994312122)]
+    [InlineData(90, 9.802775527361444)]
+    public void Evaluate_CubicBezierNumericInterpolate_MatchesMapLibreUnitBezier(double value, double expected)
+    {
+        var result = EvaluateNumeric(
+            """["interpolate", ["cubic-bezier", 0.42, 0, 0.58, 1], ["get", "value"], 0, 0, 100, 10]""", value);
+
+        result.Should().BeApproximately(expected, 1e-5);
+    }
+
+    /// <summary>
+    /// The type operand applies on the color path too (post-#2867/#2870). Expectations are
+    /// MapLibre GL JS's <c>fill-color</c> output for an exponential base-2 ramp between
+    /// #f7fbff and #08306b: base 2 keeps the color near the low stop until close to 100.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(50, 247, 251, 255)]
+    [InlineData(90, 247, 251, 255)]
+    [InlineData(100, 8, 48, 107)]
+    public void EvaluateColor_ExponentialColorRamp_MatchesMapLibreOutput(double value, byte r, byte g, byte b)
+    {
+        var expression =
+            """["interpolate", ["exponential", 2], ["get", "value"], 0, "#f7fbff", 100, "#08306b"]""";
+
+        var result = EvaluateRamp(expression, value);
+
+        result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    /// <summary>
+    /// Cubic-bezier easing on the color path. Expectations are MapLibre GL JS's
+    /// <c>fill-color</c> output for control points (0.42, 0, 0.58, 1) between #f7fbff and
+    /// #08306b.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(25, 216, 225, 236)]
+    [InlineData(50, 128, 149, 181)]
+    [InlineData(75, 39, 74, 126)]
+    public void EvaluateColor_CubicBezierColorRamp_MatchesMapLibreOutput(double value, byte r, byte g, byte b)
+    {
+        var expression =
+            """["interpolate", ["cubic-bezier", 0.42, 0, 0.58, 1], ["get", "value"], 0, "#f7fbff", 100, "#08306b"]""";
+
+        var result = EvaluateRamp(expression, value);
+
+        result.Should().Be(new SKColor(r, g, b, 255));
+    }
+
+    /// <summary>
+    /// <c>["exponential", 1]</c> on the color path is also the degenerate linear case: its
+    /// output must equal the linear <c>ChoroplethRamp</c> bytes MapLibre emits (187,200,218 at
+    /// 25; 128,149,181 at 50; 68,99,144 at 75), proving base-1 does not disturb existing color
+    /// ramps.
+    /// </summary>
+    [Theory]
+    [Trait("Category", "Unit")]
+    [Trait("Tier", "Fast")]
+    [InlineData(25, 187, 200, 218)]
+    [InlineData(50, 128, 149, 181)]
+    [InlineData(75, 68, 99, 144)]
+    public void EvaluateColor_ExponentialBaseOneColorRamp_EqualsLinear(double value, byte r, byte g, byte b)
+    {
+        var exponential = EvaluateRamp(
+            """["interpolate", ["exponential", 1], ["get", "value"], 0, "#f7fbff", 100, "#08306b"]""", value);
+        var linear = EvaluateRamp(ChoroplethRamp, value);
+
+        exponential.Should().Be(linear);
+        exponential.Should().Be(new SKColor(r, g, b, 255));
     }
 
     [UnitTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2883

## Summary
`EvaluateInterpolate` read the interpolate stops but ignored `array[1]`, the interpolation-type operand, so `["exponential", base]` and `["cubic-bezier", x1, y1, x2, y2]` silently behaved as `["linear"]`. Every ramp was linear regardless of what the style declared — a plausible-looking, silently-wrong result in the same family as #2867/#2868/#2873. It affected both zoom ramps and `["get"]` attribute ramps, and both consumers that share the evaluator (WMS `GetMap` and Esri `MapServer/export`).

This threads the declared curve into the interpolation factor `t`, ported verbatim from MapLibre GL JS. The factor feeds the existing numeric and color interpolation paths unchanged, so the type handling applies on both.

## Changes Made
- Parse the curve operand from `array[1]` (`["linear"]`, `["exponential", base]`, `["cubic-bezier", x1,y1,x2,y2]`); anything unrecognized falls back to linear, matching prior behavior.
- `linear`: kept the exact single-precision expression `(input - lower) / (upper - lower)` the evaluator already used — existing linear ramps are bit-for-bit unchanged.
- `exponential`: `(base^progress - 1) / (base^difference - 1)` over raw stop-relative progress/difference (MapLibre's `exponentialInterpolation`); `base == 1` collapses to linear (MapLibre's degenerate case).
- `cubic-bezier`: ported MapLibre's `UnitBezier.solve` (Newton-Raphson + bisection fallback) applied to the linear factor.
- Added unit tests whose expectations are captured from MapLibre GL JS's own reference implementation (`@maplibre/maplibre-gl-style-spec` `createExpression(expr, rootKey, propertySpec).evaluate(...)`), not hand-computed.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

MapLibre-verified evidence: `["exponential", 1]` equals `["linear"]` on both the numeric and color paths (byte-identical to the existing `ChoroplethRamp` stops); `cubic-bezier` (0.42,0,0.58,1) matches MapLibre's unit-bezier output (e.g. input 25 → 1.2916190056878776); exponential base-2 diverges from the linear reading as expected (stops 10→0, 14→10 at 12 → 2.0 vs linear 5.0). Existing linear numeric and color ramp tests still pass unchanged (bit-unchanged proof). ExpressionEvaluator tests: 105 passed; broader Rendering/Styling/Legend surface: 406 passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

Moves pixels for any style using a non-linear `interpolate` curve — that is the fix. No server-side visual baselines exist to regenerate.

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
