### PR TITLE
fix(geoservices): drop hardcoded currentVersion from VectorTileServer metadata (#2878)

### DIFF
--- a/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
+++ b/src/Honua.Protocols.GeoServices/VectorTileServer/Models/VectorTileServerResponses.cs
@@ -17,9 +17,9 @@ namespace Honua.Protocols.GeoServices.VectorTileServer.Models;
 /// </summary>
 internal sealed class VectorTileServerMetadataResponse
 {
-    /// <summary>ArcGIS service version number.</summary>
-    [JsonPropertyName("currentVersion")]
-    public double CurrentVersion { get; init; } = 10.81;
+    // No ArcGIS Server version (currentVersion/fullVersion) is advertised. Honua is an
+    // independent, Esri-compatible server and must not impersonate a specific ArcGIS Server
+    // release. Do NOT add a currentVersion/fullVersion field (guarded by NoArcGisServerVersionTests).
 
     /// <summary>Service name (the GeoServices service identifier the route resolves).</summary>
     [JsonPropertyName("name")]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/NoArcGisServerVersionTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/NoArcGisServerVersionTests.cs
@@ -1,17 +1,13 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Honua.Protocols.GeoServices.Catalog;
-using Honua.Protocols.GeoServices.FeatureServer.Models;
-using Honua.Protocols.GeoServices.GPServer.Models;
-using Honua.Protocols.GeoServices.ImageServer.Models;
-using Honua.Protocols.GeoServices.MapServer.Models;
-using Honua.Protocols.GeoServices.Sharing;
-using Honua.Protocols.GeoServices.VersionManagementServer.Models;
 using Honua.TestKit.Attributes;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices;
@@ -23,34 +19,60 @@ namespace Honua.Server.Tests.Features.Protocols.GeoServices;
 /// fields previously hardcoded <c>10.81</c> (and <c>10.91</c>/<c>11.1</c>), which falsely
 /// claimed to be a specific ArcGIS release.
 ///
-/// This test asserts on the actual source-generated JSON wire contract for each edited
-/// response type, so it FAILS the moment anyone re-adds a <c>currentVersion</c>/<c>fullVersion</c>
-/// property to any of these models. Do not weaken it; remove the offending property instead.
+/// This test asserts on the actual source-generated JSON wire contract for every type registered
+/// in the GeoServices assembly's serialization contexts, so it FAILS the moment anyone re-adds a
+/// <c>currentVersion</c>/<c>fullVersion</c> property to any of these models. Do not weaken it;
+/// remove the offending property instead.
 /// </summary>
 public sealed class NoArcGisServerVersionTests
 {
     private static readonly string[] ForbiddenWireNames = ["currentVersion", "fullVersion"];
 
     /// <summary>
-    /// Every GeoServices metadata response type, paired with the source-generated
-    /// <see cref="JsonTypeInfo"/> that production uses to serialize it. Covers the service-
-    /// directory root (<c>/rest/services</c>), <c>/rest/info</c>, FeatureServer service + layer,
-    /// MapServer service + layer, ImageServer service, GPServer service, the VersionManagementServer
-    /// info, and the ArcGIS Portal/Sharing facade documents.
+    /// Every type registered in a GeoServices source-generated <see cref="JsonSerializerContext"/>,
+    /// paired with the <see cref="JsonTypeInfo"/> production uses to serialize it. The set is DERIVED
+    /// by reflecting over every <see cref="JsonSerializerContext"/> in the GeoServices protocol
+    /// assembly rather than enumerated by hand — an enumerated allowlist is how
+    /// <c>VectorTileServerMetadataResponse</c> escaped this guard (honua-server#2878). Anything a
+    /// context can serialize (service directory, <c>/rest/info</c>, FeatureServer / MapServer /
+    /// ImageServer / GPServer / VersionManagementServer / VectorTileServer metadata, Portal/Sharing
+    /// facades, and any future model) is covered automatically the moment it is registered.
     /// </summary>
     private static IEnumerable<(string TypeName, JsonTypeInfo TypeInfo)> MetadataResponseTypes()
     {
-        yield return (nameof(ServicesDirectoryResponse), GeoservicesCatalogJsonContext.Default.ServicesDirectoryResponse);
-        yield return (nameof(RestInfoResponse), GeoservicesCatalogJsonContext.Default.RestInfoResponse);
-        yield return (nameof(FeatureServerResponse), FeatureServerJsonContext.Default.FeatureServerResponse);
-        yield return (nameof(LayerResponse), FeatureServerJsonContext.Default.LayerResponse);
-        yield return (nameof(MapServerResponse), MapServerJsonContext.Default.MapServerResponse);
-        yield return (nameof(MapServerLayerResponse), MapServerJsonContext.Default.MapServerLayerResponse);
-        yield return (nameof(ImageServerServiceInfo), ImageServerJsonContext.Default.ImageServerServiceInfo);
-        yield return (nameof(GPServiceInfoResponse), GPServerJsonContext.Default.GPServiceInfoResponse);
-        yield return (nameof(VersionManagementServiceInfo), VersionManagementJsonContext.Default.VersionManagementServiceInfo);
-        yield return (nameof(SharingInfoResponse), SharingRestJsonContext.Default.SharingInfoResponse);
-        yield return (nameof(PortalSelfResponse), SharingRestJsonContext.Default.PortalSelfResponse);
+        // Anchor on a known GeoServices context to locate the production assembly, then discover
+        // every JsonSerializerContext it declares and enumerate each context's generated
+        // JsonTypeInfo<T> properties.
+        var assembly = typeof(GeoservicesCatalogJsonContext).Assembly;
+
+        var contextTypes = assembly.GetTypes()
+            .Where(static type => type is { IsClass: true, IsAbstract: false }
+                && typeof(JsonSerializerContext).IsAssignableFrom(type))
+            .OrderBy(static type => type.Name, StringComparer.Ordinal);
+
+        foreach (var contextType in contextTypes)
+        {
+            var defaultProperty = contextType.GetProperty(
+                "Default", BindingFlags.Public | BindingFlags.Static);
+            if (defaultProperty?.GetValue(null) is not JsonSerializerContext context)
+            {
+                continue;
+            }
+
+            var typeInfoProperties = contextType
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(static property => property.PropertyType.IsGenericType
+                    && property.PropertyType.GetGenericTypeDefinition() == typeof(JsonTypeInfo<>))
+                .OrderBy(static property => property.Name, StringComparer.Ordinal);
+
+            foreach (var property in typeInfoProperties)
+            {
+                if (property.GetValue(context) is JsonTypeInfo typeInfo)
+                {
+                    yield return ($"{contextType.Name}.{typeInfo.Type.Name}", typeInfo);
+                }
+            }
+        }
     }
 
     [UnitTest]
@@ -58,7 +80,12 @@ public sealed class NoArcGisServerVersionTests
     {
         using var scope = new AssertionScope();
 
-        foreach (var (typeName, typeInfo) in MetadataResponseTypes())
+        var metadataResponseTypes = MetadataResponseTypes().ToArray();
+        metadataResponseTypes.Should().NotBeEmpty(
+            "the guard must discover the GeoServices serialization contexts; an empty set would "
+            + "silently pass and re-open the hole this test exists to close.");
+
+        foreach (var (typeName, typeInfo) in metadataResponseTypes)
         {
             var wireNames = typeInfo.Properties
                 .Select(static property => property.Name)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/VectorTileServer/VectorTileServerEndpointTests.cs
@@ -45,7 +45,6 @@ public sealed class VectorTileServerEndpointTests : IAsyncLifetime
 
         metadata.Should().NotBeNull();
         metadata!.Name.Should().Be(WebAppFixture.TestServiceId);
-        metadata.CurrentVersion.Should().BeGreaterThan(0);
         metadata.Capabilities.Should().Be("TilesOnly");
         metadata.Type.Should().Be("indexedVector");
         metadata.ExportTilesAllowed.Should().BeFalse();


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2878

## Summary
`VectorTileServerMetadataResponse` hardcoded an ArcGIS Server release version (`currentVersion = 10.81`), violating Honua's no-ArcGIS-Server-version policy. The policy's guard, `NoArcGisServerVersionTests`, enumerated the metadata models it checked by hand — and `VectorTileServerMetadataResponse` was absent from that list, so the guard silently did not cover the one model still carrying the value the policy exists to remove (same failure shape as #2877: a gate whose green is narrower than its name).

This PR removes the field and closes the hole in the guard by deriving its model set instead of enumerating it, so no GeoServices metadata model can escape the guard again.

## Changes Made
- Remove `currentVersion` (`10.81`) from `VectorTileServerMetadataResponse`, matching every other GeoServices metadata model, which already omit it; replaced with the standard "no ArcGIS Server version is advertised" guard comment.
- Rewrite `NoArcGisServerVersionTests` to **derive** its model set by reflecting over every `JsonSerializerContext` in the `Honua.Protocols.GeoServices` assembly and checking each registered `JsonTypeInfo` — replacing the hand-maintained allowlist that let this model slip. Added a non-empty assertion so an empty discovery set cannot silently pass.
- Drop the `metadata.CurrentVersion.Should().BeGreaterThan(0)` assertion from `VectorTileServerEndpointTests`, which previously locked the violation in.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Evidence:
- `NoArcGisServerVersionTests`: 2 passed. Proof the derived guard now covers the model — temporarily re-adding the field failed the guard with `VectorTileServerJsonContext.VectorTileServerMetadataResponse must not advertise an ArcGIS Server/Portal version (no 'currentVersion')`, then reverted.
- `VectorTileServerEndpointTests` (Server-side integration, Testcontainers + PostGIS): 25 passed.
- Governance drift guards (`FeatureCatalogDriftTests`, `GeoServicesParityMatrixDriftTests`, `EndpointRegistryDriftTests`): 22 passed — the change alters no served route surface, so `feature-catalog.json` / the parity matrix need no regeneration.
- Release build with `TreatWarningsAsErrors=true`: 0 warnings. `dotnet format --verify-no-changes` on changed files: clean.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
`currentVersion` disappears from the VectorTileServer metadata document. This is consistent with every other Honua GeoServices metadata document, all of which already omit it; the parity judgment already tells clients to treat its absence as "unknown", not a version floor. Not a functional break.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
