### PR TITLE
feat(mcp): accept OAuth 2.1 bearer tokens on /mcp as a resource server

### DIFF
--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -15322,6 +15322,11 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpBearerAuthenticationTests.Post_InitializeWithValidBearer_IsAcceptedAndBindsAuthenticatedPrincipal",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpBearerAuthenticationTests.Post_WithExpiredBearer_Returns401",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpBearerAuthenticationTests.Post_WithInvalidSignatureBearer_Returns401WithChallengeAndStructuredError",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpBearerAuthenticationTests.Post_WithTokenForDifferentAudience_Returns401",
+        "Honua.Server.Tests.Features.Protocols.Mcp.McpBearerAuthenticationTests.Post_WithoutBearer_AnonymousHandshakeStillSucceeds",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.BatchContainingInitialize_IsRejectedAsInvalidRequest",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.BatchMixedWithNotification_ReturnsOnlyResponseForRequest",
         "Honua.Server.Tests.Features.Protocols.Mcp.McpEndpointIntegrationTests.BatchOfOnlyNotifications_ReturnsAccepted",

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpBearerAuthenticationEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpBearerAuthenticationEndpointExtensions.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Ai.Protocols.Mcp.Models;
+using Honua.Infrastructure.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Ai.Protocols.Mcp;
+
+/// <summary>
+/// OAuth 2.1 resource-server acceptance of <c>Authorization: Bearer</c> tokens on the
+/// <c>/mcp</c> transport (honua-server#2850). Applied as an endpoint filter so a bearer
+/// token is validated against the host's configured OIDC authorities and, on success,
+/// projected onto <see cref="HttpContext.User"/> before the JSON-RPC handler runs — the
+/// per-tool <c>EnsureCallerAuthorizedAsync</c> grant model then decides authorization on
+/// the resulting principal exactly as it does for the X-API-Key path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The behaviour is strictly additive. It engages only when a request actually carries a
+/// bearer credential; a request with no <c>Authorization</c> header (the anonymous
+/// <c>initialize</c>/<c>tools/list</c> handshake) and a request already authenticated by
+/// another scheme (X-API-Key) both flow through untouched. Coexistence policy between the
+/// two credential families is a sibling concern (honua-server#2852) and is not decided
+/// here.
+/// </para>
+/// <para>
+/// Validation reuses the multi-authority OIDC stack rather than a parallel config surface:
+/// the token is authenticated through the already-registered
+/// <see cref="OidcAuthenticationExtensions.JwtBearerScheme"/>, which enforces issuer,
+/// audience, signature, and lifetime against every configured authority and normalizes the
+/// claims through the shared <c>OidcClaimsTransformation</c>. Acceptance is gated on the
+/// same signal that drives the RFC 9728 metadata (honua-server#2849): when no authorization
+/// server is configured there is nothing to validate against, so a presented token is left
+/// unauthenticated and the request keeps its prior anonymous behaviour.
+/// </para>
+/// <para>
+/// A token that is presented but fails validation — bad signature, expired, wrong issuer,
+/// or an audience minted for another resource — is a resource-server rejection (RFC 6750
+/// <c>invalid_token</c>): the filter short-circuits with HTTP 401 and an MCP-structured
+/// error envelope. The 401 is paired with the RFC 9728 <c>WWW-Authenticate</c> challenge by
+/// <see cref="McpProtectedResourceMetadataEndpointExtensions.StampChallengeOnUnauthorized"/>,
+/// which the transport arms on every MCP route.
+/// </para>
+/// </remarks>
+internal static class McpBearerAuthenticationEndpointExtensions
+{
+    private const string BearerPrefix = "Bearer ";
+
+    /// <summary>
+    /// Endpoint filter that validates a presented bearer token and authenticates the caller
+    /// against the configured OIDC authorities, or rejects an invalid token with a 401.
+    /// </summary>
+    public static async ValueTask<object?> AuthenticateBearerAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var httpContext = context.HttpContext;
+
+        // Only engage when a bearer credential is actually presented. Absent an
+        // Authorization header the anonymous handshake and the X-API-Key path are
+        // untouched.
+        if (!HasBearerCredential(httpContext))
+        {
+            return await next(context).ConfigureAwait(false);
+        }
+
+        // Already authenticated by an earlier scheme (for example the composite default
+        // scheme validated the same bearer, or an X-API-Key principal is present): nothing
+        // to add, and re-validating would be wasted work.
+        if (httpContext.User.Identity?.IsAuthenticated == true)
+        {
+            return await next(context).ConfigureAwait(false);
+        }
+
+        // Resource-server validation is only meaningful when an authorization server is
+        // configured. This is the same gate the RFC 9728 metadata uses (#2849): with no
+        // authority there is nothing to validate the token against, so leave the request
+        // anonymous and preserve prior behaviour. The JwtBearer scheme is registered
+        // whenever this returns a non-empty set, so AuthenticateAsync below cannot fault on
+        // a missing scheme.
+        var options = httpContext.RequestServices
+            .GetRequiredService<IOptions<OidcAuthenticationOptions>>().Value;
+        if (McpProtectedResourceMetadata.ResolveAuthorizationServers(options).Count == 0)
+        {
+            return await next(context).ConfigureAwait(false);
+        }
+
+        var result = await httpContext
+            .AuthenticateAsync(OidcAuthenticationExtensions.JwtBearerScheme)
+            .ConfigureAwait(false);
+
+        if (result.Succeeded && result.Principal is not null)
+        {
+            // Bind the validated principal to the request so the JSON-RPC handler and the
+            // per-tool grant checks observe the same claim shape the X-API-Key path
+            // produces.
+            httpContext.User = result.Principal;
+            return await next(context).ConfigureAwait(false);
+        }
+
+        // A presented-but-invalid token is an RFC 6750 invalid_token rejection. Answer 401
+        // with the MCP-structured error envelope; the RFC 9728 WWW-Authenticate challenge is
+        // stamped by the response hook the transport arms on every MCP route.
+        return BuildInvalidTokenResult();
+    }
+
+    private static bool HasBearerCredential(HttpContext context)
+    {
+        var authorization = context.Request.Headers.Authorization;
+        foreach (var value in authorization)
+        {
+            if (!string.IsNullOrEmpty(value)
+                && value.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase)
+                && value.Length > BearerPrefix.Length)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IResult BuildInvalidTokenResult()
+    {
+        var response = new McpJsonRpcResponse
+        {
+            Id = McpEndpointExtensions.JsonNullId,
+            Error = McpErrorMapper.InvalidToken()
+        };
+
+        return Results.Json(
+            response,
+            McpJsonContext.Default.McpJsonRpcResponse,
+            statusCode: StatusCodes.Status401Unauthorized);
+    }
+}

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
@@ -70,6 +70,7 @@ internal static class McpEndpointExtensions
         endpoints.MapPost(RoutePath,
                 static (HttpContext context, CancellationToken ct) => HandlePostAsync(context, ct))
             .AddEndpointFilter(ProtectedResourceChallengeFilter)
+            .AddEndpointFilter(McpBearerAuthenticationEndpointExtensions.AuthenticateBearerAsync)
             .WithDisplayName("MCP Operator Surface")
             .WithName("McpOperatorSurface")
             .WithSummary("MCP JSON-RPC dispatcher for planning, execution, lifecycle, and results.")
@@ -79,6 +80,7 @@ internal static class McpEndpointExtensions
         endpoints.MapGet(RoutePath,
                 static (HttpContext context, CancellationToken ct) => HandleGetAsync(context, ct))
             .AddEndpointFilter(ProtectedResourceChallengeFilter)
+            .AddEndpointFilter(McpBearerAuthenticationEndpointExtensions.AuthenticateBearerAsync)
             .WithDisplayName("MCP Operator Surface (SSE stream)")
             .WithName("McpOperatorSurfaceStream")
             .WithSummary("Opens the MCP server-to-client Server-Sent-Events stream.")
@@ -88,6 +90,7 @@ internal static class McpEndpointExtensions
         endpoints.MapDelete(RoutePath,
                 static (HttpContext context, CancellationToken ct) => HandleDeleteAsync(context, ct))
             .AddEndpointFilter(ProtectedResourceChallengeFilter)
+            .AddEndpointFilter(McpBearerAuthenticationEndpointExtensions.AuthenticateBearerAsync)
             .WithDisplayName("MCP Operator Surface (session termination)")
             .WithName("McpOperatorSurfaceTerminate")
             .WithSummary("Terminates an MCP session.")

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpErrorMapper.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpErrorMapper.cs
@@ -284,6 +284,27 @@ internal static class McpErrorMapper
     };
 
     /// <summary>
+    /// Creates the structured error returned when a request presents an
+    /// <c>Authorization: Bearer</c> credential that fails OAuth 2.1 resource-server
+    /// validation — a bad signature, an expired token, a wrong issuer, or an
+    /// audience minted for another resource (honua-server#2850). Carries the same
+    /// <c>unauthenticated</c> code and re-authentication signal as
+    /// <see cref="Unauthenticated"/> so a client reacts identically whether a token
+    /// was rejected or never presented; the transport pairs this envelope with an
+    /// HTTP 401 and the RFC 9728 <c>WWW-Authenticate</c> challenge.
+    /// </summary>
+    public static McpJsonRpcError InvalidToken() => new()
+    {
+        Code = JsonRpcServerError,
+        Message = "The bearer token is invalid, expired, or issued for a different resource.",
+        Data = new McpErrorData
+        {
+            Code = Codes.Unauthenticated,
+            RequiresReauthentication = true
+        }
+    };
+
+    /// <summary>
     /// Creates the structured error returned when a request presents a valid
     /// <c>Mcp-Session-Id</c> that is bound to a different principal than the caller
     /// (A3 session binding; honua-server#2537). Signals

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpProtectedResourceMetadata.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpProtectedResourceMetadata.cs
@@ -14,10 +14,12 @@ namespace Honua.Ai.Protocols.Mcp;
 /// relying on a naming policy.
 /// </summary>
 /// <remarks>
-/// Only the members Honua can honestly answer for are modelled. <c>scopes_supported</c>
-/// and <c>bearer_methods_supported</c> are deliberately absent while the surface does
-/// not yet accept bearer tokens (honua-server#2850) — advertising a token vocabulary the
-/// runtime does not enforce is the advertised-vs-actual gap #2803 exists to close.
+/// Only the members Honua can honestly answer for are modelled. <c>bearer_methods_supported</c>
+/// advertises <c>header</c> now that the surface accepts <c>Authorization: Bearer</c> tokens
+/// as a resource server (honua-server#2850). <c>scopes_supported</c> remains deliberately
+/// absent while the surface authenticates but does not yet enforce OAuth scopes
+/// (honua-server#2851) — advertising a scope vocabulary the runtime does not enforce is the
+/// advertised-vs-actual gap #2803 exists to close.
 /// </remarks>
 internal sealed class McpProtectedResourceMetadataDocument
 {
@@ -33,6 +35,15 @@ internal sealed class McpProtectedResourceMetadataDocument
     /// </summary>
     [JsonPropertyName("authorization_servers")]
     public required IReadOnlyList<string> AuthorizationServers { get; init; }
+
+    /// <summary>
+    /// The bearer-token presentation methods the resource accepts (RFC 9728
+    /// <c>bearer_methods_supported</c>, values from RFC 6750). The <c>/mcp</c> surface reads
+    /// the token from the <c>Authorization</c> request header only, so the sole advertised
+    /// method is <c>header</c>.
+    /// </summary>
+    [JsonPropertyName("bearer_methods_supported")]
+    public IReadOnlyList<string>? BearerMethodsSupported { get; init; }
 
     /// <summary>
     /// Human-readable name of the protected resource (RFC 9728 <c>resource_name</c>).
@@ -73,6 +84,13 @@ internal static class McpProtectedResourceMetadata
     /// Human-readable resource name advertised in the metadata document.
     /// </summary>
     public const string ResourceName = "Honua MCP";
+
+    /// <summary>
+    /// The RFC 6750 bearer-token presentation methods advertised in
+    /// <c>bearer_methods_supported</c>. The <c>/mcp</c> surface accepts the token only from
+    /// the <c>Authorization</c> request header (honua-server#2850).
+    /// </summary>
+    public static readonly IReadOnlyList<string> BearerMethodsSupported = ["header"];
 
     /// <summary>
     /// Resolves the issuer identifiers of every configured, valid OIDC provider. Returns an

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpProtectedResourceMetadataEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpProtectedResourceMetadataEndpointExtensions.cs
@@ -116,6 +116,7 @@ internal static class McpProtectedResourceMetadataEndpointExtensions
         {
             Resource = resource.AbsoluteUri,
             AuthorizationServers = authorizationServers,
+            BearerMethodsSupported = McpProtectedResourceMetadata.BearerMethodsSupported,
             ResourceName = McpProtectedResourceMetadata.ResourceName
         };
 

--- a/tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj
+++ b/tests/dotnet/Honua.Ai.Tests/Honua.Ai.Tests.csproj
@@ -23,6 +23,9 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
+    <!-- OAuth 2.1 bearer-token integration tests mint HS256 JWTs for the /mcp
+         resource-server acceptance suite (honua-server#2850). -->
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpBearerAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpBearerAuthenticationTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Honua.Server.Tests.Features.Protocols.Mcp;

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpBearerAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpBearerAuthenticationTests.cs
@@ -223,11 +223,13 @@ public sealed class McpBearerAuthenticationTests : IAsyncLifetime
             new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
         };
 
+        // notBefore is intentionally omitted: for the expired-token case a negative
+        // expiry would fall before any non-null notBefore and the JwtSecurityToken
+        // constructor rejects that (IDX12401). Lifetime validation keys off expiry.
         var token = new JwtSecurityToken(
             issuer: issuer,
             audience: audience,
             claims: claims,
-            notBefore: DateTime.UtcNow.AddMinutes(-1),
             expires: DateTime.UtcNow.AddMinutes(expiresInMinutes),
             signingCredentials: credentials);
 

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpBearerAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpBearerAuthenticationTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+/// <summary>
+/// Integration tests for OAuth 2.1 resource-server acceptance of
+/// <c>Authorization: Bearer</c> tokens on the <c>/mcp</c> transport
+/// (honua-server#2850). Exercised through the full ASP.NET Core pipeline with a
+/// configured OIDC authority (a symmetric-key generic provider, so tokens are
+/// minted and validated in-process without a live IdP) and the dev-auth bypass
+/// disabled, so authentication is decided purely by the presented credential.
+/// </summary>
+/// <remarks>
+/// The suite proves the three behaviours the acceptance criteria require: a valid
+/// token authenticates the caller (observed through the session principal binding,
+/// which only rejects a *different* identity), a presented-but-invalid token is
+/// rejected with HTTP 401 plus the RFC 9728 <c>WWW-Authenticate</c> challenge and an
+/// MCP-structured error, and an unauthenticated request keeps its prior anonymous
+/// handshake — the change is additive.
+/// </remarks>
+[Collection("Database")]
+[Protocol(TestProtocols.Mcp)]
+[Operation(Operations.Security)]
+public sealed class McpBearerAuthenticationTests : IAsyncLifetime
+{
+    private const string JsonMediaType = "application/json";
+    private const string PublicBaseUrl = "https://mcp.example.com";
+    private const string Issuer = "https://idp.example.com";
+    private const string Audience = "honua-mcp-client-id";
+    private const string SigningKey = "mcp-bearer-test-signing-key-at-least-32-characters-long";
+
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .UseSeed("tests/seed/server.yaml")
+        .ConfigureWebHost(builder =>
+        {
+            builder.UseEnvironment("Test");
+            // Disable the dev-auth bypass so a request is only authenticated by the
+            // credential it actually presents — the whole point of this suite.
+            builder.UseSetting("HONUA_DEV_AUTH", "false");
+            builder.UseSetting("HONUA_ADMIN_PASSWORD", "test-admin-key");
+            builder.UseSetting("Public:BaseUrl", PublicBaseUrl);
+
+            // Reuse the multi-authority OIDC stack (#2849) — a single generic
+            // provider validated against a static symmetric key so tokens can be
+            // minted in-process. Issuer/audience/lifetime validation stay at their
+            // secure defaults (true).
+            builder.UseSetting("Oidc:Enabled", "true");
+            builder.UseSetting("Oidc:RequireHttps", "true");
+            builder.UseSetting("Oidc:TokenValidation:SymmetricSigningKey", SigningKey);
+            builder.UseSetting("Oidc:TokenValidation:EnableTokenReplayProtection", "false");
+            builder.UseSetting("Oidc:Generic:Enabled", "true");
+            builder.UseSetting("Oidc:Generic:Authority", Issuer);
+            builder.UseSetting("Oidc:Generic:ClientId", Audience);
+            builder.UseSetting("Oidc:Generic:DisplayName", "Test IdP");
+        });
+
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /mcp")]
+    [InterfaceOperation(TestProtocols.Mcp, "initialize")]
+    public async Task Post_InitializeWithValidBearer_IsAcceptedAndBindsAuthenticatedPrincipal()
+    {
+        // A valid token authenticates the caller: initialize succeeds (not 401) and
+        // the resulting session is bound to the token's subject, not the anonymous
+        // principal. The binding is observed by presenting the issued session id on a
+        // follow-up request that carries NO credential — the anonymous identity does
+        // not match the authenticated subject, so the transport returns the A3
+        // principal-mismatch error. That mismatch is only possible if the bearer
+        // authenticated initialize to a non-anonymous identity.
+        var token = CreateToken(subject: "operator-123");
+
+        using var initialize = BuildInitialize(bearer: token);
+        var initializeResponse = await _client.SendAsync(initialize);
+
+        initializeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        initializeResponse.Headers.TryGetValues("Mcp-Session-Id", out var sessionIds).Should().BeTrue(
+            "a valid bearer authenticates the caller and initialize establishes a session");
+        var sessionId = sessionIds!.Single();
+
+        using var followUp = BuildRpc(
+            """{"jsonrpc":"2.0","id":2,"method":"tools/list"}""",
+            sessionId: sessionId,
+            bearer: null);
+        var followUpResponse = await _client.SendAsync(followUp);
+
+        followUpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = await ReadJsonAsync(followUpResponse);
+        var error = document.RootElement.GetProperty("error");
+        error.GetProperty("data").GetProperty("code").GetString().Should().Be(
+            "permission_denied",
+            "the session was bound to the bearer subject, so an anonymous follow-up is a principal mismatch");
+        error.GetProperty("data").GetProperty("requiresReauthentication").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /mcp")]
+    public async Task Post_WithInvalidSignatureBearer_Returns401WithChallengeAndStructuredError()
+    {
+        // A token signed with the wrong key fails signature validation. A presented
+        // token that fails validation is an RFC 6750 invalid_token rejection: HTTP 401
+        // with the RFC 9728 WWW-Authenticate challenge and an MCP-structured body.
+        var token = CreateToken(subject: "operator-123", signingKey: "a-different-wrong-signing-key-also-32-characters");
+
+        using var request = BuildInitialize(bearer: token);
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        response.Headers.TryGetValues("WWW-Authenticate", out var challenges).Should().BeTrue(
+            "an OAuth 2.1 resource server signals rejection with a WWW-Authenticate challenge");
+        var challenge = string.Join(" ", challenges!);
+        challenge.Should().Contain("Bearer");
+        challenge.Should().Contain(
+            "resource_metadata=",
+            "RFC 9728 section 5.1 points the client at the protected-resource metadata");
+
+        using var document = await ReadJsonAsync(response);
+        var error = document.RootElement.GetProperty("error");
+        error.GetProperty("data").GetProperty("code").GetString().Should().Be("unauthenticated");
+        error.GetProperty("data").GetProperty("requiresReauthentication").GetBoolean().Should().BeTrue();
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /mcp")]
+    public async Task Post_WithExpiredBearer_Returns401()
+    {
+        var token = CreateToken(subject: "operator-123", expiresInMinutes: -30);
+
+        using var request = BuildInitialize(bearer: token);
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        using var document = await ReadJsonAsync(response);
+        document.RootElement.GetProperty("error").GetProperty("data").GetProperty("code").GetString()
+            .Should().Be("unauthenticated");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /mcp")]
+    public async Task Post_WithTokenForDifferentAudience_Returns401()
+    {
+        // Audience validation binds the token to this resource: a token minted for a
+        // different audience (a different client/resource) must be rejected even
+        // though its signature, issuer, and lifetime are all valid.
+        var token = CreateToken(subject: "operator-123", audience: "some-other-resource");
+
+        using var request = BuildInitialize(bearer: token);
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        using var document = await ReadJsonAsync(response);
+        document.RootElement.GetProperty("error").GetProperty("data").GetProperty("code").GetString()
+            .Should().Be("unauthenticated");
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /mcp")]
+    [InterfaceOperation(TestProtocols.Mcp, "initialize")]
+    public async Task Post_WithoutBearer_AnonymousHandshakeStillSucceeds()
+    {
+        // The change is additive: with no Authorization header the anonymous
+        // initialize/tools-list handshake keeps working exactly as before, and the
+        // anonymous session accepts follow-up requests without a principal mismatch.
+        using var initialize = BuildInitialize(bearer: null);
+        var initializeResponse = await _client.SendAsync(initialize);
+
+        initializeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        initializeResponse.Headers.TryGetValues("Mcp-Session-Id", out var sessionIds).Should().BeTrue();
+        var sessionId = sessionIds!.Single();
+
+        using var followUp = BuildRpc(
+            """{"jsonrpc":"2.0","id":2,"method":"tools/list"}""",
+            sessionId: sessionId,
+            bearer: null);
+        var followUpResponse = await _client.SendAsync(followUp);
+
+        followUpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var document = await ReadJsonAsync(followUpResponse);
+        document.RootElement.TryGetProperty("error", out _).Should().BeFalse(
+            "an anonymous session accepts the same anonymous caller");
+    }
+
+    private static string CreateToken(
+        string subject,
+        string issuer = Issuer,
+        string audience = Audience,
+        string signingKey = SigningKey,
+        int expiresInMinutes = 60)
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
+        var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<Claim>
+        {
+            new("sub", subject),
+            new("name", "Bearer Test User"),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: issuer,
+            audience: audience,
+            claims: claims,
+            notBefore: DateTime.UtcNow.AddMinutes(-1),
+            expires: DateTime.UtcNow.AddMinutes(expiresInMinutes),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static HttpRequestMessage BuildInitialize(string? bearer) => BuildRpc(
+        """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+            "protocolVersion":"2025-06-18",
+            "capabilities":{},
+            "clientInfo":{"name":"honua-tests","version":"1.0.0"}
+        }}
+        """,
+        sessionId: null,
+        bearer: bearer);
+
+    private static HttpRequestMessage BuildRpc(string body, string? sessionId, string? bearer)
+    {
+        var content = new StringContent(body, Encoding.UTF8);
+        content.Headers.ContentType = new MediaTypeHeaderValue(JsonMediaType);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/mcp") { Content = content };
+        if (sessionId is not null)
+        {
+            request.Headers.Add("Mcp-Session-Id", sessionId);
+        }
+
+        if (bearer is not null)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        }
+
+        return request;
+    }
+
+    private static async Task<JsonDocument> ReadJsonAsync(HttpResponseMessage response)
+    {
+        var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpErrorMappingTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpErrorMappingTests.cs
@@ -184,4 +184,18 @@ public sealed class McpErrorMappingTests
         error.Data!.Code.Should().Be(McpErrorMapper.Codes.Unauthenticated);
         error.Data.RequiresReauthentication.Should().BeTrue();
     }
+
+    [UnitTest]
+    public void InvalidTokenFactory_EmitsUnauthenticatedWithReauthSignal()
+    {
+        // A presented-but-invalid bearer token (bad signature, expired, wrong issuer, or an
+        // audience minted for another resource) is an RFC 6750 invalid_token rejection. It
+        // shares the unauthenticated code and re-authentication signal with the no-credential
+        // case so a client reacts identically (#2850).
+        var error = McpErrorMapper.InvalidToken();
+
+        error.Code.Should().Be(JsonRpcServerError);
+        error.Data!.Code.Should().Be(McpErrorMapper.Codes.Unauthenticated);
+        error.Data.RequiresReauthentication.Should().BeTrue();
+    }
 }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpProtectedResourceMetadataTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpProtectedResourceMetadataTests.cs
@@ -86,7 +86,8 @@ public sealed class McpProtectedResourceMetadataTests
                     "the surface now accepts Authorization: Bearer tokens as a resource server (#2850)");
                 bearerMethods.ValueKind.Should().Be(JsonValueKind.Array);
                 bearerMethods.EnumerateArray().Select(element => element.GetString())
-                    .Should().Equal("header", because: "the /mcp resource reads the token only from the Authorization header (RFC 6750)");
+                    .Should().Equal(new[] { "header" },
+                        "the /mcp resource reads the token only from the Authorization header (RFC 6750)");
             }
         }
         finally

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpProtectedResourceMetadataTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpProtectedResourceMetadataTests.cs
@@ -36,6 +36,8 @@ public sealed class McpProtectedResourceMetadataTests
     // path, and it cannot see through a const reference. This route is registry-tracked
     // but only conditionally deployed (no OIDC authority => absent), so that source-level
     // proof is its only drift gate — keep the literal at the call site.
+    private static readonly string[] ExpectedBearerMethods = ["header"];
+
     private const string GenericAuthority = "https://auth.example.com";
     private const string PublicBaseUrl = "https://mcp.example.com";
     private const string TestTenantId = "11111111-1111-1111-1111-111111111111";
@@ -86,7 +88,7 @@ public sealed class McpProtectedResourceMetadataTests
                     "the surface now accepts Authorization: Bearer tokens as a resource server (#2850)");
                 bearerMethods.ValueKind.Should().Be(JsonValueKind.Array);
                 bearerMethods.EnumerateArray().Select(element => element.GetString())
-                    .Should().Equal(new[] { "header" },
+                    .Should().Equal(ExpectedBearerMethods,
                         "the /mcp resource reads the token only from the Authorization header (RFC 6750)");
             }
         }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpProtectedResourceMetadataTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpProtectedResourceMetadataTests.cs
@@ -81,9 +81,12 @@ public sealed class McpProtectedResourceMetadataTests
                 name.GetString().Should().NotBeNullOrWhiteSpace();
 
                 root.TryGetProperty("scopes_supported", out _).Should().BeFalse(
-                    "the surface does not enforce OAuth scopes yet (#2850), so advertising them would be dishonest");
-                root.TryGetProperty("bearer_methods_supported", out _).Should().BeFalse(
-                    "the surface does not accept bearer tokens yet (#2850)");
+                    "the surface authenticates but does not enforce OAuth scopes yet (#2851), so advertising them would be dishonest");
+                root.TryGetProperty("bearer_methods_supported", out var bearerMethods).Should().BeTrue(
+                    "the surface now accepts Authorization: Bearer tokens as a resource server (#2850)");
+                bearerMethods.ValueKind.Should().Be(JsonValueKind.Array);
+                bearerMethods.EnumerateArray().Select(element => element.GetString())
+                    .Should().Equal("header", because: "the /mcp resource reads the token only from the Authorization header (RFC 6750)");
             }
         }
         finally


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2850

## Summary
Makes the `/mcp` transport an OAuth 2.1 resource server: it now accepts and validates
`Authorization: Bearer` tokens against the host's configured OIDC authorities, the
authentication model the MCP `2025-06-18` spec defines. This is the token-acceptance slice
of epic #2848 (RFC 9728 metadata, #2849, already landed). On-prem / sovereign buyers who
federate against their own IdP (Entra, Keycloak, Okta) and reject shared static API keys can
now authenticate to the MCP surface.

The change is wiring, not a new auth system — it reuses the existing multi-authority OIDC
stack (`OidcProviderCatalog` / `Honua.Hosting/Features/Authentication`), the same
configuration #2849 derives its metadata from. It is strictly additive: a valid token
authenticates the caller; an absent token keeps the prior anonymous `initialize`/`tools/list`
handshake; a presented-but-invalid token is rejected as a resource server should. The per-tool
`EnsureCallerAuthorizedAsync` grant model remains the authorization authority.

## Changes Made
- Add `McpBearerAuthenticationEndpointExtensions` — an endpoint filter on `POST/GET/DELETE /mcp`
  that, when a bearer credential is presented and the caller is not already authenticated,
  validates it through the already-registered OIDC `JwtBearer` scheme (issuer, audience,
  signature, lifetime, multi-authority) and projects the validated principal onto
  `HttpContext.User` — the same claim shape the X-API-Key path produces, so downstream
  authorization is unchanged.
- Reject a presented-but-invalid token (bad signature, expired, wrong issuer, wrong audience)
  with HTTP 401, an MCP-structured `unauthenticated` error envelope, and the RFC 9728
  `WWW-Authenticate: Bearer resource_metadata=...` challenge #2849 already wired (RFC 6750
  `invalid_token`). Add `McpErrorMapper.InvalidToken()` for the envelope.
- Gate acceptance on the same signal that drives the RFC 9728 metadata
  (`ResolveAuthorizationServers`): with no authorization server configured a presented token is
  left unauthenticated and the request keeps its prior behaviour — no parallel config surface.
- Advertise `bearer_methods_supported: ["header"]` in the RFC 9728 protected-resource metadata
  now that the surface honestly accepts bearer tokens (closes the advertised-vs-actual note the
  #2849 metadata test left for #2850). `scopes_supported` stays absent — scope enforcement is
  sibling #2851.
- Add integration coverage (`McpBearerAuthenticationTests`): a valid token authenticates and
  binds the session to its subject; invalid / expired / wrong-audience tokens each return 401
  with the challenge and structured body; the no-credential anonymous handshake still works.
  Add a unit test for `InvalidToken()`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes

## Breaking Changes
None. Absent or invalid tokens do not change the existing anonymous / X-API-Key reachability
of `/mcp`; X-API-Key / OAuth coexistence and session-binding reconciliation are sibling #2852.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
