### PR TITLE
feat(meta): capability label sync and issue-form capability field (#2896)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -65,6 +65,20 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: capability-keys
+    attributes:
+      label: Capability Key(s)
+      description: |
+        Which capability key(s) does this bug affect? Comma-separated; use the FeatureCatalog
+        entitlement key if one exists (src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs),
+        otherwise the `cap/<category>` slug from docs/gis/data/capability-categories.seed.json
+        (e.g. `serve-ogc`, `editing`). A capability-key validation bot may comment with suggestions
+        if the value doesn't match a known category — that comment is advisory, not a blocker.
+      placeholder: "editing.feature-edits, geocoding.single-line"
+    validations:
+      required: false
+
   - type: dropdown
     id: affected-repos
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -38,6 +38,20 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: capability-keys
+    attributes:
+      label: Capability Key(s)
+      description: |
+        Which capability key(s) does this feature affect or introduce? Comma-separated; use the
+        FeatureCatalog entitlement key if one exists (src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs),
+        otherwise the `cap/<category>` slug from docs/gis/data/capability-categories.seed.json
+        (e.g. `serve-ogc`, `editing`). A capability-key validation bot may comment with suggestions
+        if the value doesn't match a known category — that comment is advisory, not a blocker.
+      placeholder: "editing.feature-edits, geocoding.single-line"
+    validations:
+      required: false
+
   - type: dropdown
     id: affected-repos
     attributes:

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -33,6 +33,19 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: capability-keys
+    attributes:
+      label: Capability Key(s) (optional)
+      description: |
+        If this work is tied to a specific capability, list the key(s) here (comma-separated):
+        the FeatureCatalog entitlement key if one exists (src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs),
+        otherwise the `cap/<category>` slug from docs/gis/data/capability-categories.seed.json
+        (e.g. `serve-ogc`, `editing`). Leave blank for cross-cutting or infra-only tech debt.
+      placeholder: "editing.feature-edits, geocoding.single-line"
+    validations:
+      required: false
+
   - type: dropdown
     id: affected-repos
     attributes:

--- a/.github/workflows/issue-capability-check.yml
+++ b/.github/workflows/issue-capability-check.yml
@@ -1,0 +1,124 @@
+name: Issue Capability Key Check
+
+# Lightweight companion to the "Validate PR Template Compliance" job in ci.yml
+# (#2896, child of #2892): when a bug or feature issue is opened, check whether
+# its "Capability Key(s)" field (bug.yml / feature.yml) is filled in and looks
+# like it maps to a known cap/<category>. This is advisory only:
+#   - Missing value       -> comment with guidance, no label/status change.
+#   - Unrecognized prefix -> gentle correction comment suggesting known
+#                            categories; the key may simply be more granular
+#                            than the category-level seed knows about.
+#   - Present and known   -> no comment at all (stay quiet on the happy path).
+# It never closes, labels, or edits the issue — the seed list (see TODO below)
+# is still category-level, not the full canonical key vocabulary, so a "warn"
+# posture (not a hard-fail) is intentional until #2893 publishes that
+# vocabulary. Tech-debt issues are skipped: the field is optional there.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: issue-capability-check-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check capability key
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only bug/feature issues carry the field as validated; tech-debt is
+    # optional there and intentionally not nagged.
+    if: contains(github.event.issue.labels.*.name, 'bug') || contains(github.event.issue.labels.*.name, 'enhancement')
+    steps:
+      - name: Checkout (seed list only)
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            docs/gis/data/capability-categories.seed.json
+          sparse-checkout-cone-mode: false
+
+      - name: Check capability key field
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- capability-key-check -->';
+
+            const seed = JSON.parse(fs.readFileSync('docs/gis/data/capability-categories.seed.json', 'utf8'));
+            const knownSlugs = new Set((seed.categories || []).map(c => c.slug));
+
+            const issueBody = context.payload.issue.body || '';
+
+            // Issue forms render each field as "### <Label>\n\n<answer>\n" in the
+            // body. Match the Capability Key(s) heading (bug.yml / feature.yml
+            // both use the exact label "Capability Key(s)") up to the next
+            // heading or end of body.
+            const match = issueBody.match(/###\s*Capability Key\(s\)\s*\n+([\s\S]*?)(?=\n###\s|\s*$)/i);
+            const rawValue = match ? match[1].trim() : '';
+            const isEmpty = !rawValue || /^_no response_$/i.test(rawValue);
+
+            let comment = null;
+
+            if (isEmpty) {
+              comment = [
+                MARKER,
+                '### Capability key needed',
+                '',
+                "This issue doesn't have a **Capability Key(s)** value yet. Adding one lets us tie the ticket to the `cap/<category>` label taxonomy and surface it in the capability evidence roadmap.",
+                '',
+                'Comma-separate one or more keys, e.g. `editing.feature-edits, geocoding.single-line`. If you only know the general area, the category slug alone is fine (e.g. `editing`, `serve-ogc`).',
+                '',
+                'Current categories: `' + Array.from(knownSlugs).join('`, `') + '`',
+                '(see `docs/gis/data/capability-categories.seed.json`).',
+                '',
+                'This is advisory — no action is required to keep the issue open.',
+              ].join('\n');
+            } else {
+              const keys = rawValue.split(',').map(k => k.trim()).filter(Boolean);
+              const unknown = keys.filter(k => {
+                const prefix = k.includes('.') ? k.split('.')[0] : k;
+                return !knownSlugs.has(prefix.toLowerCase());
+              });
+
+              if (unknown.length > 0) {
+                comment = [
+                  MARKER,
+                  '### Capability key(s) not recognized',
+                  '',
+                  'These capability key(s) don\'t match a known `cap/<category>` prefix: `' + unknown.join('`, `') + '`.',
+                  '',
+                  "If the key is just more granular than our category list knows about, that's fine — this is a heads-up, not a blocker. Known categories: `" + Array.from(knownSlugs).join('`, `') + '`',
+                  '(see `docs/gis/data/capability-categories.seed.json`). Feel free to correct the field or ignore this if the key is intentional.',
+                ].join('\n');
+              }
+            }
+
+            if (!comment) {
+              core.notice('Capability key present and recognized; no comment needed.');
+              return;
+            }
+
+            // Idempotency guard: avoid a duplicate comment if this job is
+            // ever re-run for the same issue (e.g. a manual workflow re-run).
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (comments.some(c => c.body && c.body.includes(MARKER))) {
+              core.notice('Capability key guidance comment already posted; skipping.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: comment,
+            });

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,185 @@
+name: Capability Label Sync
+
+# Keeps the cap/<category> issue-label namespace (#2896, child of #2892) in
+# sync with a canonical capability category list. Creates labels that are
+# missing and updates the description/color of labels that already exist;
+# it NEVER deletes or renames a label, so labels already applied to issues
+# are never disturbed and labels are never hand-created.
+#
+# Source of truth today: docs/gis/data/capability-categories.seed.json, a
+# small hand-committed seed derived from FeatureCatalog.Categories
+# (src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs) plus a handful
+# of obvious Community protocol-serving families that have no entitlement
+# key. TODO(#2893): once honua-server publishes the canonical
+# capability-keys.v1.json artifact, point `seed_path` at that artifact
+# instead and retire the seed file — this workflow only assumes a JSON file
+# with a top-level `categories: [{ slug, displayName, description }]` array,
+# so no workflow change should be needed beyond the path, and category slugs
+# must stay stable across the swap.
+#
+# Safety:
+#   - workflow_dispatch defaults to apply=false — a dry run that only prints
+#     the create/update diff (console + step summary). Labels are only
+#     created or updated when a human explicitly dispatches with apply=true.
+#   - A push that changes the seed file (or this workflow) always runs in
+#     dry-run mode, regardless of apply's default, so the taxonomy diff is
+#     visible in CI on trunk without any unattended label mutation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Create/update labels (false = dry-run diff only)'
+        required: false
+        type: boolean
+        default: false
+      seed_path:
+        description: 'Path to the capability category seed JSON'
+        required: false
+        type: string
+        default: 'docs/gis/data/capability-categories.seed.json'
+  push:
+    branches: [trunk]
+    paths:
+      - 'docs/gis/data/capability-categories.seed.json'
+      - '.github/workflows/label-sync.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: label-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync cap/* labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Sync capability labels
+        uses: actions/github-script@v9
+        env:
+          SEED_PATH: ${{ github.event.inputs.seed_path || 'docs/gis/data/capability-categories.seed.json' }}
+          # Only a workflow_dispatch run can set apply=true; a push-triggered
+          # run has no `inputs`, so this always falls through to 'false'.
+          APPLY: ${{ github.event.inputs.apply == 'true' }}
+        with:
+          script: |
+            const fs = require('fs');
+
+            const CAP_COLOR = '006b75';
+            const MAX_DESCRIPTION_LENGTH = 100; // GitHub label description limit.
+            const seedPath = process.env.SEED_PATH;
+            const apply = process.env.APPLY === 'true';
+
+            const raw = fs.readFileSync(seedPath, 'utf8');
+            const seed = JSON.parse(raw);
+            const categories = seed.categories || [];
+
+            if (categories.length === 0) {
+              core.setFailed(`No categories found in ${seedPath}`);
+              return;
+            }
+
+            const slugs = new Set();
+            const desired = [];
+            for (const cat of categories) {
+              if (!cat.slug || !/^[a-z0-9][a-z0-9-]*$/.test(cat.slug)) {
+                core.setFailed(`Invalid or missing slug in seed entry: ${JSON.stringify(cat)}`);
+                return;
+              }
+              if (slugs.has(cat.slug)) {
+                core.setFailed(`Duplicate slug in seed: ${cat.slug}`);
+                return;
+              }
+              slugs.add(cat.slug);
+
+              let description = cat.description || cat.displayName || cat.slug;
+              if (description.length > MAX_DESCRIPTION_LENGTH) {
+                description = description.slice(0, MAX_DESCRIPTION_LENGTH - 1) + '…';
+              }
+              desired.push({ name: `cap/${cat.slug}`, description, color: CAP_COLOR });
+            }
+
+            const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const existingByName = new Map(existing.map(l => [l.name, l]));
+
+            const toCreate = [];
+            const toUpdate = [];
+            for (const label of desired) {
+              const current = existingByName.get(label.name);
+              if (!current) {
+                toCreate.push(label);
+              } else if (current.color !== label.color || (current.description || '') !== label.description) {
+                toUpdate.push({ ...label, from: { color: current.color, description: current.description || '' } });
+              }
+            }
+
+            const lines = [];
+            lines.push(`# Capability label sync (${apply ? 'APPLY' : 'DRY RUN'})`);
+            lines.push('');
+            lines.push(`Seed: \`${seedPath}\` (${desired.length} categories)`);
+            lines.push('');
+
+            if (toCreate.length === 0 && toUpdate.length === 0) {
+              lines.push('All cap/* labels already match the seed list. Nothing to do.');
+            } else {
+              if (toCreate.length > 0) {
+                lines.push(`## Create (${toCreate.length})`);
+                lines.push('');
+                for (const l of toCreate) {
+                  lines.push(`- \`${l.name}\` — "${l.description}" (#${l.color})`);
+                }
+                lines.push('');
+              }
+              if (toUpdate.length > 0) {
+                lines.push(`## Update (${toUpdate.length})`);
+                lines.push('');
+                for (const l of toUpdate) {
+                  lines.push(`- \`${l.name}\`: "${l.from.description}" (#${l.from.color}) -> "${l.description}" (#${l.color})`);
+                }
+                lines.push('');
+              }
+            }
+
+            lines.push('No label is ever deleted or renamed by this workflow.');
+
+            const summary = lines.join('\n');
+            console.log(summary);
+            await core.summary.addRaw(summary).write();
+
+            if (!apply) {
+              core.notice('Dry run: no labels were created or updated. Re-run via workflow_dispatch with apply=true to apply this diff.');
+              return;
+            }
+
+            for (const l of toCreate) {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: l.name,
+                color: l.color,
+                description: l.description,
+              });
+            }
+            for (const l of toUpdate) {
+              await github.rest.issues.updateLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: l.name,
+                color: l.color,
+                description: l.description,
+              });
+            }
+            core.notice(`Applied: created ${toCreate.length}, updated ${toUpdate.length} cap/* labels.`);

--- a/docs/gis/data/capability-categories.seed.json
+++ b/docs/gis/data/capability-categories.seed.json
@@ -1,0 +1,156 @@
+{
+  "$comment": "Seed list for the cap/<category> issue-label namespace (#2896, child of #2892). Hand-committed today: the 20 entries with source \"feature-catalog\" are copied from src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs (Categories class), and the 5 entries with source \"community\" cover obvious Community-tier protocol-serving families that have no FeatureCatalog entry because they are not edition-gated. TODO(#2893): once honua-server publishes the canonical capability-keys.v1.json artifact, point .github/workflows/label-sync.yml's seed_path at that artifact instead of this file and retire this seed. Keep every \"slug\" value stable across that swap so existing cap/* labels, open issues, and the issue-form capability field keep working without a relabel.",
+  "version": 1,
+  "categories": [
+    {
+      "slug": "alerts",
+      "source": "feature-catalog",
+      "displayName": "Alerts",
+      "description": "Alerting and geofence features"
+    },
+    {
+      "slug": "channels",
+      "source": "feature-catalog",
+      "displayName": "Channels",
+      "description": "Alert delivery channel features"
+    },
+    {
+      "slug": "import",
+      "source": "feature-catalog",
+      "displayName": "Import",
+      "description": "Data import and ingestion features"
+    },
+    {
+      "slug": "geocoding",
+      "source": "feature-catalog",
+      "displayName": "Geocoding",
+      "description": "Geocoding and address resolution features"
+    },
+    {
+      "slug": "routing",
+      "source": "feature-catalog",
+      "displayName": "Routing",
+      "description": "Network routing and service-area analysis features"
+    },
+    {
+      "slug": "identity",
+      "source": "feature-catalog",
+      "displayName": "Identity",
+      "description": "Identity and authentication features"
+    },
+    {
+      "slug": "caching",
+      "source": "feature-catalog",
+      "displayName": "Caching",
+      "description": "Caching and performance features"
+    },
+    {
+      "slug": "static-map",
+      "source": "feature-catalog",
+      "displayName": "StaticMap",
+      "description": "Static map image rendering features"
+    },
+    {
+      "slug": "styling",
+      "source": "feature-catalog",
+      "displayName": "Styling",
+      "description": "Styling and cartographic features"
+    },
+    {
+      "slug": "raster",
+      "source": "feature-catalog",
+      "displayName": "Raster",
+      "description": "Raster and imagery features"
+    },
+    {
+      "slug": "analytics",
+      "source": "feature-catalog",
+      "displayName": "Analytics",
+      "description": "Spatial analytics: clustering, joins, density, buffer aggregate"
+    },
+    {
+      "slug": "streaming",
+      "source": "feature-catalog",
+      "displayName": "Streaming",
+      "description": "Real-time feature streaming and subscriptions"
+    },
+    {
+      "slug": "scene",
+      "source": "feature-catalog",
+      "displayName": "Scene",
+      "description": "3D scene features: CityGML/BIM ingest, Building Scene Layer publish"
+    },
+    {
+      "slug": "temporal",
+      "source": "feature-catalog",
+      "displayName": "Temporal",
+      "description": "Temporal animation, time-aware filtering, time-series tiles"
+    },
+    {
+      "slug": "printing",
+      "source": "feature-catalog",
+      "displayName": "Printing",
+      "description": "Printing and layout export features"
+    },
+    {
+      "slug": "editing",
+      "source": "feature-catalog",
+      "displayName": "Editing",
+      "description": "Branch versioning, reconcile/post, multi-user editing"
+    },
+    {
+      "slug": "field-ops",
+      "source": "feature-catalog",
+      "displayName": "FieldOps",
+      "description": "Offline field operations and disconnected sync features"
+    },
+    {
+      "slug": "ai",
+      "source": "feature-catalog",
+      "displayName": "AI",
+      "description": "Agentic AI ops: MCP discovery/query, spec plan/apply, guardrails"
+    },
+    {
+      "slug": "extensibility",
+      "source": "feature-catalog",
+      "displayName": "Extensibility",
+      "description": "Server extensibility features: plugin/extension SDK"
+    },
+    {
+      "slug": "disaster-recovery",
+      "source": "feature-catalog",
+      "displayName": "DisasterRecovery",
+      "description": "HA/DR: backup automation, failover, RTO/RPO reporting"
+    },
+    {
+      "slug": "serve-geoservices",
+      "source": "community",
+      "displayName": "Serve: GeoServices REST",
+      "description": "GeoServices REST serving: FeatureServer, MapServer, ImageServer, GPServer"
+    },
+    {
+      "slug": "serve-ogc",
+      "source": "community",
+      "displayName": "Serve: OGC",
+      "description": "OGC API Features/Tiles/Maps/Processes plus classic WFS/WMS/WMTS"
+    },
+    {
+      "slug": "serve-tiles",
+      "source": "community",
+      "displayName": "Serve: Tiles",
+      "description": "Vector/raster tile serving: MVT, TileJSON, OGC API Tiles"
+    },
+    {
+      "slug": "serve-odata",
+      "source": "community",
+      "displayName": "Serve: OData",
+      "description": "OData v4 query surface"
+    },
+    {
+      "slug": "serve-stac",
+      "source": "community",
+      "displayName": "Serve: STAC",
+      "description": "STAC catalog and search surface"
+    }
+  ]
+}

--- a/docs/internal/contributor/BACKLOG_REVIEW_CADENCE.md
+++ b/docs/internal/contributor/BACKLOG_REVIEW_CADENCE.md
@@ -4,9 +4,19 @@ A repeatable weekly operating rhythm that keeps the honua-server backlog triaged
 
 ## Backlog Review
 
-- [ ] New issues triaged (`area/*`, `priority/*`, `effort/*`, `phase/*`, assignee, milestone).
+- [ ] New issues triaged (`area/*`, `cap/*`, `priority/*`, `effort/*`, `phase/*`, assignee, milestone).
 - [ ] Next 2 weeks have enough `ready-to-start` work.
 - [ ] Blocked issues have explicit dependency notes.
+
+## Capability Labels (`cap/*`)
+
+Child of #2892/#2896. Issues carry `area/*` (code area) and `edition/*` (entitlement tier) labels, but neither ties a ticket to the customer-facing *capability* it affects. The `cap/<category>` namespace closes that gap so the backlog can be filtered per-capability and the evidence graph can show honest per-capability "known gaps & roadmap" data.
+
+- **Namespace**: one label per capability category, e.g. `cap/editing`, `cap/geocoding`, `cap/serve-ogc`. A category groups related capability keys (see below); it is coarser than an exact FeatureCatalog entitlement key.
+- **Source of truth (today)**: [`docs/gis/data/capability-categories.seed.json`](../../gis/data/capability-categories.seed.json), a small hand-committed seed listing the 20 categories from `FeatureCatalog.Categories` (`src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs`) plus 5 Community protocol-serving families that have no entitlement key (`serve-geoservices`, `serve-ogc`, `serve-tiles`, `serve-odata`, `serve-stac`). This is a **loosely-coupled placeholder**: once honua-server#2893 publishes the canonical `capability-keys.v1.json` artifact, the sync workflow's `seed_path` moves to point at that artifact instead, with category slugs held stable across the swap.
+- **Sync workflow**: [`.github/workflows/label-sync.yml`](../../../.github/workflows/label-sync.yml) reads the seed list and ensures a `cap/<category>` label exists for every entry — creating missing labels and updating the description/color of existing ones. It **never deletes or renames** a label, and labels are **never hand-created**. `workflow_dispatch` defaults to `apply=false` (dry run — prints the create/update diff only); a push that changes the seed file also always runs dry-run. Only an explicit `apply=true` dispatch mutates labels.
+- **Issue-form field**: `bug.yml` and `feature.yml` carry an optional "Capability Key(s)" text input (comma-separated, e.g. `editing.feature-edits, geocoding.single-line`); `tech-debt.yml` carries the same field but it's clearly optional there. When a bug/feature issue is opened without a parseable, recognized key, [`.github/workflows/issue-capability-check.yml`](../../../.github/workflows/issue-capability-check.yml) posts a one-time advisory comment with guidance — it never labels, closes, or blocks the issue.
+- **Applying the label**: the sync workflow only manages label *existence*, not which issues carry them. Apply `cap/<category>` to an issue by hand (or via the one-time backfill triage pass, honua-server#2896 acceptance criterion 3, tracked separately) based on the "Capability Key(s)" field's category prefix.
 
 ## Scope Gate
 
@@ -34,7 +44,7 @@ Copy the block below into a new issue comment each week:
 ## Backlog Review — YYYY-MM-DD
 
 ### Backlog Review
-- [ ] New issues triaged (`area/*`, `priority/*`, `effort/*`, `phase/*`, assignee, milestone).
+- [ ] New issues triaged (`area/*`, `cap/*`, `priority/*`, `effort/*`, `phase/*`, assignee, milestone).
 - [ ] Next 2 weeks have enough `ready-to-start` work.
 - [ ] Blocked issues have explicit dependency notes.
 


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2896

## Summary
Implements the first two slices of #2896 (capability traceability, child of #2892): a `cap/<category>` label-sync workflow and an issue-form "Capability Key(s)" field with lightweight advisory validation. This PR does **not** create any labels live (the sync workflow ships dry-run by default) and does **not** perform the open-issue backfill triage — both are explicitly deferred to a later operational pass per #2896's acceptance criteria (items 3 and 4), which is why this links `Related to` rather than `Closes`.

## Changes Made
- Add `docs/gis/data/capability-categories.seed.json`: a small hand-committed seed of 25 capability categories — the 20 categories from `FeatureCatalog.Categories` (`src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs`) plus 5 Community protocol-serving families with no entitlement key (`serve-geoservices`, `serve-ogc`, `serve-tiles`, `serve-odata`, `serve-stac`). Carries a TODO to swap the sync workflow's `seed_path` to #2893's canonical `capability-keys.v1.json` artifact once published, keeping category slugs stable across that swap.
- Add `.github/workflows/label-sync.yml`: reads the seed list and ensures a `cap/<category>` label exists for every entry, creating missing labels and updating the description/color of existing ones. Never deletes or renames a label. `workflow_dispatch` defaults to `apply=false` (dry run — prints the create/update diff to the job log and step summary); a push touching the seed file also always runs dry-run. Only an explicit `apply=true` dispatch mutates labels — **no labels are created by this PR or by any automatic trigger it adds.**
- Add `.github/workflows/issue-capability-check.yml`: on `issues: opened` for bug/feature issues, checks whether the "Capability Key(s)" field is filled in and whether its category prefix matches the seed list; posts a one-time advisory comment with guidance if not. It never labels, closes, or blocks the issue — a warn, not hard-fail, posture, since the seed is category-level only until #2893 lands the full key vocabulary.
- Add an optional "Capability Key(s)" text input to `bug.yml`, `feature.yml`, and `tech-debt.yml` (optional on all three; `tech-debt.yml`'s label is explicitly marked optional). Placed after Acceptance Criteria, before the existing dropdowns, matching the forms' current field order. Kept as free text rather than a dropdown because the full key vocabulary (finer than category) doesn't exist yet (#2893) and the forms' existing dropdowns are all small, closed enumerations — a fitting match for categories, not for composable multi-key values.
- Add a "Capability Labels (`cap/*`)" section to `docs/internal/contributor/BACKLOG_REVIEW_CADENCE.md` explaining the namespace, seed source, sync workflow, issue-form field, and how the label actually gets applied to an issue (manually / backfill pass, not by the sync workflow). Also adds `cap/*` to the existing triage checklist bullet alongside `area/*`/`priority/*`/etc.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

This is a workflow/docs-only change (no `.cs` files touched), so no dotnet test tier applies. Manual verification performed instead:
- Both new workflow YAML files parse cleanly (`yaml.safe_load`) and match the existing repo convention for `workflow_dispatch` inputs (`github.event.inputs.<name>`).
- The embedded `actions/github-script` bodies were extracted and syntax-checked (`node --check`), then exercised against stub `github`/`core`/`context` objects covering: dry-run diff (create + update + no-op cases) and apply-mode label creation/update for `label-sync.yml`; and empty-field, known-key, bare-category-slug, unknown-key, and already-commented (idempotency) cases for `issue-capability-check.yml`. All produced the expected create/update/comment/no-op behavior.
- All three issue-form YAMLs parse and the new field appears at the intended position in the field order.
- Verified the new doc's relative links (`../../gis/data/...`, `../../../.github/workflows/...`) resolve to the actual files.

**`scripts/ci/pre-pr-check.sh` note:** attempted 3x locally (full tier, then `HONUA_PRE_PR_FAST=1` twice) and could not get a clean completion — every attempt hit `ENOSPC`/"No space left on device" on this shared multi-agent dev box (`df` oscillated between 0 and ~17G free across concurrent agents' builds during the attempts), not a defect in this diff. `.github/` changes force a full-solution build scope in `compute-affected-projects.sh` regardless of the change being workflow/docs-only, which made the check far heavier than the change warrants. Cleaned up this worktree's `bin`/`obj` afterward to return space to the shared disk. Flagging so CI (which runs in an isolated runner, not this shared box) is treated as the real gate for this PR; happy to re-run locally if space frees up.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

Matches #2896's stated gate-tier impact: "Template-compliance check gains one field validation" (the new `issue-capability-check.yml` is the issue-side analog of the existing PR-template compliance job).

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (see Testing note above: 3 attempts, all blocked by shared-disk exhaustion unrelated to this diff, not a code failure)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
