### PR TITLE
feat(sdk): data-store and output-format plugin extension points

### DIFF
--- a/docs/internal/contributor/adr/0067-plugin-data-store-and-output-format-extension-points.md
+++ b/docs/internal/contributor/adr/0067-plugin-data-store-and-output-format-extension-points.md
@@ -1,0 +1,161 @@
+# ADR-0067: Plugin Data-Store and Output-Format Extension Points
+
+## Status
+Accepted
+
+## Context
+
+The plugin SDK (`src/Honua.Plugins.Abstractions/`, `src/Honua.Plugins/`) established in
+issue #347 (phase 1) and #1562 (phase 2) has compile-time, DI-aggregated extension points
+for edit hooks, computed fields, feature/field validators, custom endpoints, and background
+services. It deliberately does **no runtime assembly loading**: plugins are referenced at
+build time, discovered through explicit `builder.Add<T>()` calls, and registered in DI at
+startup. That constraint exists because `Honua.Server` publishes as Native AOT (ADR-0018),
+which forbids dynamic assembly loading, reflection-heavy discovery, and hot-deploy.
+
+The SDK has **no data-store extension point and no output-format extension point** (issue
+#2856). Every data source and every output format we support lives in core, maintained by us,
+with no exit. The pressure is real and already visible: the read/query-only cloud backends
+(Snowflake, Databricks, Redshift, Oracle) are gated behind compile-time build profiles
+(`eng/Honua.BuildProfiles.props`) precisely because we reached for a compile-time lever when
+the runtime one did not exist. GeoServer's fifteen-year modernization was made tractable in
+part because its `datastore` and output-format SPIs let modules be *evicted* from core to
+extensions rather than deleted — a move only possible because the seams existed.
+
+The open question this ADR must resolve (per the issue's follow-on split guidance): **do
+these extension points belong in the plugin SDK at all, given our compile-time/AOT-static
+posture?** A runtime data-store SPI is in genuine tension with static registration, and "no,
+and here is why" was an acceptable outcome. This ADR decides the tension **before** either
+point is split into its own implementation issue.
+
+## Decision
+
+**Qualified yes.** Both a read-only data-store point and a feature output-format point belong
+in the SDK, realized the same way every other extension point already is: **compile-time,
+DI-aggregated, statically-rooted contributions** discovered through `builder.Add<T>()`. The
+runtime-SPI framing was the wrong framing; the read-path precedent (`IComputedFieldProvider`,
+also a "contribute behavior the core doesn't own" seam) shows the static model already carries
+this class of extension without violating AOT. Neither point introduces assembly scanning,
+dynamic loading, or reflection in a hot path.
+
+### Data-store extension point — reuse the existing provider seam
+
+A plugin contributes a read-only vector source by implementing the **existing** Core provider
+contract from ADR-0035:
+`Honua.Core.Features.FeatureStore.Abstractions.IFeatureDataProvider` (with its
+`IFeatureReader`, capability declaration, and null `Writer` for read-only). We add **no new
+data-store interface**. The plugin SDK's only new surface is:
+
+- `PluginCapability.DataStore`, the declarative capability a data-store plugin must request; and
+- builder wiring that registers a `[Plugin]` type implementing `IFeatureDataProvider` as an
+  **additional** `IFeatureDataProvider` in DI.
+
+The server's existing composition (`InfrastructureCompositionRoot`) already builds
+`IFeatureDataProviderRegistry` from `serviceProvider.GetServices<IFeatureDataProvider>()`,
+resolved lazily and scoped, so it enumerates every registration — including plugin-contributed
+ones — with **no router changes and independent of registration order**. Layers bind to the
+plugin provider by name through a secure connection, exactly as first-party secondary providers
+do; `DataProviderNames.Normalize` already passes unknown provider names through, so a novel
+provider name works without a core edit. A third party therefore adds a read-only vector source
+out-of-tree by shipping an assembly that references `Honua.Core` + `Honua.Plugins.Abstractions`,
+implements `IFeatureDataProvider`, and is registered via
+`AddHonuaPlugins(cfg, p => p.Add<TSource>())` — no patching of core.
+
+Because the provider contract lives in `Honua.Core` (not the minimal
+`Honua.Plugins.Abstractions`), a data-store plugin references `Honua.Core`. That is heavier
+than a validator plugin, and it is inherent: contributing a data source *is* a Core-level
+concern. We accept and document this asymmetry rather than duplicate the mature provider
+contract into the SDK package.
+
+### Output-format extension point — a new, ASP.NET-free serializer seam
+
+There is no unified output-format registry in the codebase today; format selection is
+per-protocol, hard-coded `switch` statements. We add a new, deliberately ASP.NET-free contract
+to `Honua.Plugins.Abstractions`:
+
+- `IFeatureOutputFormat` — `FormatId` / `MediaType` / `FileExtension` +
+  `WriteAsync(IAsyncEnumerable<Feature>, FeatureOutputFormatContext, Stream, CancellationToken)`;
+- `PluginCapability.OutputFormats`, the capability a format plugin must request;
+- `IFeatureOutputFormatRegistry` (+ `NoOpFeatureOutputFormatRegistry`), the host-facing
+  aggregate that keys formats by wire token and gates resolution behind the Enterprise
+  `plugin.sdk` entitlement and the operator kill-switch.
+
+The registry is wired into the admin bulk-export path (`Honua.Io/ExportEndpoints`), the
+cleanest single dispatch seam in the codebase: it already streams `IAsyncEnumerable<Feature>`
+to a writer over the response body. A requested format that is not built-in resolves to a
+licensed plugin format. Query-protocol content negotiation (GeoServices `f=`, OGC API `f=`),
+which lives behind protocol-local `switch` statements and advertised-format sets, is a
+documented follow-up, not this ADR's scope.
+
+### Proof it is load-bearing
+
+The built-in CSV export writer is **ported to flow through `IFeatureOutputFormat`**
+(`CsvOutputFormat`), so real, in-production CSV export exercises the same contract a plugin
+format implements — the seam is load-bearing, not decorative. Byte production still delegates
+to the unchanged `CsvExportWriter`, so behavior is identical.
+
+### Interaction with build profiles
+
+The two levers are **orthogonal and complementary**:
+
+- **Build profiles** (`eng/Honua.BuildProfiles.props` → `DefineConstants` → `#if` carve-outs)
+  are the **first-party** lever: they decide which backends *we* ship in *our* image, and are
+  the correct tool for drivers that are AOT-incompatible (Oracle/Snowflake use reflection and
+  are excluded from AOT-verification publishes). A build profile is a ship-or-not switch over
+  code we own.
+- **The plugin data-store seam** is the **out-of-tree** lever: it lets a *third party* add a
+  read-only source without a core `DefineConstants` gate and without us owning the code. A
+  plugin data-store is the alternative to a build-profile gate *for sources we do not want to
+  own*; for first-party backends the build profile remains the right lever.
+
+They compose: a single build may include first-party providers (profile-gated) and third-party
+plugin providers (SDK-registered) at once. A plugin data-store is **not** a replacement for the
+build-profile mechanism, and porting the read-only cloud backends out of core is explicitly not
+a consequence this ADR mandates (it is a possible future move the seam now makes *possible*).
+
+## Consequences
+
+### Positive
+
+- Data-store reuses the mature ADR-0035 provider contract with zero router/registry changes;
+  the SDK only learns to *register* a provider-implementing plugin.
+- Output formats gain their first shared, pluggable seam, and the export path now proves it.
+- Both points stay compile-time and AOT-safe; no assembly scanning or dynamic loading is
+  introduced, honoring the non-goals in #2856.
+- A clean split follows: the data-store point and output-format point can now be extended
+  independently (e.g. wiring plugin formats into query-protocol negotiation) on top of this
+  decision.
+
+### Negative / trade-offs
+
+- Data-store plugins reference `Honua.Core`, a heavier dependency than the minimal
+  `Honua.Plugins.Abstractions` a validator needs. Inherent to contributing a data source.
+- Plugin extension instances are singletons (consistent with every other extension point), so a
+  data-store or output-format plugin **must be thread-safe**.
+- Output formats are wired into the admin export path only; query-protocol `f=` negotiation and
+  the durable async export-job pipeline remain built-in-only for now (documented follow-ups).
+- `Honua.Io` now takes a ProjectReference on `Honua.Plugins.Abstractions` (the lean contract
+  package). The module-dependency policy and Io-isolation architecture guards are updated to
+  permit exactly this edge, mirroring the existing allowance for protocol assemblies consuming
+  `IPluginEditPipeline`.
+
+### Cross-repo / SDK impact
+
+The new public surface (`IFeatureOutputFormat`, `IFeatureOutputFormatRegistry`,
+`FeatureOutputFormatContext`, `FeatureOutputField`, `PluginOutputFormatDescriptor`, and the two
+new `PluginCapability` flags) ships in the published `Honua.Plugins.Abstractions` package that
+third-party plugin authors consume. `honua-sdk-dotnet` should surface these contracts when it
+next documents the plugin SDK; there is no breaking change to existing exported contracts (the
+additions are purely additive — new enum members and new types).
+
+## Alternatives considered
+
+- **"No" — these do not belong in the SDK.** Rejected: the compile-time model already carries
+  read-path "contribute behavior" seams (`IComputedFieldProvider`), so a static data-store and
+  output-format seam is feasible without an AOT-violating runtime SPI. The tension dissolves
+  once the requirement is read as *static contribution* rather than *runtime discovery*.
+- **A parallel runtime data-store SPI with assembly scanning** (GeoServer-style dynamic SPI).
+  Rejected outright: breaks Native AOT and is an explicit non-goal (#2856).
+- **A brand-new data-store interface in the SDK package.** Rejected: it would duplicate the
+  mature `IFeatureDataProvider`/ADR-0035 contract and fork the provider ecosystem. Reusing the
+  existing seam is why the data-store point needs *no* new interface and *no* router change.

--- a/docs/internal/contributor/adr/README.md
+++ b/docs/internal/contributor/adr/README.md
@@ -69,6 +69,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0064](0064-geoprocessing-destructive-plan-approval-lane.md) | Geoprocessing Destructive-Plan Approval Lane (Fail-Closed Classifier + Control-Plane Proposal Reuse) | Accepted | 2026-07 |
 | [0065](0065-imageserver-photogrammetric-analytics.md) | ImageServer Photogrammetric Tie-Point and 3D Measurement Analytics | Accepted | 2026-07 |
 | [0066](0066-mcp-evidence-vs-intelligence-boundary.md) | Evidence-vs-Intelligence Boundary for the Open MCP Surface (Rename to `McpDataAccessSurface`) | Accepted | 2026-07 |
+| [0067](0067-plugin-data-store-and-output-format-extension-points.md) | Plugin Data-Store and Output-Format Extension Points | Accepted | 2026-07 |
 
 ## Template
 

--- a/samples/plugins/Honua.Sample.UtilityValidationPlugin/FeatureLinesOutputFormatPlugin.cs
+++ b/samples/plugins/Honua.Sample.UtilityValidationPlugin/FeatureLinesOutputFormatPlugin.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Plugins.Abstractions;
+
+namespace Honua.Sample.UtilityValidationPlugin;
+
+/// <summary>
+/// Reference plugin (issue #2856, ADR-0067) demonstrating the <see cref="IFeatureOutputFormat"/>
+/// extension point. Contributes a newline-delimited JSON feature format the host serves under the
+/// wire token <c>featurelines</c> — a third-party output format added entirely out-of-tree, with no
+/// core change. It declares the <see cref="PluginCapability.OutputFormats"/> capability required to
+/// contribute a format.
+/// </summary>
+/// <remarks>
+/// The writer is AOT-safe: it uses the low-level, reflection-free <see cref="Utf8JsonWriter"/> and a
+/// small type switch over attribute values, and encodes geometry as WKB hex so the sample takes no
+/// geometry-library dependency. It references only the lean <c>Honua.Plugins.Abstractions</c>
+/// contract package (the canonical <see cref="Feature"/> flows in transitively).
+/// </remarks>
+[Plugin("feature-lines-format", "1.0.0",
+    Description = "Newline-delimited JSON feature output format.",
+    Capabilities = PluginCapability.OutputFormats)]
+public sealed class FeatureLinesOutputFormatPlugin : IFeatureOutputFormat
+{
+    private static ReadOnlySpan<byte> Newline => "\n"u8;
+
+    /// <inheritdoc />
+    public string FormatId => "featurelines";
+
+    /// <inheritdoc />
+    public string MediaType => "application/x-ndjson";
+
+    /// <inheritdoc />
+    public string FileExtension => "ndjson";
+
+    /// <inheritdoc />
+    public async ValueTask<long> WriteAsync(
+        IAsyncEnumerable<Feature> features,
+        FeatureOutputFormatContext context,
+        Stream output,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var count = 0L;
+        await foreach (var feature in features.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            WriteFeatureLine(output, feature, context);
+            output.Write(Newline);
+            count++;
+
+            if (count % 64 == 0)
+            {
+                await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+        return count;
+    }
+
+    private static void WriteFeatureLine(Stream output, Feature feature, FeatureOutputFormatContext context)
+    {
+        using var writer = new Utf8JsonWriter(output);
+        writer.WriteStartObject();
+        writer.WriteNumber("id", feature.Id);
+
+        writer.WriteStartObject("properties");
+        foreach (var field in context.Fields)
+        {
+            feature.Attributes.TryGetValue(field.Name, out var value);
+            WriteValue(writer, field.Name, value);
+        }
+
+        writer.WriteEndObject();
+
+        if (feature.Geometry is { Length: > 0 } wkb)
+        {
+            writer.WriteString("geometryWkbHex", Convert.ToHexString(wkb));
+        }
+        else
+        {
+            writer.WriteNull("geometryWkbHex");
+        }
+
+        writer.WriteEndObject();
+        writer.Flush();
+    }
+
+    private static void WriteValue(Utf8JsonWriter writer, string name, object? value)
+    {
+        switch (value)
+        {
+            case null or DBNull:
+                writer.WriteNull(name);
+                break;
+            case string s:
+                writer.WriteString(name, s);
+                break;
+            case bool b:
+                writer.WriteBoolean(name, b);
+                break;
+            case int i:
+                writer.WriteNumber(name, i);
+                break;
+            case long l:
+                writer.WriteNumber(name, l);
+                break;
+            case double d:
+                writer.WriteNumber(name, d);
+                break;
+            case float f:
+                writer.WriteNumber(name, f);
+                break;
+            case decimal m:
+                writer.WriteNumber(name, m);
+                break;
+            default:
+                writer.WriteString(name, value.ToString());
+                break;
+        }
+    }
+}

--- a/src/Honua.Io/Features/Export/CsvOutputFormat.cs
+++ b/src/Honua.Io/Features/Export/CsvOutputFormat.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Io.Export.Writers;
+using Honua.Plugins.Abstractions;
+
+namespace Honua.Io.Export;
+
+/// <summary>
+/// Built-in CSV feature output format (issue #2856, ADR-0067). Ported to flow through the
+/// <see cref="IFeatureOutputFormat"/> extension point so the export path exercises the same contract
+/// a third-party plugin format implements — the proof the seam is load-bearing, not decorative.
+/// Delegates the actual byte production to <see cref="CsvExportWriter"/> so behavior (UTF-8, WKT
+/// geometry column, streaming) is byte-identical to the pre-extension export.
+/// </summary>
+internal sealed class CsvOutputFormat : IFeatureOutputFormat
+{
+    /// <summary>A shared, stateless singleton the export endpoint dispatches CSV through.</summary>
+    public static CsvOutputFormat Instance { get; } = new();
+
+    /// <inheritdoc />
+    public string FormatId => "csv";
+
+    /// <inheritdoc />
+    public string MediaType => "text/csv";
+
+    /// <inheritdoc />
+    public string FileExtension => "csv";
+
+    /// <inheritdoc />
+    public async ValueTask<long> WriteAsync(
+        IAsyncEnumerable<Feature> features,
+        FeatureOutputFormatContext context,
+        Stream output,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // CsvExportWriter only reads ExportField.Name (it looks values up by name from the feature's
+        // attribute bag), so the field type/nullability carried on ExportField is immaterial here.
+        var fields = new ExportField[context.Fields.Length];
+        for (var i = 0; i < fields.Length; i++)
+        {
+            fields[i] = new ExportField(context.Fields[i].Name, ExportFieldType.Unknown, context.Fields[i].Nullable);
+        }
+
+        var written = await CsvExportWriter.WriteAsync(output, features, fields, cancellationToken).ConfigureAwait(false);
+        return written;
+    }
+}

--- a/src/Honua.Io/Features/Export/ExportEndpoints.cs
+++ b/src/Honua.Io/Features/Export/ExportEndpoints.cs
@@ -15,6 +15,7 @@ using Honua.Io.Export.Writers;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Models;
 using Honua.Infrastructure.Security;
+using Honua.Plugins.Abstractions;
 using Honua.ServiceDefaults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -27,7 +28,7 @@ internal static class ExportEndpoints
 {
     private const long AsyncThreshold = 50_000;
 
-    private static readonly HashSet<string> _validFormats = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> _builtInFormats = new(StringComparer.OrdinalIgnoreCase)
     {
         "csv", "shapefile", "gpkg"
     };
@@ -61,19 +62,28 @@ internal static class ExportEndpoints
         [FromServices] IFeatureReader featureReader,
         [FromServices] IStreamingFeatureStore streamingStore,
         [FromServices] ICrsRegistry crsRegistry,
+        [FromServices] IFeatureOutputFormatRegistry pluginFormats,
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
         var logger = httpContext.RequestServices.GetRequiredService<ILogger<ExportEndpointsLog>>();
 
-        // Validate format
-        if (string.IsNullOrEmpty(format) || !_validFormats.Contains(format))
+        // Validate format. Built-in formats (csv/shapefile/gpkg) plus any active, licensed
+        // plugin-contributed output format (issue #2856, ADR-0067) are accepted.
+        var isBuiltInFormat = !string.IsNullOrEmpty(format) && _builtInFormats.Contains(format);
+        var pluginFormatResolved = !isBuiltInFormat
+            && !string.IsNullOrEmpty(format)
+            && pluginFormats.TryGetFormat(format, out _);
+        if (!isBuiltInFormat && !pluginFormatResolved)
         {
             ExportLog.FormatValidationFailed(logger, format ?? "(empty)");
+            var advertised = pluginFormats.AdvertisedFormats.Count > 0
+                ? ", " + string.Join(", ", pluginFormats.AdvertisedFormats.Select(f => f.FormatId))
+                : string.Empty;
             return ProblemDetailsHelpers.CreateAdminProblem(
                 StatusCodes.Status400BadRequest,
                 ProblemDetailsHelpers.GetTitle(StatusCodes.Status400BadRequest),
-                $"Invalid export format '{format}'. Valid formats: csv, shapefile, gpkg");
+                $"Invalid export format '{format}'. Valid formats: csv, shapefile, gpkg{advertised}");
         }
 
         // Validate service + layer against the Metadata v2 graph.
@@ -169,8 +179,11 @@ internal static class ExportEndpoints
 
         var outputSrid = outSR ?? layerSrid;
 
-        // Async path for large exports
-        if (count > AsyncThreshold)
+        // Async path for large exports. Restricted to built-in formats: the durable export-job
+        // pipeline dispatches the built-in writers by format string, so a plugin-contributed format
+        // (issue #2856) is streamed synchronously below regardless of size. Plugin writers are
+        // streaming (O(1) memory) like the built-ins, so this stays bounded.
+        if (count > AsyncThreshold && isBuiltInFormat)
         {
             var exportJobService = httpContext.RequestServices.GetService<IExportJobService>();
             if (exportJobService is null)
@@ -252,9 +265,21 @@ internal static class ExportEndpoints
 
         try
         {
+            // CSV is dispatched through the IFeatureOutputFormat contract (issue #2856): the built-in
+            // CsvOutputFormat implements the same seam a plugin format does, keeping the extension
+            // point load-bearing. Shapefile/GeoPackage keep their bespoke (CRS/.prj, temp-file)
+            // handling. A non-built-in token resolves to a licensed plugin format.
+            if (!isBuiltInFormat && pluginFormats.TryGetFormat(format, out var pluginFormat) && pluginFormat is not null)
+            {
+                return await WriteFeatureFormatResponseAsync(
+                    httpContext, pluginFormat, features, selectedFields, serviceName, layerId, layerName,
+                    outputSrid, logger, sw, activity);
+            }
+
             return format.ToLowerInvariant() switch
             {
-                "csv" => await WriteCsvResponseAsync(httpContext, features, selectedFields, serviceName, layerId, layerName, logger, sw, activity),
+                "csv" => await WriteFeatureFormatResponseAsync(httpContext, CsvOutputFormat.Instance, features, selectedFields,
+                    serviceName, layerId, layerName, outputSrid, logger, sw, activity),
                 "shapefile" => await WriteShapefileResponseAsync(httpContext, features, selectedFields, layerId, layerName, geometryType, outputSrid,
                     crsRegistry, serviceName, logger, sw, activity, cancellationToken),
                 "gpkg" => await WriteGeoPackageResponseAsync(httpContext, features, selectedFields, layerId, layerName, geometryType, outputSrid,
@@ -274,26 +299,45 @@ internal static class ExportEndpoints
         }
     }
 
-    private static async Task<IResult> WriteCsvResponseAsync(
+    /// <summary>
+    /// Streams a feature export through an <see cref="IFeatureOutputFormat"/> — the built-in CSV
+    /// writer (<see cref="CsvOutputFormat"/>) or a plugin-contributed format (issue #2856, ADR-0067).
+    /// The host owns HTTP concerns (content type, download filename, telemetry); the format owns
+    /// only byte production.
+    /// </summary>
+    private static async Task<IResult> WriteFeatureFormatResponseAsync(
         HttpContext httpContext,
+        IFeatureOutputFormat format,
         IAsyncEnumerable<Feature> features,
         ExportField[] fields,
         string serviceName,
         int layerId,
         string layerName,
+        int outputSrid,
         ILogger logger,
         Stopwatch sw,
         Activity? activity)
     {
         var response = httpContext.Response;
-        response.ContentType = "text/csv";
-        response.Headers["Content-Disposition"] = $"attachment; filename=\"{SanitizeExportFilename(serviceName, layerName)}.csv\"";
+        response.ContentType = format.MediaType;
+        response.Headers["Content-Disposition"] =
+            $"attachment; filename=\"{SanitizeExportFilename(serviceName, layerName)}.{format.FileExtension}\"";
         response.StatusCode = StatusCodes.Status200OK;
 
-        var csvRowCount = await CsvExportWriter.WriteAsync(response.Body, features, fields, httpContext.RequestAborted);
+        var outputFields = ImmutableArray.CreateBuilder<FeatureOutputField>(fields.Length);
+        foreach (var field in fields)
+        {
+            outputFields.Add(new FeatureOutputField(field.Name, field.Type.ToString(), field.Nullable));
+        }
 
-        ExportLog.ExportCompleted(logger, serviceName, layerId, "csv", csvRowCount, sw.Elapsed.TotalMilliseconds);
-        HonuaTelemetry.SetSuccess(activity, ToTelemetryFeatureCount(csvRowCount));
+        var context = new FeatureOutputFormatContext(
+            serviceName, layerId, layerName, outputFields.MoveToImmutable(), outputSrid);
+
+        var rowCount = await format.WriteAsync(features, context, response.Body, httpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        ExportLog.ExportCompleted(logger, serviceName, layerId, format.FormatId, rowCount, sw.Elapsed.TotalMilliseconds);
+        HonuaTelemetry.SetSuccess(activity, ToTelemetryFeatureCount(rowCount));
         HonuaTelemetry.CategorizeLatency(activity, sw.Elapsed.TotalMilliseconds);
         return Results.Empty;
     }

--- a/src/Honua.Io/Honua.Io.csproj
+++ b/src/Honua.Io/Honua.Io.csproj
@@ -35,6 +35,14 @@
     <ProjectReference Include="..\Honua.Core\Honua.Core.csproj" />
     <!-- Export writers (Shapefile / GeoPackage / CSV) emit NTS geometries. -->
     <ProjectReference Include="..\Honua.Geometry\Honua.Geometry.csproj" />
+    <!--
+      Lean plugin contract surface (issue #2856, ADR-0067): the export endpoint consults the
+      IFeatureOutputFormatRegistry to serve plugin-contributed feature output formats, and the
+      built-in CSV writer is expressed as an IFeatureOutputFormat. Consuming only the dependency-
+      minimal Abstractions package (never the host-side Honua.Plugins runtime) mirrors how protocol
+      assemblies depend on IPluginEditPipeline.
+    -->
+    <ProjectReference Include="..\Honua.Plugins.Abstractions\Honua.Plugins.Abstractions.csproj" />
     <ProjectReference Include="..\Honua.Hosting\Honua.Hosting.csproj" />
     <ProjectReference Include="..\Honua.ServiceDefaults\Honua.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/src/Honua.Plugins.Abstractions/FeatureOutputField.cs
+++ b/src/Honua.Plugins.Abstractions/FeatureOutputField.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// A protocol-neutral description of one attribute column an <see cref="IFeatureOutputFormat"/> is
+/// asked to project (issue #2856). Carries just enough schema for a writer to emit a header and
+/// look attribute values up by name from a feature's attribute bag, without coupling the public
+/// plugin SDK to the host's metadata model. The <see cref="TypeName"/> is an optional, advisory
+/// canonical type token (for example <c>"string"</c>, <c>"double"</c>, <c>"datetime"</c>); writers
+/// that only need the name can ignore it.
+/// </summary>
+/// <param name="Name">The attribute name, matching a key in <c>Feature.Attributes</c>.</param>
+/// <param name="TypeName">Optional advisory canonical type token; <see langword="null"/> when unknown.</param>
+/// <param name="Nullable">Whether the source field is nullable.</param>
+public sealed record FeatureOutputField(string Name, string? TypeName, bool Nullable);

--- a/src/Honua.Plugins.Abstractions/FeatureOutputFormatContext.cs
+++ b/src/Honua.Plugins.Abstractions/FeatureOutputFormatContext.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// Read-only context supplied to an <see cref="IFeatureOutputFormat"/> when serializing a stream of
+/// features (issue #2856). Carries the layer/service identity, the projected attribute schema, and
+/// the output spatial reference so a plugin format can write a header, resolve attribute values, and
+/// annotate coordinate system without coupling to the host's protocol or metadata internals.
+/// </summary>
+/// <param name="ServiceId">The service the exported layer belongs to.</param>
+/// <param name="LayerId">The published layer id being exported.</param>
+/// <param name="ResourceName">Human-readable layer/resource name used for filenames and labels.</param>
+/// <param name="Fields">The ordered attribute columns to project, matching the caller's field selection.</param>
+/// <param name="OutputSrid">The spatial reference id of the geometry the writer receives (WKB in <c>Feature.Geometry</c>).</param>
+public sealed record FeatureOutputFormatContext(
+    string ServiceId,
+    int LayerId,
+    string ResourceName,
+    ImmutableArray<FeatureOutputField> Fields,
+    int OutputSrid);

--- a/src/Honua.Plugins.Abstractions/IFeatureOutputFormat.cs
+++ b/src/Honua.Plugins.Abstractions/IFeatureOutputFormat.cs
@@ -7,7 +7,7 @@ namespace Honua.Plugins.Abstractions;
 
 /// <summary>
 /// A plugin extension point that contributes a feature output format out-of-tree (issue #2856,
-/// ADR-0066). A format declares a stable wire token (<see cref="FormatId"/>), the media type and
+/// ADR-0067). A format declares a stable wire token (<see cref="FormatId"/>), the media type and
 /// file extension it produces, and streams a sequence of canonical <see cref="Feature"/> values to
 /// an output <see cref="System.IO.Stream"/>. The host consults registered formats at its
 /// export/format-negotiation seam after the built-in formats, so a third party can add, for

--- a/src/Honua.Plugins.Abstractions/IFeatureOutputFormat.cs
+++ b/src/Honua.Plugins.Abstractions/IFeatureOutputFormat.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// A plugin extension point that contributes a feature output format out-of-tree (issue #2856,
+/// ADR-0066). A format declares a stable wire token (<see cref="FormatId"/>), the media type and
+/// file extension it produces, and streams a sequence of canonical <see cref="Feature"/> values to
+/// an output <see cref="System.IO.Stream"/>. The host consults registered formats at its
+/// export/format-negotiation seam after the built-in formats, so a third party can add, for
+/// example, a GeoJSON-Text-Sequence or TSV writer without patching core.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The contract is deliberately ASP.NET-free and streaming-first so the public plugin SDK package
+/// stays dependency-minimal and Native-AOT compatible: a writer receives an
+/// <see cref="IAsyncEnumerable{Feature}"/> and writes bytes to a <see cref="System.IO.Stream"/>; the
+/// host owns content negotiation, HTTP headers (content type, content disposition), telemetry, and
+/// authorization. Geometry arrives as WKB in <see cref="Feature.Geometry"/>; the writer decides how
+/// (or whether) to encode it.
+/// </para>
+/// <para>
+/// Implementations are resolved as singletons and must be thread-safe and side-effect-free.
+/// Contributing an output format requires the <see cref="PluginCapability.OutputFormats"/>
+/// capability on the plugin's <c>[Plugin]</c> manifest; the host refuses to register a format from a
+/// plugin that has not declared it. The whole feature is Enterprise-gated (<c>plugin.sdk</c>) and
+/// honors the operator kill-switch.
+/// </para>
+/// </remarks>
+public interface IFeatureOutputFormat
+{
+    /// <summary>
+    /// Gets the stable, lower-case wire token that selects this format (for example
+    /// <c>"geojsonl"</c>). Matched case-insensitively against the requested format; must be unique
+    /// across registered plugin formats and must not collide with a built-in format token.
+    /// </summary>
+    string FormatId { get; }
+
+    /// <summary>
+    /// Gets the media (MIME) type the host sets on the response, for example
+    /// <c>"application/geo+json-seq"</c>.
+    /// </summary>
+    string MediaType { get; }
+
+    /// <summary>
+    /// Gets the file extension (without a leading dot) the host uses for the download filename, for
+    /// example <c>"geojsonl"</c>.
+    /// </summary>
+    string FileExtension { get; }
+
+    /// <summary>
+    /// Serializes the supplied features to <paramref name="output"/> in this format.
+    /// </summary>
+    /// <param name="features">The features to write, streamed to keep memory bounded.</param>
+    /// <param name="context">Layer/service identity, projected field schema, and output SRID.</param>
+    /// <param name="output">The destination stream; the host owns its lifetime and does not expect it closed.</param>
+    /// <param name="cancellationToken">Cancellation token tied to the request lifetime.</param>
+    /// <returns>The number of features written, used by the host for telemetry and logging.</returns>
+    ValueTask<long> WriteAsync(
+        IAsyncEnumerable<Feature> features,
+        FeatureOutputFormatContext context,
+        Stream output,
+        CancellationToken cancellationToken);
+}

--- a/src/Honua.Plugins.Abstractions/IFeatureOutputFormatRegistry.cs
+++ b/src/Honua.Plugins.Abstractions/IFeatureOutputFormatRegistry.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// Host-facing lookup of plugin-contributed <see cref="IFeatureOutputFormat"/>s (issue #2856,
+/// ADR-0066). A single implementation is resolved from DI; when the plugin SDK is unlicensed, the
+/// operator kill-switch is off, or no output-format plugins are registered, the host registers
+/// <see cref="NoOpFeatureOutputFormatRegistry"/> so the export/negotiation seam has zero overhead
+/// and can depend on this abstraction unconditionally.
+/// </summary>
+/// <remarks>
+/// This is the only output-format type a format-negotiation seam (for example the admin export
+/// endpoint) needs to consume — it depends solely on this contract package and never on plugin
+/// internals. Consult it only for formats not already served by a built-in writer.
+/// </remarks>
+public interface IFeatureOutputFormatRegistry
+{
+    /// <summary>
+    /// Gets whether any plugin output formats are active (licensed, enabled, and registered). Hosts
+    /// can skip plugin-format resolution entirely when this is <see langword="false"/>.
+    /// </summary>
+    bool HasFormats { get; }
+
+    /// <summary>
+    /// Gets the advertised plugin formats, for capabilities/discovery listings. Empty when
+    /// <see cref="HasFormats"/> is <see langword="false"/>.
+    /// </summary>
+    IReadOnlyCollection<PluginOutputFormatDescriptor> AdvertisedFormats { get; }
+
+    /// <summary>
+    /// Resolves a plugin output format by its wire token, honoring the Enterprise entitlement and
+    /// operator kill-switch.
+    /// </summary>
+    /// <param name="formatId">The requested format token, matched case-insensitively.</param>
+    /// <param name="format">The resolved writer when found and active; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when an active plugin format matches.</returns>
+    bool TryGetFormat(string formatId, out IFeatureOutputFormat? format);
+}

--- a/src/Honua.Plugins.Abstractions/IFeatureOutputFormatRegistry.cs
+++ b/src/Honua.Plugins.Abstractions/IFeatureOutputFormatRegistry.cs
@@ -5,7 +5,7 @@ namespace Honua.Plugins.Abstractions;
 
 /// <summary>
 /// Host-facing lookup of plugin-contributed <see cref="IFeatureOutputFormat"/>s (issue #2856,
-/// ADR-0066). A single implementation is resolved from DI; when the plugin SDK is unlicensed, the
+/// ADR-0067). A single implementation is resolved from DI; when the plugin SDK is unlicensed, the
 /// operator kill-switch is off, or no output-format plugins are registered, the host registers
 /// <see cref="NoOpFeatureOutputFormatRegistry"/> so the export/negotiation seam has zero overhead
 /// and can depend on this abstraction unconditionally.

--- a/src/Honua.Plugins.Abstractions/NoOpFeatureOutputFormatRegistry.cs
+++ b/src/Honua.Plugins.Abstractions/NoOpFeatureOutputFormatRegistry.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// The zero-overhead <see cref="IFeatureOutputFormatRegistry"/> used when the plugin SDK is not
+/// licensed or no output-format plugins are registered. It advertises nothing and resolves nothing —
+/// the common production path, and a convenient default for tests that construct an
+/// export/negotiation seam directly.
+/// </summary>
+public sealed class NoOpFeatureOutputFormatRegistry : IFeatureOutputFormatRegistry
+{
+    /// <summary>A shared singleton instance.</summary>
+    public static NoOpFeatureOutputFormatRegistry Instance { get; } = new();
+
+    /// <inheritdoc />
+    public bool HasFormats => false;
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<PluginOutputFormatDescriptor> AdvertisedFormats { get; } = [];
+
+    /// <inheritdoc />
+    public bool TryGetFormat(string formatId, out IFeatureOutputFormat? format)
+    {
+        format = null;
+        return false;
+    }
+}

--- a/src/Honua.Plugins.Abstractions/PluginCapability.cs
+++ b/src/Honua.Plugins.Abstractions/PluginCapability.cs
@@ -39,7 +39,7 @@ public enum PluginCapability
 
     /// <summary>
     /// Permits the plugin to contribute a feature output format via the
-    /// <see cref="IFeatureOutputFormat"/> extension point (issue #2856, ADR-0066). Contributed
+    /// <see cref="IFeatureOutputFormat"/> extension point (issue #2856, ADR-0067). Contributed
     /// formats are consulted by the host's export/format-negotiation seam after the built-in
     /// formats and remain Enterprise-gated (<c>plugin.sdk</c>) plus honor the operator kill-switch.
     /// </summary>
@@ -48,7 +48,7 @@ public enum PluginCapability
     /// <summary>
     /// Permits the plugin to contribute a read-only vector data store by implementing the Core
     /// provider seam (<c>Honua.Core.Features.FeatureStore.Abstractions.IFeatureDataProvider</c>)
-    /// (issue #2856, ADR-0066). The host registers the plugin as an additional feature-data
+    /// (issue #2856, ADR-0067). The host registers the plugin as an additional feature-data
     /// provider so the existing provider registry/router bind layers to it by provider name —
     /// no runtime assembly loading, no router changes. Because the provider contract lives in
     /// <c>Honua.Core</c> rather than this minimal contract package, a data-store plugin

--- a/src/Honua.Plugins.Abstractions/PluginCapability.cs
+++ b/src/Honua.Plugins.Abstractions/PluginCapability.cs
@@ -15,7 +15,8 @@ namespace Honua.Plugins.Abstractions;
 /// The base validation extension points (<see cref="IFeatureValidator"/>,
 /// <see cref="IFieldValidator"/>, <see cref="IEditHook"/>, <see cref="IComputedFieldProvider"/>)
 /// are considered low-risk read/validate surfaces and do not require an explicit capability.
-/// Higher-impact surfaces — running background work and contributing HTTP endpoints — do.
+/// Higher-impact surfaces — running background work, contributing HTTP endpoints, contributing a
+/// feature output format, and contributing a read-only data store — do.
 /// </remarks>
 [Flags]
 public enum PluginCapability
@@ -35,4 +36,23 @@ public enum PluginCapability
     /// validation, and telemetry middleware.
     /// </summary>
     CustomEndpoints = 1 << 1,
+
+    /// <summary>
+    /// Permits the plugin to contribute a feature output format via the
+    /// <see cref="IFeatureOutputFormat"/> extension point (issue #2856, ADR-0066). Contributed
+    /// formats are consulted by the host's export/format-negotiation seam after the built-in
+    /// formats and remain Enterprise-gated (<c>plugin.sdk</c>) plus honor the operator kill-switch.
+    /// </summary>
+    OutputFormats = 1 << 2,
+
+    /// <summary>
+    /// Permits the plugin to contribute a read-only vector data store by implementing the Core
+    /// provider seam (<c>Honua.Core.Features.FeatureStore.Abstractions.IFeatureDataProvider</c>)
+    /// (issue #2856, ADR-0066). The host registers the plugin as an additional feature-data
+    /// provider so the existing provider registry/router bind layers to it by provider name —
+    /// no runtime assembly loading, no router changes. Because the provider contract lives in
+    /// <c>Honua.Core</c> rather than this minimal contract package, a data-store plugin
+    /// necessarily references <c>Honua.Core</c> in addition to this SDK.
+    /// </summary>
+    DataStore = 1 << 3,
 }

--- a/src/Honua.Plugins.Abstractions/PluginOutputFormatDescriptor.cs
+++ b/src/Honua.Plugins.Abstractions/PluginOutputFormatDescriptor.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Plugins.Abstractions;
+
+/// <summary>
+/// An advertised, license-gated feature output format contributed by a plugin (issue #2856). The
+/// host surfaces these so a format-negotiation seam can list the additional formats a caller may
+/// request without resolving the writer itself. Carries the same identity a writer declares on
+/// <see cref="IFeatureOutputFormat"/>, plus the owning plugin id for diagnostics.
+/// </summary>
+/// <param name="FormatId">The stable wire token that selects the format.</param>
+/// <param name="MediaType">The media type the host sets on the response.</param>
+/// <param name="FileExtension">The file extension (without a leading dot) for the download filename.</param>
+/// <param name="PluginId">The id of the plugin that contributed the format.</param>
+public sealed record PluginOutputFormatDescriptor(
+    string FormatId,
+    string MediaType,
+    string FileExtension,
+    string PluginId);

--- a/src/Honua.Plugins/FeatureOutputFormatRegistry.cs
+++ b/src/Honua.Plugins/FeatureOutputFormatRegistry.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Frozen;
+using System.Reflection;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Plugins.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Plugins;
+
+/// <summary>
+/// Default <see cref="IFeatureOutputFormatRegistry"/>. Aggregates the registered plugin
+/// <see cref="IFeatureOutputFormat"/>s, keys them by their case-insensitive wire token, and gates
+/// resolution behind the Enterprise <c>plugin.sdk</c> entitlement plus the operator kill-switch —
+/// when unlicensed or disabled it advertises nothing and resolves nothing. Duplicate or built-in
+/// colliding tokens are rejected at construction so a misconfigured plugin fails fast rather than
+/// silently shadowing another format.
+/// </summary>
+internal sealed class FeatureOutputFormatRegistry : IFeatureOutputFormatRegistry
+{
+    // Wire tokens owned by the built-in export writers; a plugin may not shadow these.
+    private static readonly FrozenSet<string> ReservedFormatIds =
+        new[] { "csv", "shapefile", "gpkg", "geojson", "json", "pbf" }
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private readonly FrozenDictionary<string, IFeatureOutputFormat> _formats;
+    private readonly PluginOutputFormatDescriptor[] _advertised;
+    private readonly ILicenseEntitlementService _licensing;
+    private readonly bool _enabledByConfig;
+
+    public FeatureOutputFormatRegistry(
+        IEnumerable<IFeatureOutputFormat> formats,
+        ILicenseEntitlementService licensing,
+        IOptions<PluginOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(formats);
+        ArgumentNullException.ThrowIfNull(options);
+        _licensing = licensing ?? throw new ArgumentNullException(nameof(licensing));
+        _enabledByConfig = options.Value.Enabled;
+
+        var map = new Dictionary<string, IFeatureOutputFormat>(StringComparer.OrdinalIgnoreCase);
+        foreach (var format in formats)
+        {
+            var id = format.FormatId;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new InvalidOperationException(
+                    $"Plugin output format '{format.GetType().FullName}' declares an empty FormatId.");
+            }
+
+            if (ReservedFormatIds.Contains(id))
+            {
+                throw new InvalidOperationException(
+                    $"Plugin output format '{PluginIdOf(format)}' uses the reserved format id '{id}'. "
+                    + "Choose a distinct token that does not collide with a built-in format.");
+            }
+
+            if (!map.TryAdd(id, format))
+            {
+                throw new InvalidOperationException(
+                    $"Two plugin output formats declare the same format id '{id}'. Format ids must be unique.");
+            }
+        }
+
+        _formats = map.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        _advertised = _formats.Values
+            .Select(f => new PluginOutputFormatDescriptor(f.FormatId, f.MediaType, f.FileExtension, PluginIdOf(f)))
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public bool HasFormats => _enabledByConfig && _formats.Count > 0 && IsLicensed;
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<PluginOutputFormatDescriptor> AdvertisedFormats
+        => HasFormats ? _advertised : [];
+
+    /// <inheritdoc />
+    public bool TryGetFormat(string formatId, out IFeatureOutputFormat? format)
+    {
+        format = null;
+        if (string.IsNullOrWhiteSpace(formatId) || !HasFormats)
+        {
+            return false;
+        }
+
+        return _formats.TryGetValue(formatId, out format);
+    }
+
+    private bool IsLicensed => _licensing.CheckEntitlement(FeatureCatalog.PluginSdkKey).IsActive;
+
+    private static string PluginIdOf(object instance)
+    {
+        var type = instance.GetType();
+        return type.GetCustomAttribute<PluginAttribute>()?.Id ?? type.FullName ?? type.Name;
+    }
+}

--- a/src/Honua.Plugins/HonuaPluginBuilder.cs
+++ b/src/Honua.Plugins/HonuaPluginBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Plugins.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -40,17 +41,21 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
         var providesComputedField = typeof(IComputedFieldProvider).IsAssignableFrom(type);
         var providesBackgroundService = typeof(IPluginBackgroundService).IsAssignableFrom(type);
         var providesCustomEndpoint = typeof(ICustomEndpoint).IsAssignableFrom(type);
+        var providesOutputFormat = typeof(IFeatureOutputFormat).IsAssignableFrom(type);
+        var providesDataStore = typeof(IFeatureDataProvider).IsAssignableFrom(type);
 
         if (!providesValidator && !providesFieldValidator && !providesEditHook
-            && !providesComputedField && !providesBackgroundService && !providesCustomEndpoint)
+            && !providesComputedField && !providesBackgroundService && !providesCustomEndpoint
+            && !providesOutputFormat && !providesDataStore)
         {
             throw new InvalidOperationException(
                 $"Plugin '{manifest.Id}' ({type.FullName}) must implement at least one extension point "
                 + "(IFeatureValidator, IFieldValidator, IEditHook, IComputedFieldProvider, "
-                + "IPluginBackgroundService, or ICustomEndpoint).");
+                + "IPluginBackgroundService, ICustomEndpoint, IFeatureOutputFormat, or "
+                + "IFeatureDataProvider).");
         }
 
-        EnforceCapabilities(manifest, providesBackgroundService, providesCustomEndpoint);
+        EnforceCapabilities(manifest, providesBackgroundService, providesCustomEndpoint, providesOutputFormat, providesDataStore);
 
         if (_registrations.Exists(r => string.Equals(r.Id, manifest.Id, StringComparison.OrdinalIgnoreCase)))
         {
@@ -89,6 +94,22 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
             _services.AddSingleton<ICustomEndpoint>(sp => (ICustomEndpoint)sp.GetRequiredService<TPlugin>());
         }
 
+        if (providesOutputFormat)
+        {
+            _services.AddSingleton<IFeatureOutputFormat>(sp => (IFeatureOutputFormat)sp.GetRequiredService<TPlugin>());
+        }
+
+        if (providesDataStore)
+        {
+            // Register the plugin as an additional IFeatureDataProvider. The existing
+            // FeatureDataProviderRegistry (composed in the server's InfrastructureCompositionRoot)
+            // enumerates GetServices<IFeatureDataProvider>() lazily, so the plugin provider is
+            // routed by provider name with no router changes and independent of registration order
+            // (issue #2856, ADR-0066). The provider shares the plugin's singleton instance, so — like
+            // every other extension point — a data-store plugin must be thread-safe.
+            _services.AddSingleton<IFeatureDataProvider>(sp => (IFeatureDataProvider)sp.GetRequiredService<TPlugin>());
+        }
+
         _registrations.Add(new PluginRegistration(
             manifest,
             type,
@@ -97,7 +118,9 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
             providesEditHook,
             providesComputedField,
             providesBackgroundService,
-            providesCustomEndpoint));
+            providesCustomEndpoint,
+            providesOutputFormat,
+            providesDataStore));
 
         return this;
     }
@@ -105,7 +128,9 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
     private static void EnforceCapabilities(
         PluginManifest manifest,
         bool providesBackgroundService,
-        bool providesCustomEndpoint)
+        bool providesCustomEndpoint,
+        bool providesOutputFormat,
+        bool providesDataStore)
     {
         if (providesBackgroundService
             && !manifest.Capabilities.HasFlag(PluginCapability.BackgroundExecution))
@@ -122,6 +147,24 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
             throw new InvalidOperationException(
                 $"Plugin '{manifest.Id}' implements ICustomEndpoint but does not declare the "
                 + "CustomEndpoints capability. Add Capabilities = PluginCapability.CustomEndpoints "
+                + "to its [Plugin] attribute.");
+        }
+
+        if (providesOutputFormat
+            && !manifest.Capabilities.HasFlag(PluginCapability.OutputFormats))
+        {
+            throw new InvalidOperationException(
+                $"Plugin '{manifest.Id}' implements IFeatureOutputFormat but does not declare the "
+                + "OutputFormats capability. Add Capabilities = PluginCapability.OutputFormats "
+                + "to its [Plugin] attribute.");
+        }
+
+        if (providesDataStore
+            && !manifest.Capabilities.HasFlag(PluginCapability.DataStore))
+        {
+            throw new InvalidOperationException(
+                $"Plugin '{manifest.Id}' implements IFeatureDataProvider but does not declare the "
+                + "DataStore capability. Add Capabilities = PluginCapability.DataStore "
                 + "to its [Plugin] attribute.");
         }
     }

--- a/src/Honua.Plugins/HonuaPluginBuilder.cs
+++ b/src/Honua.Plugins/HonuaPluginBuilder.cs
@@ -105,7 +105,7 @@ internal sealed class HonuaPluginBuilder(IServiceCollection services) : IHonuaPl
             // FeatureDataProviderRegistry (composed in the server's InfrastructureCompositionRoot)
             // enumerates GetServices<IFeatureDataProvider>() lazily, so the plugin provider is
             // routed by provider name with no router changes and independent of registration order
-            // (issue #2856, ADR-0066). The provider shares the plugin's singleton instance, so — like
+            // (issue #2856, ADR-0067). The provider shares the plugin's singleton instance, so — like
             // every other extension point — a data-store plugin must be thread-safe.
             _services.AddSingleton<IFeatureDataProvider>(sp => (IFeatureDataProvider)sp.GetRequiredService<TPlugin>());
         }

--- a/src/Honua.Plugins/PluginRegistration.cs
+++ b/src/Honua.Plugins/PluginRegistration.cs
@@ -16,6 +16,8 @@ namespace Honua.Plugins;
 /// <param name="ProvidesComputedField">Whether the plugin implements <c>IComputedFieldProvider</c>.</param>
 /// <param name="ProvidesBackgroundService">Whether the plugin implements <c>IPluginBackgroundService</c>.</param>
 /// <param name="ProvidesCustomEndpoint">Whether the plugin implements <c>ICustomEndpoint</c>.</param>
+/// <param name="ProvidesOutputFormat">Whether the plugin implements <c>IFeatureOutputFormat</c>.</param>
+/// <param name="ProvidesDataStore">Whether the plugin implements <c>IFeatureDataProvider</c> (read-only data store).</param>
 public sealed record PluginRegistration(
     PluginManifest Manifest,
     Type ImplementationType,
@@ -24,7 +26,9 @@ public sealed record PluginRegistration(
     bool ProvidesEditHook,
     bool ProvidesComputedField,
     bool ProvidesBackgroundService,
-    bool ProvidesCustomEndpoint)
+    bool ProvidesCustomEndpoint,
+    bool ProvidesOutputFormat,
+    bool ProvidesDataStore)
 {
     /// <summary>Gets the stable plugin identifier.</summary>
     public string Id => Manifest.Id;

--- a/src/Honua.Plugins/ServiceCollectionExtensions.cs
+++ b/src/Honua.Plugins/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static class ServiceCollectionExtensions
     /// <see cref="IPluginEditPipeline"/> / <see cref="IComputedFieldPipeline"/> /
     /// <see cref="IFeatureOutputFormatRegistry"/> unconditionally. Data-store plugins are registered
     /// as additional <c>IFeatureDataProvider</c>s picked up by the server's existing provider
-    /// registry/router (issue #2856, ADR-0066). Declared inter-plugin dependencies and
+    /// registry/router (issue #2856, ADR-0067). Declared inter-plugin dependencies and
     /// minimum-server-version constraints are validated at registration time and fail fast.
     /// </summary>
     /// <param name="services">The service collection.</param>
@@ -60,7 +60,7 @@ public static class ServiceCollectionExtensions
         // singleton license service, so it can be a singleton.
         services.TryAddSingleton<IComputedFieldPipeline, ComputedFieldPipeline>();
 
-        // Output-format registry (issue #2856, ADR-0066). Registered as the real, license-gated
+        // Output-format registry (issue #2856, ADR-0067). Registered as the real, license-gated
         // registry only when at least one output-format plugin is present; otherwise the export /
         // format-negotiation seam gets the zero-overhead no-op so it can depend on
         // IFeatureOutputFormatRegistry unconditionally. It aggregates singleton IFeatureOutputFormat

--- a/src/Honua.Plugins/ServiceCollectionExtensions.cs
+++ b/src/Honua.Plugins/ServiceCollectionExtensions.cs
@@ -17,13 +17,16 @@ namespace Honua.Plugins;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the plugin edit pipeline, computed-field pipeline, background-service host, and
-    /// any compile-time plugins supplied via <paramref name="configure"/>. The pipelines are
-    /// always registered (as no-ops when no plugins are present or the Enterprise
-    /// <c>plugin.sdk</c> entitlement is inactive) so protocol handlers can depend on
-    /// <see cref="IPluginEditPipeline"/> / <see cref="IComputedFieldPipeline"/> unconditionally.
-    /// Declared inter-plugin dependencies and minimum-server-version constraints are validated at
-    /// registration time and fail fast.
+    /// Registers the plugin edit pipeline, computed-field pipeline, output-format registry,
+    /// background-service host, any read-only data-store providers, and any compile-time plugins
+    /// supplied via <paramref name="configure"/>. The pipelines and the output-format registry are
+    /// always registered (as no-ops when no plugins are present or the Enterprise <c>plugin.sdk</c>
+    /// entitlement is inactive) so protocol/export handlers can depend on
+    /// <see cref="IPluginEditPipeline"/> / <see cref="IComputedFieldPipeline"/> /
+    /// <see cref="IFeatureOutputFormatRegistry"/> unconditionally. Data-store plugins are registered
+    /// as additional <c>IFeatureDataProvider</c>s picked up by the server's existing provider
+    /// registry/router (issue #2856, ADR-0066). Declared inter-plugin dependencies and
+    /// minimum-server-version constraints are validated at registration time and fail fast.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="configuration">Application configuration (binds the <c>Plugins</c> section).</param>
@@ -56,6 +59,20 @@ public static class ServiceCollectionExtensions
         // Computed-field pipeline is read-path only and consumes singleton providers + the
         // singleton license service, so it can be a singleton.
         services.TryAddSingleton<IComputedFieldPipeline, ComputedFieldPipeline>();
+
+        // Output-format registry (issue #2856, ADR-0066). Registered as the real, license-gated
+        // registry only when at least one output-format plugin is present; otherwise the export /
+        // format-negotiation seam gets the zero-overhead no-op so it can depend on
+        // IFeatureOutputFormatRegistry unconditionally. It aggregates singleton IFeatureOutputFormat
+        // registrations and the singleton license service, so it can be a singleton.
+        if (builder.Registrations.Any(r => r.ProvidesOutputFormat))
+        {
+            services.TryAddSingleton<IFeatureOutputFormatRegistry, FeatureOutputFormatRegistry>();
+        }
+        else
+        {
+            services.TryAddSingleton<IFeatureOutputFormatRegistry>(NoOpFeatureOutputFormatRegistry.Instance);
+        }
 
         // Host plugin background services with failure isolation. Only registered when at least
         // one is present so the common path adds no hosted service.

--- a/tests/dotnet/Honua.Architecture.Tests/HonuaIoIsolationTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/HonuaIoIsolationTests.cs
@@ -32,6 +32,12 @@ public sealed class HonuaIoIsolationTests
         "Honua.Geometry",
         "Honua.Hosting",
         "Honua.ServiceDefaults",
+        // Lean plugin contract surface (issue #2856, ADR-0067): the export endpoint consumes
+        // IFeatureOutputFormatRegistry to serve plugin-contributed feature output formats and
+        // expresses the built-in CSV writer as an IFeatureOutputFormat. This is the dependency-
+        // minimal Abstractions package (never the host-side Honua.Plugins runtime), mirroring how
+        // protocol assemblies depend on IPluginEditPipeline.
+        "Honua.Plugins.Abstractions",
     };
 
     [ArchitectureTest]

--- a/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ModuleDependencyPolicyTests.cs
@@ -292,6 +292,11 @@ public sealed class ModuleDependencyPolicyTests
         (ModuleRole.Io, ModuleRole.Geometry),
         (ModuleRole.Io, ModuleRole.Hosting),
         (ModuleRole.Io, ModuleRole.ServiceDefaults),
+        // Io consumes the lean plugin contract surface to serve plugin-contributed feature output
+        // formats from the export endpoint (issue #2856, ADR-0067) — the same allowance protocol
+        // assemblies have for IPluginEditPipeline. It must NOT couple to the host-side runtime
+        // (ModuleRole.Plugins), which only Server composes.
+        (ModuleRole.Io, ModuleRole.PluginsAbstractions),
 
         // Import: the data-ingest / migration HTTP surface (Migration endpoints
         // + job managers, file-import upload plumbing, raster-import endpoints).

--- a/tests/dotnet/Honua.Plugins.Tests/OutputFormatAndDataStoreTests.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/OutputFormatAndDataStoreTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Immutable;
+using System.Text;
+using FluentAssertions;
+using Honua.Core.Features.AuditLog;
+using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
+using Honua.Core.Features.Licensing.Abstractions;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Plugins.Abstractions;
+using Honua.Sample.UtilityValidationPlugin;
+using Honua.TestKit.Helpers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Honua.Plugins.Tests;
+
+/// <summary>
+/// Tests for the data-store and output-format plugin extension points (issue #2856, ADR-0067).
+/// </summary>
+public sealed class OutputFormatAndDataStoreTests
+{
+    private static ServiceProvider BuildProvider(
+        HonuaEdition edition,
+        Action<IHonuaPluginBuilder>? configure,
+        bool enabled = true)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ILicenseEntitlementService>(new TestLicenseEntitlementService(edition));
+        services.AddSingleton<IAuditLog, NullAuditLog>();
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Plugins:Enabled"] = enabled ? "true" : "false",
+            })
+            .Build();
+
+        services.AddHonuaPlugins(config, configure);
+        return services.BuildServiceProvider();
+    }
+
+    // ---- Output format ----------------------------------------------------------------------
+
+    [Fact]
+    public void OutputFormatRegistry_Resolves_LicensedPluginFormat()
+    {
+        using var provider = BuildProvider(HonuaEdition.Enterprise, p => p.Add<FeatureLinesOutputFormatPlugin>());
+
+        var registry = provider.GetRequiredService<IFeatureOutputFormatRegistry>();
+        registry.HasFormats.Should().BeTrue();
+        registry.AdvertisedFormats.Should().ContainSingle().Which.FormatId.Should().Be("featurelines");
+
+        registry.TryGetFormat("FEATURELINES", out var format).Should().BeTrue();
+        format!.MediaType.Should().Be("application/x-ndjson");
+    }
+
+    [Fact]
+    public void OutputFormatRegistry_IsInert_WhenUnlicensed()
+    {
+        using var provider = BuildProvider(HonuaEdition.Community, p => p.Add<FeatureLinesOutputFormatPlugin>());
+
+        var registry = provider.GetRequiredService<IFeatureOutputFormatRegistry>();
+        registry.HasFormats.Should().BeFalse();
+        registry.AdvertisedFormats.Should().BeEmpty();
+        registry.TryGetFormat("featurelines", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OutputFormatRegistry_IsInert_WhenKillSwitchOff()
+    {
+        using var provider = BuildProvider(HonuaEdition.Enterprise, p => p.Add<FeatureLinesOutputFormatPlugin>(), enabled: false);
+
+        provider.GetRequiredService<IFeatureOutputFormatRegistry>().HasFormats.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OutputFormatRegistry_IsNoOp_WhenNoFormatPlugins()
+    {
+        using var provider = BuildProvider(HonuaEdition.Enterprise, configure: null);
+
+        var registry = provider.GetRequiredService<IFeatureOutputFormatRegistry>();
+        registry.Should().BeSameAs(NoOpFeatureOutputFormatRegistry.Instance);
+        registry.HasFormats.Should().BeFalse();
+    }
+
+    [Fact]
+    public void OutputFormatPlugin_WithoutCapability_FailsFast()
+    {
+        var act = () => BuildProvider(HonuaEdition.Enterprise, p => p.Add<UncappedOutputFormatPlugin>());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*OutputFormats capability*");
+    }
+
+    [Fact]
+    public void OutputFormatRegistry_Rejects_ReservedBuiltInToken()
+    {
+        var act = () => BuildProvider(HonuaEdition.Enterprise, p => p.Add<ReservedTokenOutputFormatPlugin>())
+            .GetRequiredService<IFeatureOutputFormatRegistry>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*reserved format id 'csv'*");
+    }
+
+    [Fact]
+    public async Task OutputFormatPlugin_Writes_NewlineDelimitedJson()
+    {
+        using var provider = BuildProvider(HonuaEdition.Enterprise, p => p.Add<FeatureLinesOutputFormatPlugin>());
+        var registry = provider.GetRequiredService<IFeatureOutputFormatRegistry>();
+        registry.TryGetFormat("featurelines", out var format).Should().BeTrue();
+
+        var context = new FeatureOutputFormatContext(
+            "svc", 1, "Layer",
+            [new FeatureOutputField("name", "String", true)],
+            4326);
+
+        using var stream = new MemoryStream();
+        var written = await format!.WriteAsync(TwoFeatures(), context, stream, CancellationToken.None);
+
+        written.Should().Be(2);
+        var text = Encoding.UTF8.GetString(stream.ToArray());
+        var lines = text.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        lines.Should().HaveCount(2);
+        lines[0].Should().Contain("\"name\":\"Alpha\"").And.Contain("\"id\":1");
+    }
+
+    private static async IAsyncEnumerable<Feature> TwoFeatures()
+    {
+        yield return Feature.Create(1, geometry: null, ImmutableDictionary<string, object?>.Empty.SetItem("name", "Alpha"));
+        yield return Feature.Create(2, geometry: null, ImmutableDictionary<string, object?>.Empty.SetItem("name", "Beta"));
+        await Task.CompletedTask;
+    }
+
+    // ---- Data store -------------------------------------------------------------------------
+
+    [Fact]
+    public void DataStorePlugin_IsRegistered_AsFeatureDataProvider()
+    {
+        using var provider = BuildProvider(HonuaEdition.Enterprise, p => p.Add<ReadOnlyVectorSourcePlugin>());
+
+        // The plugin is registered as an additional IFeatureDataProvider, so the same registry the
+        // server composes (from GetServices<IFeatureDataProvider>()) routes to it by provider name —
+        // no router changes.
+        var registry = new FeatureDataProviderRegistry(provider.GetServices<IFeatureDataProvider>());
+
+        registry.TryGetProvider(ReadOnlyVectorSourcePlugin.Name, out var resolved).Should().BeTrue();
+        resolved.ProviderName.Should().Be(ReadOnlyVectorSourcePlugin.Name);
+        resolved.Writer.Should().BeNull("the contributed source is read-only");
+
+        var catalog = provider.GetRequiredService<PluginCatalog>();
+        catalog.Plugins.Should().ContainSingle()
+            .Which.ProvidesDataStore.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DataStorePlugin_WithoutCapability_FailsFast()
+    {
+        var act = () => BuildProvider(HonuaEdition.Enterprise, p => p.Add<UncappedDataStorePlugin>());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*DataStore capability*");
+    }
+}

--- a/tests/dotnet/Honua.Plugins.Tests/TestDoubles.cs
+++ b/tests/dotnet/Honua.Plugins.Tests/TestDoubles.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Honua.Core.Features.AuditLog.Abstractions;
+using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Plugins.Abstractions;
 
@@ -79,6 +80,120 @@ internal sealed class FaultingAfterHook : IEditHook
         AfterAttempts++;
         throw new InvalidOperationException("after-hook boom");
     }
+}
+
+/// <summary>
+/// Minimal read-only <see cref="IFeatureReader"/> stub shared by the data-store test doubles. It
+/// answers reads with empties and never throws; the data-store tests assert registration/resolution
+/// through the provider registry, not query execution.
+/// </summary>
+internal sealed class StubFeatureReader : IFeatureReader
+{
+    public static StubFeatureReader Instance { get; } = new();
+
+    public Task<Feature?> GetAsync(int layerId, long featureId, CancellationToken cancellationToken = default)
+        => Task.FromResult<Feature?>(null);
+
+    public Task<QueryResult<Feature>> QueryAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+        => Task.FromResult(QueryResult<Feature>.Empty());
+
+    public Task<byte[]?> QueryFlatGeobufAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+        => Task.FromResult<byte[]?>(null);
+
+    public Task<ImmutableArray<long>> QueryObjectIdsAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+        => Task.FromResult(ImmutableArray<long>.Empty);
+
+    public Task<long> CountAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+        => Task.FromResult(0L);
+
+    public Task<FeatureExtent?> GetExtentAsync(int layerId, FeatureQuery? query = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<FeatureExtent?>(null);
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryStatisticsAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+        => Task.FromResult(ImmutableArray<IReadOnlyDictionary<string, object?>>.Empty);
+
+    public Task<TemporalExtentResult?> GetTemporalExtentAsync(int layerId, string fieldName, TemporalPropertyType propertyType, CancellationToken cancellationToken = default)
+        => Task.FromResult<TemporalExtentResult?>(null);
+
+    public Task<EstimateResult> GetEstimatesAsync(int layerId, CancellationToken cancellationToken = default)
+        => Task.FromResult(default(EstimateResult));
+
+    public Task<QueryResult<Feature>> QueryTopFeaturesAsync(int layerId, FeatureQuery query, CancellationToken cancellationToken = default)
+        => Task.FromResult(QueryResult<Feature>.Empty());
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryDateBinsAsync(int layerId, FeatureQuery query, DateBinDefinition dateBin, CancellationToken cancellationToken = default)
+        => Task.FromResult(ImmutableArray<IReadOnlyDictionary<string, object?>>.Empty);
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryBinsAsync(int layerId, FeatureQuery query, BinDefinition binDefinition, CancellationToken cancellationToken = default)
+        => Task.FromResult(ImmutableArray<IReadOnlyDictionary<string, object?>>.Empty);
+
+    public Task<ImmutableArray<IReadOnlyDictionary<string, object?>>> QueryH3Async(int layerId, FeatureQuery query, H3AggregationQuery h3Query, CancellationToken cancellationToken = default)
+        => Task.FromResult(ImmutableArray<IReadOnlyDictionary<string, object?>>.Empty);
+}
+
+/// <summary>
+/// Read-only vector data-store plugin (issue #2856): a <c>[Plugin]</c> implementing the Core
+/// <see cref="IFeatureDataProvider"/> seam, declaring the <see cref="PluginCapability.DataStore"/>
+/// capability. Proves a third party can contribute a read-only source that the existing provider
+/// registry/router resolve by name.
+/// </summary>
+[Plugin("sample-vector-source", "1.0.0",
+    Description = "Read-only in-memory vector source.",
+    Capabilities = PluginCapability.DataStore)]
+internal sealed class ReadOnlyVectorSourcePlugin : IFeatureDataProvider
+{
+    public const string Name = "sample-vector-source";
+
+    public string ProviderName => Name;
+
+    public FeatureProviderCapabilities Capabilities => FeatureProviderCapabilities.ReadOnlyAnalytical;
+
+    public IFeatureReader Reader => StubFeatureReader.Instance;
+
+    public IFeatureWriter? Writer => null;
+}
+
+/// <summary>Data-store plugin that omits the required <see cref="PluginCapability.DataStore"/> flag.</summary>
+[Plugin("uncapped-source", "1.0.0")]
+internal sealed class UncappedDataStorePlugin : IFeatureDataProvider
+{
+    public string ProviderName => "uncapped-source";
+
+    public FeatureProviderCapabilities Capabilities => FeatureProviderCapabilities.ReadOnlyAnalytical;
+
+    public IFeatureReader Reader => StubFeatureReader.Instance;
+
+    public IFeatureWriter? Writer => null;
+}
+
+/// <summary>Output-format plugin that omits the required <see cref="PluginCapability.OutputFormats"/> flag.</summary>
+[Plugin("uncapped-format", "1.0.0")]
+internal sealed class UncappedOutputFormatPlugin : IFeatureOutputFormat
+{
+    public string FormatId => "uncapped";
+
+    public string MediaType => "text/plain";
+
+    public string FileExtension => "txt";
+
+    public ValueTask<long> WriteAsync(
+        IAsyncEnumerable<Feature> features, FeatureOutputFormatContext context, Stream output, CancellationToken cancellationToken)
+        => ValueTask.FromResult(0L);
+}
+
+/// <summary>Output-format plugin that illegally claims a reserved built-in wire token (<c>csv</c>).</summary>
+[Plugin("reserved-format-collision", "1.0.0", Capabilities = PluginCapability.OutputFormats)]
+internal sealed class ReservedTokenOutputFormatPlugin : IFeatureOutputFormat
+{
+    public string FormatId => "csv";
+
+    public string MediaType => "text/csv";
+
+    public string FileExtension => "csv";
+
+    public ValueTask<long> WriteAsync(
+        IAsyncEnumerable<Feature> features, FeatureOutputFormatContext context, Stream output, CancellationToken cancellationToken)
+        => ValueTask.FromResult(0L);
 }
 
 /// <summary>Edit hook that records before/after invocations and can reject the batch.</summary>


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2856

## Summary
Adds the two plugin extension points issue #2856 asked for — a read-only **data-store**
point and a feature **output-format** point — after first resolving the central question in
**ADR-0067**: do these belong in the SDK given our compile-time/AOT-static plugin posture? The
answer is a **qualified yes**. Both are realized the same way every existing extension point is —
compile-time, DI-aggregated, statically-rooted contributions discovered via `builder.Add<T>()` —
so neither introduces runtime assembly loading or reflection, and AOT is not regressed.

- **Data-store** reuses the existing `IFeatureDataProvider` provider seam (ADR-0035): a
  `[Plugin]` implementing it is registered as an additional provider that the server's existing
  `FeatureDataProviderRegistry`/router bind by name — **zero router changes**.
- **Output-format** adds a new ASP.NET-free `IFeatureOutputFormat` contract aggregated by a
  license-gated registry, wired into the admin export path. The in-core CSV writer is **ported to
  flow through the contract** as proof the seam is load-bearing.

## Changes Made
- Add **ADR-0067** deciding the static-registration tension (qualified yes) and documenting the
  build-profile interaction (orthogonal: build profiles gate first-party backends; the plugin
  data-store seam is the out-of-tree alternative).
- Add `PluginCapability.OutputFormats` and `PluginCapability.DataStore`; enforce both at
  registration time (fail-fast when the interface is implemented without the capability).
- Add the output-format contract surface to `Honua.Plugins.Abstractions`: `IFeatureOutputFormat`,
  `FeatureOutputFormatContext`, `FeatureOutputField`, `PluginOutputFormatDescriptor`,
  `IFeatureOutputFormatRegistry` (+ `NoOpFeatureOutputFormatRegistry`).
- Wire both points through `HonuaPluginBuilder`; add the license/kill-switch-gated
  `FeatureOutputFormatRegistry` (rejects reserved built-in tokens and duplicates).
- Port the built-in CSV export to `CsvOutputFormat : IFeatureOutputFormat` and dispatch CSV plus
  any plugin format through the contract in `ExportEndpoints` (behavior byte-identical; async
  export-job pipeline stays built-in-only).
- Add a sample plugin output format (`FeatureLinesOutputFormatPlugin`, NDJSON) and plugin unit
  tests covering resolution, license/kill-switch gating, capability enforcement, reserved-token
  rejection, and data-store resolution through the existing provider registry.
- Update the Io-isolation and module-dependency architecture guards to permit
  `Honua.Io → Honua.Plugins.Abstractions` (the lean contract package), mirroring the existing
  protocol-assembly allowance.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

**Local validation ran (green):** `Honua.Plugins` and `Honua.Io` Release builds
(`TreatWarningsAsErrors=true`, 0 warnings); `Honua.Plugins.Tests` — **75/75 passed** including the
8 new data-store/output-format tests.

**Could not complete locally:** the full `Honua.Architecture.Tests` run and the Docker/PostGIS
`ExportEndpointTests` — the shared build host hit **ENOSPC (disk 100% full)** mid-build. The two
architecture-guard edits are deterministic and correspond exactly to the new
`Honua.Io → Honua.Plugins.Abstractions` reference; the CSV port is behavior-preserving (delegates
to the unchanged `CsvExportWriter`, same headers/body). The merge-train batch CI validates both.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] Control plane SDK surface changed
- [x] Documentation updated

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None — the public surface additions are purely additive (new `PluginCapability` members and new
types in `Honua.Plugins.Abstractions`). `honua-sdk-dotnet` should surface these contracts when it
next documents the plugin SDK; no exported contract changes.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed — could not run the full script
  locally: the shared build host is at 100% disk (ENOSPC). Ran the equivalent for the affected
  code (targeted Release builds + full plugin unit-test suite, all green); batch CI runs the rest.
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
