### PR TITLE
tech-debt(mcp): rename McpOperatorSurface to McpDataAccessSurface and document evidence-vs-intelligence boundary

### DIFF
--- a/docs/guides/connect/ai-agents-mcp.md
+++ b/docs/guides/connect/ai-agents-mcp.md
@@ -8,6 +8,29 @@ For operations work, MCP is the agent seat in the same control loop that Console
 
 The endpoint is `POST /mcp`: JSON-RPC 2.0 over HTTP (single requests and batches), MCP protocol revision `2025-03-26`. The handshake methods (`initialize`, `tools/list`, `resources/list`, `resources/templates/list`) are open; `tools/call` and `resources/read` require an authenticated principal plus the matching operator grant.
 
+## Two MCP surfaces: data-access (open) vs. operator (proprietary)
+
+There are two distinct MCP surfaces in the Honua platform, and it is easy to
+conflate them. This page documents the **open** one. The boundary between them is
+**evidence vs. intelligence** (ADR-0066), which is also the open-core licensing
+line (ADR-0024).
+
+| | **This repo — MCP data-access surface** | **`honua-devops` — operator surface** |
+|---|---|---|
+| Dispatcher | `McpDataAccessSurface` in `honua-server` | operator agent in `honua-devops` (private) |
+| Transport | HTTP `POST /mcp` (Streamable HTTP), authenticated | MCP stdio (`--mcp`) |
+| Roster | ~27 studio/data-access tools (query, render, style, geocode/route, plan/execute, authoring/packaging) + **8 bounded, read-only ops-*evidence* tools** | ~35 operator-*intelligence* tools |
+| What it does | Serves geospatial data-access and studio workflows, and reads bounded operational **evidence**; at most it *proposes* a control-plane action that a human approves in the Console inbox (ADR-0062) | Reasons over that evidence and acts: diagnose, tune, upgrade planning with rollback gates, GitOps rollout, remediation planning. Consumes this repo's evidence tools via its `honua_observe_diagnose_propose` day-2 loop |
+| Licensing | Open-core (ELv2); included in Community (ADR-0024) | Private/proprietary; **not** part of the open-core runtime promise |
+
+The 8 ops-evidence tools (`honua_ops_health`, `honua_ops_findings`,
+`honua_alert_events`, `honua_operate_events`, `honua_platform_release_status`,
+`honua_deploy_operations`, `honua_supported_operation_kinds`,
+`honua_propose_rollback`) are deliberately public: they expose bounded read-only
+facts and human-gated proposals, not operator reasoning. This repo serves the
+*evidence*; `honua-devops` supplies the *intelligence* that acts on it. Nothing
+named "operator surface" ships in this repo.
+
 ## Steps
 
 1. Confirm the endpoint answers:

--- a/docs/internal/contributor/adr/0054-evidence-based-feature-catalog.md
+++ b/docs/internal/contributor/adr/0054-evidence-based-feature-catalog.md
@@ -124,7 +124,7 @@ So a new endpoint added without regenerating, or a hand-edit, fails the build.
 server with no repo checkout serves *exactly what CI gated* — reading the
 embedded text verbatim keeps it AOT-safe and prevents a runtime re-projection
 from disagreeing with the committed file. The resource is registered in the
-**default** server composition (`AddMcpOperatorSurface` → `FeatureRegistrationExtensions`),
+**default** server composition (`AddMcpDataAccessSurface` → `FeatureRegistrationExtensions`),
 unlike the persistence-backed promotion resources which stay opt-in: the catalog
 has no runtime dependency and cannot advertise an empty or stale surface.
 

--- a/docs/internal/contributor/adr/0056-mcp-redesign-unified-governed-surface.md
+++ b/docs/internal/contributor/adr/0056-mcp-redesign-unified-governed-surface.md
@@ -38,7 +38,7 @@ lands in; that sequencing decision is this ADR's purpose.
 
 | Capability | Reality in `src/Honua.Ai/.../Mcp/` | Owning issue |
 |---|---|---|
-| Tool/resource dispatch over `POST /mcp` | `McpEndpointExtensions` (JSON-RPC, pinned MCP `2025-03-26`), `McpOperatorSurface` | base |
+| Tool/resource dispatch over `POST /mcp` | `McpEndpointExtensions` (JSON-RPC, pinned MCP `2025-03-26`), `McpDataAccessSurface` | base |
 | Grounding-as-tools | `GroundCandidatesTool`, `ClarifyIntentTool`, `ValidatePlanTool`, `DryRunPlanTool` exist | #1949 (partial) |
 | Tool annotations + output schemas | `McpToolAnnotationSets`, `McpToolOutputSchemas`, `McpToolDescriptor.annotations` | #1953 (in flight) |
 | Live planner | `LivePlanAnalysisService` on the `IPlanAnalysisService` seam, config-gated by `WorkflowGeneration:DefaultProvider` (`ShouldUseLivePlanner`), `FixturePlanAnalysisService` fallback | #1955 (in flight) |

--- a/docs/internal/contributor/adr/0066-mcp-evidence-vs-intelligence-boundary.md
+++ b/docs/internal/contributor/adr/0066-mcp-evidence-vs-intelligence-boundary.md
@@ -1,0 +1,150 @@
+# ADR-0066: Evidence-vs-Intelligence Boundary for the Open MCP Surface
+
+## Status
+Accepted
+
+## Context
+
+`honua-server` serves a public MCP surface over `POST /mcp`. Its JSON-RPC
+dispatcher and registry was named `McpOperatorSurface`. That name is wrong, and
+the way it is wrong matters for licensing and positioning, not just aesthetics.
+
+What the surface actually dispatches:
+
+- **~27 studio / analysis / publish tools** — `honua_render_map`,
+  `honua_get_style`, `honua_apply_style_preset`, `honua_list_layers`,
+  `honua_query_features`, `honua_describe_layer`, the geocode/route tools, the
+  seven plan/execute tools (`honua_plan_analysis`, `honua_validate_plan`,
+  `honua_dry_run_plan`, `honua_execute_plan`, `honua_cancel_job`,
+  `honua_list_jobs`, grounding), and the authoring/packaging tools. This is the
+  implementation of the `geospatial-mcp` open standard, which is scoped to
+  *"analyst, map, and app-builder workflows"* — i.e. studio.
+- **8 bounded, read-only ops *evidence* tools** — `honua_ops_health`,
+  `honua_ops_findings`, `honua_alert_events`, `honua_operate_events`,
+  `honua_platform_release_status`, `honua_deploy_operations`,
+  `honua_supported_operation_kinds`, `honua_propose_rollback`. These read
+  operational state and, at most, *propose* a control-plane action that still
+  resolves through the Console approval inbox (ADR-0062 graduated autonomy;
+  MCP never approves its own proposals).
+- **Zero operator intelligence.** No diagnosis, no tuning, no upgrade planning,
+  no GitOps rollout, no remediation reasoning lives here.
+
+The real boundary is **evidence vs. intelligence**, not operator vs. studio.
+This repo serves bounded, read-only operational *evidence* openly. The
+*intelligence* that reasons over that evidence and acts on it — diagnose, tune,
+upgrade planning with rollback gates, GitOps rollout, remediation planning,
+requirements analysis — lives in `honua-devops`, which is private and
+proprietary. `honua-devops` exposes its own ~35-tool operator surface over MCP
+stdio (`--mcp`) and consumes *our* evidence tools through its
+`honua_observe_diagnose_propose` day-2 loop.
+
+The name `McpOperatorSurface`, in the public repo, implies the operator surface
+is open-core. It is not. ADR-0024 (Open-Core Edition Model) draws this line
+explicitly: the open-core promise covers "the runtime, protocols, SDKs,
+deployment targets, and base MCP **data-access** surface"; "higher-level
+operator/copilot tooling may remain private." `honua-devops`'s own README
+restates it: *"`honua-devops` is private operator tooling and is not part of
+Honua's open-core runtime promise… Public/open surfaces remain in `honua-server`,
+the official SDK repos, the mobile repos, and the base MCP data-access surface."*
+
+A dispatcher literally named for the *operator* surface, sitting in the public
+repo, invites the exact wrong conclusion about where the proprietary line sits.
+That already happened once: during a competitive-analysis pass the tool list was
+read as "operator-first" when it is in fact studio-dominant with a bounded
+evidence wing. The misread costs us twice — it obscures what is actually
+defensible (the operator intelligence), and it implies we are giving away
+something we are not.
+
+This ADR writes the boundary down first, then lets the boundary pick the name —
+so we do not choose a second name that ages as badly as the first.
+
+## Decision
+
+### 1. The boundary: evidence stays open, intelligence stays proprietary
+
+| | Evidence (open) | Intelligence (proprietary) |
+|---|---|---|
+| **Where** | `honua-server`, this MCP surface + the SDK data-access MCP package (`@honua/mcp-server`) | `honua-devops` (private) |
+| **What** | Studio/data-access tools + 8 bounded read-only ops-evidence tools | Diagnose, tune, upgrade planning with rollback gates, GitOps rollout, remediation planning, requirements analysis |
+| **Transport** | HTTP `POST /mcp` (Streamable HTTP), authenticated per ADR-0026 | MCP stdio (`--mcp`), ~35 operator tools |
+| **Posture** | Read state; at most *propose* an action that a human approves through Console (ADR-0062) | Reasons over evidence and drives the day-2 loop; consumes our evidence tools via `honua_observe_diagnose_propose` |
+| **Licensing** | Open-core (ELv2), included in Community (ADR-0024) | Private enterprise tooling on top of the public control-plane API |
+
+The 8 ops-evidence tools are **correctly public**, not a leak across the line.
+They expose bounded, read-only operational *facts* and human-gated *proposals*;
+they contain none of the reasoning that constitutes the operator moat. Removing
+them would break the evidence path that `honua_observe_diagnose_propose` depends
+on and would protect nothing that is actually proprietary. Evidence is the
+substrate the intelligence stands on; publishing the substrate is the open-core
+promise working as designed, consistent with the two-plane operability model
+(ADR-0060) and the fix-forward operate model (ADR-0059).
+
+### 2. The name: `McpDataAccessSurface`
+
+The dispatcher/registry type and its registration surface are renamed:
+
+- `McpOperatorSurface` → **`McpDataAccessSurface`**
+- `AddMcpOperatorSurface` → `AddMcpDataAccessSurface`
+- `MapMcpOperatorSurface` → `MapMcpDataAccessSurface`
+
+`DataAccessSurface` is the canonical open-core term already in use for exactly
+this thing: ADR-0024 and the `honua-devops` README both call it the **"base MCP
+data-access surface."** Naming the type to match the licensing language it
+implements makes the boundary self-documenting — the public surface is named for
+the open side of the line, and nothing in the public repo claims the operator
+surface. The name describes what the surface *is* (bounded data access plus
+evidence), not the intelligence it deliberately *is not*.
+
+### 3. Scope guardrails (what this decision does NOT do)
+
+This is a **mechanical rename plus documentation**. It does not:
+
+- add, remove, rename, or re-gate any tool; `tools/list` output is
+  byte-identical before and after;
+- change any wire-visible behavior — method names, session semantics, the
+  `/mcp` route, error contracts, and JSON-RPC framing are untouched;
+- move the 8 ops-evidence tools out of this repo (they are deliberately public);
+- split the MCP surface into two endpoints or two assemblies;
+- change anything in `honua-devops`; or
+- revisit ADR-0028 (no AI-driven data editing).
+
+## Consequences
+
+### Positive
+
+- **The proprietary line is legible in the code.** A contributor, evaluator, or
+  future maintainer reading the public tool registry no longer infers that the
+  operator surface is open-core. The type name now agrees with ADR-0024 and the
+  `honua-devops` README.
+- **The moat is described accurately.** Evidence vs. intelligence names what is
+  actually defensible (the reasoning in `honua-devops`) and what is deliberately
+  open (bounded evidence + studio), so competitive positioning stops turning on
+  a misread of the tool list.
+- **Cheap now, expensive later.** The name is corrected before it propagates
+  further into docs, SDK-facing terminology, and third-party integrations.
+
+### Negative / costs
+
+- A class rename touches every reference (dispatcher, registration extensions,
+  `<see cref>` docs, log category, and tests). The compiler enforces
+  completeness, and CI proves `tools/list` is unchanged.
+- Historical ADRs (0054, 0056) that referenced the old identifier are updated to
+  the new one so `grep` stays coherent; they remain otherwise as-authored.
+
+### Neutral
+
+- No release or deploy impact. No SDK-published type changes: `McpDataAccessSurface`
+  and its registration extensions are `internal` to `Honua.Ai` and are not
+  exported to `honua-sdk-dotnet` / `honua-sdk-js`, so no consumer coordination is
+  required. The SDK-hosted data-access MCP package (`@honua/mcp-server`) is a
+  separate, already-open surface and is unaffected.
+
+### Related decisions
+
+- ADR-0024 — Open-Core Edition Model (the licensing line this rename honors).
+- ADR-0026 — AI-First Operator Contract (the authenticated MCP contract).
+- ADR-0059 — First-Release Scope and Fix-Forward Operate Model.
+- ADR-0060 — Two-Plane Operability Architecture.
+- ADR-0062 — Graduated Autonomy Policy for Ops Findings (why proposals are
+  human-gated).
+- ADR-0028 — AI-Driven Data Editing Is Not Allowed (explicitly not revisited).

--- a/docs/internal/contributor/adr/README.md
+++ b/docs/internal/contributor/adr/README.md
@@ -68,6 +68,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0063](0063-custom-code-execution-is-aws-batch-only.md) | Custom-code (custom GP tool) execution is AWS-Batch-only | Accepted | 2026-07 |
 | [0064](0064-geoprocessing-destructive-plan-approval-lane.md) | Geoprocessing Destructive-Plan Approval Lane (Fail-Closed Classifier + Control-Plane Proposal Reuse) | Accepted | 2026-07 |
 | [0065](0065-imageserver-photogrammetric-analytics.md) | ImageServer Photogrammetric Tie-Point and 3D Measurement Analytics | Accepted | 2026-07 |
+| [0066](0066-mcp-evidence-vs-intelligence-boundary.md) | Evidence-vs-Intelligence Boundary for the Open MCP Surface (Rename to `McpDataAccessSurface`) | Accepted | 2026-07 |
 
 ## Template
 

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ListCapabilitiesTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Discovery/ListCapabilitiesTool.cs
@@ -84,13 +84,13 @@ internal sealed class ListCapabilitiesTool : IMcpTool
         {
             ServerName = serverInfo.Name,
             ServerVersion = serverInfo.Version,
-            ProtocolVersions = McpOperatorSurface.SupportedProtocolVersions
+            ProtocolVersions = McpDataAccessSurface.SupportedProtocolVersions
         };
 
         // Project the live in-process catalog. Resolved leniently so a lightweight
         // host that did not register the surface still returns a valid (if empty)
         // manifest rather than throwing.
-        var surface = httpContext.RequestServices.GetService<McpOperatorSurface>();
+        var surface = httpContext.RequestServices.GetService<McpDataAccessSurface>();
         if (surface is not null)
         {
             // The unified capability registry (ADR-0058 B2, #2334) is the source of
@@ -127,7 +127,7 @@ internal sealed class ListCapabilitiesTool : IMcpTool
     }
 
     private static List<McpCapabilityTool> BuildToolManifest(
-        McpOperatorSurface surface,
+        McpDataAccessSurface surface,
         ICapabilityRegistry? registry)
     {
         var registryToolNames = registry is null
@@ -165,7 +165,7 @@ internal sealed class ListCapabilitiesTool : IMcpTool
     }
 
     private static List<McpCapabilityResource> BuildResourceManifest(
-        McpOperatorSurface surface,
+        McpDataAccessSurface surface,
         ICapabilityRegistry? registry)
     {
         var registryFamilies = registry is null

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpDataAccessSurface.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpDataAccessSurface.cs
@@ -12,7 +12,12 @@ using Honua.Ai.Protocols.Mcp.Tools;
 namespace Honua.Ai.Protocols.Mcp;
 
 /// <summary>
-/// Central JSON-RPC dispatcher and registry for the MCP operator surface.
+/// Central JSON-RPC dispatcher and registry for the open MCP data-access
+/// surface — the studio/data-access tools plus the bounded, read-only
+/// ops-evidence tools this repo serves publicly. This is the evidence side of
+/// the evidence-vs-intelligence boundary (ADR-0066); operator <em>intelligence</em>
+/// (diagnose/tune/upgrade-planning with rollback gates) lives in the private
+/// <c>honua-devops</c> operator surface, not here.
 /// Hosts the tool and resource catalogs, routes <c>initialize</c>,
 /// <c>notifications/initialized</c>, <c>tools/list</c>, <c>tools/call</c>,
 /// <c>resources/list</c>, <c>resources/templates/list</c>,
@@ -20,7 +25,7 @@ namespace Honua.Ai.Protocols.Mcp;
 /// and converts domain exceptions into JSON-RPC errors via
 /// <see cref="McpErrorMapper"/>.
 /// </summary>
-internal sealed class McpOperatorSurface
+internal sealed class McpDataAccessSurface
 {
     /// <summary>
     /// MCP protocol revisions this server can negotiate during <c>initialize</c>.
@@ -43,12 +48,12 @@ internal sealed class McpOperatorSurface
     private readonly List<IMcpToolSource> _toolSources;
     private readonly IReadOnlyList<IMcpResource> _resources;
     private readonly McpSurfaceLimits _limits;
-    private readonly ILogger<McpOperatorSurface> _logger;
+    private readonly ILogger<McpDataAccessSurface> _logger;
 
-    public McpOperatorSurface(
+    public McpDataAccessSurface(
         IEnumerable<IMcpTool> tools,
         IEnumerable<IMcpResource> resources,
-        ILogger<McpOperatorSurface> logger,
+        ILogger<McpDataAccessSurface> logger,
         McpSurfaceLimits? limits = null,
         IEnumerable<IMcpToolSource>? toolSources = null)
     {

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpEndpointExtensions.cs
@@ -49,7 +49,7 @@ internal static class McpEndpointExtensions
     /// client's original id, in which case it MUST be <c>null</c>. Assigning this
     /// element to <see cref="McpJsonRpcResponse.Id"/> prevents the
     /// <c>WhenWritingNull</c> ignore condition from dropping the property.
-    /// Exposed <c>internal</c> so <see cref="McpOperatorSurface"/> can emit
+    /// Exposed <c>internal</c> so <see cref="McpDataAccessSurface"/> can emit
     /// invalid_request error envelopes for malformed requests that reach the
     /// dispatcher without a valid id.
     /// </summary>
@@ -61,7 +61,7 @@ internal static class McpEndpointExtensions
     /// termination, alongside the RFC 9728 protected-resource metadata that
     /// describes the surface.
     /// </summary>
-    public static IEndpointRouteBuilder MapMcpOperatorSurface(this IEndpointRouteBuilder endpoints)
+    public static IEndpointRouteBuilder MapMcpDataAccessSurface(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
@@ -71,7 +71,7 @@ internal static class McpEndpointExtensions
                 static (HttpContext context, CancellationToken ct) => HandlePostAsync(context, ct))
             .AddEndpointFilter(ProtectedResourceChallengeFilter)
             .WithDisplayName("MCP Operator Surface")
-            .WithName("McpOperatorSurface")
+            .WithName("McpDataAccessSurface")
             .WithSummary("MCP JSON-RPC dispatcher for planning, execution, lifecycle, and results.")
             .WithDescription("Accepts JSON-RPC 2.0 requests over the Streamable-HTTP transport. Issues an Mcp-Session-Id on initialize and validates it on subsequent requests. Responds with application/json or, when the client accepts text/event-stream, a single SSE message frame. Single-request-only: initialize (MCP lifecycle forbids batching). Single or batched: notifications/initialized, tools/list, tools/call, resources/list, resources/templates/list, resources/read, prompts/list, and prompts/get.")
             .WithTags("Mcp");
@@ -80,7 +80,7 @@ internal static class McpEndpointExtensions
                 static (HttpContext context, CancellationToken ct) => HandleGetAsync(context, ct))
             .AddEndpointFilter(ProtectedResourceChallengeFilter)
             .WithDisplayName("MCP Operator Surface (SSE stream)")
-            .WithName("McpOperatorSurfaceStream")
+            .WithName("McpDataAccessSurfaceStream")
             .WithSummary("Opens the MCP server-to-client Server-Sent-Events stream.")
             .WithDescription("Streamable-HTTP transport GET endpoint. Opens a text/event-stream the server uses to push notifications (e.g. progress, listChanged). Requires a valid Mcp-Session-Id.")
             .WithTags("Mcp");
@@ -89,7 +89,7 @@ internal static class McpEndpointExtensions
                 static (HttpContext context, CancellationToken ct) => HandleDeleteAsync(context, ct))
             .AddEndpointFilter(ProtectedResourceChallengeFilter)
             .WithDisplayName("MCP Operator Surface (session termination)")
-            .WithName("McpOperatorSurfaceTerminate")
+            .WithName("McpDataAccessSurfaceTerminate")
             .WithSummary("Terminates an MCP session.")
             .WithDescription("Streamable-HTTP transport DELETE endpoint. Removes the session identified by the Mcp-Session-Id header.")
             .WithTags("Mcp");
@@ -113,9 +113,9 @@ internal static class McpEndpointExtensions
 
     private static async Task HandlePostAsync(HttpContext context, CancellationToken cancellationToken)
     {
-        var surface = context.RequestServices.GetRequiredService<McpOperatorSurface>();
+        var surface = context.RequestServices.GetRequiredService<McpDataAccessSurface>();
         var sessions = context.RequestServices.GetRequiredService<McpSessionManager>();
-        var logger = context.RequestServices.GetRequiredService<ILogger<McpOperatorSurface>>();
+        var logger = context.RequestServices.GetRequiredService<ILogger<McpDataAccessSurface>>();
 
         JsonDocument? document;
         try
@@ -211,7 +211,7 @@ internal static class McpEndpointExtensions
                 // the session so clarification-emitting tools can later choose the
                 // MCP-native elicitation projection over the proprietary envelope.
                 var elicitationSupported =
-                    context.Items.TryGetValue(McpOperatorSurface.ElicitationCapabilityItemKey, out var flag)
+                    context.Items.TryGetValue(McpDataAccessSurface.ElicitationCapabilityItemKey, out var flag)
                     && flag is true;
                 if (sessions.TryCreateSession(principalKey, elicitationSupported, out var sessionId))
                 {
@@ -241,7 +241,7 @@ internal static class McpEndpointExtensions
     private static async Task HandleGetAsync(HttpContext context, CancellationToken cancellationToken)
     {
         var sessions = context.RequestServices.GetRequiredService<McpSessionManager>();
-        var logger = context.RequestServices.GetRequiredService<ILogger<McpOperatorSurface>>();
+        var logger = context.RequestServices.GetRequiredService<ILogger<McpDataAccessSurface>>();
         var options = context.RequestServices.GetRequiredService<IOptions<McpOptions>>().Value;
 
         // Per the Streamable-HTTP spec the standalone GET stream is optional: a
@@ -334,7 +334,7 @@ internal static class McpEndpointExtensions
     private static Task HandleDeleteAsync(HttpContext context, CancellationToken cancellationToken)
     {
         var sessions = context.RequestServices.GetRequiredService<McpSessionManager>();
-        var logger = context.RequestServices.GetRequiredService<ILogger<McpOperatorSurface>>();
+        var logger = context.RequestServices.GetRequiredService<ILogger<McpDataAccessSurface>>();
 
         var sessionId = context.Request.Headers[McpSessionManager.SessionHeaderName].ToString();
         if (string.IsNullOrEmpty(sessionId))
@@ -380,7 +380,7 @@ internal static class McpEndpointExtensions
 
     private static async Task HandleBatchAsync(
         HttpContext context,
-        McpOperatorSurface surface,
+        McpDataAccessSurface surface,
         JsonElement batch,
         CancellationToken cancellationToken)
     {
@@ -448,7 +448,7 @@ internal static class McpEndpointExtensions
     /// </summary>
     private static async Task<McpJsonRpcResponse?> ProcessMessageAsync(
         HttpContext context,
-        McpOperatorSurface surface,
+        McpDataAccessSurface surface,
         JsonElement message,
         CancellationToken cancellationToken)
     {

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpPagination.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpPagination.cs
@@ -259,7 +259,7 @@ internal static class McpPagination
 /// <summary>
 /// Host-tunable limits for the MCP operator surface: the list-pagination page
 /// size and the per-page character budget for chunked <c>resources/read</c>
-/// responses. Injected into <see cref="McpOperatorSurface"/>; defaults to
+/// responses. Injected into <see cref="McpDataAccessSurface"/>; defaults to
 /// <see cref="Default"/> when the host does not register an override.
 /// </summary>
 internal sealed record McpSurfaceLimits(int ListPageSize, int MaxResourceReadChars)

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryBindingStartupCheck.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryBindingStartupCheck.cs
@@ -17,12 +17,12 @@ namespace Honua.Ai.Protocols.Mcp;
 /// </summary>
 internal sealed class McpRegistryBindingStartupCheck : IHostedService
 {
-    private readonly McpOperatorSurface _surface;
+    private readonly McpDataAccessSurface _surface;
     private readonly ICapabilityRegistry _registry;
     private readonly CapabilityRegistryBindingOptions _options;
 
     public McpRegistryBindingStartupCheck(
-        McpOperatorSurface surface,
+        McpDataAccessSurface surface,
         ICapabilityRegistry registry,
         IOptions<CapabilityRegistryBindingOptions> options)
     {

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryCompositionValidator.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpRegistryCompositionValidator.cs
@@ -31,7 +31,7 @@ internal static class McpRegistryCompositionValidator
     /// </summary>
     /// <param name="surface">The live MCP operator surface (the served catalog).</param>
     /// <param name="registry">The unified capability registry (source of truth).</param>
-    public static IReadOnlyList<string> FindDrift(McpOperatorSurface surface, ICapabilityRegistry registry)
+    public static IReadOnlyList<string> FindDrift(McpDataAccessSurface surface, ICapabilityRegistry registry)
     {
         ArgumentNullException.ThrowIfNull(surface);
         ArgumentNullException.ThrowIfNull(registry);

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/McpServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ internal static class McpServiceCollectionExtensions
     /// <see cref="AddMcpPromotionSurface"/> to advertise those resources; the
     /// Postgres server profile does this through the server composition gate.
     /// </summary>
-    public static IServiceCollection AddMcpOperatorSurface(
+    public static IServiceCollection AddMcpDataAccessSurface(
         this IServiceCollection services,
         IConfiguration configuration)
     {
@@ -48,7 +48,7 @@ internal static class McpServiceCollectionExtensions
         // with a live default provider, otherwise the deterministic fixture
         // replay. The fixture catalog is always registered as the fallback, so
         // CI (no provider configured) stays AI-credit-free. Hosts can still call
-        // services.Replace(...) after AddMcpOperatorSurface to force a specific
+        // services.Replace(...) after AddMcpDataAccessSurface to force a specific
         // implementation.
         services.AddAiBuilderPlanAnalysis(configuration);
 
@@ -65,7 +65,7 @@ internal static class McpServiceCollectionExtensions
         // paging) over the canonical IGeoprocessingJobService.ListJobsAsync, so an
         // agent can find a queued/stuck job to feed honua_cancel_job. Registered
         // unconditionally alongside honua_cancel_job — both depend only on the
-        // IGeoprocessingJobService that is composed before AddMcpOperatorSurface,
+        // IGeoprocessingJobService that is composed before AddMcpDataAccessSurface,
         // and the service enforces the job-read grant + per-job ownership itself.
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, ListJobsTool>());
         // (honua_describe_layer is registered below in the Metadata v2 + feature
@@ -77,7 +77,7 @@ internal static class McpServiceCollectionExtensions
         // ServicePublishExecutor → ILayerPublishingService rather than
         // reimplementing publish. Registered unconditionally and gated at
         // invocation time: the operations toolset (AddOperationsToolset) is wired
-        // later in the server composition root than AddMcpOperatorSurface, so a
+        // later in the server composition root than AddMcpDataAccessSurface, so a
         // descriptor-list check here would never see IOperationInvoker. Instead
         // the tool resolves the invoker per-request and returns a structured
         // "unavailable" handle when no operations toolset is composed — the same
@@ -91,14 +91,14 @@ internal static class McpServiceCollectionExtensions
         // same canonical IOperationInvoker (service.publish) as PublishServiceTool.
         // Registered unconditionally and gated at invocation time for the same
         // reason PublishServiceTool is: the operations toolset is composed later
-        // than AddMcpOperatorSurface, so the tool resolves the invoker per-request
+        // than AddMcpDataAccessSurface, so the tool resolves the invoker per-request
         // and returns a structured "unavailable" handle when none is composed.
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, PublishResultTool>());
 
         // Authoring tools (#1951): create_map_package / create_app_package route
         // through the canonical IMapGenerationService / IAppGenerationService
         // generation pipelines. Those services are registered later in the host
-        // composition root than AddMcpOperatorSurface, so the tools resolve them
+        // composition root than AddMcpDataAccessSurface, so the tools resolve them
         // per-request (like PublishServiceTool resolves IOperationInvoker) and
         // return a structured capability-unavailable result when no generation
         // service is composed. Registered unconditionally so the catalog is
@@ -144,11 +144,11 @@ internal static class McpServiceCollectionExtensions
 
         // Geocode/route tools (#1597) are only advertised when the host
         // composition has wired the underlying canonical services (AddGeocoding
-        // / AddRouting run before AddMcpOperatorSurface in the server
+        // / AddRouting run before AddMcpDataAccessSurface in the server
         // composition root). Checking the descriptor list here keeps
         // tools/list honest: hosts without the capability never advertise a
         // tool that could only fail at invocation time, and tests that call
-        // AddMcpOperatorSurface in isolation keep working.
+        // AddMcpDataAccessSurface in isolation keep working.
         if (services.Any(d => d.ServiceType == typeof(Honua.Geocoding.Features.Geocoding.Abstractions.IGeocodeCoordinatorService)))
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, GeocodeTool>());
@@ -161,7 +161,7 @@ internal static class McpServiceCollectionExtensions
         // honua_ingest_dataset: inline CSV/GeoJSON → catalog table through the
         // canonical IFileImportService pipeline (the REST admin import service).
         // Gated on the import service being wired (the Postgres provider
-        // registers it before AddMcpOperatorSurface) so tools/list stays honest
+        // registers it before AddMcpDataAccessSurface) so tools/list stays honest
         // in compositions without an import-capable data provider.
         if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.FileImport.Abstractions.IFileImportService)))
         {
@@ -178,7 +178,7 @@ internal static class McpServiceCollectionExtensions
         // pipeline. They are only advertised when the host composition has wired
         // IMetadataV2GraphProvider (the same provider that backs /rest/services
         // and FeatureServer query). Gating keeps tools/list honest in tests that
-        // call AddMcpOperatorSurface in isolation without a data provider.
+        // call AddMcpDataAccessSurface in isolation without a data provider.
         if (services.Any(d => d.ServiceType == typeof(Honua.Core.Features.Metadata.Abstractions.IMetadataV2GraphProvider)))
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpTool, MapTools.ListLayersTool>());
@@ -255,13 +255,13 @@ internal static class McpServiceCollectionExtensions
         // IAnalysisReportService. AddAnalysisReporting is the canonical
         // registrar and is gated on Reporting:Enabled; checking for the
         // service here covers both the disabled-feature case and tests that
-        // call AddMcpOperatorSurface in isolation.
+        // call AddMcpDataAccessSurface in isolation.
         if (services.Any(d => d.ServiceType == typeof(IAnalysisReportService)))
         {
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IMcpResource, AnalysisReportResource>());
         }
 
-        services.TryAddSingleton<McpOperatorSurface>();
+        services.TryAddSingleton<McpDataAccessSurface>();
 
         // MCP transport + session-lifecycle options (A3 hardening; #2537):
         // server-initiated GET-stream toggle, idle TTL, session cap, and eviction
@@ -315,7 +315,7 @@ internal static class McpServiceCollectionExtensions
     /// AFTER the operations toolset is composed (<c>AddOperationsToolset</c>), because
     /// the tool source resolves the canonical <see cref="Honua.Core.Features.Operations.Abstractions.IOperationCatalog"/>
     /// — call it from a host that has the operations toolset wired, not from a bare
-    /// <see cref="AddMcpOperatorSurface"/> composition.
+    /// <see cref="AddMcpDataAccessSurface"/> composition.
     /// </summary>
     public static IServiceCollection AddMcpPublishedOperationTools(
         this IServiceCollection services,

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Resources/IMcpResource.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Resources/IMcpResource.cs
@@ -49,7 +49,7 @@ internal interface IMcpResource
 
     /// <summary>
     /// Reads the resource at <paramref name="uri"/>. Implementations throw
-    /// domain exceptions on failure; <see cref="McpOperatorSurface"/> converts
+    /// domain exceptions on failure; <see cref="McpDataAccessSurface"/> converts
     /// them to JSON-RPC errors via <see cref="McpErrorMapper"/>.
     /// </summary>
     Task<McpResourcesReadResult> ReadAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Resources/IStubMcpResource.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Resources/IStubMcpResource.cs
@@ -6,7 +6,7 @@ namespace Honua.Ai.Protocols.Mcp.Resources;
 /// <summary>
 /// Marker interface applied to MCP resources whose backing service has not yet
 /// shipped and which therefore return structured <c>not_implemented</c>
-/// output. <see cref="McpOperatorSurface"/> uses this signal to tag the
+/// output. <see cref="McpDataAccessSurface"/> uses this signal to tag the
 /// <c>honua.mcp.resource.read</c> counter with
 /// <see cref="McpTelemetry.Status.NotImplemented"/> so dashboards can
 /// distinguish contract stubs from functional resource reads.

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/CreateMapPackageTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/CreateMapPackageTool.cs
@@ -89,7 +89,7 @@ internal sealed class CreateMapPackageTool : IMcpTool
         }
 
         // Resolve the generation service per-request: it is registered in the
-        // host composition root after AddMcpOperatorSurface, so a descriptor-list
+        // host composition root after AddMcpDataAccessSurface, so a descriptor-list
         // gate at registration time would miss it. When no service is composed
         // (e.g. an isolated test container) return a structured
         // capability-unavailable result rather than failing the call.

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpTool.cs
@@ -34,7 +34,7 @@ internal interface IMcpTool
 
     /// <summary>
     /// Invokes the tool. Implementations throw domain exceptions on failure;
-    /// <see cref="McpOperatorSurface"/> converts those exceptions into JSON-RPC
+    /// <see cref="McpDataAccessSurface"/> converts those exceptions into JSON-RPC
     /// error envelopes via <see cref="McpErrorMapper"/>.
     /// </summary>
     Task<McpToolsCallResult> InvokeAsync(

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpToolSource.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IMcpToolSource.cs
@@ -5,7 +5,7 @@ namespace Honua.Ai.Protocols.Mcp.Tools;
 
 /// <summary>
 /// A source of dynamic, runtime-published MCP tools that the
-/// <see cref="McpOperatorSurface"/> merges into <c>tools/list</c> and
+/// <see cref="McpDataAccessSurface"/> merges into <c>tools/list</c> and
 /// <c>tools/call</c> in addition to the statically-registered
 /// <see cref="IMcpTool"/> set (#2483, ADR-0056 Increment 4).
 /// </summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IStubMcpTool.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/IStubMcpTool.cs
@@ -6,7 +6,7 @@ namespace Honua.Ai.Protocols.Mcp.Tools;
 /// <summary>
 /// Marker interface applied to MCP tools whose backing service has not yet
 /// shipped and which therefore return structured <c>not_implemented</c>
-/// output. <see cref="McpOperatorSurface"/> uses this signal to emit
+/// output. <see cref="McpDataAccessSurface"/> uses this signal to emit
 /// <see cref="McpTelemetry.Status.NotImplemented"/> in counters and completion
 /// logs so dashboards can distinguish contract stubs from functional tools.
 /// </summary>

--- a/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationToolSource.cs
+++ b/src/Honua.Ai/Features/Protocols/Mcp/Mcp/Tools/PublishedOperationToolSource.cs
@@ -12,7 +12,7 @@ namespace Honua.Ai.Protocols.Mcp.Tools;
 /// Projects validated operations-toolset descriptors from the <see cref="IOperationCatalog"/>
 /// into first-class, typed, policy-governed MCP tools (#2483, ADR-0056 Increment 4).
 /// A descriptor present in the catalog is "published"; this source turns each one into a
-/// <see cref="PublishedOperationTool"/> that the <see cref="McpOperatorSurface"/> merges into
+/// <see cref="PublishedOperationTool"/> that the <see cref="McpDataAccessSurface"/> merges into
 /// <c>tools/list</c> and <c>tools/call</c>.
 /// </summary>
 /// <remarks>

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -10,7 +10,7 @@ namespace Honua.Core.Features.Capabilities;
 /// The default <see cref="ICapabilityRegistry"/> — the single source of truth
 /// for the platform capability roster (ADR-0058, Decision B). B1 populates it to
 /// <b>faithfully mirror the live roster that exists today</b>: the <c>/mcp</c>
-/// tools and resources (from <c>McpOperatorSurface</c> /
+/// tools and resources (from <c>McpDataAccessSurface</c> /
 /// <c>McpServiceCollectionExtensions</c>), the #1186 capability-manifest
 /// capabilities (from <c>CapabilityManifestService</c>), and the platform data
 /// formats (from <c>SupportedFileFormat</c> and the shared format readers/writers).

--- a/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
+++ b/src/Honua.Server/Features/Infrastructure/Hosting/FeatureRegistrationExtensions.cs
@@ -178,7 +178,7 @@ internal static class FeatureRegistrationExtensions
         // the ICapabilityRegistry registered by AddCapabilityManifest above.
         services.AddCapabilityGatedOpenApi();
         services.AddPackageReview();
-        services.AddMcpOperatorSurface(configuration);
+        services.AddMcpDataAccessSurface(configuration);
         services.AddSpecGrounding();
         services.AddSpatialAnalytics();
         services.AddDataEnrichment(configuration);
@@ -325,7 +325,7 @@ internal static class FeatureRegistrationExtensions
         endpoints.MapTemporalHistorySliceEndpoints();
         endpoints.MapAnalysisReporting();
         endpoints.MapCapabilityManifestEndpoints();
-        endpoints.MapMcpOperatorSurface();
+        endpoints.MapMcpDataAccessSurface();
         endpoints.MapSpecGroundingEndpoints();
         endpoints.MapSpecEndpoints();
         // Plugin-contributed REST routes (ICustomEndpoint, #1562). A no-op unless a custom build

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpAuthoringToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpAuthoringToolTests.cs
@@ -37,13 +37,13 @@ public sealed class McpAuthoringToolTests
     [InterfaceOperation(TestProtocols.Mcp, "tools/list")]
     public async Task ToolsList_IncludesAuthoringTools()
     {
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [
                 new CreateMapPackageTool(_jobService, NullLogger<CreateMapPackageTool>.Instance),
                 new CreateAppPackageTool(_jobService, NullLogger<CreateAppPackageTool>.Instance),
             ],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(new ServiceCollection().BuildServiceProvider()),
@@ -80,10 +80,10 @@ public sealed class McpAuthoringToolTests
             .AddSingleton(mapGen)
             .BuildServiceProvider();
 
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new CreateMapPackageTool(_jobService, NullLogger<CreateMapPackageTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),
@@ -133,10 +133,10 @@ public sealed class McpAuthoringToolTests
             .AddSingleton(appGen)
             .BuildServiceProvider();
 
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new CreateAppPackageTool(_jobService, NullLogger<CreateAppPackageTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),
@@ -163,10 +163,10 @@ public sealed class McpAuthoringToolTests
     [InterfaceOperation(TestProtocols.Mcp, "tools/call")]
     public async Task ToolsCall_CreateMapPackage_WithoutGenerationService_ReturnsCapabilityUnavailable()
     {
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new CreateMapPackageTool(_jobService, NullLogger<CreateMapPackageTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(new ServiceCollection().BuildServiceProvider()),
@@ -190,10 +190,10 @@ public sealed class McpAuthoringToolTests
         var mapGen = Substitute.For<IMapGenerationService>();
         var services = new ServiceCollection().AddSingleton(mapGen).BuildServiceProvider();
 
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new CreateMapPackageTool(_jobService, NullLogger<CreateMapPackageTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpAuthorizationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpAuthorizationTests.cs
@@ -391,7 +391,7 @@ public sealed class McpAuthorizationTests
         response.Error!.Data!.Code.Should().Be(McpErrorMapper.Codes.Unauthenticated);
     }
 
-    private McpOperatorSurface BuildSurface()
+    private McpDataAccessSurface BuildSurface()
     {
         var tools = new IMcpTool[]
         {
@@ -407,6 +407,6 @@ public sealed class McpAuthorizationTests
             new WorkspaceResource(_jobService, NullLogger<WorkspaceResource>.Instance),
             new ProcessCatalogResource(_jobService, NullLogger<ProcessCatalogResource>.Instance)
         };
-        return new McpOperatorSurface(tools, resources, NullLogger<McpOperatorSurface>.Instance);
+        return new McpDataAccessSurface(tools, resources, NullLogger<McpDataAccessSurface>.Instance);
     }
 }

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpDiscoveryToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpDiscoveryToolTests.cs
@@ -136,7 +136,7 @@ public sealed class McpDiscoveryToolTests
         DiscoveryJsonContext.Default.McpListCapabilitiesOutput.Should().NotBeNull();
     }
 
-    private McpOperatorSurface BuildSurface() => new(
+    private McpDataAccessSurface BuildSurface() => new(
         [
             new ResolveEntityTool(_jobService, NullLogger<ResolveEntityTool>.Instance),
             new ListCapabilitiesTool(_jobService, NullLogger<ListCapabilitiesTool>.Instance)
@@ -144,7 +144,7 @@ public sealed class McpDiscoveryToolTests
         [
             new FeatureCatalogResource(_jobService, NullLogger<FeatureCatalogResource>.Instance)
         ],
-        NullLogger<McpOperatorSurface>.Instance);
+        NullLogger<McpDataAccessSurface>.Instance);
 
     private static TestMetadataV2GraphProvider BuildGraphProvider() =>
         new TestMetadataV2GraphBuilder()
@@ -158,7 +158,7 @@ public sealed class McpDiscoveryToolTests
             .AddPublication("pub-roads", "svc-roads", "res-roads", layerIndex: 0, storageBindingId: "bind-roads")
             .BuildProvider();
 
-    private static ServiceProvider BuildServices(McpOperatorSurface? surface = null)
+    private static ServiceProvider BuildServices(McpDataAccessSurface? surface = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IMetadataV2GraphProvider>(BuildGraphProvider());

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpDispatcherTelemetryTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpDispatcherTelemetryTests.cs
@@ -283,7 +283,7 @@ public sealed class McpDispatcherTelemetryTests
     private static string? GetTagString(KeyValuePair<string, object?>[] tags, string name)
         => tags.Where(tag => tag.Key == name).Select(tag => tag.Value as string).FirstOrDefault();
 
-    private McpOperatorSurface BuildSurface()
+    private McpDataAccessSurface BuildSurface()
     {
         var tools = new IMcpTool[]
         {
@@ -299,10 +299,10 @@ public sealed class McpDispatcherTelemetryTests
             new WorkspaceResource(_jobService, NullLogger<WorkspaceResource>.Instance),
             new ProcessCatalogResource(_jobService, NullLogger<ProcessCatalogResource>.Instance)
         };
-        return new McpOperatorSurface(tools, resources, NullLogger<McpOperatorSurface>.Instance);
+        return new McpDataAccessSurface(tools, resources, NullLogger<McpDataAccessSurface>.Instance);
     }
 
-    private McpOperatorSurface BuildPromotionSurface()
+    private McpDataAccessSurface BuildPromotionSurface()
     {
         var tools = Array.Empty<IMcpTool>();
         var resources = new IMcpResource[]
@@ -311,7 +311,7 @@ public sealed class McpDispatcherTelemetryTests
                 _services, _deployments, _jobService,
                 NullLogger<PromotionSurfaceIndexResource>.Instance)
         };
-        return new McpOperatorSurface(tools, resources, NullLogger<McpOperatorSurface>.Instance);
+        return new McpDataAccessSurface(tools, resources, NullLogger<McpDataAccessSurface>.Instance);
     }
 
     private readonly record struct MeasurementSample(long Value, KeyValuePair<string, object?>[] Tags);

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpGeocodeAddressesToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpGeocodeAddressesToolTests.cs
@@ -201,10 +201,10 @@ public sealed class McpGeocodeAddressesToolTests
         services.AddSingleton(license);
         services.AddSingleton(coordinator);
 
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new GeocodeAddressesTool(_jobService, NullLogger<GeocodeAddressesTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var context = McpTestFactory.AuthenticatedHttpContext();
         context.RequestServices = services.BuildServiceProvider();

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpIngestDatasetToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpIngestDatasetToolTests.cs
@@ -382,10 +382,10 @@ public sealed class McpIngestDatasetToolTests
 
     private async Task<McpJsonRpcResponse?> DispatchAsync(ServiceProvider services, string argumentsJson)
     {
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new IngestDatasetTool(_jobService, NullLogger<IngestDatasetTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var context = McpTestFactory.AuthenticatedHttpContext();
         context.RequestServices = services;

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpListJobsToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpListJobsToolTests.cs
@@ -117,10 +117,10 @@ public sealed class McpListJobsToolTests
 
     private async Task<McpJsonRpcResponse?> Dispatch(McpJsonRpcRequest request)
     {
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new ListJobsTool(_jobService, NullLogger<ListJobsTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var services = new ServiceCollection().BuildServiceProvider();
         var context = McpTestFactory.AuthenticatedHttpContext();

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpLocationToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpLocationToolTests.cs
@@ -69,10 +69,10 @@ public sealed class McpLocationToolTests
         var services = BuildServices(
             ActiveLicense(GeocodeTool.EntitlementKey),
             geocodeCoordinator: coordinator);
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new GeocodeTool(_jobService, NullLogger<GeocodeTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),
@@ -130,10 +130,10 @@ public sealed class McpLocationToolTests
         var services = BuildServices(
             ActiveLicense(RouteTool.EntitlementKey),
             routingProvider: routingProvider);
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new RouteTool(_jobService, NullLogger<RouteTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),
@@ -183,13 +183,13 @@ public sealed class McpLocationToolTests
         string argumentsJson)
     {
         var services = BuildServices(InactiveLicense(entitlementKey));
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [
                 new GeocodeTool(_jobService, NullLogger<GeocodeTool>.Instance),
                 new RouteTool(_jobService, NullLogger<RouteTool>.Instance)
             ],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),
@@ -223,10 +223,10 @@ public sealed class McpLocationToolTests
         var services = BuildServices(
             ActiveLicense(GeocodeTool.EntitlementKey),
             geocodeCoordinator: Substitute.For<IGeocodeCoordinatorService>());
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new GeocodeTool(_jobService, NullLogger<GeocodeTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),
@@ -266,10 +266,10 @@ public sealed class McpLocationToolTests
         var services = BuildServices(
             ActiveLicense(GeocodeTool.EntitlementKey),
             geocodeCoordinator: coordinator);
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new GeocodeTool(_jobService, NullLogger<GeocodeTool>.Instance)],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(services),

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpMapToolTests.cs
@@ -1003,7 +1003,7 @@ public sealed class McpMapToolTests
         StructuredContentShouldMatchOutputSchema(result, McpToolOutputSchemas.RenderMapOutputSchema);
     }
 
-    private McpOperatorSurface BuildSurface() => new(
+    private McpDataAccessSurface BuildSurface() => new(
         [
             new ListLayersTool(_jobService, NullLogger<ListLayersTool>.Instance),
             new DescribeLayerTool(_jobService, NullLogger<DescribeLayerTool>.Instance),
@@ -1011,7 +1011,7 @@ public sealed class McpMapToolTests
             new RenderMapTool(_jobService, NullLogger<RenderMapTool>.Instance)
         ],
         [],
-        NullLogger<McpOperatorSurface>.Instance);
+        NullLogger<McpDataAccessSurface>.Instance);
 
     private static TestMetadataV2GraphProvider BuildGraphProvider()
     {

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpPaginationTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpPaginationTests.cs
@@ -137,10 +137,10 @@ public sealed class McpPaginationTests
     [UnitTest]
     public async Task ToolsList_OverDispatcher_PagesWithNextCursor()
     {
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             tools: Enumerable.Range(0, 5).Select(i => (IMcpTool)new StubTool($"honua_tool_{i}")),
             resources: [],
-            logger: NullLogger<McpOperatorSurface>.Instance,
+            logger: NullLogger<McpDataAccessSurface>.Instance,
             limits: new McpSurfaceLimits(ListPageSize: 2, MaxResourceReadChars: 1000));
 
         var firstNames = await ListToolPageAsync(surface, cursor: null);
@@ -158,10 +158,10 @@ public sealed class McpPaginationTests
     [UnitTest]
     public async Task ToolsList_WithInvalidCursor_ReturnsInvalidParams()
     {
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             tools: [new StubTool("honua_tool_0")],
             resources: [],
-            logger: NullLogger<McpOperatorSurface>.Instance,
+            logger: NullLogger<McpDataAccessSurface>.Instance,
             limits: new McpSurfaceLimits(ListPageSize: 2, MaxResourceReadChars: 1000));
 
         var response = await DispatchAsync(
@@ -177,10 +177,10 @@ public sealed class McpPaginationTests
     public async Task ResourcesRead_OverDispatcher_ChunksLargeDocument()
     {
         var text = new string('z', 50);
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             tools: [],
             resources: [new StubResource("honua://big/doc", text)],
-            logger: NullLogger<McpOperatorSurface>.Instance,
+            logger: NullLogger<McpDataAccessSurface>.Instance,
             limits: new McpSurfaceLimits(ListPageSize: 50, MaxResourceReadChars: 20));
 
         var context = McpTestFactory.AuthenticatedHttpContext();
@@ -206,7 +206,7 @@ public sealed class McpPaginationTests
     }
 
     private static async Task<(string[] Names, string? NextCursor)> ListToolPageAsync(
-        McpOperatorSurface surface,
+        McpDataAccessSurface surface,
         string? cursor)
     {
         var paramsJson = cursor is null
@@ -226,7 +226,7 @@ public sealed class McpPaginationTests
     }
 
     private static async Task<McpJsonRpcResponse?> DispatchAsync(
-        McpOperatorSurface surface,
+        McpDataAccessSurface surface,
         string body,
         HttpContext? context = null)
     {

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpRegistryCompositionTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpRegistryCompositionTests.cs
@@ -67,13 +67,13 @@ public sealed class McpRegistryCompositionTests
     public void OrphanTool_WithoutRegistryDescriptor_IsDetectedAsDrift()
     {
         var jobService = Substitute.For<IGeoprocessingJobService>();
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [
                 new ListCapabilitiesTool(jobService, NullLogger<ListCapabilitiesTool>.Instance),
                 new StubOrphanTool(),
             ],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         McpRegistryCompositionValidator.FindDrift(surface, Registry)
             .Should().ContainSingle()
@@ -84,10 +84,10 @@ public sealed class McpRegistryCompositionTests
     public void OrphanResource_WithoutRegistryDescriptor_IsDetectedAsDrift()
     {
         var jobService = Substitute.For<IGeoprocessingJobService>();
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [new ListCapabilitiesTool(jobService, NullLogger<ListCapabilitiesTool>.Instance)],
             [new StubOrphanResource()],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         McpRegistryCompositionValidator.FindDrift(surface, Registry)
             .Should().ContainSingle()
@@ -98,7 +98,7 @@ public sealed class McpRegistryCompositionTests
     public async Task StartupCheck_Throws_OnDrift_WhenRegistryBindingEnabled()
     {
         var check = new McpRegistryBindingStartupCheck(
-            new McpOperatorSurface([new StubOrphanTool()], [], NullLogger<McpOperatorSurface>.Instance),
+            new McpDataAccessSurface([new StubOrphanTool()], [], NullLogger<McpDataAccessSurface>.Instance),
             Registry,
             Options.Create(new CapabilityRegistryBindingOptions { RegistryBinding = true }));
 
@@ -112,7 +112,7 @@ public sealed class McpRegistryCompositionTests
     public async Task StartupCheck_Skips_WhenRegistryBindingDisabled()
     {
         var check = new McpRegistryBindingStartupCheck(
-            new McpOperatorSurface([new StubOrphanTool()], [], NullLogger<McpOperatorSurface>.Instance),
+            new McpDataAccessSurface([new StubOrphanTool()], [], NullLogger<McpDataAccessSurface>.Instance),
             Registry,
             Options.Create(new CapabilityRegistryBindingOptions { RegistryBinding = false }));
 
@@ -147,10 +147,10 @@ public sealed class McpRegistryCompositionTests
     private static string TitleCase(string value) =>
         string.IsNullOrEmpty(value) ? value : char.ToUpperInvariant(value[0]) + value[1..];
 
-    private static McpOperatorSurface BuildConformantSurface()
+    private static McpDataAccessSurface BuildConformantSurface()
     {
         var jobService = Substitute.For<IGeoprocessingJobService>();
-        return new McpOperatorSurface(
+        return new McpDataAccessSurface(
             [
                 new ValidatePlanTool(jobService, NullLogger<ValidatePlanTool>.Instance),
                 new ExecutePlanTool(jobService, NullLogger<ExecutePlanTool>.Instance),
@@ -163,7 +163,7 @@ public sealed class McpRegistryCompositionTests
                 new WorkspaceResource(jobService, NullLogger<WorkspaceResource>.Instance),
                 new FeatureCatalogResource(jobService, NullLogger<FeatureCatalogResource>.Instance),
             ],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
     }
 
     /// <summary>A tool with a name no capability-registry descriptor advertises.</summary>

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpServiceCollectionExtensionsTests.cs
@@ -30,10 +30,10 @@ namespace Honua.Server.Tests.Features.Protocols.Mcp;
 public sealed class McpServiceCollectionExtensionsTests
 {
     [UnitTest]
-    public void AddMcpOperatorSurface_DoesNotRegisterPromotionResourceHandlers()
+    public void AddMcpDataAccessSurface_DoesNotRegisterPromotionResourceHandlers()
     {
         var services = BuildBaseServices();
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredResourceHandlers(services)
             .Should().NotContain(new[]
@@ -47,10 +47,10 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_RegistersFeatureCatalogResource()
+    public void AddMcpDataAccessSurface_RegistersFeatureCatalogResource()
     {
         var services = BuildBaseServices();
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredResourceHandlers(services)
             .Should().Contain(typeof(FeatureCatalogResource),
@@ -60,10 +60,10 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_RegistersPublishServiceTool()
+    public void AddMcpDataAccessSurface_RegistersPublishServiceTool()
     {
         var services = BuildBaseServices();
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredToolHandlers(services)
             .Should().Contain(typeof(PublishServiceTool),
@@ -72,10 +72,10 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_DoesNotRegisterFallbackPromotionStores()
+    public void AddMcpDataAccessSurface_DoesNotRegisterFallbackPromotionStores()
     {
         var services = BuildBaseServices();
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         services.Any(d => d.ServiceType == typeof(IPublishedServiceStore))
             .Should().BeFalse("the transport registrar must not invent canonical publishing persistence");
@@ -86,13 +86,13 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_WithLocationServicesRegistered_RegistersGeocodeAndRouteTools()
+    public void AddMcpDataAccessSurface_WithLocationServicesRegistered_RegistersGeocodeAndRouteTools()
     {
         var services = BuildBaseServices();
         services.AddScoped(_ => Substitute.For<IGeocodeCoordinatorService>());
         services.AddScoped(_ => Substitute.For<IRoutingProvider>());
 
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredToolHandlers(services)
             .Should().Contain(new[]
@@ -103,11 +103,11 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_WithoutOpsObservabilityReader_DoesNotRegisterOpsObservabilitySurface()
+    public void AddMcpDataAccessSurface_WithoutOpsObservabilityReader_DoesNotRegisterOpsObservabilitySurface()
     {
         var services = BuildBaseServices();
 
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredToolHandlers(services)
             .Should().NotContain(new[]
@@ -126,12 +126,12 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_WithOpsObservabilityReader_RegistersOpsObservabilitySurface()
+    public void AddMcpDataAccessSurface_WithOpsObservabilityReader_RegistersOpsObservabilitySurface()
     {
         var services = BuildBaseServices();
         services.AddScoped(_ => Substitute.For<IMcpOpsObservabilityReader>());
 
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredToolHandlers(services)
             .Should().Contain(new[]
@@ -150,11 +150,11 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_WithoutPlatformOpsReader_DoesNotRegisterPlatformOpsTools()
+    public void AddMcpDataAccessSurface_WithoutPlatformOpsReader_DoesNotRegisterPlatformOpsTools()
     {
         var services = BuildBaseServices();
 
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredToolHandlers(services)
             .Should().NotContain(new[]
@@ -167,12 +167,12 @@ public sealed class McpServiceCollectionExtensionsTests
     }
 
     [UnitTest]
-    public void AddMcpOperatorSurface_WithPlatformOpsReader_RegistersPlatformOpsTools()
+    public void AddMcpDataAccessSurface_WithPlatformOpsReader_RegistersPlatformOpsTools()
     {
         var services = BuildBaseServices();
         services.AddScoped(_ => Substitute.For<IMcpPlatformOpsReader>());
 
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
 
         RegisteredToolHandlers(services)
             .Should().Contain(new[]
@@ -188,7 +188,7 @@ public sealed class McpServiceCollectionExtensionsTests
     public void AddMcpPromotionSurface_RegistersPromotionResourceHandlersOnly()
     {
         var services = BuildBaseServices();
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
         services.AddMcpPromotionSurface();
 
         RegisteredResourceHandlers(services)
@@ -218,7 +218,7 @@ public sealed class McpServiceCollectionExtensionsTests
         var services = BuildBaseServices();
         services.AddSingleton(canonicalPublishedServices);
         services.AddSingleton(canonicalDeployments);
-        services.AddMcpOperatorSurface(new ConfigurationBuilder().Build());
+        services.AddMcpDataAccessSurface(new ConfigurationBuilder().Build());
         services.AddMcpPromotionSurface();
 
         using var provider = services.BuildServiceProvider();

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpStyleToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpStyleToolTests.cs
@@ -277,14 +277,14 @@ public sealed class McpStyleToolTests
         IMetadataV2StyleGraphSync? graphSync = null,
         IRasterMapRenderer? renderer = null)
     {
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [
                 new GetStyleTool(_jobService, NullLogger<GetStyleTool>.Instance),
                 new ApplyStylePresetTool(_jobService, NullLogger<ApplyStylePresetTool>.Instance),
                 new RenderMapTool(_jobService, NullLogger<RenderMapTool>.Instance),
             ],
             [],
-            NullLogger<McpOperatorSurface>.Instance);
+            NullLogger<McpDataAccessSurface>.Instance);
 
         var services = new ServiceCollection();
         services.AddSingleton<IMetadataV2GraphProvider>(BuildGraphProvider());

--- a/tests/dotnet/Honua.Ai.Tests/Source/PublishedOperationToolTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/PublishedOperationToolTests.cs
@@ -339,10 +339,10 @@ public sealed class PublishedOperationToolTests
             Options.Create(new McpPublishedOperationOptions { Enabled = true }),
             NullLogger<PublishedOperationToolSource>.Instance);
 
-        var surface = new McpOperatorSurface(
+        var surface = new McpDataAccessSurface(
             [],
             [],
-            NullLogger<McpOperatorSurface>.Instance,
+            NullLogger<McpDataAccessSurface>.Instance,
             limits: null,
             toolSources: [source]);
 
@@ -383,8 +383,8 @@ public sealed class PublishedOperationToolTests
             Options.Create(new McpPublishedOperationOptions { Enabled = true }),
             NullLogger<PublishedOperationToolSource>.Instance);
 
-        var surface = new McpOperatorSurface(
-            [staticTool], [], NullLogger<McpOperatorSurface>.Instance, limits: null, toolSources: [source]);
+        var surface = new McpDataAccessSurface(
+            [staticTool], [], NullLogger<McpDataAccessSurface>.Instance, limits: null, toolSources: [source]);
 
         var response = await surface.DispatchAsync(
             AuthenticatedContext(new ServiceCollection().BuildServiceProvider()),


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #2857

## Summary
`McpOperatorSurface` — the JSON-RPC dispatcher/registry for the public `POST /mcp` surface — is misnamed. That surface dispatches ~27 studio/data-access tools plus 8 bounded, read-only ops-*evidence* tools, and **zero** operator intelligence. The operator intelligence (diagnose, tune, upgrade planning with rollback gates, GitOps rollout, remediation planning) lives in the private `honua-devops` repo and exposes its own ~35-tool operator surface over MCP stdio. A dispatcher named for the operator surface, in the public repo, implies the operator surface is open-core — it is not (ADR-0024).

This PR writes the **evidence-vs-intelligence** boundary down (ADR-0066) and then does a mechanical rename picked by that boundary: `McpOperatorSurface` → `McpDataAccessSurface`, matching the "base MCP data-access surface" open-core language already used by ADR-0024 and the `honua-devops` README.

## Changes Made
- Added **ADR-0066** recording the evidence-vs-intelligence boundary: what stays open in `honua-server` (studio/data-access + 8 bounded ops-evidence tools), what is proprietary in `honua-devops`, and why the 8 ops-evidence tools are correctly public rather than a leak across the line. Indexed it in the ADR README.
- Renamed the dispatcher and its registration surface: `McpOperatorSurface` → `McpDataAccessSurface`, `AddMcpOperatorSurface` → `AddMcpDataAccessSurface`, `MapMcpOperatorSurface` → `MapMcpDataAccessSurface` (identifier-only; all references updated compiler-clean).
- Documented the two-surface picture in `docs/guides/connect/ai-agents-mcp.md` (this repo's HTTP MCP data-access surface vs. `honua-devops`' stdio operator surface).
- Updated stale identifier references in ADR-0054 and ADR-0056 to the new names.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [x] Documentation updated
- [ ] None — no docs or contract impact

Mechanical rename only: no tool added/removed/renamed/re-gated; `tools/list` output is byte-identical before and after. No wire-visible change — method names, session semantics, the `/mcp` route, and error contracts are untouched. The renamed type and its registration extensions are `internal` to `Honua.Ai` and are not exported to `honua-sdk-dotnet` / `honua-sdk-js`, so there is no SDK/consumer impact.

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
