### PR TITLE
fix: skip static-web-assets in API test hosts to stop shard-wide DirectoryNotFoundException (#2904)

### DIFF
--- a/scripts/ci/merge-train/lib.sh
+++ b/scripts/ci/merge-train/lib.sh
@@ -38,7 +38,18 @@ set -euo pipefail
 # per-test schema is migrated (honua-server#1568/#2049). These are intermittent:
 # the rerun clears a true race, while a genuine missing-migration bug reproduces
 # and still escalates — so it is safe to treat them as flake candidates.
-: "${TRAIN_FLAKE_REGEX:=40P01|deadlock detected|ryuk|Testcontainers.*(timed out|connection refused)|relation .* does not exist|column .* does not exist|schema .* does not exist|does not exist at character}"
+#
+# The ASP.NET static-web-assets loader signature (StaticWebAssetsLoader / an
+# obj/<config>/<tfm>/compressed/ path in a DirectoryNotFoundException) is the
+# honua-server#2904 environmental race: the sharded Release test build did not
+# reliably materialize the Blazor compressed-assets content root, so the test
+# host aborted construction and failed EVERY test in the shard identically —
+# which the attributor then blunt-escalated onto every PR in the batch. The
+# host bootstrap fix (Program.cs skips the loader for API test hosts and hardens
+# the opt-in demo path) removes the race; this signature is defense-in-depth so
+# any residual/related static-web-assets content-root race is rerun-and-merged-
+# through rather than escalating the whole batch.
+: "${TRAIN_FLAKE_REGEX:=40P01|deadlock detected|ryuk|Testcontainers.*(timed out|connection refused)|relation .* does not exist|column .* does not exist|schema .* does not exist|does not exist at character|StaticWebAssetsLoader|obj/[^ ]*/compressed}"
 
 # Heavy CI jobs the train treats as NON-BLOCKING. They run on EVERY batch (not
 # shard-targeted), flake on environment (Docker registry, browser, JS/Python

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -147,9 +147,23 @@ var serveApiDocs = builder.Configuration.GetValue(
     builder.Configuration.GetValue("HONUA_SERVE_API_DOCS", builder.Environment.IsDevelopment()));
 var requiresDurableDistributedEvents = !builder.Environment.IsDevelopment() && !isTestEnvironment;
 var stacOpsDemoPathPrefix = new PathString("/samples/stac-ops");
-if (serveStacOpsDemo && !builder.Environment.IsDevelopment())
+// ASP.NET's static-web-assets loader eagerly opens every content root listed in the runtime
+// manifest — including obj/<Config>/<tfm>/compressed/ (the hosted Blazor demo's precompressed
+// assets). In the sharded Release *test* build that directory is not reliably materialized, so
+// the loader throws DirectoryNotFoundException at host construction and fails every test in the
+// shard before any test logic runs (honua-server#2904). API integration tests do not need the
+// hosted Blazor assets, so the Test host skips the loader by default; the few tests that assert
+// the hosted STAC ops demo shell opt back in with HONUA_TEST_HOSTED_BLAZOR_ASSETS=true (loaded
+// through the resilient path below, which pre-creates any missing content roots).
+var loadHostedBlazorStaticWebAssets = serveStacOpsDemo && !builder.Environment.IsDevelopment();
+if (isTestEnvironment)
 {
-    builder.WebHost.UseStaticWebAssets();
+    loadHostedBlazorStaticWebAssets =
+        builder.Configuration.GetValue("HONUA_TEST_HOSTED_BLAZOR_ASSETS", false);
+}
+if (loadHostedBlazorStaticWebAssets)
+{
+    StartupConfigurationHelpers.LoadHostedBlazorStaticWebAssets(builder);
 }
 
 // Load optional security configuration without overriding environment-specific settings.

--- a/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
+++ b/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Text.Json;
 using Honua.Core.Configuration;
 using Honua.Core.Features.Caching;
 using Honua.Core.Features.Infrastructure.Domain;
@@ -10,6 +11,8 @@ using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Security;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.Options;
@@ -222,5 +225,68 @@ internal static class StartupConfigurationHelpers
         services.AddSingleton<IValidateOptions<CloudStorageOptions>>(new CloudStorageOptionsValidator());
         services.AddSingleton<IValidateOptions<OidcAuthenticationOptions>>(new OidcAuthenticationOptionsValidator());
         services.AddSingleton<IValidateOptions<FileUploadSecurityOptions>>(new FileUploadSecurityOptionsValidator());
+    }
+
+    /// <summary>
+    /// Loads the ASP.NET static web assets for the hosted Blazor demo shells (currently the
+    /// optional STAC ops demo at <c>/samples/stac-ops</c>) after hardening the load against a
+    /// missing compressed-asset content root.
+    /// </summary>
+    /// <remarks>
+    /// The static-web-assets runtime manifest lists content-root directories that the loader
+    /// eagerly opens as <c>PhysicalFileProvider</c> instances during host construction. In
+    /// sharded Release builds one of those roots — <c>obj/&lt;Config&gt;/&lt;tfm&gt;/compressed/</c>,
+    /// the Blazor precompressed-assets output — is sometimes referenced by the manifest but not
+    /// materialized on disk, and <c>PhysicalFileProvider</c> throws
+    /// <see cref="DirectoryNotFoundException"/> for a missing root. That aborted host
+    /// construction and failed every test in the affected shard before any test logic ran
+    /// (honua-server#2904). Pre-creating any missing referenced roots lets the loader open them;
+    /// an empty <c>compressed/</c> root simply means content negotiation falls back to the
+    /// uncompressed asset, which is the behavior the hosted-demo integration tests assert.
+    /// </remarks>
+    public static void LoadHostedBlazorStaticWebAssets(WebApplicationBuilder builder)
+    {
+        EnsureStaticWebAssetContentRootsExist();
+        builder.WebHost.UseStaticWebAssets();
+    }
+
+    private static void EnsureStaticWebAssetContentRootsExist()
+    {
+        try
+        {
+            var manifests = Directory.EnumerateFiles(
+                AppContext.BaseDirectory,
+                "*.staticwebassets.runtime.json",
+                SearchOption.TopDirectoryOnly);
+
+            foreach (var manifestPath in manifests)
+            {
+                using var stream = File.OpenRead(manifestPath);
+                using var document = JsonDocument.Parse(stream);
+
+                if (!document.RootElement.TryGetProperty("ContentRoots", out var contentRoots) ||
+                    contentRoots.ValueKind != JsonValueKind.Array)
+                {
+                    continue;
+                }
+
+                foreach (var contentRoot in contentRoots.EnumerateArray())
+                {
+                    var path = contentRoot.GetString();
+                    if (!string.IsNullOrWhiteSpace(path) && !Directory.Exists(path))
+                    {
+                        Directory.CreateDirectory(path);
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (
+            ex is IOException or UnauthorizedAccessException or NotSupportedException or
+                ArgumentException or JsonException)
+        {
+            // Best-effort hardening only. If a manifest cannot be read or a root cannot be
+            // created, fall through to the loader with its normal behavior — this guard must
+            // never be the reason host construction fails.
+        }
     }
 }

--- a/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacOpsDemoEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacOpsDemoEndpointTests.cs
@@ -11,15 +11,38 @@ using Microsoft.AspNetCore.Hosting;
 namespace Honua.Server.Tests.Features.Protocols.Stac;
 
 /// <summary>
+/// Isolated <see cref="WebAppFixture"/> that opts the hosted Blazor static web assets back
+/// on for the STAC ops demo shell tests. The Test host skips ASP.NET's static-web-assets
+/// loader by default (honua-server#2904) because it aborts host construction when the
+/// sharded Release build has not materialized the Blazor <c>compressed/</c> content root; the
+/// few tests that actually assert the served demo shell set
+/// <c>HONUA_TEST_HOSTED_BLAZOR_ASSETS=true</c> so the resilient loader runs for this host only.
+/// </summary>
+public sealed class StacOpsDemoWebAppFixture : IAsyncLifetime
+{
+    private readonly WebAppFixture _inner = new WebAppFixture()
+        .ConfigureWebHost(builder => builder.UseSetting("HONUA_TEST_HOSTED_BLAZOR_ASSETS", "true"));
+
+    /// <summary>Gets the HTTP client bound to the demo-enabled test host.</summary>
+    public HttpClient Client => _inner.Client;
+
+    /// <inheritdoc />
+    public Task InitializeAsync() => _inner.InitializeAsync();
+
+    /// <inheritdoc />
+    public Task DisposeAsync() => _inner.DisposeAsync();
+}
+
+/// <summary>
 /// Integration tests for the hosted STAC operations demo shell.
 /// </summary>
 [Protocol(TestProtocols.Stac)]
 [Collection("Database")]
-public sealed class StacOpsDemoEndpointTests : IClassFixture<WebAppFixture>
+public sealed class StacOpsDemoEndpointTests : IClassFixture<StacOpsDemoWebAppFixture>
 {
-    private readonly WebAppFixture _fixture;
+    private readonly StacOpsDemoWebAppFixture _fixture;
 
-    public StacOpsDemoEndpointTests(WebAppFixture fixture) => _fixture = fixture;
+    public StacOpsDemoEndpointTests(StacOpsDemoWebAppFixture fixture) => _fixture = fixture;
 
     [IntegrationTest]
     [Operation(Operations.StacCatalog)]


### PR DESCRIPTION
## Issue Link
Closes #2904

## Summary
The `Server Tests` shards intermittently died with a mass `System.IO.DirectoryNotFoundException` (`.../src/Honua.Server/obj/Release/net10.0/compressed/`), failing every test in the shard identically at host construction and blunt-escalating every PR in the batch off the merge train.

Root cause: the `WebApplicationFactory` test host boots the real `Program.Main`, which called `builder.WebHost.UseStaticWebAssets()` in any non-Development environment (Test included). ASP.NET's static-web-assets loader eagerly opens every content root in the runtime manifest as a `PhysicalFileProvider`, including the hosted Blazor demo's precompressed-assets output `obj/<Config>/<tfm>/compressed/`. The sharded Release test build does not reliably materialize that directory, so `PhysicalFileProvider` construction threw before any test logic ran.

API integration tests do not need the hosted Blazor assets, so the Test host now skips the loader by default. The only tests that assert served static content (the STAC ops demo shell) opt back in and load through a resilient path that pre-creates any missing manifest content roots. Production/Development behavior is unchanged apart from the same best-effort hardening.

## Changes Made
- `src/Honua.Server/Program.cs`: in the Test environment, skip `UseStaticWebAssets()` by default; enable it only when `HONUA_TEST_HOSTED_BLAZOR_ASSETS=true`. Route the load through the resilient helper.
- `src/Honua.Server/Startup/StartupConfigurationHelpers.cs`: add `LoadHostedBlazorStaticWebAssets` which pre-creates any missing static-web-assets content-root directories (best-effort; never fails host construction) before calling `UseStaticWebAssets()`.
- `tests/dotnet/Honua.Protocols.Stac.Tests/Source/StacOpsDemoEndpointTests.cs`: opt the demo-shell tests into static assets via an isolated `StacOpsDemoWebAppFixture` (the only tests that serve static content).
- `scripts/ci/merge-train/lib.sh`: add the static-web-assets loader signature (`StaticWebAssetsLoader` / `obj/.../compressed`) to `TRAIN_FLAKE_REGEX` so any residual/related content-root race is rerun-and-merged-through instead of blunt-escalating the whole batch.

## Testing
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Verification (Release, `--no-build`, with **both** `compressed/` dirs deleted to simulate the flaky shard):
- Admin/Console shard host-boot test (`AdminCapabilitiesEndpointTests`) run 5×: all green, **zero `DirectoryNotFoundException`**, and the `compressed/` dir stayed absent (default path never touches static web assets).
- `StacOpsDemoEndpointTests` (opt-in path) run 3×: all 4 tests green each time (including the `blazor.webassembly.js` serving assertion), zero `DirectoryNotFoundException`, and the resilient loader recreated the deleted `compressed/` root — direct proof the previously-throwing path now self-heals.
- `scripts/ci/merge-train/fixtures/validate-merge-train.sh`: identical result with and without the regex change (144 passed / 7 pre-existing env failures) — no new failures.

## Gate Impact
- [x] PR gates (build, test, governance)

## Docs or Contract Impact
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality

## Notes
- Added `train:hold` so this PR does not itself ride (and potentially flake) a batch while it is validated.
- `blocked` status is the known #2865 steady state; not a problem with this PR.
- The blunt batch-escalation lever is addressed here via the flake-classifier signature (rerun + merge-through). A deeper fix (per-PR attribution of infra failures) remains a larger follow-up in the merge-train attributor.
