### PR TITLE
docs(ogc-cite): canonicalize CITE numbers in cite-status.md and gate the mirrors (#2924)

### DIFF
--- a/docs/cite-status.md
+++ b/docs/cite-status.md
@@ -7,10 +7,17 @@ This page is the single fixed-path answer to "what is the current OGC CITE
 pass rate for each protocol on `trunk`?" It exists so re-grading agents and
 auditors can find an authoritative number without spelunking workflow artifacts.
 
-**Source of truth.** This page mirrors the totals in
-[`docs/internal/contributor/ogc-cite-conformance-evidence.md`](internal/contributor/ogc-cite-conformance-evidence.md),
-which is the website-linkable copy of this page. The suite totals here are
-the canonical source of truth for this repo’s OGC CITE evidence snapshot.
+**Source of truth.** This page is the single canonical snapshot of OGC CITE
+per-suite pass rates. [`docs/contributor/ogc-cite-conformance-evidence.md`](internal/contributor/ogc-cite-conformance-evidence.md)
+is the stable, website-linkable evidence-run narrative (workflow links,
+artifact contents, refresh steps) and links here for the numbers rather than
+restating them — see that page. The `x-honua-cite-compliance` vendor
+extension in `src/Honua.Server/openapi.json` and the other four
+`*-openapi.json` files also declares this page as its `authoritativeSource`,
+and an architecture test
+(`tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/CiteStatusComplianceDriftTests.cs`)
+gates every one of those five files against the table below so they can
+never silently drift from it.
 
 **Local results note.** The per-suite result directories
 (`cite-results/`, `cite-wfs20-results/`, `cite-tiles-results/`,
@@ -155,15 +162,18 @@ hand-maintained table below.
    `cite-conformance-evidence-*` artifact's `conformance-summary.md` into the
    table above.
 4. Update "Last reviewed", the run number, the commit SHA, and the run date.
-5. If a suite regresses, both this page and
-   `docs/internal/contributor/ogc-cite-conformance-evidence.md` must be updated in the
-   same commit, and the public claim should be downgraded until the regression
-   clears.
+5. If a suite regresses, update this page (the canonical numbers), the
+   evidence-run narrative in `docs/contributor/ogc-cite-conformance-evidence.md`,
+   and the `x-honua-cite-compliance` vendor extension in the affected
+   `*-openapi.json` file(s) in the same commit — `CiteStatusComplianceDriftTests`
+   fails the build if any of them disagree. Downgrade the public claim until
+   the regression clears.
 
 ## Related Documents
 
-- [`docs/internal/contributor/ogc-cite-conformance-evidence.md`](internal/contributor/ogc-cite-conformance-evidence.md)
-  — canonical, website-linkable summary (source of truth).
+- [`docs/contributor/ogc-cite-conformance-evidence.md`](internal/contributor/ogc-cite-conformance-evidence.md)
+  — stable, website-linkable evidence-run narrative; see this page for the
+  canonical per-suite numbers.
 - [`docs/contributor/cite-runbook.md`](internal/contributor/cite-runbook.md) —
   per-suite scope, scripts, workflow files, and open issues.
 - [`docs/contributor/ogc-certification-path.md`](internal/contributor/ogc-certification-path.md)

--- a/docs/gis/capability-matrix-schema.md
+++ b/docs/gis/capability-matrix-schema.md
@@ -113,8 +113,18 @@ key list:
 ## Drift and freshness
 
 Unlike `feature-catalog.json` (drift-gated by an xUnit `[Fact]` in
-`Honua.Architecture.Tests`), `capability-matrix.v1.json` is drift-checked by
-the CI workflow itself (`--check` mode above), not a C# test — its inputs span
-a hand-maintained Markdown table (`cite-status.md`) that a C# architecture
-test has no reason to parse independently. Treat a workflow failure exactly
-like a failed architecture test: regenerate locally and commit the result.
+`Honua.Architecture.Tests`), `capability-matrix.v1.json` itself is
+drift-checked by the CI workflow (`--check` mode above), not a C# test.
+Treat a workflow failure exactly like a failed architecture test: regenerate
+locally and commit the result.
+
+`cite-status.md`'s per-suite table — one of this artifact's source inputs —
+*is* independently parsed by a C# architecture test,
+`CiteStatusComplianceDriftTests`
+(`tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/CiteStatusComplianceDriftTests.cs`,
+#2924). That test uses the same row-parsing pattern as
+`generate-capability-matrix.py`'s `parse_cite_status`, but for a different
+join: it gates the `x-honua-cite-compliance` vendor extension in
+`src/Honua.Server/openapi.json` and the other four `*-openapi.json` files
+against `cite-status.md`'s totals, independently of this capability-matrix
+aggregation.

--- a/docs/internal/contributor/ogc-cite-conformance-evidence.md
+++ b/docs/internal/contributor/ogc-cite-conformance-evidence.md
@@ -39,21 +39,11 @@ suite/profile is removed from the public claim.
 
 ## All-Pass Suite Set
 
-The public all-pass suite set is:
-
-| Suite | Profile | Total | Passed | Failed | Skipped | CantTell | Status |
-|---|---:|---:|---:|---:|---:|---:|---|
-| OGC API Features 1.0 | `default` | 137 | 137 | 0 | 0 | 0 | Passing |
-| OGC API Tiles 1.0 | `default` | 16 | 16 | 0 | 0 | 0 | Passing |
-| GeoPackage 1.2 | `applicable` | 31 | 31 | 0 | 0 | 0 | Passing |
-| GML 3.2 | `applicable` | 17 | 17 | 0 | 0 | 0 | Passing |
-| KML 2.2 | `applicable` | 42 | 42 | 0 | 0 | 0 | Passing |
-| WFS 1.0 | `basic` | 162 | 162 | 0 | 0 | 0 | Passing |
-| WFS 1.1 | `basic` | 39 | 39 | 0 | 0 | 0 | Passing |
-| WFS 2.0 | `basic` | 167 | 167 | 0 | 0 | 0 | Passing |
-| WCS 2.0 | `core` | 82 | 82 | 0 | 0 | 0 | Passing |
-| WMS 1.3 | `default` | 199 | 199 | 0 | 0 | 0 | Passing |
-| WMTS 1.0 | `default` | 60 | 60 | 0 | 0 | 0 | Passing |
+The canonical per-suite pass/total numbers live in
+[`docs/cite-status.md`](../../cite-status.md) — see that page for the
+current table; do not restate the numbers here. This page's job is the
+evidence-run narrative (workflow links, artifact contents, refresh steps)
+around whatever `cite-status.md` currently reports.
 
 ## Suite Scope Notes
 

--- a/docs/reference/compatibility/ogc-conformance.md
+++ b/docs/reference/compatibility/ogc-conformance.md
@@ -1,29 +1,17 @@
 # OGC conformance
 
-Honua Server passes 952 / 952 assertions (100%) across 11 OGC CITE suites on `trunk`,
-with 0 failed, 0 skipped, and 0 CantTell. The authoritative snapshot, evidence-run
-links, and re-grading guidance live in [`docs/cite-status.md`](../../cite-status.md);
-the numbers below are copied directly from that page.
+Honua Server passes every OGC CITE suite it runs on `trunk` at 100%. The
+canonical per-suite pass rates, evidence-run links, and re-grading guidance
+live in [`docs/cite-status.md`](../../cite-status.md) — see that page for the
+current numbers; they are not restated here so there is nothing for this page
+to fall out of sync with.
 
 ## CITE pass rates per suite
 
-Snapshot from the 2026-05-17 evidence run (`allPassed=true`):
-
-| Suite | Profile | Passed / Total | Pass rate |
-|---|---|---:|---:|
-| OGC API Features 1.0 | `default` | 137 / 137 | 100% |
-| OGC API Tiles 1.0 | `default` | 16 / 16 | 100% |
-| GeoPackage 1.2 | `applicable` | 31 / 31 | 100% |
-| GML 3.2 | `applicable` | 17 / 17 | 100% |
-| KML 2.2 | `applicable` | 42 / 42 | 100% |
-| WFS 1.0 | `basic` | 162 / 162 | 100% |
-| WFS 1.1 | `basic` | 39 / 39 | 100% |
-| WFS 2.0 | `basic` | 167 / 167 | 100% |
-| WCS 2.0 | `core` | 82 / 82 | 100% |
-| WMS 1.3 | `default` | 199 / 199 | 100% |
-| WMTS 1.0 | `default` | 60 / 60 | 100% |
-
-The WFS 2.0 explicit transactional slice is tracked separately and passes 25 / 25.
+See the "Current Per-Protocol Status" table in
+[`docs/cite-status.md`](../../cite-status.md#current-per-protocol-status) for
+the canonical passed/total counts and pass rate per suite, including the WFS
+2.0 explicit transactional slice.
 
 ## What conformance means per protocol
 
@@ -70,6 +58,8 @@ Each OGC API surface declares its implemented conformance classes at runtime
 
 The OpenAPI specs under `src/Honua.Server/*-openapi.json` carry the same CITE
 totals in an `x-honua-cite-compliance` vendor extension on the `info` object.
+An architecture test (`CiteStatusComplianceDriftTests`) fails the build if any
+of those five files disagree with `docs/cite-status.md`.
 
 ## API versioning in one paragraph
 
@@ -85,8 +75,8 @@ breaking changes require a new major package (`Geospatial.V2`); see the
 
 ## Related
 
-- [`docs/cite-status.md`](../../cite-status.md) — authoritative CITE snapshot (source of truth for the table above).
-- [CITE conformance evidence](../../internal/contributor/ogc-cite-conformance-evidence.md) — canonical, website-linkable evidence summary.
+- [`docs/cite-status.md`](../../cite-status.md) — authoritative CITE snapshot (source of truth for the numbers above).
+- [CITE conformance evidence](../../internal/contributor/ogc-cite-conformance-evidence.md) — stable, website-linkable evidence-run narrative; see `cite-status.md` for the numbers.
 - [CITE runbook](../../internal/contributor/cite-runbook.md) — per-suite scope, scripts, and workflow files.
 - [OGC certification path](../../internal/contributor/ogc-certification-path.md) — formal certification posture.
 - [Supported clients](clients.md) — which clients consume these protocols, with tested versions.

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/CiteStatusComplianceDriftTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/CiteStatusComplianceDriftTests.cs
@@ -1,0 +1,300 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace Honua.Architecture.Tests.FeatureCatalog;
+
+/// <summary>
+/// Drift guard for the CITE canonical-numbers join (#2924).
+/// <c>docs/cite-status.md</c> is the single canonical snapshot of OGC CITE
+/// per-suite pass rates. The <c>x-honua-cite-compliance</c> vendor extension
+/// embedded in the <c>info</c> object of <c>src/Honua.Server/openapi.json</c>
+/// and the four protocol-scoped <c>*-openapi.json</c> files
+/// (<c>ogc-processes</c>, <c>ogc-tiles</c>, <c>ogc-coverages</c>,
+/// <c>ogc-maps</c>) each restate a subset of the same numbers. Before this
+/// guard, nothing checked that join — a hand-edit to any one of the five
+/// artifacts could silently diverge from cite-status.md forever.
+/// </summary>
+[Trait("Category", "Architecture")]
+public sealed partial class CiteStatusComplianceDriftTests
+{
+    private const string CiteStatusRelativePath = "docs/cite-status.md";
+
+    private static readonly (string DisplayPath, string[] Segments)[] VendorExtensionArtifacts =
+    [
+        ("src/Honua.Server/openapi.json", ["src", "Honua.Server", "openapi.json"]),
+        ("src/Honua.Server/ogc-processes-openapi.json", ["src", "Honua.Server", "ogc-processes-openapi.json"]),
+        ("src/Honua.Server/ogc-tiles-openapi.json", ["src", "Honua.Server", "ogc-tiles-openapi.json"]),
+        ("src/Honua.Server/ogc-coverages-openapi.json", ["src", "Honua.Server", "ogc-coverages-openapi.json"]),
+        ("src/Honua.Server/ogc-maps-openapi.json", ["src", "Honua.Server", "ogc-maps-openapi.json"]),
+    ];
+
+    // Mirrors scripts/ci/generate-capability-matrix.py's parse_cite_status row
+    // pattern exactly (same capture groups, same anchors) so the Python
+    // capability-matrix generator and this architecture-test gate can never
+    // silently disagree about what counts as a per-suite row in
+    // docs/cite-status.md's "Current Per-Protocol Status" table.
+    [GeneratedRegex(
+        @"^\|\s*([^|]+?)\s*\|\s*`?([^|`]+?)`?\s*\|\s*(\d+)\s*/\s*(\d+)\s*\|\s*([\d.]+)%\s*\|",
+        RegexOptions.Multiline)]
+    private static partial Regex CiteStatusRowPattern();
+
+    // Matches the aggregate-restatement phrasing used across the vendor
+    // extensions' "summary" prose: either "<passed>/<total> across <n>
+    // conformance suites" (ogc-processes-openapi.json, which has no official
+    // CITE ETS of its own and only restates the full-suite aggregate) or
+    // "full Honua suite is <passed>/<total>" (the protocol-scoped
+    // ogc-tiles/ogc-coverages/ogc-maps files, which also carry a suites[]
+    // array for their own suite(s) but redundantly mention the full-suite
+    // aggregate too). The trailing "across <n> conformance suites" clause is
+    // optional so both phrasings share one pattern.
+    [GeneratedRegex(
+        @"(?:full Honua suite is|surrounding Honua OGC stack passes)\s+(\d+)\s*/\s*(\d+)(?:\s+across\s+(\d+)\s+conformance suites)?",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex ProseAggregatePattern();
+
+    [ArchitectureTest]
+    public void EveryVendorExtension_AgreesWithCiteStatusPerSuiteTotals()
+    {
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var canonical = ParseCanonicalSuites(repoRoot);
+
+        canonical.Should().NotBeEmpty(
+            $"{CiteStatusRelativePath}'s 'Current Per-Protocol Status' table must have at least one parseable " +
+            "suite row (| Suite | Profile | Passed / Total | Pass Rate | ... |) or this drift gate has nothing " +
+            "to check the OpenAPI vendor extensions against.");
+
+        foreach (var (suite, row) in canonical)
+        {
+            row.Passed.Should().Be(row.Total,
+                $"{CiteStatusRelativePath}'s row for suite '{suite}' reports {row.Passed}/{row.Total} passed/total. " +
+                "The page's own 'Public Evidence Standard' only permits listing suites at 100% pass -- fix or " +
+                $"remove the row in {CiteStatusRelativePath} before this gate can trust it as canonical.");
+        }
+
+        var canonicalTotalPassed = canonical.Values.Sum(row => row.Passed);
+
+        foreach (var (displayPath, segments) in VendorExtensionArtifacts)
+        {
+            var absolutePath = ArchitectureTestHelpers.CombinePath([repoRoot, .. segments]);
+            using var document = JsonDocument.Parse(File.ReadAllBytes(absolutePath));
+            var extension = document.RootElement.GetProperty("info").GetProperty("x-honua-cite-compliance");
+
+            AssertAuthoritativeSource(displayPath, extension);
+
+            var hasTotals = extension.TryGetProperty("totals", out var totalsElement);
+            var hasSuites = extension.TryGetProperty("suites", out var suitesElement);
+
+            if (hasTotals)
+            {
+                AssertTotals(displayPath, totalsElement, canonicalTotalPassed);
+            }
+
+            // Required only when the extension has neither a totals object nor a
+            // suites array to check (ogc-processes-openapi.json today) -- that
+            // leaves prose as the only place its aggregate claim could possibly
+            // be gated. Where a totals object or suites array already exists,
+            // any prose aggregate mention found is still validated, but its
+            // absence is not itself a failure.
+            AssertProseAggregate(displayPath, extension, canonicalTotalPassed, canonical.Count, required: !hasTotals && !hasSuites);
+
+            if (hasSuites)
+            {
+                AssertSuiteRows(displayPath, suitesElement, canonical);
+            }
+        }
+    }
+
+    [ArchitectureTest]
+    public void PrimaryOpenApiVendorExtension_ListsEveryCiteStatusSuite()
+    {
+        // src/Honua.Server/openapi.json is the only vendor extension whose
+        // summary claims to cover the *full* suite set ("All 11 conformance
+        // suites pass at 100% on trunk"), so it -- and only it -- must be a
+        // complete mirror of cite-status.md's suite set, not merely a
+        // non-diverging subset like the protocol-scoped *-openapi.json files.
+        var repoRoot = ArchitectureTestHelpers.ResolveRepositoryRoot();
+        var canonical = ParseCanonicalSuites(repoRoot);
+
+        var primaryPath = ArchitectureTestHelpers.CombinePath(repoRoot, "src", "Honua.Server", "openapi.json");
+        using var document = JsonDocument.Parse(File.ReadAllBytes(primaryPath));
+        var extension = document.RootElement.GetProperty("info").GetProperty("x-honua-cite-compliance");
+        var suitesElement = extension.GetProperty("suites");
+
+        var extensionSuiteNames = suitesElement.EnumerateArray()
+            .Select(entry => entry.GetProperty("suite").GetString() ?? string.Empty)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = canonical.Keys
+            .Where(suite => !extensionSuiteNames.Contains(suite))
+            .OrderBy(suite => suite, StringComparer.Ordinal)
+            .ToArray();
+        var extra = extensionSuiteNames
+            .Where(suite => !canonical.ContainsKey(suite))
+            .OrderBy(suite => suite, StringComparer.Ordinal)
+            .ToArray();
+
+        missing.Should().BeEmpty(
+            $"src/Honua.Server/openapi.json's x-honua-cite-compliance.suites is missing [{string.Join(", ", missing)}], " +
+            $"which {CiteStatusRelativePath} lists -- add the missing row(s) to openapi.json's suites array so the two " +
+            "never silently disagree about which suites exist.");
+        extra.Should().BeEmpty(
+            $"src/Honua.Server/openapi.json's x-honua-cite-compliance.suites has stale suite(s) [{string.Join(", ", extra)}] " +
+            $"that no longer exist in {CiteStatusRelativePath}'s table -- remove the stale row(s) from openapi.json, or add " +
+            $"the suite to {CiteStatusRelativePath} if it is a genuinely new CITE suite.");
+    }
+
+    private static void AssertAuthoritativeSource(string displayPath, JsonElement extension)
+    {
+        var hasSource = extension.TryGetProperty("authoritativeSource", out var sourceElement);
+        hasSource.Should().BeTrue(
+            $"{displayPath}'s x-honua-cite-compliance extension must declare an authoritativeSource field pointing " +
+            $"at {CiteStatusRelativePath} so readers know which page wins on divergence.");
+        sourceElement.GetString().Should().Be(CiteStatusRelativePath,
+            $"{displayPath}'s x-honua-cite-compliance.authoritativeSource must be '{CiteStatusRelativePath}' -- " +
+            $"update the extension in {displayPath} (not {CiteStatusRelativePath}) to fix this.");
+    }
+
+    private static void AssertTotals(string displayPath, JsonElement totalsElement, int canonicalTotalPassed)
+    {
+        var passed = totalsElement.GetProperty("passed").GetInt32();
+        var failed = totalsElement.GetProperty("failed").GetInt32();
+        var skipped = totalsElement.GetProperty("skipped").GetInt32();
+        var cantTell = totalsElement.GetProperty("cantTell").GetInt32();
+
+        passed.Should().Be(canonicalTotalPassed,
+            $"{displayPath}'s x-honua-cite-compliance.totals.passed is {passed}, but the sum of Passed across every " +
+            $"row in {CiteStatusRelativePath} is {canonicalTotalPassed}. Regenerate {displayPath}'s totals from the " +
+            $"latest CITE Evidence Report run, or correct {CiteStatusRelativePath} if the OpenAPI extension already " +
+            "reflects a newer one.");
+        failed.Should().Be(0,
+            $"{displayPath}'s x-honua-cite-compliance.totals.failed is {failed}, but {CiteStatusRelativePath} only " +
+            $"ever documents suites at 100% pass -- a nonzero failed count means {displayPath} is stale.");
+        skipped.Should().Be(0,
+            $"{displayPath}'s x-honua-cite-compliance.totals.skipped is {skipped}, but {CiteStatusRelativePath} only " +
+            $"ever documents suites at 100% pass -- a nonzero skipped count means {displayPath} is stale.");
+        cantTell.Should().Be(0,
+            $"{displayPath}'s x-honua-cite-compliance.totals.cantTell is {cantTell}, but {CiteStatusRelativePath} only " +
+            $"ever documents suites at 100% pass -- a nonzero cantTell count means {displayPath} is stale.");
+    }
+
+    private static void AssertProseAggregate(
+        string displayPath,
+        JsonElement extension,
+        int canonicalTotalPassed,
+        int canonicalSuiteCount,
+        bool required)
+    {
+        var summary = extension.TryGetProperty("summary", out var summaryElement)
+            ? summaryElement.GetString() ?? string.Empty
+            : string.Empty;
+        var match = ProseAggregatePattern().Match(summary);
+
+        if (!match.Success)
+        {
+            // Only a hard failure when this was the last remaining place this
+            // extension could be gated at all (no totals object, no suites
+            // array). Otherwise a missing/differently-worded aggregate mention
+            // is fine -- the totals/suites checks already cover the claim.
+            required.Should().BeFalse(
+                $"{displayPath}'s x-honua-cite-compliance.summary (\"{summary}\") has no totals object, no suites " +
+                "array, and no recognizable aggregate pass-count phrase either (\"<passed>/<total> across <n> " +
+                "conformance suites\" or \"full Honua suite is <passed>/<total>\"), so this drift gate cannot check " +
+                $"its claim at all -- add one of the three so it stays gated against {CiteStatusRelativePath}.");
+            return;
+        }
+
+        var passed = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        var total = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+
+        passed.Should().Be(canonicalTotalPassed,
+            $"{displayPath}'s x-honua-cite-compliance.summary claims {passed}/{total} passed, but " +
+            $"{CiteStatusRelativePath}'s per-suite table sums to {canonicalTotalPassed} passed -- update the summary " +
+            $"prose in {displayPath} to match {CiteStatusRelativePath}.");
+        total.Should().Be(canonicalTotalPassed,
+            $"{displayPath}'s x-honua-cite-compliance.summary claims {passed}/{total}, which is not a 100%-pass claim " +
+            $"({canonicalTotalPassed}/{canonicalTotalPassed} expected); {CiteStatusRelativePath} only documents " +
+            "100%-pass suites, so this prose must read a matching total.");
+
+        if (match.Groups[3].Success)
+        {
+            var suiteCount = int.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture);
+            suiteCount.Should().Be(canonicalSuiteCount,
+                $"{displayPath}'s x-honua-cite-compliance.summary claims {suiteCount} conformance suites, but " +
+                $"{CiteStatusRelativePath}'s 'Current Per-Protocol Status' table has {canonicalSuiteCount} rows -- " +
+                $"update the summary prose in {displayPath} to match {CiteStatusRelativePath}.");
+        }
+    }
+
+    private static void AssertSuiteRows(
+        string displayPath,
+        JsonElement suitesElement,
+        IReadOnlyDictionary<string, CanonicalSuiteRow> canonical)
+    {
+        foreach (var suiteElement in suitesElement.EnumerateArray())
+        {
+            var suiteName = suiteElement.GetProperty("suite").GetString() ?? string.Empty;
+
+            var found = canonical.TryGetValue(suiteName, out var expected);
+            found.Should().BeTrue(
+                $"{displayPath}'s x-honua-cite-compliance.suites references suite '{suiteName}', which does not " +
+                $"exist in {CiteStatusRelativePath}'s 'Current Per-Protocol Status' table -- rename or remove the " +
+                $"stale entry in {displayPath}, or add the suite to {CiteStatusRelativePath} if it is genuinely new.");
+            if (!found)
+            {
+                continue;
+            }
+
+            var profile = suiteElement.GetProperty("profile").GetString();
+            var passed = suiteElement.GetProperty("passed").GetInt32();
+            var total = suiteElement.GetProperty("total").GetInt32();
+            var passRate = suiteElement.GetProperty("passRate").GetString();
+
+            profile.Should().Be(expected!.Profile,
+                $"{displayPath}'s suite '{suiteName}' declares profile '{profile}', but {CiteStatusRelativePath} " +
+                $"declares '{expected.Profile}' -- fix whichever side is stale.");
+            passed.Should().Be(expected.Passed,
+                $"{displayPath}'s suite '{suiteName}' reports {passed}/{total} passed/total, but " +
+                $"{CiteStatusRelativePath} reports {expected.Passed}/{expected.Total} -- update {displayPath} from " +
+                "the latest evidence run.");
+            total.Should().Be(expected.Total,
+                $"{displayPath}'s suite '{suiteName}' reports {passed}/{total} passed/total, but " +
+                $"{CiteStatusRelativePath} reports {expected.Passed}/{expected.Total} -- update {displayPath} from " +
+                "the latest evidence run.");
+            passRate.Should().Be(expected.PassRateText,
+                $"{displayPath}'s suite '{suiteName}' reports passRate '{passRate}', but {CiteStatusRelativePath} " +
+                $"reports '{expected.PassRateText}' -- update {displayPath} from the latest evidence run.");
+        }
+    }
+
+    private static Dictionary<string, CanonicalSuiteRow> ParseCanonicalSuites(string repoRoot)
+    {
+        var path = ArchitectureTestHelpers.CombinePath(repoRoot, "docs", "cite-status.md");
+        var text = File.ReadAllText(path);
+
+        var suites = new Dictionary<string, CanonicalSuiteRow>(StringComparer.Ordinal);
+        foreach (Match match in CiteStatusRowPattern().Matches(text))
+        {
+            var suite = match.Groups[1].Value.Trim();
+            if (suite is "Suite" or "---")
+            {
+                continue;
+            }
+
+            suites[suite] = new CanonicalSuiteRow(
+                Profile: match.Groups[2].Value.Trim(),
+                Passed: int.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture),
+                Total: int.Parse(match.Groups[4].Value, CultureInfo.InvariantCulture),
+                PassRateText: $"{match.Groups[5].Value}%");
+        }
+
+        return suites;
+    }
+
+    private sealed record CanonicalSuiteRow(string Profile, int Passed, int Total, string PassRateText);
+}

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/CiteStatusComplianceDriftTests.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/CiteStatusComplianceDriftTests.cs
@@ -58,6 +58,16 @@ public sealed partial class CiteStatusComplianceDriftTests
         RegexOptions.IgnoreCase)]
     private static partial Regex ProseAggregatePattern();
 
+    // Catches every "<passed>/<total>" fraction in the summary prose, not just the
+    // full-suite aggregate ProseAggregatePattern anchors on. The protocol-scoped
+    // *-openapi.json files restate their own suite's count ahead of the aggregate
+    // (e.g. "OGC API Tiles ETS passes 16/16 on trunk; full Honua suite is
+    // 952/952") -- AssertSuiteRows only checks the structured suites[] entries,
+    // so without this a stale leading count in the prose would slip past the gate
+    // even though suites[] and cite-status.md still agree.
+    [GeneratedRegex(@"\b(\d+)\s*/\s*(\d+)\b")]
+    private static partial Regex ProseFractionPattern();
+
     [ArchitectureTest]
     public void EveryVendorExtension_AgreesWithCiteStatusPerSuiteTotals()
     {
@@ -107,6 +117,8 @@ public sealed partial class CiteStatusComplianceDriftTests
             {
                 AssertSuiteRows(displayPath, suitesElement, canonical);
             }
+
+            AssertEveryProseFractionIsKnown(displayPath, extension, canonicalTotalPassed, hasSuites ? suitesElement : null);
         }
     }
 
@@ -228,6 +240,50 @@ public sealed partial class CiteStatusComplianceDriftTests
                 $"{displayPath}'s x-honua-cite-compliance.summary claims {suiteCount} conformance suites, but " +
                 $"{CiteStatusRelativePath}'s 'Current Per-Protocol Status' table has {canonicalSuiteCount} rows -- " +
                 $"update the summary prose in {displayPath} to match {CiteStatusRelativePath}.");
+        }
+    }
+
+    /// <summary>
+    /// Validates every "&lt;passed&gt;/&lt;total&gt;" fraction mentioned anywhere in the
+    /// extension's summary prose -- not just the full-suite aggregate
+    /// <see cref="ProseAggregatePattern"/> anchors on. The protocol-scoped
+    /// *-openapi.json files restate their own suite's count ahead of the aggregate
+    /// (e.g. "OGC API Tiles ETS passes 16/16 on trunk; full Honua suite is
+    /// 952/952"); <see cref="AssertSuiteRows"/> only checks the structured
+    /// suites[] entries, so a stale leading count in the prose would otherwise
+    /// slip past this gate even when suites[] and cite-status.md still agree.
+    /// Each fraction found must equal either the canonical full-suite aggregate
+    /// or one of this file's own suites[] (passed, total) pairs.
+    /// </summary>
+    private static void AssertEveryProseFractionIsKnown(
+        string displayPath,
+        JsonElement extension,
+        int canonicalTotalPassed,
+        JsonElement? suitesElement)
+    {
+        var summary = extension.TryGetProperty("summary", out var summaryElement)
+            ? summaryElement.GetString() ?? string.Empty
+            : string.Empty;
+
+        (int Passed, int Total)[] knownSuiteTotals = suitesElement is null
+            ? []
+            : [.. suitesElement.Value.EnumerateArray()
+                .Select(suite => (Passed: suite.GetProperty("passed").GetInt32(), Total: suite.GetProperty("total").GetInt32()))];
+
+        foreach (Match fraction in ProseFractionPattern().Matches(summary))
+        {
+            var passed = int.Parse(fraction.Groups[1].Value, CultureInfo.InvariantCulture);
+            var total = int.Parse(fraction.Groups[2].Value, CultureInfo.InvariantCulture);
+
+            var isCanonicalAggregate = passed == canonicalTotalPassed && total == canonicalTotalPassed;
+            var isKnownSuiteTotal = knownSuiteTotals.Any(suite => suite.Passed == passed && suite.Total == total);
+
+            (isCanonicalAggregate || isKnownSuiteTotal).Should().BeTrue(
+                $"{displayPath}'s x-honua-cite-compliance.summary mentions \"{passed}/{total}\", which matches " +
+                $"neither the canonical full-suite aggregate ({canonicalTotalPassed}/{canonicalTotalPassed}) nor " +
+                $"any per-suite total in {displayPath}'s own suites[] array -- the summary prose has drifted from " +
+                $"{CiteStatusRelativePath} (or {displayPath}'s own suites[] entries). Update the summary in " +
+                $"{displayPath} to match.");
         }
     }
 


### PR DESCRIPTION
Closes #2924. Related to #2861.

## Summary
Implements the #2924 acceptance criteria: docs/cite-status.md is the one canonical CITE snapshot; mirrors link instead of restating; the circular authority language is resolved to one direction; the stale self-referential URL is fixed; and a new architecture drift test gates the canonical table against the x-honua-cite-compliance vendor extension across all five openapi documents with per-artifact failure messages.

## Changes Made
- docs/cite-status.md — canonical; authority language one-directional.
- docs/internal/contributor/ogc-cite-conformance-evidence.md — numbers table replaced by a link; self-referential GitHub path fixed (missing internal/ segment).
- docs/reference/compatibility/ogc-conformance.md — links instead of restating.
- docs/gis/capability-matrix-schema.md — cross-reference note.
- tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/CiteStatusComplianceDriftTests.cs — the gate (reuses the capability-matrix generator's parsing expectations for the cite-status table).

## Breaking Changes
None.

## Gate Impact
- [x] Adds architecture drift tests (22/22 green in the FeatureCatalog group).

## Testing
- [x] dotnet test --filter FullyQualifiedName~CiteStatus|FeatureCatalog — 22/22.
- [x] dotnet format --verify-no-changes — clean.
- [ ] Ran scripts/ci/pre-pr-check.sh and all checks passed
  - Build/format/targeted-test phases pass; the full server-test shard phase fails with the known local-environment signatures on this shared box (Honua.Server.deps.json copy + Testcontainers flavor issues, same as documented on #2911 — reproduce independent of any diff). Diff is docs + one architecture-test file; the 22 relevant tests pass. Per the #2901/#2911 precedent, PR Gate on isolated runners is the verification of record.
