### PR TITLE
feat(migration): apply GeoServer styles to live catalog

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -301,7 +301,7 @@
       "max_cpu_count": "",
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
-      "filter": "FullyQualifiedName~Honua.Server.Tests.Import.ArcGisMigration|FullyQualifiedName~Honua.Server.Tests.Import.GeoServer|FullyQualifiedName~Honua.Server.Tests.Import.Geoservices|FullyQualifiedName~Honua.Server.Tests.Import.Migration|FullyQualifiedName~Honua.Server.Tests.Import.OgcApiFeatures|FullyQualifiedName~Honua.Server.Tests.Import.OgcCoverage|FullyQualifiedName~Honua.Server.Tests.Import.OgcTileCache|FullyQualifiedName~Honua.Server.Tests.Import.OgcWcs|FullyQualifiedName~Honua.Server.Tests.Import.OgcWfs|FullyQualifiedName~Honua.Server.Tests.Import.RedisImportJobManager|FullyQualifiedName~Honua.Server.Tests.Import.UniversalProgressStore",
+      "filter": "FullyQualifiedName~Honua.Server.Tests.Import.ArcGisMigration|FullyQualifiedName~Honua.Server.Tests.Import.GeoServer|FullyQualifiedName~Honua.Server.Tests.Import.Geoservices|FullyQualifiedName~Honua.Server.Tests.Import.Migration|FullyQualifiedName~Honua.Server.Tests.Import.OgcApiFeatures|FullyQualifiedName~Honua.Server.Tests.Import.OgcCoverage|FullyQualifiedName~Honua.Server.Tests.Import.OgcTileCache|FullyQualifiedName~Honua.Server.Tests.Import.OgcWcs|FullyQualifiedName~Honua.Server.Tests.Import.OgcWfs|FullyQualifiedName~Honua.Server.Tests.Import.PostgresMigrationStyleApplicator|FullyQualifiedName~Honua.Server.Tests.Import.RedisImportJobManager|FullyQualifiedName~Honua.Server.Tests.Import.UniversalProgressStore",
       "paths": [
         "src/Honua.Core/Features/Migration/",
         "src/Honua.Postgres/Features/Migration/",
@@ -326,6 +326,7 @@
         "tests/dotnet/Honua.Server.Tests/Import/OgcTileCacheExportEndpointTests.cs",
         "tests/dotnet/Honua.Server.Tests/Import/OgcWcsImportEndpointTests.cs",
         "tests/dotnet/Honua.Server.Tests/Import/OgcWfsImportEndpointTests.cs",
+        "tests/dotnet/Honua.Server.Tests/Import/PostgresMigrationStyleApplicatorTests.cs",
         "tests/dotnet/Honua.Server.Tests/Import/RedisImportJobManagerAtomicityTests.cs",
         "tests/dotnet/Honua.Server.Tests/Import/RedisImportJobManagerIntegrationTests.cs",
         "tests/dotnet/Honua.Server.Tests/Import/RedisImportTestStubs.cs",

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -890,6 +890,10 @@ echo "Checking server-test shard coverage (no orphaned test classes)..."
     "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
     "Core" \
   --assert-owner \
+    "Honua.Server.Tests.Import.PostgresMigrationStyleApplicatorTests" \
+    "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
+    "Migration" \
+  --assert-owner \
     "Honua.Server.Tests.Features.Protocols.Zarr.DatacubeTileEndpointTests" \
     "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
     "Server Features Misc" \

--- a/src/Honua.Core/Features/Migration/Abstractions/IMigrationStyleApplicator.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IMigrationStyleApplicator.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.Core.Features.Migration.Abstractions;
+
+/// <summary>
+/// Applies a successfully converted migration style to Honua's live, render-facing style catalogs.
+/// </summary>
+public interface IMigrationStyleApplicator
+{
+    /// <summary>
+    /// Idempotently creates or updates the canonical style and assigns it to published target layers.
+    /// </summary>
+    /// <param name="request">Converted style and deterministic target-layer assignments.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The live catalog application outcome.</returns>
+    Task<MigrationStyleApplyOutcome> ApplyAsync(
+        MigrationLiveStyleApplyRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A converted migration style ready for application to the canonical style catalogs.
+/// </summary>
+public sealed record MigrationLiveStyleApplyRequest
+{
+    /// <summary>Stable canonical style identifier.</summary>
+    public required string TargetStyleId { get; init; }
+
+    /// <summary>Operator-facing style title.</summary>
+    public required string Title { get; init; }
+
+    /// <summary>Converted JSON array of MapLibre layer objects.</summary>
+    public string? MapLibreLayersJson { get; init; }
+
+    /// <summary>Evidence disposition; only <c>applied</c> styles may reach live storage.</summary>
+    public required string ReviewDisposition { get; init; }
+
+    /// <summary>Published target layers ordered by GeoServer style precedence.</summary>
+    public IReadOnlyList<MigrationStyleLayerTarget> LayerTargets { get; init; } = [];
+}
+
+/// <summary>
+/// A published target layer that references a migrated source style.
+/// </summary>
+/// <param name="LayerId">Canonical Honua layer identifier returned by publication.</param>
+/// <param name="Ordinal">Style precedence for the layer; zero is the default style.</param>
+public sealed record MigrationStyleLayerTarget(int LayerId, int Ordinal);
+
+/// <summary>
+/// Result of applying a migrated style to live render-facing storage.
+/// </summary>
+public enum MigrationStyleApplyOutcome
+{
+    /// <summary>The canonical style or at least one layer assignment was changed.</summary>
+    Applied,
+
+    /// <summary>The canonical style and all assignments already matched.</summary>
+    AlreadyApplied,
+
+    /// <summary>The conversion requires manual review and was deliberately not applied.</summary>
+    SkippedManualReview,
+
+    /// <summary>No successfully published target layer referenced the style.</summary>
+    SkippedNoPublishedLayers
+}

--- a/src/Honua.Core/Features/Migration/Abstractions/IMigrationStyleApplicator.cs
+++ b/src/Honua.Core/Features/Migration/Abstractions/IMigrationStyleApplicator.cs
@@ -61,6 +61,9 @@ public enum MigrationStyleApplyOutcome
     /// <summary>The conversion requires manual review and was deliberately not applied.</summary>
     SkippedManualReview,
 
+    /// <summary>An operator-owned style or stale association conflicts with the migration replay.</summary>
+    SkippedConflict,
+
     /// <summary>No successfully published target layer referenced the style.</summary>
     SkippedNoPublishedLayers
 }

--- a/src/Honua.Postgres/Features/Migration/GeoServerImportService.Apply.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoServerImportService.Apply.cs
@@ -876,20 +876,20 @@ internal sealed partial class GeoServerImportService
         {
             var styleRequest = new MigrationStyleRequest
             {
-                        SourceKind = applyPlan.SourceKind,
-                        SourceId = step.SourceId,
-                        TargetStyleId = targetStyleId,
-                        StyleName = style.Name,
-                        WorkspaceName = string.IsNullOrWhiteSpace(style.WorkspaceName) ? null : style.WorkspaceName,
-                        SourceFormat = sourceFormat,
-                        SourceLanguageVersion = string.IsNullOrWhiteSpace(style.LanguageVersion) ? null : style.LanguageVersion,
-                        SourceBody = string.IsNullOrWhiteSpace(style.SldContent) ? null : style.SldContent,
-                        ConvertedBody = convertedBody,
-                        ConvertedFormat = convertedFormat,
-                        DiagnosticsJson = SerializeStyleDiagnostics(diagnostics),
-                        // Stage evidence conservatively. This row is promoted to applied only
-                        // after the render-facing catalogs accept every assignment.
-                        ReviewDisposition = "manual-review"
+                SourceKind = applyPlan.SourceKind,
+                SourceId = step.SourceId,
+                TargetStyleId = targetStyleId,
+                StyleName = style.Name,
+                WorkspaceName = string.IsNullOrWhiteSpace(style.WorkspaceName) ? null : style.WorkspaceName,
+                SourceFormat = sourceFormat,
+                SourceLanguageVersion = string.IsNullOrWhiteSpace(style.LanguageVersion) ? null : style.LanguageVersion,
+                SourceBody = string.IsNullOrWhiteSpace(style.SldContent) ? null : style.SldContent,
+                ConvertedBody = convertedBody,
+                ConvertedFormat = convertedFormat,
+                DiagnosticsJson = SerializeStyleDiagnostics(diagnostics),
+                // Stage evidence conservatively. This row is promoted to applied only
+                // after the render-facing catalogs accept every assignment.
+                ReviewDisposition = "manual-review"
             };
             var outcome = await _catalogWriter.EnsureStyleAsync(
                     _connectionProvider.GetConnectionString(),

--- a/src/Honua.Postgres/Features/Migration/GeoServerImportService.Apply.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoServerImportService.Apply.cs
@@ -95,6 +95,7 @@ internal sealed partial class GeoServerImportService
         // apply path can resolve the underlying GeoServerStyleInfo (and its
         // SLD body) without re-running discovery.
         var stylesById = filteredResources.Styles.ToDictionary(GetStyleId, StringComparer.Ordinal);
+        var publishedLayerIdsBySourceId = new Dictionary<string, int>(StringComparer.Ordinal);
 
         // Slice 1: apply workspace-level catalog entries first so that any subsequent
         // layer-group / layer apply can reference them. These records are deterministic
@@ -118,7 +119,8 @@ internal sealed partial class GeoServerImportService
             .ConfigureAwait(false);
         stepResults.AddRange(dataSourceStepResults);
 
-        foreach (var step in applyPlan.Steps.OrderBy(static item => item.Sequence))
+        var orderedSteps = applyPlan.Steps.OrderBy(static item => item.Sequence).ToArray();
+        foreach (var step in orderedSteps.Where(static item => !string.Equals(item.Kind, "style", StringComparison.Ordinal)))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -130,6 +132,34 @@ internal sealed partial class GeoServerImportService
                     stylesById,
                     applyPlan,
                     filteredResources,
+                    request,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            stepResults.Add(stepResult);
+            if (stepResult.HonuaLayerId is { } targetLayerId && string.Equals(step.Kind, "layer", StringComparison.Ordinal))
+            {
+                publishedLayerIdsBySourceId[step.SourceId] = targetLayerId;
+            }
+
+            progress?.Report(currentProgress with
+            {
+                Status = GeoServerImportStatus.Validating,
+                ResourcesProcessed = stepResults.Count,
+                CurrentPhase = $"Processed GeoServer migration step {stepResults.Count} of {applyPlan.Summary.TotalStepCount}"
+            });
+        }
+
+        // Style application depends on the canonical layer ids returned by publication.
+        // Execute these steps last even when the manifest interleaves them with layers.
+        foreach (var step in orderedSteps.Where(static item => string.Equals(item.Kind, "style", StringComparison.Ordinal)))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var stepResult = await ApplyStyleCatalogStepAsync(
+                    step,
+                    stylesById,
+                    publishedLayerIdsBySourceId,
+                    filteredResources,
+                    applyPlan,
                     request,
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -177,23 +207,6 @@ internal sealed partial class GeoServerImportService
         GeoServerImportRequest request,
         CancellationToken cancellationToken)
     {
-        // Slice 3 (#1015): style steps still need to persist into the Honua
-        // style catalog even when the manifest translator marks them
-        // unsupported/manual-review, so the migration evidence pack carries
-        // explicit conversion diagnostics rather than silently dropping the
-        // source style. Dispatch to the style branch before the early
-        // unsupported/manual-review returns below.
-        if (string.Equals(step.Kind, "style", StringComparison.Ordinal))
-        {
-            return await ApplyStyleCatalogStepAsync(
-                    step,
-                    stylesById,
-                    applyPlan,
-                    request,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
-
         if (step.Disposition == "unsupported")
         {
             return CreateExecutionStepResult(
@@ -745,6 +758,8 @@ internal sealed partial class GeoServerImportService
     private async Task<MigrationApplyExecutionStepResult> ApplyStyleCatalogStepAsync(
         MigrationApplyPlanStep step,
         Dictionary<string, GeoServerStyleInfo> stylesById,
+        IReadOnlyDictionary<string, int> publishedLayerIdsBySourceId,
+        FilteredResources filteredResources,
         MigrationApplyPlanArtifact applyPlan,
         GeoServerImportRequest request,
         CancellationToken cancellationToken)
@@ -859,10 +874,8 @@ internal sealed partial class GeoServerImportService
 
         try
         {
-            var outcome = await _catalogWriter.EnsureStyleAsync(
-                    _connectionProvider.GetConnectionString(),
-                    new MigrationStyleRequest
-                    {
+            var styleRequest = new MigrationStyleRequest
+            {
                         SourceKind = applyPlan.SourceKind,
                         SourceId = step.SourceId,
                         TargetStyleId = targetStyleId,
@@ -874,27 +887,76 @@ internal sealed partial class GeoServerImportService
                         ConvertedBody = convertedBody,
                         ConvertedFormat = convertedFormat,
                         DiagnosticsJson = SerializeStyleDiagnostics(diagnostics),
-                        ReviewDisposition = disposition
-                    },
+                        // Stage evidence conservatively. This row is promoted to applied only
+                        // after the render-facing catalogs accept every assignment.
+                        ReviewDisposition = "manual-review"
+            };
+            var outcome = await _catalogWriter.EnsureStyleAsync(
+                    _connectionProvider.GetConnectionString(),
+                    styleRequest,
                     cancellationToken)
                 .ConfigureAwait(false);
 
             var diagnosticSummary = BuildStyleDiagnosticSummary(diagnostics);
-            return outcome switch
+            if (disposition == "manual-review")
             {
-                MigrationCatalogWriteOutcome.Created when disposition == "manual-review" => CreateExecutionStepResult(
+                return CreateExecutionStepResult(
                     step,
                     "manual-review",
-                    $"Persisted style '{step.SourceId}' with manual-review disposition. {diagnosticSummary} Do not claim visual parity until the diagnostics are resolved."),
-                MigrationCatalogWriteOutcome.Created => CreateExecutionStepResult(
+                    $"Persisted style '{step.SourceId}' with manual-review disposition. {diagnosticSummary} Do not claim visual parity until the diagnostics are resolved.");
+            }
+
+            if (_styleApplicator == null)
+            {
+                return CreateExecutionStepResult(
+                    step,
+                    "manual-review",
+                    $"Persisted converted style '{step.SourceId}' as migration evidence, but the live style applicator is unavailable; no render-facing assignment was made.");
+            }
+
+            var layerTargets = BuildStyleLayerTargets(
+                step.SourceId,
+                filteredResources,
+                publishedLayerIdsBySourceId);
+            var liveOutcome = await _styleApplicator.ApplyAsync(
+                    new MigrationLiveStyleApplyRequest
+                    {
+                        TargetStyleId = targetStyleId,
+                        Title = style.Name,
+                        MapLibreLayersJson = convertedBody,
+                        ReviewDisposition = disposition,
+                        LayerTargets = layerTargets
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (liveOutcome is MigrationStyleApplyOutcome.Applied or MigrationStyleApplyOutcome.AlreadyApplied)
+            {
+                _ = await _catalogWriter.EnsureStyleAsync(
+                        _connectionProvider.GetConnectionString(),
+                        styleRequest with { ReviewDisposition = "applied" },
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return liveOutcome switch
+            {
+                MigrationStyleApplyOutcome.Applied => CreateExecutionStepResult(
                     step,
                     "applied",
-                    $"Applied {sourceFormat} style '{step.SourceId}' to honua.migration_styles.{(diagnosticSummary.Length > 0 ? " " + diagnosticSummary : string.Empty)}"),
-                MigrationCatalogWriteOutcome.AlreadyExists => CreateExecutionStepResult(
+                    $"Applied {sourceFormat} style '{step.SourceId}' to migration evidence and {layerTargets.Count} published render-facing layer(s).{(diagnosticSummary.Length > 0 ? " " + diagnosticSummary : string.Empty)}"),
+                MigrationStyleApplyOutcome.AlreadyApplied => CreateExecutionStepResult(
                     step,
                     "already-applied",
-                    $"Style '{step.SourceId}' already present; idempotent re-apply made no changes."),
-                _ => CreateExecutionStepResult(step, "manual-review", "Catalog writer returned an unexpected outcome.")
+                    $"Style '{step.SourceId}' and its {layerTargets.Count} live layer assignment(s) already match; idempotent re-apply made no changes."),
+                MigrationStyleApplyOutcome.SkippedNoPublishedLayers => CreateExecutionStepResult(
+                    step,
+                    "manual-review",
+                    $"Persisted converted style '{step.SourceId}' as migration evidence, but no successfully published target layer referenced it; no render-facing assignment was made."),
+                _ => CreateExecutionStepResult(
+                    step,
+                    outcome == MigrationCatalogWriteOutcome.AlreadyExists ? "already-applied" : "manual-review",
+                    $"Style '{step.SourceId}' was not applied to live storage because its conversion requires review.")
             };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -905,6 +967,41 @@ internal sealed partial class GeoServerImportService
                 "failed",
                 $"Style apply for '{step.SourceId}' failed unexpectedly and requires operator review.");
         }
+    }
+
+    private static List<MigrationStyleLayerTarget> BuildStyleLayerTargets(
+        string sourceStyleId,
+        FilteredResources filteredResources,
+        IReadOnlyDictionary<string, int> publishedLayerIdsBySourceId)
+    {
+        var styleIdsByReference = BuildStyleReferenceLookup(filteredResources.Styles);
+        var targets = new List<MigrationStyleLayerTarget>();
+        foreach (var layer in filteredResources.Layers.OrderBy(GetLayerId, StringComparer.Ordinal))
+        {
+            if (!publishedLayerIdsBySourceId.TryGetValue(GetLayerId(layer), out var targetLayerId))
+            {
+                continue;
+            }
+
+            if (ResolveStyleIds(styleIdsByReference, layer.WorkspaceName, layer.DefaultStyle)
+                .Contains(sourceStyleId, StringComparer.Ordinal))
+            {
+                targets.Add(new MigrationStyleLayerTarget(targetLayerId, 0));
+                continue;
+            }
+
+            for (var index = 0; index < layer.AlternativeStyles.Length; index++)
+            {
+                if (ResolveStyleIds(styleIdsByReference, layer.WorkspaceName, layer.AlternativeStyles[index])
+                    .Contains(sourceStyleId, StringComparer.Ordinal))
+                {
+                    targets.Add(new MigrationStyleLayerTarget(targetLayerId, index + 1));
+                    break;
+                }
+            }
+        }
+
+        return targets;
     }
 
     private static string BuildTargetStyleId(MigrationSourceIdentity source, GeoServerStyleInfo style)

--- a/src/Honua.Postgres/Features/Migration/GeoServerImportService.Apply.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoServerImportService.Apply.cs
@@ -953,6 +953,10 @@ internal sealed partial class GeoServerImportService
                     step,
                     "manual-review",
                     $"Persisted converted style '{step.SourceId}' as migration evidence, but no successfully published target layer referenced it; no render-facing assignment was made."),
+                MigrationStyleApplyOutcome.SkippedConflict => CreateExecutionStepResult(
+                    step,
+                    "manual-review",
+                    $"Persisted style '{step.SourceId}' as migration evidence, but operator-owned live style content or stale associations conflict with replay; no live content was overwritten."),
                 _ => CreateExecutionStepResult(
                     step,
                     outcome == MigrationCatalogWriteOutcome.AlreadyExists ? "already-applied" : "manual-review",

--- a/src/Honua.Postgres/Features/Migration/GeoServerImportService.cs
+++ b/src/Honua.Postgres/Features/Migration/GeoServerImportService.cs
@@ -34,6 +34,7 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
     private readonly ISldStyleConverter? _sldConverter;
     private readonly ILayerPublishingService? _layerPublishingService;
     private readonly IMigrationCatalogWriter? _catalogWriter;
+    private readonly IMigrationStyleApplicator? _styleApplicator;
     private readonly ILogger<GeoServerImportService> _logger;
 
     public GeoServerImportService(
@@ -43,7 +44,8 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
         ILogger<GeoServerImportService> logger,
         ISldStyleConverter? sldConverter = null,
         ILayerPublishingService? layerPublishingService = null,
-        IMigrationCatalogWriter? catalogWriter = null)
+        IMigrationCatalogWriter? catalogWriter = null,
+        IMigrationStyleApplicator? styleApplicator = null)
     {
         _restClient = restClient ?? throw new ArgumentNullException(nameof(restClient));
         _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
@@ -52,6 +54,7 @@ internal sealed partial class GeoServerImportService : IGeoServerImportService
         _sldConverter = sldConverter;
         _layerPublishingService = layerPublishingService;
         _catalogWriter = catalogWriter;
+        _styleApplicator = styleApplicator;
     }
 
     /// <inheritdoc />

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
@@ -266,10 +266,9 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-        // Idempotent upsert on (source_kind, source_id). Slice 3 deliberately
-        // does not overwrite existing rows because the source-of-truth for a
-        // migrated style is the source system being scanned; operators who
-        // need to refresh diagnostics should delete the row and re-apply.
+        // Idempotent upsert on (source_kind, source_id). Conversion evidence is
+        // refreshed on replay, and a conservatively staged manual-review row may
+        // be promoted to applied only after the live style catalogs succeed.
         const string sql = """
             INSERT INTO honua.migration_styles (
                 source_kind,
@@ -299,8 +298,18 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
                 CAST(@diagnostics AS jsonb),
                 @reviewDisposition
             )
-            ON CONFLICT (source_kind, source_id) DO NOTHING
-            RETURNING source_id;
+            ON CONFLICT (source_kind, source_id) DO UPDATE SET
+                workspace_name = EXCLUDED.workspace_name,
+                style_name = EXCLUDED.style_name,
+                source_format = EXCLUDED.source_format,
+                source_language_version = EXCLUDED.source_language_version,
+                target_style_id = EXCLUDED.target_style_id,
+                source_body = EXCLUDED.source_body,
+                converted_body = EXCLUDED.converted_body,
+                converted_format = EXCLUDED.converted_format,
+                diagnostics = EXCLUDED.diagnostics,
+                review_disposition = EXCLUDED.review_disposition
+            RETURNING (xmax = 0);
             """;
 
         await using var command = new NpgsqlCommand(sql, connection);
@@ -318,9 +327,9 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
         command.Parameters.AddWithValue("@reviewDisposition", request.ReviewDisposition);
 
         var inserted = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-        var outcome = inserted is null
-            ? MigrationCatalogWriteOutcome.AlreadyExists
-            : MigrationCatalogWriteOutcome.Created;
+        var outcome = inserted is true
+            ? MigrationCatalogWriteOutcome.Created
+            : MigrationCatalogWriteOutcome.AlreadyExists;
 
         Log.StylePersisted(_logger, request.SourceFormat, request.SourceId, request.ReviewDisposition, outcome.ToString());
         return outcome;

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationStyleApplicator.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationStyleApplicator.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Styling.Abstractions;
+
+namespace Honua.Postgres.Features.Migration;
+
+/// <summary>
+/// Applies converted migration styles through the canonical style catalog abstractions.
+/// </summary>
+internal sealed class PostgresMigrationStyleApplicator(
+    IStyleCatalog styleCatalog,
+    ILayerStyleCatalog layerStyleCatalog,
+    IMetadataV2StyleGraphSync? styleGraphSync = null) : IMigrationStyleApplicator
+{
+    /// <inheritdoc />
+    public async Task<MigrationStyleApplyOutcome> ApplyAsync(
+        MigrationLiveStyleApplyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!string.Equals(request.ReviewDisposition, "applied", StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(request.MapLibreLayersJson))
+        {
+            return MigrationStyleApplyOutcome.SkippedManualReview;
+        }
+
+        var targets = request.LayerTargets
+            .DistinctBy(static target => target.LayerId)
+            .OrderBy(static target => target.Ordinal)
+            .ThenBy(static target => target.LayerId)
+            .ToArray();
+        if (targets.Length == 0)
+        {
+            return MigrationStyleApplyOutcome.SkippedNoPublishedLayers;
+        }
+
+        var canonicalJson = BuildMapLibreStyleDocument(
+            request.Title,
+            request.MapLibreLayersJson,
+            targets.Select(static target => target.LayerId).ToArray());
+        var changed = await EnsureCanonicalStyleAsync(request, canonicalJson, cancellationToken).ConfigureAwait(false);
+
+        foreach (var target in targets)
+        {
+            var layerJson = BuildMapLibreStyleDocument(
+                request.Title,
+                request.MapLibreLayersJson,
+                [target.LayerId]);
+            var current = await layerStyleCatalog.GetLayerStyleAsync(target.LayerId, cancellationToken).ConfigureAwait(false);
+            if (!JsonEquals(current?.MapLibreStyleJson, layerJson))
+            {
+                var updated = await layerStyleCatalog.SetMapLibreStyleAsync(
+                        target.LayerId,
+                        layerJson,
+                        revisedBy: "geoserver-migration",
+                        changeSummary: $"Applied migrated style {request.TargetStyleId}.",
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (updated == null)
+                {
+                    throw new InvalidOperationException($"Published target layer {target.LayerId} was not found while applying its migrated style.");
+                }
+
+                changed = true;
+            }
+
+            if (!await styleCatalog.AssociateLayerAsync(
+                    target.LayerId,
+                    request.TargetStyleId,
+                    target.Ordinal,
+                    cancellationToken)
+                .ConfigureAwait(false))
+            {
+                throw new InvalidOperationException($"Could not associate migrated style {request.TargetStyleId} with published target layer {target.LayerId}.");
+            }
+
+            if (styleGraphSync != null)
+            {
+                await styleGraphSync.SyncLayerStylesAsync(target.LayerId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return changed ? MigrationStyleApplyOutcome.Applied : MigrationStyleApplyOutcome.AlreadyApplied;
+    }
+
+    private async Task<bool> EnsureCanonicalStyleAsync(
+        MigrationLiveStyleApplyRequest request,
+        string canonicalJson,
+        CancellationToken cancellationToken)
+    {
+        var current = await styleCatalog.GetStyleAsync(request.TargetStyleId, cancellationToken).ConfigureAwait(false);
+        if (current == null)
+        {
+            var created = await styleCatalog.CreateStyleAsync(
+                    request.TargetStyleId,
+                    canonicalJson,
+                    request.Title,
+                    description: "Imported from GeoServer SLD/SE.",
+                    revisedBy: "geoserver-migration",
+                    changeSummary: "Created by GeoServer migration.",
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+            if (created != null)
+            {
+                return true;
+            }
+
+            current = await styleCatalog.GetStyleAsync(request.TargetStyleId, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (JsonEquals(current?.MapLibreStyleJson, canonicalJson))
+        {
+            return false;
+        }
+
+        _ = await styleCatalog.UpsertStyleAsync(
+                request.TargetStyleId,
+                canonicalJson,
+                request.Title,
+                description: "Imported from GeoServer SLD/SE.",
+                revisedBy: "geoserver-migration",
+                changeSummary: "Updated by GeoServer migration.",
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return true;
+    }
+
+    private static string BuildMapLibreStyleDocument(
+        string title,
+        string mapLibreLayersJson,
+        int[] layerIds)
+    {
+        using var layersDocument = JsonDocument.Parse(mapLibreLayersJson);
+        if (layersDocument.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException("Converted SLD style must contain a JSON array of MapLibre layers.");
+        }
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("version", 8);
+            writer.WriteString("name", title);
+            writer.WritePropertyName("sources");
+            writer.WriteStartObject();
+            foreach (var layerId in layerIds)
+            {
+                writer.WritePropertyName($"layer-{layerId}");
+                writer.WriteStartObject();
+                writer.WriteString("type", "vector");
+                writer.WritePropertyName("tiles");
+                writer.WriteStartArray();
+                writer.WriteStringValue($"/tiles/{layerId}/{{z}}/{{x}}/{{y}}.mvt");
+                writer.WriteEndArray();
+                writer.WriteNumber("minzoom", 0);
+                writer.WriteNumber("maxzoom", 22);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndObject();
+            writer.WritePropertyName("layers");
+            writer.WriteStartArray();
+            foreach (var layerId in layerIds)
+            {
+                foreach (var convertedLayer in layersDocument.RootElement.EnumerateArray())
+                {
+                    WriteLayer(writer, convertedLayer, layerId, layerIds.Length > 1);
+                }
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static void WriteLayer(Utf8JsonWriter writer, JsonElement convertedLayer, int layerId, bool qualifyId)
+    {
+        if (convertedLayer.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("Each converted SLD style layer must be a JSON object.");
+        }
+
+        writer.WriteStartObject();
+        var hasId = false;
+        foreach (var property in convertedLayer.EnumerateObject())
+        {
+            if (property.NameEquals("source") || property.NameEquals("source-layer"))
+            {
+                continue;
+            }
+
+            if (property.NameEquals("id"))
+            {
+                hasId = true;
+                writer.WriteString("id", qualifyId ? $"{property.Value.GetString()}-layer-{layerId}" : property.Value.GetString());
+                continue;
+            }
+
+            property.WriteTo(writer);
+        }
+
+        if (!hasId)
+        {
+            writer.WriteString("id", $"migrated-style-layer-{layerId}");
+        }
+
+        writer.WriteString("source", $"layer-{layerId}");
+        writer.WriteString("source-layer", "layer");
+        writer.WriteEndObject();
+    }
+
+    private static bool JsonEquals(string? left, string right)
+    {
+        if (string.IsNullOrWhiteSpace(left))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var leftDocument = JsonDocument.Parse(left);
+            using var rightDocument = JsonDocument.Parse(right);
+            return JsonElement.DeepEquals(leftDocument.RootElement, rightDocument.RootElement);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationStyleApplicator.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationStyleApplicator.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.Styling.Abstractions;
+using Honua.Core.Features.Styling.Domain;
 
 namespace Honua.Postgres.Features.Migration;
 
@@ -44,15 +45,74 @@ internal sealed class PostgresMigrationStyleApplicator(
             request.Title,
             request.MapLibreLayersJson,
             targets.Select(static target => target.LayerId).ToArray());
-        var changed = await EnsureCanonicalStyleAsync(request, canonicalJson, cancellationToken).ConfigureAwait(false);
+        var currentStyle = await styleCatalog.GetStyleAsync(request.TargetStyleId, cancellationToken).ConfigureAwait(false);
+        if (currentStyle != null &&
+            !JsonEquals(currentStyle.MapLibreStyleJson, canonicalJson) &&
+            !IsMigrationOwned(currentStyle.RevisedBy))
+        {
+            return MigrationStyleApplyOutcome.SkippedConflict;
+        }
 
+        var currentAssociations = await styleCatalog.ListAssociationsAsync(cancellationToken).ConfigureAwait(false);
+        var requestedAssociations = targets
+            .Select(target => new StyleLayerAssociation(target.LayerId, request.TargetStyleId, target.Ordinal))
+            .ToArray();
+        if (currentAssociations.Any(existing =>
+                string.Equals(existing.StyleId, request.TargetStyleId, StringComparison.Ordinal) &&
+                !requestedAssociations.Contains(existing)))
+        {
+            // IStyleCatalog currently has no remove-association operation. Refuse to
+            // claim a reordered/removed binding was reconciled when stale refs remain.
+            return MigrationStyleApplyOutcome.SkippedConflict;
+        }
+
+        var defaultTargets = targets.Where(static target => target.Ordinal == 0).ToArray();
+        var currentLayerStyles = new Dictionary<int, Honua.Core.Features.Styling.Domain.LayerStyleDefinition?>();
+        foreach (var target in defaultTargets)
+        {
+            var layerJson = BuildMapLibreStyleDocument(request.Title, request.MapLibreLayersJson, [target.LayerId]);
+            var current = await layerStyleCatalog.GetLayerStyleAsync(target.LayerId, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(current?.MapLibreStyleJson) &&
+                !JsonEquals(current.MapLibreStyleJson, layerJson) &&
+                !IsMigrationOwned(current.StyleRevisedBy))
+            {
+                return MigrationStyleApplyOutcome.SkippedConflict;
+            }
+
+            currentLayerStyles[target.LayerId] = current;
+        }
+
+        var changed = await EnsureCanonicalStyleAsync(request, canonicalJson, currentStyle, cancellationToken).ConfigureAwait(false);
+
+        // Apply associations before the render-facing layer value. A failed
+        // association leaves a resumable canonical record, but never exposes a
+        // partially replaced default layer style.
         foreach (var target in targets)
+        {
+            var association = new StyleLayerAssociation(target.LayerId, request.TargetStyleId, target.Ordinal);
+            var associationAlreadyPresent = currentAssociations.Contains(association);
+            if (!await styleCatalog.AssociateLayerAsync(
+                    target.LayerId,
+                    request.TargetStyleId,
+                    target.Ordinal,
+                    cancellationToken)
+                .ConfigureAwait(false))
+            {
+                throw new InvalidOperationException($"Could not associate migrated style {request.TargetStyleId} with published target layer {target.LayerId}.");
+            }
+
+            changed |= !associationAlreadyPresent;
+        }
+
+        // Only GeoServer's default style owns the layer's render-facing value.
+        // Alternative styles remain independent-catalog associations by ordinal.
+        foreach (var target in defaultTargets)
         {
             var layerJson = BuildMapLibreStyleDocument(
                 request.Title,
                 request.MapLibreLayersJson,
                 [target.LayerId]);
-            var current = await layerStyleCatalog.GetLayerStyleAsync(target.LayerId, cancellationToken).ConfigureAwait(false);
+            var current = currentLayerStyles[target.LayerId];
             if (!JsonEquals(current?.MapLibreStyleJson, layerJson))
             {
                 var updated = await layerStyleCatalog.SetMapLibreStyleAsync(
@@ -69,20 +129,13 @@ internal sealed class PostgresMigrationStyleApplicator(
 
                 changed = true;
             }
+        }
 
-            if (!await styleCatalog.AssociateLayerAsync(
-                    target.LayerId,
-                    request.TargetStyleId,
-                    target.Ordinal,
-                    cancellationToken)
-                .ConfigureAwait(false))
+        if (styleGraphSync != null)
+        {
+            foreach (var layerId in targets.Select(static target => target.LayerId).Distinct())
             {
-                throw new InvalidOperationException($"Could not associate migrated style {request.TargetStyleId} with published target layer {target.LayerId}.");
-            }
-
-            if (styleGraphSync != null)
-            {
-                await styleGraphSync.SyncLayerStylesAsync(target.LayerId, cancellationToken).ConfigureAwait(false);
+                await styleGraphSync.SyncLayerStylesAsync(layerId, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -92,9 +145,9 @@ internal sealed class PostgresMigrationStyleApplicator(
     private async Task<bool> EnsureCanonicalStyleAsync(
         MigrationLiveStyleApplyRequest request,
         string canonicalJson,
+        Honua.Core.Features.Styling.Domain.StyleCatalogRecord? current,
         CancellationToken cancellationToken)
     {
-        var current = await styleCatalog.GetStyleAsync(request.TargetStyleId, cancellationToken).ConfigureAwait(false);
         if (current == null)
         {
             var created = await styleCatalog.CreateStyleAsync(
@@ -119,7 +172,7 @@ internal sealed class PostgresMigrationStyleApplicator(
             return false;
         }
 
-        _ = await styleCatalog.UpsertStyleAsync(
+        var updated = await styleCatalog.UpsertStyleAsync(
                 request.TargetStyleId,
                 canonicalJson,
                 request.Title,
@@ -128,8 +181,16 @@ internal sealed class PostgresMigrationStyleApplicator(
                 changeSummary: "Updated by GeoServer migration.",
                 cancellationToken: cancellationToken)
             .ConfigureAwait(false);
+        if (updated == null)
+        {
+            throw new InvalidOperationException($"Canonical style upsert returned no record for {request.TargetStyleId}.");
+        }
+
         return true;
     }
+
+    private static bool IsMigrationOwned(string? revisedBy) =>
+        string.Equals(revisedBy, "geoserver-migration", StringComparison.Ordinal);
 
     private static string BuildMapLibreStyleDocument(
         string title,

--- a/src/Honua.Postgres/ServiceCollectionExtensions.cs
+++ b/src/Honua.Postgres/ServiceCollectionExtensions.cs
@@ -621,6 +621,7 @@ internal static class ServiceCollectionExtensions
 
         // Register migration catalog writer used by apply-mode imports.
         services.AddScoped<IMigrationCatalogWriter, PostgresMigrationCatalogWriter>();
+        services.AddScoped<IMigrationStyleApplicator, PostgresMigrationStyleApplicator>();
 
         // Register ArcGIS migration evidence store (#1025 slice 6). Replaces the Core
         // in-memory default so admin endpoints can serve persisted manifest + parity

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceStyleApplyTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Import/GeoServerImportServiceStyleApplyTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Honua.Core.Features.Admin.Abstractions;
+using Honua.Core.Features.Admin.Domain;
 using Honua.Core.Features.Import.Abstractions;
 using Honua.Core.Features.Migration.Abstractions;
 using Honua.Core.Features.FileImport.Abstractions;
@@ -75,7 +76,7 @@ public sealed class GeoServerImportServiceStyleApplyTests
         // Diagnostics are persisted as JSON even when empty so operators can
         // query the column without null-handling.
         catalogWriter.StyleRequests
-            .Single(r => r.SourceId == "style:ops:line").DiagnosticsJson
+            .Single(r => r.SourceId == "style:ops:line" && r.ReviewDisposition == "applied").DiagnosticsJson
             .Should().StartWith("[").And.EndWith("]");
     }
 
@@ -97,11 +98,11 @@ public sealed class GeoServerImportServiceStyleApplyTests
             .Single(s => s.Kind == "style" && s.SourceId == "style:ops:line");
         step.Outcome.Should().Be("already-applied");
 
-        // Idempotency contract: the writer is still invoked, but the underlying
-        // upsert reports "already-applied" rather than creating a duplicate row.
+        // Idempotency contract: each run stages evidence as manual-review and
+        // promotes it after the live assignment succeeds without creating a duplicate row.
         catalogWriter.StyleRequests
             .Count(r => r.SourceId == "style:ops:line")
-            .Should().Be(2);
+            .Should().Be(4);
     }
 
     [Fact]
@@ -306,6 +307,12 @@ public sealed class GeoServerImportServiceStyleApplyTests
                     _ => null
                 }));
 
+        var styleApplicator = catalogWriter as IMigrationStyleApplicator;
+        if (styleApplicator != null && layerPublishingService == null)
+        {
+            layerPublishingService = CreateLayerPublishingService();
+        }
+
         return new GeoServerImportService(
             restClient,
             connectionProvider.Object,
@@ -313,7 +320,31 @@ public sealed class GeoServerImportServiceStyleApplyTests
             NullLogger<GeoServerImportService>.Instance,
             sldConverter: sldConverter,
             layerPublishingService: layerPublishingService,
-            catalogWriter: catalogWriter);
+            catalogWriter: catalogWriter,
+            styleApplicator: styleApplicator);
+    }
+
+    private static ILayerPublishingService CreateLayerPublishingService()
+    {
+        var service = new Mock<ILayerPublishingService>();
+        service.Setup(publisher => publisher.PublishLayerAsync(
+                It.IsAny<string>(),
+                It.IsAny<LayerPublishRequest>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, LayerPublishRequest request, CancellationToken _) => new PublishedLayerSummary
+            {
+                LayerId = 42,
+                LayerName = request.LayerName,
+                Schema = request.Schema,
+                Table = request.Table,
+                GeometryType = request.GeometryType ?? "Unknown",
+                Srid = request.Srid ?? 4326,
+                PrimaryKey = request.PrimaryKey,
+                FieldCount = request.Fields.Count,
+                Enabled = request.Enabled,
+                ServiceName = request.ServiceName ?? "geoserver-migration"
+            });
+        return service.Object;
     }
 
     private sealed record FixtureScenario(string ServiceUrl, IReadOnlyDictionary<string, string> Responses);
@@ -372,11 +403,12 @@ public sealed class GeoServerImportServiceStyleApplyTests
                 Errors: _errors);
     }
 
-    private sealed class RecordingMigrationCatalogWriter : IMigrationCatalogWriter
+    private sealed class RecordingMigrationCatalogWriter : IMigrationCatalogWriter, IMigrationStyleApplicator
     {
         private readonly HashSet<string> _existing = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _existingDataSources = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _existingStyles = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _appliedStyles = new(StringComparer.OrdinalIgnoreCase);
 
         public List<MigrationCatalogServiceRequest> Requests { get; } = [];
 
@@ -434,6 +466,21 @@ public sealed class GeoServerImportServiceStyleApplyTests
             var outcome = _existingStyles.Add(key)
                 ? MigrationCatalogWriteOutcome.Created
                 : MigrationCatalogWriteOutcome.AlreadyExists;
+            return Task.FromResult(outcome);
+        }
+
+        public Task<MigrationStyleApplyOutcome> ApplyAsync(
+            MigrationLiveStyleApplyRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request.LayerTargets.Count == 0)
+            {
+                return Task.FromResult(MigrationStyleApplyOutcome.SkippedNoPublishedLayers);
+            }
+
+            var outcome = _appliedStyles.Add(request.TargetStyleId)
+                ? MigrationStyleApplyOutcome.Applied
+                : MigrationStyleApplyOutcome.AlreadyApplied;
             return Task.FromResult(outcome);
         }
 

--- a/tests/dotnet/Honua.Server.Tests/Import/PostgresMigrationStyleApplicatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/PostgresMigrationStyleApplicatorTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Migration.Abstractions;
+using Honua.Core.Features.Styling.Abstractions;
+using Honua.Core.Features.Styling.Domain;
+using Honua.Postgres.Features.Migration;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Import;
+
+public sealed class PostgresMigrationStyleApplicatorTests
+{
+    private const string ConvertedLayers = """
+        [{"id":"roads","type":"line","paint":{"line-color":"#224466"}}]
+        """;
+
+    [Fact]
+    public async Task ApplyAsync_CleanConversion_PopulatesLiveCatalogsAndIsIdempotent()
+    {
+        var styleCatalog = Substitute.For<IStyleCatalog>();
+        var layerCatalog = Substitute.For<ILayerStyleCatalog>();
+        var graphSync = Substitute.For<IMetadataV2StyleGraphSync>();
+        StyleCatalogRecord? storedStyle = null;
+        var storedLayers = new Dictionary<int, LayerStyleDefinition>();
+        var styleWrites = 0;
+        var layerWrites = 0;
+
+        styleCatalog.GetStyleAsync("style:geoserver:roads", Arg.Any<CancellationToken>())
+            .Returns(_ => storedStyle);
+        styleCatalog.CreateStyleAsync(
+                "style:geoserver:roads",
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                styleWrites++;
+                storedStyle = new StyleCatalogRecord
+                {
+                    StyleId = "style:geoserver:roads",
+                    Title = call.ArgAt<string?>(2),
+                    MapLibreStyleJson = call.ArgAt<string>(1),
+                    StyleVersion = 1
+                };
+                return storedStyle;
+            });
+        styleCatalog.AssociateLayerAsync(Arg.Any<int>(), "style:geoserver:roads", Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        layerCatalog.GetLayerStyleAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(call => storedLayers.GetValueOrDefault(call.ArgAt<int>(0)));
+        layerCatalog.SetMapLibreStyleAsync(
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                layerWrites++;
+                var value = new LayerStyleDefinition
+                {
+                    LayerId = call.ArgAt<int>(0),
+                    MapLibreStyleJson = call.ArgAt<string>(1),
+                    StyleVersion = 1
+                };
+                storedLayers[value.LayerId] = value;
+                return value;
+            });
+
+        var applicator = new PostgresMigrationStyleApplicator(styleCatalog, layerCatalog, graphSync);
+        var request = new MigrationLiveStyleApplyRequest
+        {
+            TargetStyleId = "style:geoserver:roads",
+            Title = "Roads",
+            MapLibreLayersJson = ConvertedLayers,
+            ReviewDisposition = "applied",
+            LayerTargets = [new MigrationStyleLayerTarget(42, 0), new MigrationStyleLayerTarget(84, 1)]
+        };
+
+        var first = await applicator.ApplyAsync(request);
+        var retrievedStyle = await styleCatalog.GetStyleAsync(request.TargetStyleId);
+        var retrievedLayer = await layerCatalog.GetLayerStyleAsync(42);
+        var second = await applicator.ApplyAsync(request);
+
+        first.Should().Be(MigrationStyleApplyOutcome.Applied);
+        second.Should().Be(MigrationStyleApplyOutcome.AlreadyApplied);
+        retrievedStyle!.MapLibreStyleJson.Should().Contain("/tiles/42/{z}/{x}/{y}.mvt");
+        retrievedStyle.MapLibreStyleJson.Should().Contain("/tiles/84/{z}/{x}/{y}.mvt");
+        retrievedLayer!.MapLibreStyleJson.Should().Contain("\"source\":\"layer-42\"");
+        styleWrites.Should().Be(1);
+        layerWrites.Should().Be(2);
+        await styleCatalog.Received(2).AssociateLayerAsync(42, request.TargetStyleId, 0, Arg.Any<CancellationToken>());
+        await styleCatalog.Received(2).AssociateLayerAsync(84, request.TargetStyleId, 1, Arg.Any<CancellationToken>());
+        await graphSync.Received(2).SyncLayerStylesAsync(42, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("manual-review", ConvertedLayers)]
+    [InlineData("applied", null)]
+    public async Task ApplyAsync_ManualReviewOrFatalConversion_DoesNotAssignLiveStyle(
+        string disposition,
+        string? convertedLayers)
+    {
+        var styleCatalog = Substitute.For<IStyleCatalog>();
+        var layerCatalog = Substitute.For<ILayerStyleCatalog>();
+        var applicator = new PostgresMigrationStyleApplicator(styleCatalog, layerCatalog);
+
+        var outcome = await applicator.ApplyAsync(new MigrationLiveStyleApplyRequest
+        {
+            TargetStyleId = "style:geoserver:roads",
+            Title = "Roads",
+            MapLibreLayersJson = convertedLayers,
+            ReviewDisposition = disposition,
+            LayerTargets = [new MigrationStyleLayerTarget(42, 0)]
+        });
+
+        outcome.Should().Be(MigrationStyleApplyOutcome.SkippedManualReview);
+        await styleCatalog.DidNotReceiveWithAnyArgs().CreateStyleAsync(default!, default!);
+        await styleCatalog.DidNotReceiveWithAnyArgs().AssociateLayerAsync(default, default!);
+        await layerCatalog.DidNotReceiveWithAnyArgs().SetMapLibreStyleAsync(default, default!);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_NoPublishedLayer_DoesNotCreateStandaloneRenderStyle()
+    {
+        var styleCatalog = Substitute.For<IStyleCatalog>();
+        var layerCatalog = Substitute.For<ILayerStyleCatalog>();
+        var applicator = new PostgresMigrationStyleApplicator(styleCatalog, layerCatalog);
+
+        var outcome = await applicator.ApplyAsync(new MigrationLiveStyleApplyRequest
+        {
+            TargetStyleId = "style:geoserver:roads",
+            Title = "Roads",
+            MapLibreLayersJson = ConvertedLayers,
+            ReviewDisposition = "applied"
+        });
+
+        outcome.Should().Be(MigrationStyleApplyOutcome.SkippedNoPublishedLayers);
+        await styleCatalog.DidNotReceiveWithAnyArgs().CreateStyleAsync(default!, default!);
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Import/PostgresMigrationStyleApplicatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Import/PostgresMigrationStyleApplicatorTests.cs
@@ -25,11 +25,14 @@ public sealed class PostgresMigrationStyleApplicatorTests
         var graphSync = Substitute.For<IMetadataV2StyleGraphSync>();
         StyleCatalogRecord? storedStyle = null;
         var storedLayers = new Dictionary<int, LayerStyleDefinition>();
+        var storedAssociations = new List<StyleLayerAssociation>();
         var styleWrites = 0;
         var layerWrites = 0;
 
         styleCatalog.GetStyleAsync("style:geoserver:roads", Arg.Any<CancellationToken>())
             .Returns(_ => storedStyle);
+        styleCatalog.ListAssociationsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => storedAssociations.ToArray());
         styleCatalog.CreateStyleAsync(
                 "style:geoserver:roads",
                 Arg.Any<string>(),
@@ -47,12 +50,22 @@ public sealed class PostgresMigrationStyleApplicatorTests
                     StyleId = "style:geoserver:roads",
                     Title = call.ArgAt<string?>(2),
                     MapLibreStyleJson = call.ArgAt<string>(1),
-                    StyleVersion = 1
+                    StyleVersion = 1,
+                    RevisedBy = "geoserver-migration"
                 };
                 return storedStyle;
             });
         styleCatalog.AssociateLayerAsync(Arg.Any<int>(), "style:geoserver:roads", Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(true);
+            .Returns(call =>
+            {
+                var association = new StyleLayerAssociation(call.ArgAt<int>(0), "style:geoserver:roads", call.ArgAt<int>(2));
+                if (!storedAssociations.Contains(association))
+                {
+                    storedAssociations.Add(association);
+                }
+
+                return true;
+            });
         layerCatalog.GetLayerStyleAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(call => storedLayers.GetValueOrDefault(call.ArgAt<int>(0)));
         layerCatalog.SetMapLibreStyleAsync(
@@ -68,7 +81,8 @@ public sealed class PostgresMigrationStyleApplicatorTests
                 {
                     LayerId = call.ArgAt<int>(0),
                     MapLibreStyleJson = call.ArgAt<string>(1),
-                    StyleVersion = 1
+                    StyleVersion = 1,
+                    StyleRevisedBy = "geoserver-migration"
                 };
                 storedLayers[value.LayerId] = value;
                 return value;
@@ -95,11 +109,90 @@ public sealed class PostgresMigrationStyleApplicatorTests
         retrievedStyle.MapLibreStyleJson.Should().Contain("/tiles/84/{z}/{x}/{y}.mvt");
         retrievedLayer!.MapLibreStyleJson.Should().Contain("\"source\":\"layer-42\"");
         styleWrites.Should().Be(1);
-        layerWrites.Should().Be(2);
+        layerWrites.Should().Be(1);
+        storedLayers.Should().NotContainKey(84, "alternative styles must not replace a layer's render-facing default");
         await styleCatalog.Received(2).AssociateLayerAsync(42, request.TargetStyleId, 0, Arg.Any<CancellationToken>());
         await styleCatalog.Received(2).AssociateLayerAsync(84, request.TargetStyleId, 1, Arg.Any<CancellationToken>());
         await graphSync.Received(2).SyncLayerStylesAsync(42, Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ApplyAsync_OperatorEditedCanonicalStyle_ReturnsConflictWithoutMutation()
+    {
+        var styleCatalog = Substitute.For<IStyleCatalog>();
+        var layerCatalog = Substitute.For<ILayerStyleCatalog>();
+        styleCatalog.GetStyleAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new StyleCatalogRecord
+        {
+            StyleId = "style:geoserver:roads",
+            MapLibreStyleJson = "{\"version\":8,\"sources\":{},\"layers\":[]}",
+            RevisedBy = "operator@example.com"
+        });
+        styleCatalog.ListAssociationsAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<StyleLayerAssociation>());
+        var applicator = new PostgresMigrationStyleApplicator(styleCatalog, layerCatalog);
+
+        var outcome = await applicator.ApplyAsync(CreateRequest());
+
+        outcome.Should().Be(MigrationStyleApplyOutcome.SkippedConflict);
+        await styleCatalog.DidNotReceiveWithAnyArgs().UpsertStyleAsync(default!, default!);
+        await layerCatalog.DidNotReceiveWithAnyArgs().SetMapLibreStyleAsync(default, default!);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_NullCanonicalUpsert_ThrowsAndDoesNotReplaceLayerStyle()
+    {
+        var styleCatalog = Substitute.For<IStyleCatalog>();
+        var layerCatalog = Substitute.For<ILayerStyleCatalog>();
+        styleCatalog.GetStyleAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new StyleCatalogRecord
+        {
+            StyleId = "style:geoserver:roads",
+            MapLibreStyleJson = "{\"version\":8,\"sources\":{},\"layers\":[]}",
+            RevisedBy = "geoserver-migration"
+        });
+        styleCatalog.ListAssociationsAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<StyleLayerAssociation>());
+        styleCatalog.UpsertStyleAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((StyleCatalogRecord)null!);
+        layerCatalog.GetLayerStyleAsync(42, Arg.Any<CancellationToken>()).Returns(new LayerStyleDefinition { LayerId = 42 });
+        var applicator = new PostgresMigrationStyleApplicator(styleCatalog, layerCatalog);
+
+        var action = () => applicator.ApplyAsync(CreateRequest());
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*upsert returned no record*");
+        await layerCatalog.DidNotReceiveWithAnyArgs().SetMapLibreStyleAsync(default, default!);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_AssociationFailure_LeavesDefaultLayerUnchangedForResumableRetry()
+    {
+        var styleCatalog = Substitute.For<IStyleCatalog>();
+        var layerCatalog = Substitute.For<ILayerStyleCatalog>();
+        var canonicalJson = "{\"version\":8,\"name\":\"Roads\",\"sources\":{\"layer-42\":{\"type\":\"vector\",\"tiles\":[\"/tiles/42/{z}/{x}/{y}.mvt\"],\"minzoom\":0,\"maxzoom\":22}},\"layers\":[{\"id\":\"roads\",\"type\":\"line\",\"paint\":{\"line-color\":\"#224466\"},\"source\":\"layer-42\",\"source-layer\":\"layer\"}]}";
+        styleCatalog.GetStyleAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new StyleCatalogRecord
+        {
+            StyleId = "style:geoserver:roads",
+            MapLibreStyleJson = canonicalJson,
+            RevisedBy = "geoserver-migration"
+        });
+        styleCatalog.ListAssociationsAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<StyleLayerAssociation>());
+        styleCatalog.AssociateLayerAsync(42, Arg.Any<string>(), 0, Arg.Any<CancellationToken>()).Returns(false);
+        layerCatalog.GetLayerStyleAsync(42, Arg.Any<CancellationToken>()).Returns(new LayerStyleDefinition { LayerId = 42 });
+        var applicator = new PostgresMigrationStyleApplicator(styleCatalog, layerCatalog);
+
+        var action = () => applicator.ApplyAsync(CreateRequest());
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Could not associate*");
+        await layerCatalog.DidNotReceiveWithAnyArgs().SetMapLibreStyleAsync(default, default!);
+    }
+
+    private static MigrationLiveStyleApplyRequest CreateRequest() => new()
+    {
+        TargetStyleId = "style:geoserver:roads",
+        Title = "Roads",
+        MapLibreLayersJson = ConvertedLayers,
+        ReviewDisposition = "applied",
+        LayerTargets = [new MigrationStyleLayerTarget(42, 0)]
+    };
 
     [Theory]
     [InlineData("manual-review", ConvertedLayers)]
@@ -110,6 +203,7 @@ public sealed class PostgresMigrationStyleApplicatorTests
     {
         var styleCatalog = Substitute.For<IStyleCatalog>();
         var layerCatalog = Substitute.For<ILayerStyleCatalog>();
+        styleCatalog.ListAssociationsAsync(Arg.Any<CancellationToken>()).Returns(Array.Empty<StyleLayerAssociation>());
         var applicator = new PostgresMigrationStyleApplicator(styleCatalog, layerCatalog);
 
         var outcome = await applicator.ApplyAsync(new MigrationLiveStyleApplyRequest


### PR DESCRIPTION
## Issue Link
Closes #2449

## Summary
Applies safely converted GeoServer SLD/SE styles to Honua's live render-facing style catalogs instead of retaining them only as migration evidence. Manual-review conversions and operator-edited styles remain untouched.

## Changes Made
- Add a migration style applicator over canonical and layer style catalogs
- Publish target layers before resolving and applying source style references
- Preserve deterministic default/alternative associations and protect operator edits on replay
- Promote migration evidence to applied only after all live writes succeed
- Add focused integration tests for idempotency, conflicts, failures, and style precedence

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Focused test: `PostgresMigrationStyleApplicatorTests` (7 passed, 0 failed).

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review