### PR TITLE
feat(wps): add WPS 2.0 process adapter

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -621,14 +621,16 @@
       "upload_operator_eval_report": false,
       "upload_odata_evidence": false,
       "csproj": "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj",
-      "_comment": "ADR-0037 finer-sharding CATCH-ALL: the Wfs20 + Wcs20 namespaces EXCEPT Wfs20EndpointsTests (a single 74-test class isolated into WFS Endpoints). NOTE: this also FIXES a pre-existing coverage gap — Wcs20EndpointsTests (28 [IntegrationTest]s) previously matched no shard filter and never ran in CI; it now runs here. Complementary with WFS Endpoints (which selects only Wfs20EndpointsTests).",
-      "filter": "(FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wcs20)&FullyQualifiedName!~Wfs20EndpointsTests",
+      "_comment": "ADR-0037 finer-sharding CATCH-ALL: the Wfs20 + Wcs20 + Wps20 namespaces EXCEPT Wfs20EndpointsTests (a single 74-test class isolated into WFS Endpoints). NOTE: this also FIXES pre-existing coverage gaps — Wcs20EndpointsTests (28 [IntegrationTest]s) and Wps20EndpointsTests previously matched no shard filter and never ran in CI; they now run here. Complementary with WFS Endpoints (which selects only Wfs20EndpointsTests).",
+      "filter": "(FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wcs20|FullyQualifiedName~Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wps20)&FullyQualifiedName!~Wfs20EndpointsTests",
       "paths": [
         "src/Honua.Protocols.OgcClassic/Wfs20/",
         "src/Honua.Protocols.OgcClassic/Wcs20/",
+        "src/Honua.Protocols.OgcClassic/Wps20/",
         "src/Honua.Core/Features/Raster/",
         "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wfs20/",
         "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wcs20/",
+        "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/",
         "src/Honua.Core/Features/Validation/",
         "src/Honua.Hosting/Features/Services/"
       ]

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -2377,6 +2377,42 @@
       ]
     },
     {
+      "surfaceId": "wps-2.0.2",
+      "displayName": "WPS 2.0.2",
+      "surfaceKind": "http-route-family",
+      "protocol": "WPS 2.0.2",
+      "canonicalIdentifier": "/wps",
+      "parentSurfaceId": null,
+      "endpointPrefixes": [
+        "/wps"
+      ],
+      "endpointExactMatches": [],
+      "endpointContains": [],
+      "operationKeys": [
+        "WPS-2.0.2::GetCapabilities",
+        "WPS-2.0.2::DescribeProcess",
+        "WPS-2.0.2::Execute",
+        "WPS-2.0.2::GetStatus",
+        "WPS-2.0.2::GetResult"
+      ],
+      "proofs": [
+        {
+          "proofClass": "operation-coverage",
+          "proofMechanism": "WPS 2.0.2 endpoint integration tests cover capabilities, process descriptions, execution submission, status polling, result retrieval, and OWS exception responses.",
+          "executionLane": "ci:test-all+architecture",
+          "evidenceLocations": [
+            "src/Honua.Protocols.OgcClassic/Wps20/Wps20Endpoint.cs",
+            "src/Honua.Server/OperationRegistry.cs",
+            "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/Wps20EndpointsTests.cs"
+          ],
+          "ownerRepo": "honua-server",
+          "status": "implemented",
+          "linkedTicket": "#2450",
+          "versionCaptureRule": null
+        }
+      ]
+    },
+    {
       "surfaceId": "odata-v4",
       "displayName": "OData v4",
       "surfaceKind": "http-route-family",

--- a/docs/gis/data/public-interface-proof.json
+++ b/docs/gis/data/public-interface-proof.json
@@ -2398,7 +2398,7 @@
       "proofs": [
         {
           "proofClass": "operation-coverage",
-          "proofMechanism": "WPS 2.0.2 endpoint integration tests cover capabilities, process descriptions, execution submission, status polling, result retrieval, and OWS exception responses.",
+          "proofMechanism": "WPS 2.0.2 endpoint integration tests cover capabilities, process descriptions, execution submission, GetStatus request and error handling, result retrieval, and OWS exception responses.",
           "executionLane": "ci:test-all+architecture",
           "evidenceLocations": [
             "src/Honua.Protocols.OgcClassic/Wps20/Wps20Endpoint.cs",

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -874,6 +874,10 @@ if [[ -n "${PYTHON_BIN}" ]]; then
 echo "Checking server-test shard coverage (no orphaned test classes)..."
 "${PYTHON_BIN}" scripts/ci/check-server-test-shard-coverage.py \
   --assert-owner \
+    "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wps20.Wps20EndpointsTests" \
+    "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj" \
+    "WFS" \
+  --assert-owner \
     "Honua.Server.Tests.Features.Protocols.GeoServices.Tiles.CompactTilePackageWriterTests" \
     "tests/dotnet/Honua.Protocols.GeoServices.Tests/Honua.Protocols.GeoServices.Tests.csproj" \
     "GeoServices ImageServer" \
@@ -889,10 +893,6 @@ echo "Checking server-test shard coverage (no orphaned test classes)..."
     "Honua.Server.Tests.Routing.PgRoutingProviderIntegrationTests" \
     "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
     "Core" \
-  --assert-owner \
-    "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wps20.Wps20EndpointsTests" \
-    "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj" \
-    "WFS" \
   --assert-owner \
     "Honua.Server.Tests.Features.Protocols.Zarr.DatacubeTileEndpointTests" \
     "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \

--- a/scripts/ci/validate-ci-router.sh
+++ b/scripts/ci/validate-ci-router.sh
@@ -890,6 +890,10 @@ echo "Checking server-test shard coverage (no orphaned test classes)..."
     "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
     "Core" \
   --assert-owner \
+    "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wps20.Wps20EndpointsTests" \
+    "tests/dotnet/Honua.Protocols.OgcClassic.Tests/Honua.Protocols.OgcClassic.Tests.csproj" \
+    "WFS" \
+  --assert-owner \
     "Honua.Server.Tests.Features.Protocols.Zarr.DatacubeTileEndpointTests" \
     "tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj" \
     "Server Features Misc" \

--- a/src/Honua.Geoprocessing/Honua.Geoprocessing.csproj
+++ b/src/Honua.Geoprocessing/Honua.Geoprocessing.csproj
@@ -50,6 +50,8 @@
     <InternalsVisibleTo Include="Honua.Architecture.Tests" />
     <InternalsVisibleTo Include="Honua.Protocols.OgcApi" />
     <InternalsVisibleTo Include="Honua.Protocols.OgcApi.Tests" />
+    <InternalsVisibleTo Include="Honua.Protocols.OgcClassic" />
+    <InternalsVisibleTo Include="Honua.Protocols.OgcClassic.Tests" />
     <InternalsVisibleTo Include="Honua.Protocols.GeoServices" />
     <InternalsVisibleTo Include="Honua.Protocols.GeoServices.Tests" />
     <InternalsVisibleTo Include="Honua.Ai.Tests" />

--- a/src/Honua.Protocols.OgcClassic/Honua.Protocols.OgcClassic.csproj
+++ b/src/Honua.Protocols.OgcClassic/Honua.Protocols.OgcClassic.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Honua.Core\Honua.Core.csproj" />
     <ProjectReference Include="..\Honua.Geometry\Honua.Geometry.csproj" />
     <ProjectReference Include="..\Honua.Hosting\Honua.Hosting.csproj" />
+    <ProjectReference Include="..\Honua.Geoprocessing\Honua.Geoprocessing.csproj" />
     <ProjectReference Include="..\Honua.ServiceDefaults\Honua.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Honua.Protocols.Ogc.Shared\Honua.Protocols.Ogc.Shared.csproj" />
   </ItemGroup>

--- a/src/Honua.Protocols.OgcClassic/OgcClassicEndpoints.cs
+++ b/src/Honua.Protocols.OgcClassic/OgcClassicEndpoints.cs
@@ -3,6 +3,7 @@
 
 using Honua.Protocols.Ogc.Classic.Wms;
 using Honua.Protocols.Ogc.Classic.Wmts;
+using Honua.Protocols.Ogc.Classic.Wps20;
 
 namespace Honua.Protocols.Ogc.Classic;
 
@@ -17,6 +18,8 @@ internal static class OgcClassicEndpoints
     public static IEndpointRouteBuilder MapOgcClassicEndpoints(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
+
+        endpoints.MapWps20Endpoint();
 
         endpoints.MapGet("/rest/services/{serviceId}/MapServer/WMTS",
                 static (HttpContext context, CancellationToken cancellationToken) => WmtsRequestHandlers.HandleWmts(context))

--- a/src/Honua.Protocols.OgcClassic/Wps20/Wps20Endpoint.cs
+++ b/src/Honua.Protocols.OgcClassic/Wps20/Wps20Endpoint.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using Honua.Infrastructure.Helpers;
+using Honua.ServiceDefaults;
+
+namespace Honua.Protocols.Ogc.Classic.Wps20;
+
+/// <summary>
+/// Thin WPS 2.0.2 XML adapter over the canonical process catalog and job service.
+/// </summary>
+internal static partial class Wps20Endpoint
+{
+    internal const string WpsNamespace = "http://www.opengis.net/wps/2.0";
+    internal const string OwsNamespace = "http://www.opengis.net/ows/2.0";
+    private const string Version = "2.0.0";
+    private const int MaxInputs = 64;
+    private const int MaxInputCharacters = 65_536;
+    private static readonly string[] Methods = ["GET", "POST"];
+
+    internal static IEndpointRouteBuilder MapWps20Endpoint(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapMethods("/wps", Methods, DispatchAsync)
+            .WithDisplayName("WPS 2.0.2 Service")
+            .WithName("Wps20Service")
+            .WithSummary("OGC Web Processing Service 2.0.2")
+            .WithDescription("Provides GetCapabilities, DescribeProcess, Execute, GetStatus, and GetResult over the canonical geoprocessing runtime")
+            .WithTags("WPS 2.0", "OGC")
+            .CacheOutput(policy => policy.NoCache())
+            .Produces(200, contentType: "application/xml")
+            .Produces(400, contentType: "application/xml")
+            .Produces(401, contentType: "application/xml")
+            .Produces(403, contentType: "application/xml")
+            .Produces(404, contentType: "application/xml")
+            .AllowAnonymous();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> DispatchAsync(
+        HttpContext context,
+        IProcessCatalog catalog,
+        IGeoprocessingJobService jobs,
+        ILogger<Wps20EndpointLog> logger)
+    {
+        WpsRequest request;
+        try
+        {
+            request = await ReadRequestAsync(context).ConfigureAwait(false);
+        }
+        catch (WpsRequestException ex)
+        {
+            Log.InvalidRequest(logger, ex.Message);
+            return Exception(ex.Code, ex.Message, ex.Locator, ex.StatusCode);
+        }
+        catch (XmlException ex)
+        {
+            Log.InvalidRequest(logger, ex.Message);
+            return Exception("InvalidParameterValue", "The XML request is not valid or contains prohibited constructs.", "request");
+        }
+
+        using var activity = HonuaTelemetry.ActivitySource.StartActivity("ogc.wps." + request.Operation.ToLowerInvariant());
+        activity?.SetTag(HonuaTelemetry.Tags.Protocol, "WPS-2.0.2");
+        activity?.SetTag(HonuaTelemetry.Tags.Operation, request.Operation);
+        if (request.JobId is not null)
+        {
+            activity?.SetTag(HonuaTelemetry.Tags.JobId, request.JobId);
+        }
+        context.Items["__honua_request_operation"] = "wps." + request.Operation.ToLowerInvariant();
+        Log.OperationRequested(logger, request.Operation);
+
+        try
+        {
+            return request.Operation.ToUpperInvariant() switch
+            {
+                "GETCAPABILITIES" => GetCapabilities(context, catalog),
+                "DESCRIBEPROCESS" => DescribeProcess(catalog, request.Identifier),
+                "EXECUTE" => await ExecuteAsync(context, catalog, jobs, request).ConfigureAwait(false),
+                "GETSTATUS" => await GetStatusAsync(context, jobs, request.JobId).ConfigureAwait(false),
+                "GETRESULT" => await GetResultAsync(jobs, context.User, request.JobId, context.RequestAborted).ConfigureAwait(false),
+                _ => Exception("OperationNotSupported", $"Operation '{request.Operation}' is not implemented.", "request", StatusCodes.Status501NotImplemented)
+            };
+        }
+        catch (GeoprocessingAuthorizationException ex)
+        {
+            return Exception("AccessDenied", ex.RequiresAuthentication ? "Authentication is required." : "The caller is not authorized.", null,
+                ex.RequiresAuthentication ? StatusCodes.Status401Unauthorized : StatusCodes.Status403Forbidden);
+        }
+        catch (GeoprocessingNotFoundException)
+        {
+            return Exception("NoSuchJob", "The requested job does not exist.", "jobId", StatusCodes.Status404NotFound);
+        }
+        catch (GeoprocessingValidationException ex)
+        {
+            return Exception("InvalidParameterValue", ex.Message, "input");
+        }
+        catch (GeoprocessingStoreUnavailableException)
+        {
+            return Exception("ServerBusy", "The job store is unavailable.", null, StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    private static IResult GetCapabilities(HttpContext context, IProcessCatalog catalog)
+    {
+        var endpoint = OgcClassicRequestHelpers.EscapeXml($"{context.Request.Scheme}://{context.Request.Host}{context.Request.PathBase}/wps");
+        var offerings = string.Join(string.Empty, catalog.ListProcesses().OrderBy(p => p.ProcessId, StringComparer.Ordinal).Select(p =>
+            $"<wps:ProcessSummary jobControlOptions=\"async-execute\" outputTransmission=\"value\"><ows:Title>{X(p.Title)}</ows:Title><ows:Identifier>{X(p.ProcessId)}</ows:Identifier></wps:ProcessSummary>"));
+        return Xml($"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wps:Capabilities xmlns:wps="{WpsNamespace}" xmlns:ows="{OwsNamespace}" version="{Version}">
+              <ows:ServiceIdentification><ows:Title>Honua Web Processing Service</ows:Title><ows:ServiceType>WPS</ows:ServiceType><ows:ServiceTypeVersion>{Version}</ows:ServiceTypeVersion></ows:ServiceIdentification>
+              <ows:OperationsMetadata>
+                {Operation("GetCapabilities", endpoint)}{Operation("DescribeProcess", endpoint)}{Operation("Execute", endpoint)}{Operation("GetStatus", endpoint)}{Operation("GetResult", endpoint)}
+              </ows:OperationsMetadata>
+              <wps:Contents>{offerings}</wps:Contents>
+            </wps:Capabilities>
+            """);
+    }
+
+    private static IResult DescribeProcess(IProcessCatalog catalog, string? identifier)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            return Exception("MissingParameterValue", "An Identifier is required.", "identifier");
+        }
+
+        var process = catalog.GetProcess(identifier);
+        if (process is null)
+        {
+            return Exception("NoSuchProcess", $"Process '{identifier}' does not exist.", "identifier", StatusCodes.Status404NotFound);
+        }
+
+        var inputs = string.Join(string.Empty, process.Parameters.Select(parameter =>
+            $"<wps:Input minOccurs=\"{(parameter.Required ? "1" : "0")}\" maxOccurs=\"1\"><ows:Title>{X(parameter.DisplayName)}</ows:Title><ows:Abstract>{X(parameter.Description)}</ows:Abstract><ows:Identifier>{X(parameter.Name)}</ows:Identifier><wps:LiteralData><wps:Format mimeType=\"text/plain\" default=\"true\"/></wps:LiteralData></wps:Input>"));
+        var outputs = string.Join(string.Empty, process.OutputArtifactKinds.Select(kind =>
+            $"<wps:Output><ows:Title>{X(kind.ToString())}</ows:Title><ows:Identifier>{X(kind.ToString())}</ows:Identifier><wps:LiteralData><wps:Format mimeType=\"text/plain\" default=\"true\"/></wps:LiteralData></wps:Output>"));
+
+        return Xml($"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wps:ProcessOfferings xmlns:wps="{WpsNamespace}" xmlns:ows="{OwsNamespace}">
+              <wps:ProcessOffering jobControlOptions="async-execute" outputTransmission="value">
+                <wps:Process><ows:Title>{X(process.Title)}</ows:Title><ows:Abstract>{X(process.Description)}</ows:Abstract><ows:Identifier>{X(process.ProcessId)}</ows:Identifier>{inputs}{outputs}</wps:Process>
+              </wps:ProcessOffering>
+            </wps:ProcessOfferings>
+            """);
+    }
+
+    private static async Task<IResult> ExecuteAsync(HttpContext context, IProcessCatalog catalog, IGeoprocessingJobService jobs, WpsRequest request)
+    {
+        await jobs.EnsureCallerAuthorizedAsync(context.User, OperatorResourceType.Process, OperatorOperation.Execute, context.RequestAborted).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(request.Identifier))
+        {
+            return Exception("MissingParameterValue", "An Identifier is required.", "identifier");
+        }
+
+        var process = catalog.GetProcess(request.Identifier);
+        if (process is null)
+        {
+            return Exception("NoSuchProcess", $"Process '{request.Identifier}' does not exist.", "identifier", StatusCodes.Status404NotFound);
+        }
+
+        var known = process.Parameters.Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var unknown = request.Inputs.Keys.FirstOrDefault(key => !known.Contains(key));
+        if (unknown is not null)
+        {
+            return Exception("InvalidParameterValue", $"Input '{unknown}' is not defined by process '{process.ProcessId}'.", unknown);
+        }
+        var missing = process.Parameters.FirstOrDefault(p => p.Required && !request.Inputs.ContainsKey(p.Name) && p.DefaultValue is null);
+        if (missing is not null)
+        {
+            return Exception("MissingParameterValue", $"Required input '{missing.Name}' is missing.", missing.Name);
+        }
+
+        var inputValues = process.Parameters
+            .Where(p => request.Inputs.ContainsKey(p.Name) || p.DefaultValue is not null)
+            .ToDictionary(p => p.Name, p => request.Inputs.GetValueOrDefault(p.Name) ?? p.DefaultValue!, StringComparer.Ordinal);
+        var plan = new AnalysisPlan
+        {
+            PlanId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture),
+            IntentId = "wps-2.0",
+            Outputs = process.OutputArtifactKinds,
+            Steps = [new AnalysisPlanStep { StepId = "wps-step", Kind = AnalysisPlanStepKind.Geoprocess, ProcessId = process.ProcessId, Inputs = inputValues }]
+        };
+        var job = await jobs.SubmitJobAsync(plan, null, context.User,
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["submittedVia"] = "WPS-2.0.2", ["protocolProcessId"] = process.ProcessId },
+            context.RequestAborted).ConfigureAwait(false);
+        var location = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.PathBase}/wps?service=WPS&request=GetStatus&version={Version}&jobId={Uri.EscapeDataString(job.OperationId)}";
+        context.Response.Headers.Location = location;
+        return StatusInfo(job, StatusCodes.Status201Created);
+    }
+
+    private static async Task<IResult> GetStatusAsync(HttpContext context, IGeoprocessingJobService jobs, string? jobId)
+    {
+        if (string.IsNullOrWhiteSpace(jobId))
+        {
+            return Exception("MissingParameterValue", "A JobID is required.", "jobId");
+        }
+        var job = await jobs.GetJobAsync(jobId, context.User, context.RequestAborted).ConfigureAwait(false);
+        return StatusInfo(job);
+    }
+
+    private static async Task<IResult> GetResultAsync(IGeoprocessingJobService jobs, System.Security.Claims.ClaimsPrincipal user, string? jobId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(jobId))
+        {
+            return Exception("MissingParameterValue", "A JobID is required.", "jobId");
+        }
+        var package = await jobs.GetJobResultsAsync(jobId, user, cancellationToken).ConfigureAwait(false);
+        var artifacts = string.Join(string.Empty, package.Artifacts.Select((artifact, index) =>
+            $"<wps:Output id=\"result-{index.ToString(CultureInfo.InvariantCulture)}\"><wps:Data mimeType=\"text/plain\"><wps:LiteralValue>{X(artifact.ToString() ?? string.Empty)}</wps:LiteralValue></wps:Data></wps:Output>"));
+        return Xml($"<?xml version=\"1.0\" encoding=\"UTF-8\"?><wps:Result xmlns:wps=\"{WpsNamespace}\" xmlns:ows=\"{OwsNamespace}\" jobID=\"{X(jobId)}\"><wps:Output id=\"summary\"><wps:Data mimeType=\"text/plain\"><wps:LiteralValue>{X(package.Summary.Title)}</wps:LiteralValue></wps:Data></wps:Output>{artifacts}</wps:Result>");
+    }
+
+    private static IResult StatusInfo(ExecutionJobRecord job, int statusCode = StatusCodes.Status200OK)
+    {
+        var status = job.Status switch
+        {
+            ExecutionJobStatus.Queued or ExecutionJobStatus.Provisioning => "Accepted",
+            ExecutionJobStatus.Running => "Running",
+            ExecutionJobStatus.Succeeded => "Succeeded",
+            ExecutionJobStatus.Failed => "Failed",
+            ExecutionJobStatus.Cancelled => "Dismissed",
+            _ => "Failed"
+        };
+        var percent = job.PercentComplete is double value
+            ? $"<wps:PercentCompleted>{Math.Clamp(value, 0, 100).ToString("0.##", CultureInfo.InvariantCulture)}</wps:PercentCompleted>"
+            : string.Empty;
+        return Xml($"<?xml version=\"1.0\" encoding=\"UTF-8\"?><wps:StatusInfo xmlns:wps=\"{WpsNamespace}\"><wps:JobID>{X(job.OperationId)}</wps:JobID><wps:Status>{status}</wps:Status>{percent}</wps:StatusInfo>", statusCode);
+    }
+
+    private static async Task<WpsRequest> ReadRequestAsync(HttpContext context)
+    {
+        if (HttpMethods.IsGet(context.Request.Method))
+        {
+            return FromValues(context.Request.Query.ToDictionary(pair => pair.Key, pair => pair.Value.ToString(), StringComparer.OrdinalIgnoreCase));
+        }
+        if (context.Request.HasFormContentType)
+        {
+            var form = await context.Request.ReadFormAsync(context.RequestAborted).ConfigureAwait(false);
+            return FromValues(form.ToDictionary(pair => pair.Key, pair => pair.Value.ToString(), StringComparer.OrdinalIgnoreCase));
+        }
+
+        var settings = new XmlReaderSettings
+        {
+            Async = true,
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = RequestBodySizeGuard.ResolveMaxBodyBytes(context),
+            MaxCharactersFromEntities = 0,
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true
+        };
+        using var reader = XmlReader.Create(context.Request.Body, settings);
+        var document = await XDocument.LoadAsync(reader, LoadOptions.None, context.RequestAborted).ConfigureAwait(false);
+        var root = document.Root ?? throw new WpsRequestException("MissingParameterValue", "The request document is empty.", "request");
+        if (root.Name.NamespaceName != WpsNamespace)
+        {
+            throw new WpsRequestException("InvalidParameterValue", "The request root must use the WPS 2.0 namespace.", "request");
+        }
+        var operation = root.Name.LocalName;
+        var identifier = root.Descendants(XName.Get("Identifier", OwsNamespace)).FirstOrDefault()?.Value.Trim();
+        var jobId = root.Descendants(XName.Get("JobID", WpsNamespace)).FirstOrDefault()?.Value.Trim();
+        var inputs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var input in root.Elements(XName.Get("Input", WpsNamespace)))
+        {
+            if (inputs.Count >= MaxInputs)
+            {
+                throw new WpsRequestException("InvalidParameterValue", $"At most {MaxInputs} inputs are allowed.", "input");
+            }
+            var name = input.Element(XName.Get("Identifier", OwsNamespace))?.Value.Trim();
+            var value = input.Descendants(XName.Get("LiteralValue", WpsNamespace)).FirstOrDefault()?.Value;
+            AddInput(inputs, name, value);
+        }
+        return new WpsRequest(operation, identifier, jobId, inputs);
+    }
+
+    private static WpsRequest FromValues(Dictionary<string, string> values)
+    {
+        if (!values.TryGetValue("request", out var operation) || string.IsNullOrWhiteSpace(operation))
+        {
+            throw new WpsRequestException("MissingParameterValue", "The request parameter is required.", "request");
+        }
+        values.TryGetValue("identifier", out var identifier);
+        values.TryGetValue("jobId", out var jobId);
+        var inputs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (values.TryGetValue("dataInputs", out var dataInputs) && !string.IsNullOrWhiteSpace(dataInputs))
+        {
+            foreach (var item in dataInputs.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var separator = item.IndexOf('=');
+                if (separator <= 0)
+                {
+                    throw new WpsRequestException("InvalidParameterValue", "DataInputs must use name=value pairs separated by semicolons.", "dataInputs");
+                }
+                AddInput(inputs, item[..separator], item[(separator + 1)..]);
+            }
+        }
+        return new WpsRequest(operation.Trim(), identifier?.Trim(), jobId?.Trim(), inputs);
+    }
+
+    private static void AddInput(Dictionary<string, string> inputs, string? name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(name) || value is null || value.Length > MaxInputCharacters || inputs.Count >= MaxInputs)
+        {
+            throw new WpsRequestException("InvalidParameterValue", "Each input requires a bounded identifier and literal value.", "input");
+        }
+        if (!inputs.TryAdd(name.Trim(), value))
+        {
+            throw new WpsRequestException("InvalidParameterValue", $"Input '{name}' is repeated.", name);
+        }
+    }
+
+    private static string Operation(string name, string endpoint) =>
+        $"<ows:Operation name=\"{name}\"><ows:DCP><ows:HTTP><ows:Get xmlns:xlink=\"http://www.w3.org/1999/xlink\" xlink:href=\"{endpoint}\"/><ows:Post xmlns:xlink=\"http://www.w3.org/1999/xlink\" xlink:href=\"{endpoint}\"/></ows:HTTP></ows:DCP></ows:Operation>";
+
+    private static IResult Exception(string code, string message, string? locator = null, int statusCode = StatusCodes.Status400BadRequest)
+    {
+        var locatorAttribute = locator is null ? string.Empty : $" locator=\"{X(locator)}\"";
+        return Xml($"<?xml version=\"1.0\" encoding=\"UTF-8\"?><ows:ExceptionReport xmlns:ows=\"{OwsNamespace}\" version=\"{Version}\"><ows:Exception exceptionCode=\"{X(code)}\"{locatorAttribute}><ows:ExceptionText>{X(message)}</ows:ExceptionText></ows:Exception></ows:ExceptionReport>", statusCode);
+    }
+
+    private static IResult Xml(string content, int statusCode = StatusCodes.Status200OK) =>
+        Results.Content(content, "application/xml", Encoding.UTF8, statusCode);
+
+    private static string X(string value) => OgcClassicRequestHelpers.EscapeXml(value);
+
+    private sealed record WpsRequest(string Operation, string? Identifier, string? JobId, IReadOnlyDictionary<string, string> Inputs);
+
+    private sealed class WpsRequestException(string code, string message, string? locator, int statusCode = StatusCodes.Status400BadRequest) : Exception(message)
+    {
+        public string Code { get; } = code;
+        public string? Locator { get; } = locator;
+        public int StatusCode { get; } = statusCode;
+    }
+
+    internal sealed class Wps20EndpointLog;
+
+    private static partial class Log
+    {
+        [LoggerMessage(7101, LogLevel.Debug, "WPS operation {Operation} requested")]
+        public static partial void OperationRequested(ILogger logger, string operation);
+
+        [LoggerMessage(7102, LogLevel.Warning, "Invalid WPS request: {Reason}")]
+        public static partial void InvalidRequest(ILogger logger, string reason);
+    }
+}

--- a/src/Honua.Protocols.OgcClassic/Wps20/Wps20Endpoint.cs
+++ b/src/Honua.Protocols.OgcClassic/Wps20/Wps20Endpoint.cs
@@ -114,7 +114,7 @@ internal static partial class Wps20Endpoint
     {
         var endpoint = OgcClassicRequestHelpers.EscapeXml($"{context.Request.Scheme}://{context.Request.Host}{context.Request.PathBase}/wps");
         var offerings = string.Join(string.Empty, catalog.ListProcesses().OrderBy(p => p.ProcessId, StringComparer.Ordinal).Select(p =>
-            $"<wps:ProcessSummary jobControlOptions=\"async-execute\" outputTransmission=\"value\"><ows:Title>{X(p.Title)}</ows:Title><ows:Identifier>{X(p.ProcessId)}</ows:Identifier></wps:ProcessSummary>"));
+            $"<wps:ProcessSummary processVersion=\"1.0.0\" jobControlOptions=\"async-execute\" outputTransmission=\"value\"><ows:Title>{X(p.Title)}</ows:Title><ows:Identifier>{X(p.ProcessId)}</ows:Identifier></wps:ProcessSummary>"));
         return Xml($"""
             <?xml version="1.0" encoding="UTF-8"?>
             <wps:Capabilities xmlns:wps="{WpsNamespace}" xmlns:ows="{OwsNamespace}" version="{Version}">
@@ -142,14 +142,13 @@ internal static partial class Wps20Endpoint
 
         var inputs = string.Join(string.Empty, process.Parameters.Select(parameter =>
             $"<wps:Input minOccurs=\"{(parameter.Required ? "1" : "0")}\" maxOccurs=\"1\"><ows:Title>{X(parameter.DisplayName)}</ows:Title><ows:Abstract>{X(parameter.Description)}</ows:Abstract><ows:Identifier>{X(parameter.Name)}</ows:Identifier><wps:LiteralData><wps:Format mimeType=\"text/plain\" default=\"true\"/></wps:LiteralData></wps:Input>"));
-        var outputs = string.Join(string.Empty, process.OutputArtifactKinds.Select(kind =>
-            $"<wps:Output><ows:Title>{X(kind.ToString())}</ows:Title><ows:Identifier>{X(kind.ToString())}</ows:Identifier><wps:LiteralData><wps:Format mimeType=\"text/plain\" default=\"true\"/></wps:LiteralData></wps:Output>"));
+        const string outputs = "<wps:Output><ows:Title>Result summary</ows:Title><ows:Identifier>result</ows:Identifier><wps:LiteralData><wps:Format mimeType=\"text/plain\" default=\"true\"/></wps:LiteralData></wps:Output>";
 
         return Xml($"""
             <?xml version="1.0" encoding="UTF-8"?>
             <wps:ProcessOfferings xmlns:wps="{WpsNamespace}" xmlns:ows="{OwsNamespace}">
               <wps:ProcessOffering jobControlOptions="async-execute" outputTransmission="value">
-                <wps:Process><ows:Title>{X(process.Title)}</ows:Title><ows:Abstract>{X(process.Description)}</ows:Abstract><ows:Identifier>{X(process.ProcessId)}</ows:Identifier>{inputs}{outputs}</wps:Process>
+                <wps:Process processVersion="1.0.0"><ows:Title>{X(process.Title)}</ows:Title><ows:Abstract>{X(process.Description)}</ows:Abstract><ows:Identifier>{X(process.ProcessId)}</ows:Identifier>{inputs}{outputs}</wps:Process>
               </wps:ProcessOffering>
             </wps:ProcessOfferings>
             """);
@@ -216,9 +215,7 @@ internal static partial class Wps20Endpoint
             return Exception("MissingParameterValue", "A JobID is required.", "jobId");
         }
         var package = await jobs.GetJobResultsAsync(jobId, user, cancellationToken).ConfigureAwait(false);
-        var artifacts = string.Join(string.Empty, package.Artifacts.Select((artifact, index) =>
-            $"<wps:Output id=\"result-{index.ToString(CultureInfo.InvariantCulture)}\"><wps:Data mimeType=\"text/plain\"><wps:LiteralValue>{X(artifact.ToString() ?? string.Empty)}</wps:LiteralValue></wps:Data></wps:Output>"));
-        return Xml($"<?xml version=\"1.0\" encoding=\"UTF-8\"?><wps:Result xmlns:wps=\"{WpsNamespace}\" xmlns:ows=\"{OwsNamespace}\" jobID=\"{X(jobId)}\"><wps:Output id=\"summary\"><wps:Data mimeType=\"text/plain\"><wps:LiteralValue>{X(package.Summary.Title)}</wps:LiteralValue></wps:Data></wps:Output>{artifacts}</wps:Result>");
+        return Xml($"<?xml version=\"1.0\" encoding=\"UTF-8\"?><wps:Result xmlns:wps=\"{WpsNamespace}\" xmlns:ows=\"{OwsNamespace}\" jobID=\"{X(jobId)}\"><wps:Output><ows:Identifier>result</ows:Identifier><wps:Data mimeType=\"text/plain\"><wps:LiteralValue>{X(package.Summary.Title)}</wps:LiteralValue></wps:Data></wps:Output></wps:Result>");
     }
 
     private static IResult StatusInfo(ExecutionJobRecord job, int statusCode = StatusCodes.Status200OK)
@@ -233,7 +230,7 @@ internal static partial class Wps20Endpoint
             _ => "Failed"
         };
         var percent = job.PercentComplete is double value
-            ? $"<wps:PercentCompleted>{Math.Clamp(value, 0, 100).ToString("0.##", CultureInfo.InvariantCulture)}</wps:PercentCompleted>"
+            ? $"<wps:PercentCompleted>{((int)Math.Round(Math.Clamp(value, 0, 100), MidpointRounding.AwayFromZero)).ToString(CultureInfo.InvariantCulture)}</wps:PercentCompleted>"
             : string.Empty;
         return Xml($"<?xml version=\"1.0\" encoding=\"UTF-8\"?><wps:StatusInfo xmlns:wps=\"{WpsNamespace}\"><wps:JobID>{X(job.OperationId)}</wps:JobID><wps:Status>{status}</wps:Status>{percent}</wps:StatusInfo>", statusCode);
     }
@@ -267,6 +264,8 @@ internal static partial class Wps20Endpoint
         {
             throw new WpsRequestException("InvalidParameterValue", "The request root must use the WPS 2.0 namespace.", "request");
         }
+        ValidateBindingValue(root.Attribute("service")?.Value, "WPS", "service");
+        ValidateBindingValue(root.Attribute("version")?.Value, Version, "version");
         var operation = root.Name.LocalName;
         var identifier = root.Descendants(XName.Get("Identifier", OwsNamespace)).FirstOrDefault()?.Value.Trim();
         var jobId = root.Descendants(XName.Get("JobID", WpsNamespace)).FirstOrDefault()?.Value.Trim();
@@ -277,7 +276,7 @@ internal static partial class Wps20Endpoint
             {
                 throw new WpsRequestException("InvalidParameterValue", $"At most {MaxInputs} inputs are allowed.", "input");
             }
-            var name = input.Element(XName.Get("Identifier", OwsNamespace))?.Value.Trim();
+            var name = input.Attribute("id")?.Value.Trim();
             var value = input.Descendants(XName.Get("LiteralValue", WpsNamespace)).FirstOrDefault()?.Value;
             AddInput(inputs, name, value);
         }
@@ -286,6 +285,10 @@ internal static partial class Wps20Endpoint
 
     private static WpsRequest FromValues(Dictionary<string, string> values)
     {
+        values.TryGetValue("service", out var service);
+        values.TryGetValue("version", out var version);
+        ValidateBindingValue(service, "WPS", "service");
+        ValidateBindingValue(version, Version, "version");
         if (!values.TryGetValue("request", out var operation) || string.IsNullOrWhiteSpace(operation))
         {
             throw new WpsRequestException("MissingParameterValue", "The request parameter is required.", "request");
@@ -306,6 +309,18 @@ internal static partial class Wps20Endpoint
             }
         }
         return new WpsRequest(operation.Trim(), identifier?.Trim(), jobId?.Trim(), inputs);
+    }
+
+    private static void ValidateBindingValue(string? actual, string expected, string locator)
+    {
+        if (string.IsNullOrWhiteSpace(actual))
+        {
+            throw new WpsRequestException("MissingParameterValue", $"The {locator} value is required.", locator);
+        }
+        if (!string.Equals(actual.Trim(), expected, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new WpsRequestException("InvalidParameterValue", $"The {locator} value must be '{expected}'.", locator);
+        }
     }
 
     private static void AddInput(Dictionary<string, string> inputs, string? name, string? value)

--- a/src/Honua.Server/OperationRegistry.cs
+++ b/src/Honua.Server/OperationRegistry.cs
@@ -32,6 +32,7 @@ public static class OperationRegistry
     private const string Wms111 = "WMS-1.1.1";
     private const string Wmts10 = "WMTS-1.0.0";
     private const string Wcs201 = "WCS-2.0.1";
+    private const string Wps202 = "WPS-2.0.2";
     private const string ODataV4 = "OData-v4";
     private const string Grpc = "Grpc";
     private const string Mcp = "Mcp";
@@ -82,6 +83,13 @@ public static class OperationRegistry
         new(Wcs201, "GetCapabilities"),
         new(Wcs201, "DescribeCoverage"),
         new(Wcs201, "GetCoverage"),
+
+        // WPS 2.0.2 operations (KVP and XML dispatched through GET|POST /wps)
+        new(Wps202, "GetCapabilities"),
+        new(Wps202, "DescribeProcess"),
+        new(Wps202, "Execute"),
+        new(Wps202, "GetStatus"),
+        new(Wps202, "GetResult"),
 
         // OData operation families that share routes with query-option or payload dispatch
         new(ODataV4, "Metadata"),

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/Wps20EndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/Wps20EndpointsTests.cs
@@ -6,6 +6,11 @@ using System.Text;
 using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Abstractions;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
+using NSubstitute;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wps20;
 
@@ -31,6 +36,7 @@ public sealed class Wps20EndpointsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK, xml);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
         xml.Should().Contain("<wps:Capabilities").And.Contain("jobControlOptions=\"async-execute\"");
+        xml.Should().Contain("processVersion=\"1.0.0\"");
         xml.Should().NotContain("Operation name=\"Dismiss\"").And.NotContain("sync-execute");
     }
 
@@ -46,6 +52,108 @@ public sealed class Wps20EndpointsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK, xml);
         xml.Should().Contain($"xmlns:wps=\"http://www.opengis.net/wps/2.0\"");
         xml.Should().Contain("<ows:Identifier>geometry.buffer</ows:Identifier>");
+        xml.Should().Contain("<ows:Identifier>result</ows:Identifier>");
+        xml.Should().Contain("<wps:Process processVersion=\"1.0.0\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessExecution)]
+    [Endpoint("POST /wps")]
+    [InterfaceOperation(TestProtocols.Wps202, "Execute")]
+    public async Task Execute_XmlInputId_SubmitsCanonicalPlan()
+    {
+        AnalysisPlan? submittedPlan = null;
+        var catalog = Substitute.For<IProcessCatalog>();
+        catalog.GetProcess("echo").Returns(new ProcessDefinition
+        {
+            ProcessId = "echo",
+            Title = "Echo",
+            Description = "Echoes a literal value.",
+            Category = "test",
+            Parameters = [new ProcessParameterSpec { Name = "value", DisplayName = "Value", Description = "Value to echo.", ValueType = ProcessParameterValueType.Text, Required = true }],
+            OutputArtifactKinds = []
+        });
+        var jobs = Substitute.For<IGeoprocessingJobService>();
+        jobs.SubmitJobAsync(Arg.Do<AnalysisPlan>(plan => submittedPlan = plan), Arg.Any<string?>(), Arg.Any<System.Security.Claims.ClaimsPrincipal>(), Arg.Any<IReadOnlyDictionary<string, string>?>(), Arg.Any<CancellationToken>())
+            .Returns(new ExecutionJobRecord
+            {
+                OperationId = "wps-job-1",
+                Status = ExecutionJobStatus.Queued,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                Spec = new ExecutionJobSpec { TargetKind = default, Backend = "test", Kind = ExecutionJobKind.Geoprocessing, WorkloadName = "echo" }
+            });
+        await using var fixture = new WebAppFixture().ReplaceService(catalog).ReplaceService(jobs);
+        await fixture.InitializeAsync();
+        const string body = "<wps:Execute service='WPS' version='2.0.0' xmlns:wps='http://www.opengis.net/wps/2.0' xmlns:ows='http://www.opengis.net/ows/2.0'><ows:Identifier>echo</ows:Identifier><wps:Input id='value'><wps:Data><wps:LiteralValue>aloha</wps:LiteralValue></wps:Data></wps:Input></wps:Execute>";
+
+        using var content = new StringContent(body, Encoding.UTF8, "application/xml");
+        var response = await fixture.Client.PostAsync("/wps", content);
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, xml);
+        submittedPlan.Should().NotBeNull();
+        submittedPlan!.Steps.Single().Inputs["value"].Should().Be("aloha");
+    }
+
+    [Theory]
+    [InlineData("OTHER", "2.0.0", "service")]
+    [InlineData("WPS", "1.0.0", "version")]
+    [Operation(Operations.ContractTesting)]
+    [Endpoint("GET /wps")]
+    public async Task Kvp_WrongServiceOrVersion_ReturnsProtocolException(string service, string version, string locator)
+    {
+        var response = await _fixture.Client.GetAsync($"/wps?service={service}&request=GetCapabilities&version={version}");
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, xml);
+        xml.Should().Contain("exceptionCode=\"InvalidParameterValue\"");
+        xml.Should().Contain($"locator=\"{locator}\"");
+    }
+
+    [Theory]
+    [InlineData("OTHER", "2.0.0", "service")]
+    [InlineData("WPS", "2.0.2", "version")]
+    [Operation(Operations.ContractTesting)]
+    [Endpoint("POST /wps")]
+    public async Task Xml_WrongServiceOrVersion_ReturnsProtocolException(string service, string version, string locator)
+    {
+        var body = $"<wps:GetCapabilities service='{service}' version='{version}' xmlns:wps='http://www.opengis.net/wps/2.0'/>";
+        using var content = new StringContent(body, Encoding.UTF8, "application/xml");
+
+        var response = await _fixture.Client.PostAsync("/wps", content);
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, xml);
+        xml.Should().Contain("exceptionCode=\"InvalidParameterValue\"");
+        xml.Should().Contain($"locator=\"{locator}\"");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobResults)]
+    [Endpoint("GET /wps")]
+    [InterfaceOperation(TestProtocols.Wps202, "GetResult")]
+    public async Task GetResult_MapsAdvertisedResultIdentifierAndLiteralMediaType()
+    {
+        var jobs = Substitute.For<IGeoprocessingJobService>();
+        jobs.GetJobResultsAsync("wps-job-result", Arg.Any<System.Security.Claims.ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(new AnalysisResultPackage
+            {
+                ResultPackageId = "result-1",
+                Status = GeoprocessingWorkflowStatus.Completed,
+                Summary = new ResultSummary { Title = "buffer complete" },
+                Provenance = null!
+            });
+        await using var fixture = new WebAppFixture().ReplaceService(jobs);
+        await fixture.InitializeAsync();
+
+        var response = await fixture.Client.GetAsync("/wps?service=WPS&request=GetResult&version=2.0.0&jobId=wps-job-result");
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, xml);
+        xml.Should().Contain("<ows:Identifier>result</ows:Identifier>");
+        xml.Should().Contain("<wps:Data mimeType=\"text/plain\">");
+        xml.Should().Contain("<wps:LiteralValue>buffer complete</wps:LiteralValue>");
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/Wps20EndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/Wps20EndpointsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Text;
+using System.Xml.Linq;
 using FluentAssertions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
@@ -28,16 +29,23 @@ public sealed class Wps20EndpointsTests : IAsyncLifetime
     [Operation(Operations.Metadata)]
     [Endpoint("GET /wps")]
     [InterfaceOperation(TestProtocols.Wps202, "GetCapabilities")]
-    public async Task GetCapabilities_AdvertisesOnlyImplementedAsyncOperations()
+    public async Task GetCapabilities_AdvertisesAsyncExecutionForCanonicalProcesses()
     {
         var response = await _fixture.Client.GetAsync("/wps?service=WPS&request=GetCapabilities&version=2.0.0");
         var xml = await response.Content.ReadAsStringAsync();
+        var document = XDocument.Parse(xml);
+        XNamespace wps = "http://www.opengis.net/wps/2.0";
+        XNamespace ows = "http://www.opengis.net/ows/2.0";
+        var canonicalProcess = document
+            .Descendants(wps + "ProcessSummary")
+            .Single(summary => summary.Element(ows + "Identifier")?.Value == "geometry.buffer");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, xml);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
-        xml.Should().Contain("<wps:Capabilities").And.Contain("jobControlOptions=\"async-execute\"");
+        xml.Should().Contain("<wps:Capabilities");
+        canonicalProcess.Attribute("jobControlOptions")?.Value.Should().Be("async-execute");
         xml.Should().Contain("processVersion=\"1.0.0\"");
-        xml.Should().NotContain("Operation name=\"Dismiss\"").And.NotContain("sync-execute");
+        xml.Should().NotContain("Operation name=\"Dismiss\"");
     }
 
     [IntegrationTest]
@@ -178,7 +186,13 @@ public sealed class Wps20EndpointsTests : IAsyncLifetime
     [InterfaceOperation(TestProtocols.Wps202, "GetStatus")]
     public async Task GetStatus_UnknownJob_ReturnsOwsExceptionReport()
     {
-        var response = await _fixture.Client.GetAsync("/wps?service=WPS&request=GetStatus&version=2.0.0&jobId=missing-job");
+        var jobs = Substitute.For<IGeoprocessingJobService>();
+        jobs.GetJobAsync("missing-job", Arg.Any<System.Security.Claims.ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<ExecutionJobRecord>(new GeoprocessingNotFoundException("Job 'missing-job' not found.")));
+        await using var fixture = new WebAppFixture().ReplaceService(jobs);
+        await fixture.InitializeAsync();
+
+        var response = await fixture.Client.GetAsync("/wps?service=WPS&request=GetStatus&version=2.0.0&jobId=missing-job");
         var xml = await response.Content.ReadAsStringAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound, xml);

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/Wps20EndpointsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wps20/Wps20EndpointsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wps20;
+
+[Collection("Database")]
+[Protocol(TestProtocols.Wps202)]
+public sealed class Wps20EndpointsTests : IAsyncLifetime
+{
+    private readonly WebAppFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /wps")]
+    [InterfaceOperation(TestProtocols.Wps202, "GetCapabilities")]
+    public async Task GetCapabilities_AdvertisesOnlyImplementedAsyncOperations()
+    {
+        var response = await _fixture.Client.GetAsync("/wps?service=WPS&request=GetCapabilities&version=2.0.0");
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, xml);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        xml.Should().Contain("<wps:Capabilities").And.Contain("jobControlOptions=\"async-execute\"");
+        xml.Should().NotContain("Operation name=\"Dismiss\"").And.NotContain("sync-execute");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ProcessDiscovery)]
+    [Endpoint("GET /wps")]
+    [InterfaceOperation(TestProtocols.Wps202, "DescribeProcess")]
+    public async Task DescribeProcess_Kvp_ReturnsNamespaceCorrectDescription()
+    {
+        var response = await _fixture.Client.GetAsync("/wps?service=WPS&request=DescribeProcess&version=2.0.0&identifier=geometry.buffer");
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, xml);
+        xml.Should().Contain($"xmlns:wps=\"http://www.opengis.net/wps/2.0\"");
+        xml.Should().Contain("<ows:Identifier>geometry.buffer</ows:Identifier>");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.SecurityTesting)]
+    [Endpoint("POST /wps")]
+    [InterfaceOperation(TestProtocols.Wps202, "Execute")]
+    public async Task Execute_XmlWithDtd_IsRejectedWithoutEntityExpansion()
+    {
+        const string body = "<!DOCTYPE x [<!ENTITY xxe SYSTEM 'file:///etc/passwd'>]><wps:Execute xmlns:wps='http://www.opengis.net/wps/2.0' xmlns:ows='http://www.opengis.net/ows/2.0'><ows:Identifier>&xxe;</ows:Identifier></wps:Execute>";
+        using var content = new StringContent(body, Encoding.UTF8, "application/xml");
+
+        var response = await _fixture.Client.PostAsync("/wps", content);
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, xml);
+        xml.Should().Contain("ExceptionReport").And.Contain("prohibited constructs");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.JobStatus)]
+    [Endpoint("GET /wps")]
+    [InterfaceOperation(TestProtocols.Wps202, "GetStatus")]
+    public async Task GetStatus_UnknownJob_ReturnsOwsExceptionReport()
+    {
+        var response = await _fixture.Client.GetAsync("/wps?service=WPS&request=GetStatus&version=2.0.0&jobId=missing-job");
+        var xml = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound, xml);
+        xml.Should().Contain("exceptionCode=\"NoSuchJob\"");
+        xml.Should().Contain("xmlns:ows=\"http://www.opengis.net/ows/2.0\"");
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Constants/ProtocolNames.cs
+++ b/tests/dotnet/Honua.TestKit/Constants/ProtocolNames.cs
@@ -175,6 +175,11 @@ public static class ProtocolNames
     public const string Wcs201 = "WCS-2.0.1";
 
     /// <summary>
+    /// OGC Web Processing Service 2.0.2 protocol.
+    /// </summary>
+    public const string Wps202 = "WPS-2.0.2";
+
+    /// <summary>
     /// OGC WFS 1.1.0 compatibility protocol.
     /// </summary>
     public const string Wfs11 = "WFS-1.1.0";


### PR DESCRIPTION
## Issue Link
Closes #2450

## Summary
Adds a bounded WPS 2.0 compatibility adapter over Honua's canonical process catalog and durable geoprocessing jobs for existing WPS clients.

## Changes Made
- Add GET/POST `/wps` dispatch for GetCapabilities, DescribeProcess, Execute, GetStatus, and GetResult
- Support strict WPS 2.0 KVP, form, and secure bounded XML requests
- Map async execution, ownership-safe status, and results to canonical GP services
- Advertise only implemented literal/value behavior; intentionally omit Dismiss and sync execution
- Register endpoint/operation coverage and add focused protocol/security tests

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Release builds passed for `Honua.Protocols.OgcClassic` and its test project with zero warnings/errors. The WPS-only integration run timed out during fixture startup before producing a result.

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review