### PR TITLE
fix(quality): address AI and export findings

### DIFF
--- a/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerSensorModel.cs
+++ b/src/Honua.Protocols.GeoServices/ImageServer/Services/ImageServerSensorModel.cs
@@ -80,9 +80,9 @@ internal static class ImageServerSensorModel
                 !TryReadAny(root, out var longOffset, "longOffset", "longOff", "long_off") ||
                 !TryReadAny(root, out var latOffset, "latOffset", "latOff", "lat_off") ||
                 !TryReadAny(root, out var sampleScale, "sampleScale", "sampScale", "samp_scale") ||
-                !TryReadAny(root, out var lineScale, "lineScale", "lineScale", "line_scale") ||
-                !TryReadAny(root, out var longScale, "longScale", "longScale", "long_scale") ||
-                !TryReadAny(root, out var latScale, "latScale", "latScale", "lat_scale"))
+                !TryReadAny(root, out var lineScale, "lineScale", "lineScl", "line_scale") ||
+                !TryReadAny(root, out var longScale, "longScale", "longScl", "long_scale") ||
+                !TryReadAny(root, out var latScale, "latScale", "latScl", "lat_scale"))
             {
                 return null;
             }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerSensorModelTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/ImageServer/ImageServerSensorModelTests.cs
@@ -110,6 +110,30 @@ public class ImageServerSensorModelTests
     }
 
     [UnitTest]
+    public void TryReadRpc_WithAbbreviatedScaleAliases_BuildsModel()
+    {
+        var metadata = new RasterSensorMetadata
+        {
+            RasterDataId = 1,
+            RpcJson = """
+            {
+                "sampleOffset": 1000, "lineOffset": 800,
+                "longOffset": -120.0, "latOffset": 35.0,
+                "sampScale": 1000, "lineScl": 800,
+                "longScl": 0.05, "latScl": 0.04
+            }
+            """,
+        };
+
+        var rpc = ImageServerSensorModel.TryReadRpc(metadata);
+
+        rpc.Should().NotBeNull();
+        rpc.Value.LineScale.Should().Be(800);
+        rpc.Value.LongitudeScale.Should().Be(0.05);
+        rpc.Value.LatitudeScale.Should().Be(0.04);
+    }
+
+    [UnitTest]
     public void TryReadRpc_WithNoMetadata_ReturnsNull()
     {
         ImageServerSensorModel.TryReadRpc(null).Should().BeNull();

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wcs20/Wcs20RequestCrsValidationTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wcs20/Wcs20RequestCrsValidationTests.cs
@@ -98,6 +98,19 @@ public sealed class Wcs20RequestCrsValidationTests
     }
 
     [Fact]
+    public void TryResolveRequestCrs_WithNativeSridOutsideSupportedSet_AcceptsNativeDefault()
+    {
+        var query = BuildQuery();
+
+        var resolved = Wcs20Handler.TryResolveRequestCrs(
+            query, CreateRaster(32632), SupportedSrids, out var subsettingCrs, out var outputSrid, out _);
+
+        resolved.Should().BeTrue();
+        outputSrid.Should().BeNull();
+        subsettingCrs.Srid.Should().Be(32632);
+    }
+
+    [Fact]
     public void TryResolveRequestCrs_WithSupportedSubsettingCrs_Accepts()
     {
         var query = BuildQuery(("SUBSETTINGCRS", "EPSG:3857"));

--- a/tests/dotnet/Honua.Server.Tests/Features/Geocoding/NoHonuaServerArcGisVersionTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Geocoding/NoHonuaServerArcGisVersionTests.cs
@@ -84,7 +84,7 @@ public sealed class NoHonuaServerArcGisVersionTests
             {
                 if (property.GetValue(context) is JsonTypeInfo typeInfo)
                 {
-                    yield return ($"{contextType.Name}.{typeInfo.Type.Name}", typeInfo);
+                    yield return (typeInfo.Type.FullName ?? typeInfo.Type.Name, typeInfo);
                 }
             }
         }

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/SkiaMapRendererTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Rendering/SkiaMapRendererTests.cs
@@ -251,6 +251,33 @@ public class SkiaMapRendererTests
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
+    public void RenderMap_NonPositiveHeight_ThrowsArgumentOutOfRangeException(int height)
+    {
+        using var renderer = new SkiaMapRenderer();
+        var extent = new SkiaMapRenderer.RenderExtent(0, 0, 1, 1);
+
+        var act = () => renderer.RenderMap([], [], extent, 10, height, true, null, MetadataV2GeometryType.None, RenderZoom.NotDerivable("unit test"));
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("imageHeight");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void RenderLegendSwatch_NonPositiveWidth_ThrowsArgumentOutOfRangeException(int width)
+    {
+        var layer = new MapLibreStyleLayer { Type = "fill" };
+
+        var act = () => SkiaMapRenderer.RenderLegendSwatch(layer, MetadataV2GeometryType.Polygon, width: width, height: 20);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("width");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
     public void RenderLegendSwatch_NonPositiveHeight_ThrowsArgumentOutOfRangeException(int height)
     {
         var layer = new MapLibreStyleLayer { Type = "fill" };
@@ -376,7 +403,7 @@ public class SkiaMapRendererTests
     }
 
     [UnitTest]
-    public void RenderExtent_Width_IsCorrect()
+    public void RenderExtent_WidthAndHeight_AreCorrect()
     {
         var extent = new SkiaMapRenderer.RenderExtent(10, 20, 30, 50);
 

--- a/tests/python/shared/__init__.py
+++ b/tests/python/shared/__init__.py
@@ -10,9 +10,15 @@ unless they are explicitly requested by a test.
 
 from __future__ import annotations
 
-# Names below are resolved lazily via module __getattr__ (PEP 562, see below)
-# rather than bound at module level, so static analyzers that don't model
-# PEP 562 (e.g. CodeQL py/undefined-export) will report false positives here.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .geometry import ALL_GEOMETRY_TYPES, GeometryGenerator
+    from .postgis import PostGISFixture, TestDataBuilder
+    from .seed import SeedRunner
+    from .server import HonuaServer
+
+
 __all__ = [
     "GeometryGenerator",
     "ALL_GEOMETRY_TYPES",

--- a/tests/python/unit/test_shared_exports.py
+++ b/tests/python/unit/test_shared_exports.py
@@ -1,0 +1,31 @@
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+"""Tests for the shared test-infrastructure package exports."""
+
+from __future__ import annotations
+
+import sys
+
+
+EXPECTED_EXPORTS = {
+    "GeometryGenerator",
+    "ALL_GEOMETRY_TYPES",
+    "PostGISFixture",
+    "TestDataBuilder",
+    "SeedRunner",
+    "HonuaServer",
+}
+
+
+def test_shared_exports_are_declared_and_loaded_lazily():
+    sys.modules.pop("shared.geometry", None)
+    sys.modules.pop("shared", None)
+
+    import shared
+
+    assert set(shared.__all__) == EXPECTED_EXPORTS
+    assert "shared.geometry" not in sys.modules
+
+    assert shared.GeometryGenerator is not None
+    assert shared.ALL_GEOMETRY_TYPES is not None
+    assert "shared.geometry" in sys.modules


### PR DESCRIPTION
## Issue Link
- [Standard findings](https://github.com/honua-io/honua-server/security/quality)
- [AI findings](https://github.com/honua-io/honua-server/security/quality/ai-findings)

## Summary
Addresses all six current GitHub Security Quality AI suggestions and the six actionable error-severity Python undefined-export findings without changing runtime lazy-loading behavior.

## Changes Made
- Improve geocoding diagnostics and complete renderer validation coverage
- Restore abbreviated RPC sensor-model aliases with focused coverage
- Add WCS native-CRS coverage outside the configured supported set
- Give CodeQL static bindings for PEP 562 lazy exports and test the export contract

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Validation:
- Python shared export test: 1 passed
- Server geocoding/rendering slice: 31 passed
- GeoServices sensor model slice: 18 passed
- OGC Classic WCS CRS slice: 8 passed
- Independent code review: no findings

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

## Standard finding scope
The Quality page currently reports 1,998 historical findings across 22 rules. This PR fixes the concrete error-severity undefined-export locations. The remaining locationless error counts are already documented/suppressed intentional patterns, and broad note/warning cleanup is intentionally excluded from this bounded patch.

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review