### PR TITLE
test(mcp): validate cartographic skill live surface

### DIFF
--- a/.github/ci-shards.json
+++ b/.github/ci-shards.json
@@ -1086,6 +1086,7 @@
         "src/Honua.Core/Features/Publishing/",
         "src/Honua.Postgres/Features/Publishing/",
         "tests/dotnet/Honua.Ai.Tests/Source/",
+        "tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/",
         "src/Honua.Core/Features/Validation/"
       ]
     },

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/README.md
@@ -39,6 +39,16 @@ tools (the map/app composition and publish families, the `mutation` profile's
 geoprocessing verbs) are tracked as **known-gaps**: their absence does not
 fail the suite; only NON-CONFORMANCE of an implemented tool fails.
 
+## Skills live-surface contract provenance
+
+- `geospatial-mcp/skills/` vendors `skills/catalog.json`,
+  `skills/catalog.schema.json`, and `skills/contracts/live-surface.json` from
+  geospatial-mcp commit **`bed89302a8b9ea0a168aa89554d867681ee732dd`**.
+- The MCP conformance suite resolves the contract's canonical tool names to
+  Honua's production descriptors and checks their advertised input schemas.
+- Skill prose and evaluation artifacts remain owned by geospatial-mcp and are
+  not vendored into honua-server.
+
 ## Honua extensions (`x-honua-extension`)
 
 A few schemas under `geospatial-mcp/tools/` are **documented Honua extensions**

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/skills/catalog.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/skills/catalog.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "catalog.schema.json",
+  "specVersion": "1.0",
+  "license": "Apache-2.0",
+  "skills": [
+    {
+      "name": "choosing-a-visualization",
+      "path": "choosing-a-visualization",
+      "description": "Use when an agent must choose, compose, validate, or prepare to publish a geospatial visualization.",
+      "workflowFamilies": ["Analyze", "Publish Data", "Build App"],
+      "coverage": ["choosing-visualization", "layer-composition", "query-shaping", "publishing", "anti-patterns"],
+      "standardTools": [
+        "list_layers", "query_features", "summarize_statistics", "plan_analysis",
+        "reproject_features", "create_map_package", "refine_map_package",
+        "compose_mixed_protocol_map", "apply_style_preset", "render_map",
+        "preview_map_package", "publish_result"
+      ]
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/skills/catalog.schema.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/skills/catalog.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://geospatial-mcp.org/schemas/skills/catalog.schema.json",
+  "title": "Geospatial MCP skills catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["specVersion", "license", "skills"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "specVersion": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+$" },
+    "license": { "const": "Apache-2.0" },
+    "skills": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/skill" } }
+  },
+  "$defs": {
+    "skill": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "path", "description", "workflowFamilies", "coverage", "standardTools"],
+      "properties": {
+        "name": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+        "path": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+        "description": { "type": "string", "pattern": "^Use when " },
+        "workflowFamilies": {
+          "type": "array",
+          "items": { "enum": ["Analyze", "Publish Data", "Build App", "Automate / Deploy"] },
+          "uniqueItems": true
+        },
+        "coverage": {
+          "type": "array",
+          "items": { "enum": ["choosing-visualization", "layer-composition", "query-shaping", "publishing", "anti-patterns"] },
+          "uniqueItems": true
+        },
+        "standardTools": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/skills/contracts/live-surface.json
+++ b/tests/dotnet/Honua.Ai.Tests/ConformanceSchemas/geospatial-mcp/skills/contracts/live-surface.json
@@ -1,0 +1,57 @@
+{
+  "contractVersion": "1",
+  "specVersion": "1.0",
+  "assertions": [
+    {
+      "skill": "choosing-a-visualization", "standardTool": "list_layers", "profile": "base",
+      "requiredFields": [], "requiredProperties": ["filter"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "query_features", "profile": "base",
+      "requiredFields": ["serviceId", "layerId"],
+      "requiredProperties": ["where", "bbox", "bboxSrid", "outFields", "limit", "resultOffset", "returnGeometry", "returnCountOnly", "outSrid", "geometryPrecision"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "summarize_statistics", "profile": "analysis", "fallbackTool": "plan_analysis",
+      "requiredFields": ["source", "statistics"], "requiredProperties": ["groupByFields", "where"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "reproject_features", "profile": "analysis", "fallbackTool": "plan_analysis",
+      "requiredFields": ["source", "targetSrid"], "requiredProperties": ["sourceSrid", "where"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "plan_analysis", "profile": "base",
+      "requiredFields": ["intent"], "requiredProperties": ["context"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "create_map_package", "profile": "base",
+      "requiredFields": [], "requiredProperties": ["templateId", "styleId", "themeId"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "refine_map_package", "profile": "base",
+      "requiredFields": ["mapPackageId"], "requiredProperties": ["styleId", "themeId", "sourceBindings", "initialView"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "compose_mixed_protocol_map", "profile": "base",
+      "requiredFields": ["sourceBindings"], "requiredProperties": ["templateId", "styleId", "themeId", "initialView"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "apply_style_preset", "profile": "base",
+      "requiredFields": ["serviceId", "layerId", "styleId"], "requiredProperties": []
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "render_map", "profile": "base",
+      "requiredFields": ["layers", "bbox"],
+      "requiredProperties": ["bboxSrid", "width", "height", "transparent", "maxInlineBytes"],
+      "forbiddenProperties": ["palette", "classBreaks"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "preview_map_package", "profile": "base",
+      "requiredFields": ["mapPackageId"], "requiredProperties": ["width", "height"]
+    },
+    {
+      "skill": "choosing-a-visualization", "standardTool": "publish_result", "profile": "base",
+      "requiredFields": ["sourceId"], "requiredProperties": ["targetKind", "visibility", "routePrefix"]
+    }
+  ]
+}

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpSkillLiveSurfaceContractTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpSkillLiveSurfaceContractTests.cs
@@ -4,6 +4,8 @@
 using System.Text.Json;
 using FluentAssertions;
 using Honua.TestKit.Attributes;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
 
 namespace Honua.Server.Tests.Features.Protocols.Mcp;
 
@@ -14,8 +16,13 @@ public sealed partial class McpTaxonomyAlignmentTests
     [UnitTest]
     public void SkillLiveSurfaceContract_MatchesProductionToolDescriptors()
     {
-        using var catalogDocument = JsonDocument.Parse(
-            File.ReadAllText(Path.Join(SkillContractRoot, "catalog.json")));
+        var catalogPath = Path.Join(SkillContractRoot, "catalog.json");
+        var catalogJson = File.ReadAllText(catalogPath);
+        var catalogSchema = LoadSchema(Path.Join(SkillContractRoot, "catalog.schema.json"));
+        JToken.Parse(catalogJson).IsValid(catalogSchema, out IList<string> catalogErrors);
+        catalogErrors.Should().BeEmpty("the vendored skill catalog must satisfy its upstream schema");
+
+        using var catalogDocument = JsonDocument.Parse(catalogJson);
         using var contractDocument = JsonDocument.Parse(
             File.ReadAllText(Path.Join(SkillContractRoot, "contracts", "live-surface.json")));
 
@@ -63,6 +70,18 @@ public sealed partial class McpTaxonomyAlignmentTests
                     var fallbackName = fallbackTool.GetString()!;
                     liveNamesByStandardName.Should().ContainKey(fallbackName,
                         $"fallback '{fallbackName}' for '{standardName}' must resolve to a live production tool");
+                    var fallbackLiveNames = liveNamesByStandardName[fallbackName];
+                    fallbackLiveNames.Should().ContainSingle(
+                        $"fallback '{fallbackName}' must resolve unambiguously to one production descriptor");
+                    liveTools.Should().ContainKey(fallbackLiveNames[0],
+                        $"fallback '{fallbackName}' must be present in BuildTools()");
+
+                    var fallbackDescriptor = liveTools[fallbackLiveNames[0]].Describe();
+                    fallbackDescriptor.Name.Should().Be(fallbackLiveNames[0]);
+                    using var fallbackSchemaDocument = JsonDocument.Parse(
+                        JsonSerializer.Serialize(fallbackDescriptor.InputSchema));
+                    fallbackSchemaDocument.RootElement.ValueKind.Should().Be(JsonValueKind.Object,
+                        $"fallback '{fallbackName}' must advertise a describable input schema");
                 }
 
                 continue;

--- a/tests/dotnet/Honua.Ai.Tests/Source/McpSkillLiveSurfaceContractTests.cs
+++ b/tests/dotnet/Honua.Ai.Tests/Source/McpSkillLiveSurfaceContractTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using FluentAssertions;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Server.Tests.Features.Protocols.Mcp;
+
+public sealed partial class McpTaxonomyAlignmentTests
+{
+    private static string SkillContractRoot => Path.Join(SchemaRoot, "skills");
+
+    [UnitTest]
+    public void SkillLiveSurfaceContract_MatchesProductionToolDescriptors()
+    {
+        using var catalogDocument = JsonDocument.Parse(
+            File.ReadAllText(Path.Join(SkillContractRoot, "catalog.json")));
+        using var contractDocument = JsonDocument.Parse(
+            File.ReadAllText(Path.Join(SkillContractRoot, "contracts", "live-surface.json")));
+
+        var declaredToolsBySkill = catalogDocument.RootElement
+            .GetProperty("skills")
+            .EnumerateArray()
+            .ToDictionary(
+                skill => skill.GetProperty("name").GetString()!,
+                skill => skill.GetProperty("standardTools").EnumerateArray()
+                    .Select(tool => tool.GetString()!)
+                    .ToHashSet(StringComparer.Ordinal),
+                StringComparer.Ordinal);
+        var assertions = contractDocument.RootElement.GetProperty("assertions").EnumerateArray().ToArray();
+
+        foreach (var (skill, declaredTools) in declaredToolsBySkill)
+        {
+            assertions
+                .Where(assertion => assertion.GetProperty("skill").GetString() == skill)
+                .Select(assertion => assertion.GetProperty("standardTool").GetString())
+                .Should().BeEquivalentTo(declaredTools,
+                    $"every tool declared by skill '{skill}' must have a live-surface assertion");
+        }
+
+        var liveTools = BuildTools().ToDictionary(tool => tool.Name, StringComparer.Ordinal);
+        var liveNamesByStandardName = ImplementedToolStandardNames
+            .GroupBy(pair => pair.Value, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(pair => pair.Key).ToArray(),
+                StringComparer.Ordinal);
+
+        foreach (var assertion in assertions)
+        {
+            var skill = assertion.GetProperty("skill").GetString()!;
+            var standardName = assertion.GetProperty("standardTool").GetString()!;
+            declaredToolsBySkill.Should().ContainKey(skill);
+            declaredToolsBySkill[skill].Should().Contain(standardName);
+
+            if (!liveNamesByStandardName.TryGetValue(standardName, out var liveNames))
+            {
+                KnownGapStandardTools.Should().Contain(standardName,
+                    $"skill tool '{standardName}' must be live or an explicit standard gap");
+                if (assertion.TryGetProperty("fallbackTool", out var fallbackTool))
+                {
+                    var fallbackName = fallbackTool.GetString()!;
+                    liveNamesByStandardName.Should().ContainKey(fallbackName,
+                        $"fallback '{fallbackName}' for '{standardName}' must resolve to a live production tool");
+                }
+
+                continue;
+            }
+
+            liveNames.Should().ContainSingle(
+                $"skill tool '{standardName}' must resolve unambiguously to one production descriptor");
+            liveTools.Should().ContainKey(liveNames[0]);
+            var descriptor = liveTools[liveNames[0]].Describe();
+            using var liveSchemaDocument = JsonDocument.Parse(JsonSerializer.Serialize(descriptor.InputSchema));
+            var liveSchema = liveSchemaDocument.RootElement;
+            var liveProperties = liveSchema.GetProperty("properties");
+            var liveRequired = liveSchema.TryGetProperty("required", out var required)
+                ? required.EnumerateArray().Select(field => field.GetString()!).ToArray()
+                : [];
+            var expectedRequired = assertion.GetProperty("requiredFields")
+                .EnumerateArray().Select(field => field.GetString()!).ToArray();
+
+            liveRequired.Should().BeEquivalentTo(expectedRequired,
+                $"live required fields for '{liveNames[0]}' must match skill '{skill}'");
+
+            var assertedProperties = expectedRequired
+                .Concat(assertion.GetProperty("requiredProperties")
+                    .EnumerateArray().Select(property => property.GetString()!))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            using var standardSchemaDocument = JsonDocument.Parse(
+                File.ReadAllText(Path.Join(SchemaRoot, "tools", standardName + ".schema.json")));
+            var standardProperties = standardSchemaDocument.RootElement.GetProperty("properties");
+
+            foreach (var propertyName in assertedProperties)
+            {
+                liveProperties.TryGetProperty(propertyName, out var liveProperty).Should().BeTrue(
+                    $"skill '{skill}' references '{standardName}.{propertyName}', which '{liveNames[0]}' must advertise");
+
+                var standardProperty = standardProperties.GetProperty(propertyName);
+                if (standardProperty.TryGetProperty("enum", out var standardEnum))
+                {
+                    liveProperty.TryGetProperty("enum", out var liveEnum).Should().BeTrue(
+                        $"live enum path '{liveNames[0]}.{propertyName}' must remain advertised");
+                    liveEnum.EnumerateArray().Select(value => value.GetRawText()).Should().BeEquivalentTo(
+                        standardEnum.EnumerateArray().Select(value => value.GetRawText()),
+                        $"live enum values for '{liveNames[0]}.{propertyName}' must match the canonical schema");
+                }
+            }
+
+            if (assertion.TryGetProperty("forbiddenProperties", out var forbiddenProperties))
+            {
+                foreach (var forbiddenProperty in forbiddenProperties.EnumerateArray())
+                {
+                    liveProperties.TryGetProperty(forbiddenProperty.GetString()!, out _).Should().BeFalse(
+                        $"skill '{skill}' forbids non-canonical argument '{standardName}.{forbiddenProperty.GetString()}'");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary

Pins the geospatial-mcp cartographic-skill contract and proves its referenced surface against Honua production MCP descriptors in batch CI.

Related to #2858

Depends on the companion geospatial-mcp skills PR.

## Changes Made

- Vendor only the portable catalog/schema/live-surface contract artifacts.
- Validate catalog structure before consuming the contract.
- Resolve canonical tools through the existing production BuildTools descriptors.
- Fail on missing required properties, enum drift, forbidden properties, ambiguous mappings, or unavailable fallbacks.
- Route contract-only changes to the existing MCP CI shard.

## Gate Impact

- [x] MCP batch CI
- [x] Contract and schema conformance
- [ ] Runtime product behavior

## Testing

- [x] Focused Release live-surface test (1/1)
- [x] Contract-only shard routing selects MCP
- [x] Vendored JSON parsing
- [x] Diff checks

## Breaking Changes

None.

