### PR TITLE
fix(ci): harden live merge train execution

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -59,6 +59,7 @@ concurrency:
 
 permissions:
   contents: write        # push the batch branch / fast-forward trunk
+  packages: read         # restore private GitHub Packages during catalog generation
   pull-requests: write   # merge PRs, edit labels, comment
   actions: write         # dispatch and rerun CI runs
   issues: write          # maintain the Merge Train State issue
@@ -130,6 +131,15 @@ jobs:
       - name: Install Claude Code CLI (autofix fix-agent engine, Bedrock)
         if: steps.mode.outputs.train_autofix == '1'
         run: npm install -g @anthropic-ai/claude-code
+
+      - name: Authenticate GitHub Packages
+        env:
+          NUGET_AUTH_TOKEN: ${{ github.token }}
+        run: |
+          dotnet nuget update source github-honua \
+            --username "${{ github.actor }}" \
+            --password "${NUGET_AUTH_TOKEN}" \
+            --store-password-in-clear-text
 
       - name: Run train
         env:

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -347,6 +347,9 @@ desc="$(train_smart_ci_shards smartci-batch)"
 assert_contains "smart-ci: descriptor is valid JSON with shards" "$(jq -r 'has("shards")' <<<"${desc}")" "true"
 assert_contains "smart-ci: FeatureServer-only diff targets FeatureServer shard" "${desc}" "FeatureServer"
 assert_eq "smart-ci: not run_all for a targeted feature diff" "$(jq -r '.run_all' <<<"${desc}")" "false"
+assert_contains "derived artifacts: shell generators do not require executable bits" \
+  "$(cat "${TRAIN_DIR}/train.sh")" \
+  'bash "${repo_root}/scripts/generate-geoservices-parity.sh"'
 
 # A dispatched run may become visible on the first post-dispatch query. The
 # baseline must be captured before dispatch or that run is rejected as stale.

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -348,6 +348,35 @@ assert_contains "smart-ci: descriptor is valid JSON with shards" "$(jq -r 'has("
 assert_contains "smart-ci: FeatureServer-only diff targets FeatureServer shard" "${desc}" "FeatureServer"
 assert_eq "smart-ci: not run_all for a targeted feature diff" "$(jq -r '.run_all' <<<"${desc}")" "false"
 
+# A dispatched run may become visible on the first post-dispatch query. The
+# baseline must be captured before dispatch or that run is rejected as stale.
+smart_ci_dispatched=0
+gh() {
+  if [[ "$1 $2" == "workflow run" ]]; then
+    smart_ci_dispatched=1
+    return 0
+  fi
+  if [[ "$1 $2" == "run list" ]]; then
+    if [[ "${smart_ci_dispatched}" == "1" ]]; then echo "222"; else echo "111"; fi
+    return 0
+  fi
+  if [[ "$1 $2" == "run view" && "$*" == *"--json status"* ]]; then
+    echo "completed"
+    return 0
+  fi
+  if [[ "$1 $2" == "run view" && "$*" == *"--json jobs"* ]]; then
+    echo "success"
+    return 0
+  fi
+  return 1
+}
+immediate_gate="$(TRAIN_APPLY=1 \
+  TRAIN_SMART_CI_DISCOVERY_TIMEOUT_SECONDS=0 \
+  TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS=0 \
+  train_smart_ci_run smartci-batch)"
+unset -f gh
+assert_eq "smart-ci: immediately visible dispatched run is not in baseline" "${immediate_gate}" "SUCCESS"
+
 echo
 echo "== State JSON rendering (crash-resume contract) =="
 body="$(train_state_render train/batch/abc/1 deadbeef "101,102" smart-ci 555 1 0 cafef00d)"

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -352,12 +352,24 @@ assert_eq "smart-ci: not run_all for a targeted feature diff" "$(jq -r '.run_all
 # baseline must be captured before dispatch or that run is rejected as stale.
 smart_ci_dispatched=0
 smart_ci_mode=immediate
+smart_ci_dispatch_marker="${SCRATCH}/smart-ci-dispatched"
+smart_ci_baseline_calls="${SCRATCH}/smart-ci-baseline-calls"
 gh() {
   if [[ "$1 $2" == "workflow run" ]]; then
     smart_ci_dispatched=1
+    : >"${smart_ci_dispatch_marker}"
     return 0
   fi
   if [[ "$1 $2" == "run list" ]]; then
+    if [[ "${smart_ci_mode}" == "baseline-failure" ]]; then
+      local baseline_calls=0
+      [[ -f "${smart_ci_baseline_calls}" ]] && baseline_calls="$(cat "${smart_ci_baseline_calls}")"
+      baseline_calls=$((baseline_calls + 1))
+      printf '%s\n' "${baseline_calls}" >"${smart_ci_baseline_calls}"
+      if [[ "${baseline_calls}" == "1" ]]; then return 1; fi
+      echo "444"
+      return 0
+    fi
     if [[ "${smart_ci_mode}" == "stale" ]]; then
       echo "333"
       return 0
@@ -386,8 +398,17 @@ stale_gate="$(TRAIN_APPLY=1 \
   TRAIN_SMART_CI_DISCOVERY_TIMEOUT_SECONDS=0 \
   TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS=0 \
   train_smart_ci_run smartci-batch)"
-unset -f gh
 assert_eq "smart-ci: stale green run fails closed when no new run appears" "${stale_gate}" "FAILURE"
+
+rm -f "${smart_ci_dispatch_marker}" "${smart_ci_baseline_calls}"
+smart_ci_mode=baseline-failure
+baseline_failure_gate="$(TRAIN_APPLY=1 \
+  TRAIN_SMART_CI_DISCOVERY_TIMEOUT_SECONDS=0 \
+  TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS=0 \
+  train_smart_ci_run smartci-batch)"
+unset -f gh
+assert_eq "smart-ci: baseline query failure fails closed" "${baseline_failure_gate}" "FAILURE"
+assert_eq "smart-ci: baseline query failure prevents dispatch" "$([[ -e "${smart_ci_dispatch_marker}" ]] && echo yes || echo no)" "no"
 
 echo
 echo "== State JSON rendering (crash-resume contract) =="

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -351,12 +351,17 @@ assert_eq "smart-ci: not run_all for a targeted feature diff" "$(jq -r '.run_all
 # A dispatched run may become visible on the first post-dispatch query. The
 # baseline must be captured before dispatch or that run is rejected as stale.
 smart_ci_dispatched=0
+smart_ci_mode=immediate
 gh() {
   if [[ "$1 $2" == "workflow run" ]]; then
     smart_ci_dispatched=1
     return 0
   fi
   if [[ "$1 $2" == "run list" ]]; then
+    if [[ "${smart_ci_mode}" == "stale" ]]; then
+      echo "333"
+      return 0
+    fi
     if [[ "${smart_ci_dispatched}" == "1" ]]; then echo "222"; else echo "111"; fi
     return 0
   fi
@@ -374,8 +379,15 @@ immediate_gate="$(TRAIN_APPLY=1 \
   TRAIN_SMART_CI_DISCOVERY_TIMEOUT_SECONDS=0 \
   TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS=0 \
   train_smart_ci_run smartci-batch)"
-unset -f gh
 assert_eq "smart-ci: immediately visible dispatched run is not in baseline" "${immediate_gate}" "SUCCESS"
+
+smart_ci_mode=stale
+stale_gate="$(TRAIN_APPLY=1 \
+  TRAIN_SMART_CI_DISCOVERY_TIMEOUT_SECONDS=0 \
+  TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS=0 \
+  train_smart_ci_run smartci-batch)"
+unset -f gh
+assert_eq "smart-ci: stale green run fails closed when no new run appears" "${stale_gate}" "FAILURE"
 
 echo
 echo "== State JSON rendering (crash-resume contract) =="

--- a/scripts/ci/merge-train/smart-ci.sh
+++ b/scripts/ci/merge-train/smart-ci.sh
@@ -52,18 +52,21 @@ train_smart_ci_run() {
   local discovery_interval="${TRAIN_SMART_CI_DISCOVERY_POLL_SECONDS:-10}"
   local poll_timeout="${TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS:-3600}"
   local poll_interval="${TRAIN_SMART_CI_POLL_SECONDS:-30}"
-  local pre_dispatch_runs now timeout_at
+  local pre_dispatch_runs baseline_rc=0 now timeout_at
 
-  # Prefer the newest run generated after the dispatch. If no NEW run appears on
-  # this branch, CI did not start (or is severely throttled). This is exactly
-  # the failure mode we must fail closed for in live mode (missing PAT or
-  # workflow dispatch auth issues).
+  # Snapshot the baseline before dispatch. If the query fails, an empty baseline
+  # would let any stale run masquerade as newly dispatched, so fail closed.
   pre_dispatch_runs="$(
     gh run list --workflow ci.yml --branch "${batch}" \
       --json databaseId,headBranch \
       --jq '.[] | select(.headBranch=="'"${batch}"'") | .databaseId' \
-      2>/dev/null || true
-  )"
+      2>/dev/null
+  )" || baseline_rc=$?
+  if [[ "${baseline_rc}" != "0" ]]; then
+    train_err "could not snapshot existing ci.yml runs for ${batch}; refusing to dispatch without a trustworthy baseline"
+    echo "FAILURE"
+    return 0
+  fi
 
   git -C "${TRAIN_REPO_ROOT}" push "${TRAIN_REMOTE}" "${batch}:${batch}"
   gh workflow run ci.yml --ref "${batch}" 1>&2

--- a/scripts/ci/merge-train/smart-ci.sh
+++ b/scripts/ci/merge-train/smart-ci.sh
@@ -48,9 +48,6 @@ train_smart_ci_run() {
   # gh releases print the created run's URL on stdout — route it to stderr or
   # the gate becomes "<url>\nSUCCESS", which matches neither SUCCESS nor
   # FAILURE and fail-closes every live batch.
-  git -C "${TRAIN_REPO_ROOT}" push "${TRAIN_REMOTE}" "${batch}:${batch}"
-  gh workflow run ci.yml --ref "${batch}" 1>&2
-
   local discovery_timeout="${TRAIN_SMART_CI_DISCOVERY_TIMEOUT_SECONDS:-300}"
   local discovery_interval="${TRAIN_SMART_CI_DISCOVERY_POLL_SECONDS:-10}"
   local poll_timeout="${TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS:-3600}"
@@ -67,6 +64,9 @@ train_smart_ci_run() {
       --jq '.[] | select(.headBranch=="'"${batch}"'") | .databaseId' \
       2>/dev/null || true
   )"
+
+  git -C "${TRAIN_REPO_ROOT}" push "${TRAIN_REMOTE}" "${batch}:${batch}"
+  gh workflow run ci.yml --ref "${batch}" 1>&2
 
   # Find the dispatched run id (most recent ci.yml run on this ref).
   local run_id=""

--- a/scripts/ci/merge-train/smart-ci.sh
+++ b/scripts/ci/merge-train/smart-ci.sh
@@ -69,7 +69,7 @@ train_smart_ci_run() {
   gh workflow run ci.yml --ref "${batch}" 1>&2
 
   # Find the dispatched run id (most recent ci.yml run on this ref).
-  local run_id=""
+  local run_id="" found_new_run=0
   timeout_at=$(( $(train_now) + discovery_timeout ))
   while :; do
     run_id="$(gh run list --workflow ci.yml --branch "${batch}" \
@@ -77,6 +77,7 @@ train_smart_ci_run() {
       --jq '[.[] | select(.headBranch=="'"${batch}"'")][0].databaseId' 2>/dev/null || echo "")"
     if [[ -n "${run_id}" && "${run_id}" != "null" ]]; then
       if ! grep -qx "${run_id}" <<<"${pre_dispatch_runs}" ; then
+        found_new_run=1
         break
       fi
     fi
@@ -85,7 +86,7 @@ train_smart_ci_run() {
     sleep "${discovery_interval}"
   done
 
-  if [[ -z "${run_id}" || "${run_id}" == "null" ]]; then
+  if [[ "${found_new_run}" != "1" ]]; then
     train_err "could not locate a newly dispatched ci.yml run for ${batch} within ${discovery_timeout}s; live mode requires MERGE_TRAIN_TOKEN for batch-branch CI dispatch"
     echo "FAILURE"; return 0
   fi

--- a/scripts/ci/merge-train/smart-ci.sh
+++ b/scripts/ci/merge-train/smart-ci.sh
@@ -53,7 +53,7 @@ train_smart_ci_run() {
 
   local discovery_timeout="${TRAIN_SMART_CI_DISCOVERY_TIMEOUT_SECONDS:-300}"
   local discovery_interval="${TRAIN_SMART_CI_DISCOVERY_POLL_SECONDS:-10}"
-  local poll_timeout="${TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS:-1800}"
+  local poll_timeout="${TRAIN_SMART_CI_POLL_TIMEOUT_SECONDS:-3600}"
   local poll_interval="${TRAIN_SMART_CI_POLL_SECONDS:-30}"
   local pre_dispatch_runs now timeout_at
 

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -99,11 +99,11 @@ train_regenerate_derived_artifacts() {
   local status
 
   train_log "regenerating derived artifacts on ${batch} (feature-catalog, geoservices-parity, capability-matrix)"
-  if ! "${repo_root}/scripts/generate-feature-catalog.sh" 1>&2; then
+  if ! bash "${repo_root}/scripts/generate-feature-catalog.sh" 1>&2; then
     train_err "feature-catalog generation failed for ${batch}"
     return 1
   fi
-  if ! "${repo_root}/scripts/generate-geoservices-parity.sh" 1>&2; then
+  if ! bash "${repo_root}/scripts/generate-geoservices-parity.sh" 1>&2; then
     train_err "GeoServices parity generation failed for ${batch}"
     return 1
   fi

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -99,19 +99,37 @@ train_regenerate_derived_artifacts() {
   local status
 
   train_log "regenerating derived artifacts on ${batch} (feature-catalog, geoservices-parity, capability-matrix)"
-  "${repo_root}/scripts/generate-feature-catalog.sh"
-  "${repo_root}/scripts/generate-geoservices-parity.sh"
-  python3 "${repo_root}/scripts/ci/generate-capability-matrix.py"
+  if ! "${repo_root}/scripts/generate-feature-catalog.sh" 1>&2; then
+    train_err "feature-catalog generation failed for ${batch}"
+    return 1
+  fi
+  if ! "${repo_root}/scripts/generate-geoservices-parity.sh" 1>&2; then
+    train_err "GeoServices parity generation failed for ${batch}"
+    return 1
+  fi
+  if ! python3 "${repo_root}/scripts/ci/generate-capability-matrix.py" 1>&2; then
+    train_err "capability-matrix generation failed for ${batch}"
+    return 1
+  fi
 
-  status="$(git -C "${repo_root}" status --short -- "${feature_catalog}" "${geoservices_parity}" "${capability_matrix}" || echo "")"
+  if ! status="$(git -C "${repo_root}" status --short -- "${feature_catalog}" "${geoservices_parity}" "${capability_matrix}")"; then
+    train_err "could not inspect regenerated artifacts for ${batch}"
+    return 1
+  fi
   if [[ -z "${status}" ]]; then
     train_log "derived artifacts already up to date on ${batch}"
     return 0
   fi
 
-  git -C "${repo_root}" add -- "${feature_catalog}" "${geoservices_parity}" "${capability_matrix}"
-  git -C "${repo_root}" commit -m "chore(ci): refresh generated merge-train artifacts" \
-    >/dev/null
+  if ! git -C "${repo_root}" add -- "${feature_catalog}" "${geoservices_parity}" "${capability_matrix}"; then
+    train_err "could not stage regenerated artifacts for ${batch}"
+    return 1
+  fi
+  if ! git -C "${repo_root}" commit -m "chore(ci): refresh generated merge-train artifacts" \
+    >/dev/null; then
+    train_err "could not commit regenerated artifacts for ${batch}"
+    return 1
+  fi
   train_metric_inc derived_artifact_refreshes
   train_decision "DERIVED ARTIFACTS refreshed on ${batch}"
 }
@@ -123,7 +141,9 @@ train_regenerate_derived_artifacts() {
 train_run_batch_ci() {
   local batch="$1"
   if [[ "${TRAIN_APPLY}" == "1" ]]; then
-    if ! train_regenerate_derived_artifacts "${batch}"; then
+    local regeneration_rc=0
+    train_regenerate_derived_artifacts "${batch}" || regeneration_rc=$?
+    if [[ "${regeneration_rc}" != "0" ]]; then
       train_err "derived-artifact regeneration failed for ${batch}"
       echo "FAILURE"
       return 0


### PR DESCRIPTION
Related to #2865

## Summary
Hardens live merge-train execution so package restores authenticate, long batch CI runs are observed, artifact generation fails closed, and dispatched CI cannot be confused with stale runs.

## Changes Made
- Grant read access to GitHub Packages and authenticate the Honua NuGet source.
- Keep generated-artifact diagnostics off the gate output and propagate generator/git failures explicitly.
- Increase the smart-CI polling timeout from 30 to 60 minutes.
- Snapshot CI runs before dispatch and require an explicitly new run before accepting results.
- Fail closed when the run baseline cannot be queried.
- Add regression fixtures for immediate visibility, stale green runs, and baseline-query failure.

## Breaking Changes
None.

## Gate Impact
- [x] CI / merge-train infrastructure

## Testing
- [x] Ran focused merge-train fixture validation (155 passed, 0 failed)
- [x] Ran shell syntax and whitespace validation
- [ ] Ran scripts/ci/pre-pr-check.sh and all checks passed

## Residual Risk
The GitHub Packages credential path and the 60-minute live polling window require GitHub Actions for end-to-end validation. The outer job remains capped at 120 minutes, which is sufficient for the expected single approximately 50-minute batch but may truncate extended retry diagnosis.