### PR TITLE
ci(wps): retain tested server provenance

### DIFF
--- a/.github/workflows/cite-conformance-common.yml
+++ b/.github/workflows/cite-conformance-common.yml
@@ -65,6 +65,13 @@ on:
         required: false
         type: string
         default: ''
+      tested-honua-git-sha:
+        description: >-
+          Optional checked-out Honua workflow commit. Suites that retain
+          certification evidence should set this to github.sha.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -150,6 +157,10 @@ jobs:
         env:
           CITE_PROFILE: ${{ inputs.cite-profile }}
           HONUA_CITE_SKIP_BUILD: 'true'
+          HONUA_CITE_TESTED_GIT_SHA: ${{ inputs.tested-honua-git-sha }}
+          HONUA_CITE_REQUIRE_SERVER_PROVENANCE: ${{ inputs.tested-honua-git-sha != '' && 'true' || 'false' }}
+          HONUA_CITE_SERVER_BUILD_MODE: ${{ inputs.honua-image == '' && 'source-build' || 'prebuilt' }}
+          HONUA_CITE_REQUESTED_SERVER_IMAGE: ${{ inputs.honua-image }}
         run: |
           set +e
           timeout ${{ inputs.timeout-seconds }} ${{ inputs.runner-script }} \

--- a/.github/workflows/cite-wps20-conformance.yml
+++ b/.github/workflows/cite-wps20-conformance.yml
@@ -36,4 +36,5 @@ jobs:
       timeout-seconds: 3600
       job-timeout-minutes: 70
       cite-profile: ${{ inputs.profile || 'basic-async' }}
+      tested-honua-git-sha: ${{ github.sha }}
       extra-artifact-paths: docker/cite/wps20/config/

--- a/docs/internal/contributor/cite-runbook.md
+++ b/docs/internal/contributor/cite-runbook.md
@@ -138,6 +138,14 @@ and source provenance. A failure or skip in a selected class fails the lane.
 ./scripts/conformance/cite/run-cite-wps20-tests.sh --profile basic-async --verbose
 ```
 
+WPS result bundles include the checked-out Honua commit, build mode, requested
+prebuilt reference when applicable, registry digests, the immutable image ID
+from the running Compose container, and a full Docker image inspection. CI
+supplies and requires a checkout SHA that exactly matches `git rev-parse HEAD`.
+Local runs derive it from Git; outside a Git checkout they continue with an
+explicit `unknown` warning. Local `--skip-build` runs are marked
+`local-existing` rather than claiming a source-to-image build relationship.
+
 ### WFS 2.0
 
 - **Scope:** Basic WFS, XML/KVP encoding, FES filter encoding; transactional WFS optional.

--- a/scripts/conformance/cite/run-cite-wps20-tests.sh
+++ b/scripts/conformance/cite/run-cite-wps20-tests.sh
@@ -13,6 +13,9 @@ CLEANUP=true
 INTERACTIVE=false
 VERBOSE=false
 SKIP_BUILD="${HONUA_CITE_SKIP_BUILD:-false}"
+REQUIRE_SERVER_PROVENANCE="${HONUA_CITE_REQUIRE_SERVER_PROVENANCE:-false}"
+SERVER_BUILD_MODE="${HONUA_CITE_SERVER_BUILD_MODE:-}"
+REQUESTED_SERVER_IMAGE="${HONUA_CITE_REQUESTED_SERVER_IMAGE:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -33,6 +36,34 @@ case "$PROFILE" in
     basic-async|basic-sync|all) ;;
     *) echo "Unknown WPS CITE profile: $PROFILE" >&2; exit 2 ;;
 esac
+
+case "$REQUIRE_SERVER_PROVENANCE" in
+    true|false) ;;
+    *) echo "HONUA_CITE_REQUIRE_SERVER_PROVENANCE must be true or false" >&2; exit 2 ;;
+esac
+
+if [[ -z "$SERVER_BUILD_MODE" ]]; then
+    if [[ "$SKIP_BUILD" == "true" ]]; then
+        SERVER_BUILD_MODE="local-existing"
+    else
+        SERVER_BUILD_MODE="source-build"
+    fi
+fi
+
+if [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; then
+    REQUIRE_SERVER_PROVENANCE=true
+    if [[ -z "${HONUA_CITE_TESTED_GIT_SHA:-}" ]]; then
+        echo "HONUA_CITE_TESTED_GIT_SHA is required in GitHub Actions" >&2
+        exit 2
+    fi
+fi
+
+TESTED_HONUA_GIT_SHA="${HONUA_CITE_TESTED_GIT_SHA:-}"
+CHECKED_OUT_HONUA_GIT_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
+if [[ -z "$TESTED_HONUA_GIT_SHA" ]]; then
+    TESTED_HONUA_GIT_SHA="${CHECKED_OUT_HONUA_GIT_SHA:-unknown}"
+    echo "Warning: HONUA_CITE_TESTED_GIT_SHA is unset; using local checkout SHA '$TESTED_HONUA_GIT_SHA'" >&2
+fi
 
 if [[ ! "$ECHO_PROCESS_ID" =~ ^[A-Za-z0-9._:-]+$ ]]; then
     echo "Invalid WPS echo process identifier" >&2
@@ -87,6 +118,42 @@ trap cleanup EXIT
 
 "${COMPOSE_CMD[@]}" -f "$CITE_COMPOSE_FILE" --profile test down --remove-orphans --volumes >/dev/null 2>&1 || true
 "${COMPOSE_CMD[@]}" -f "$CITE_COMPOSE_FILE" up -d postgres redis honua-server
+
+mapfile -t honua_server_container_ids < <(
+    "${COMPOSE_CMD[@]}" -f "$CITE_COMPOSE_FILE" ps --all -q honua-server | sed '/^$/d'
+)
+if [[ "${#honua_server_container_ids[@]}" -ne 1 ]]; then
+    echo "Expected exactly one WPS CITE Honua Server container; found ${#honua_server_container_ids[@]}" >&2
+    exit 2
+fi
+HONUA_SERVER_CONTAINER_ID="${honua_server_container_ids[0]}"
+HONUA_SERVER_IMAGE_ID="$(docker inspect --format '{{.Image}}' "$HONUA_SERVER_CONTAINER_ID")"
+if [[ -z "$HONUA_SERVER_IMAGE_ID" ]]; then
+    echo "Unable to identify the WPS CITE Honua Server image" >&2
+    exit 2
+fi
+
+printf '%s\n' "$TESTED_HONUA_GIT_SHA" > "$CITE_RESULTS_DIR/tested-honua-git-sha.txt.tmp"
+mv "$CITE_RESULTS_DIR/tested-honua-git-sha.txt.tmp" "$CITE_RESULTS_DIR/tested-honua-git-sha.txt"
+printf '%s\n' "$HONUA_SERVER_IMAGE_ID" > "$CITE_RESULTS_DIR/honua-server-image-id.txt.tmp"
+mv "$CITE_RESULTS_DIR/honua-server-image-id.txt.tmp" "$CITE_RESULTS_DIR/honua-server-image-id.txt"
+docker image inspect "$HONUA_SERVER_IMAGE_ID" > "$CITE_RESULTS_DIR/honua-server-image-inspect.json.tmp"
+test -s "$CITE_RESULTS_DIR/honua-server-image-inspect.json.tmp"
+mv "$CITE_RESULTS_DIR/honua-server-image-inspect.json.tmp" "$CITE_RESULTS_DIR/honua-server-image-inspect.json"
+provenance_args=(
+    --tested-git-sha "$TESTED_HONUA_GIT_SHA"
+    --checkout-git-sha "${CHECKED_OUT_HONUA_GIT_SHA:-unknown}"
+    --server-container-id "$HONUA_SERVER_CONTAINER_ID"
+    --server-image-id "$HONUA_SERVER_IMAGE_ID"
+    --server-build-mode "$SERVER_BUILD_MODE"
+    --requested-server-image "$REQUESTED_SERVER_IMAGE"
+    --image-inspect "$CITE_RESULTS_DIR/honua-server-image-inspect.json"
+    --output "$CITE_RESULTS_DIR/honua-server-provenance.json"
+)
+if [[ "$REQUIRE_SERVER_PROVENANCE" == "true" ]]; then
+    provenance_args+=(--require-tested-git-sha)
+fi
+python3 scripts/conformance/cite/write_wps20_provenance.py "${provenance_args[@]}"
 
 HONUA_BASE_URL="http://localhost:${HONUA_CITE_WPS20_SERVER_PORT}"
 deadline=$((SECONDS + HONUA_HEALTHCHECK_TIMEOUT))

--- a/scripts/conformance/cite/tests/test-wps20-runner-provenance-policy.sh
+++ b/scripts/conformance/cite/tests/test-wps20-runner-provenance-policy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+runner="scripts/conformance/cite/run-cite-wps20-tests.sh"
+temporary_dir="$(mktemp -d)"
+trap 'rm -rf "$temporary_dir"' EXIT
+
+set +e
+GITHUB_ACTIONS=true HONUA_CITE_TESTED_GIT_SHA= bash "$runner" >"$temporary_dir/ci.out" 2>"$temporary_dir/ci.err"
+ci_exit_code=$?
+set -e
+if [[ "$ci_exit_code" -ne 2 ]]; then
+    echo "Expected missing CI SHA to exit 2, got $ci_exit_code" >&2
+    exit 1
+fi
+grep -F "HONUA_CITE_TESTED_GIT_SHA is required in GitHub Actions" "$temporary_dir/ci.err" >/dev/null
+
+set +e
+PATH=/nonexistent GITHUB_ACTIONS=false HONUA_CITE_TESTED_GIT_SHA= /bin/bash "$runner" >"$temporary_dir/local.out" 2>"$temporary_dir/local.err"
+local_exit_code=$?
+set -e
+if [[ "$local_exit_code" -ne 2 ]]; then
+    echo "Expected dependency-free local probe to exit 2, got $local_exit_code" >&2
+    exit 1
+fi
+grep -F "Warning: HONUA_CITE_TESTED_GIT_SHA is unset; using local checkout SHA 'unknown'" "$temporary_dir/local.err" >/dev/null

--- a/scripts/conformance/cite/tests/test_write_wps20_provenance.py
+++ b/scripts/conformance/cite/tests/test_write_wps20_provenance.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.conformance.cite.write_wps20_provenance import write_provenance
+
+
+class WriteWps20ProvenanceTests(unittest.TestCase):
+    def test_writes_linked_source_and_image_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_id = "sha256:" + ("b" * 64)
+            inspect_path = root / "honua-server-image-inspect.json"
+            inspect_path.write_text(json.dumps([{"Id": image_id}]), encoding="utf-8")
+            output_path = root / "honua-server-provenance.json"
+
+            write_provenance(
+                "a" * 40,
+                "a" * 40,
+                "d" * 64,
+                image_id,
+                "source-build",
+                "",
+                inspect_path,
+                output_path,
+                True,
+            )
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["testedHonuaGitSha"], "a" * 40)
+            self.assertEqual(payload["serverImageId"], image_id)
+            self.assertEqual(payload["serverImageInspectFile"], inspect_path.name)
+            self.assertEqual(payload["serverBuildMode"], "source-build")
+
+    def test_required_git_sha_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_id = "sha256:" + ("b" * 64)
+            inspect_path = root / "inspect.json"
+            inspect_path.write_text(json.dumps([{"Id": image_id}]), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "full tested Honua git SHA"):
+                write_provenance(
+                    "unknown", "unknown", "d" * 64, image_id, "source-build", "", inspect_path, root / "out.json", True
+                )
+
+    def test_mismatched_checkout_sha_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_id = "sha256:" + ("b" * 64)
+            inspect_path = root / "inspect.json"
+            inspect_path.write_text(json.dumps([{"Id": image_id}]), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                write_provenance(
+                    "a" * 40, "e" * 40, "d" * 64, image_id, "source-build", "", inspect_path, root / "out.json", True
+                )
+
+    def test_mismatched_image_inspection_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_id = "sha256:" + ("b" * 64)
+            inspect_path = root / "inspect.json"
+            inspect_path.write_text(json.dumps([{"Id": "sha256:" + ("c" * 64)}]), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                write_provenance(
+                    "a" * 40,
+                    "a" * 40,
+                    "d" * 64,
+                    image_id,
+                    "source-build",
+                    "",
+                    inspect_path,
+                    root / "out.json",
+                    True,
+                )
+
+    def test_prebuilt_image_records_requested_reference_and_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_id = "sha256:" + ("b" * 64)
+            digest = "ghcr.io/honua-io/honua-server@sha256:" + ("c" * 64)
+            inspect_path = root / "inspect.json"
+            inspect_path.write_text(json.dumps([{"Id": image_id, "RepoDigests": [digest]}]), encoding="utf-8")
+            output_path = root / "out.json"
+
+            write_provenance(
+                "a" * 40,
+                "a" * 40,
+                "d" * 64,
+                image_id,
+                "prebuilt",
+                digest,
+                inspect_path,
+                output_path,
+                True,
+            )
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["requestedServerImage"], digest)
+            self.assertEqual(payload["serverImageRepoDigests"], [digest])
+
+    def test_required_provenance_rejects_local_existing_image(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            image_id = "sha256:" + ("b" * 64)
+            inspect_path = root / "inspect.json"
+            inspect_path.write_text(json.dumps([{"Id": image_id}]), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "untracked local-existing image"):
+                write_provenance(
+                    "a" * 40,
+                    "a" * 40,
+                    "d" * 64,
+                    image_id,
+                    "local-existing",
+                    "",
+                    inspect_path,
+                    root / "out.json",
+                    True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/conformance/cite/write_wps20_provenance.py
+++ b/scripts/conformance/cite/write_wps20_provenance.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Write validated Honua server provenance for a WPS 2.0 CITE run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+GIT_SHA = re.compile(r"^[0-9a-fA-F]{40,64}$")
+IMAGE_ID = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+
+
+def write_provenance(
+    tested_git_sha: str,
+    checkout_git_sha: str,
+    server_container_id: str,
+    server_image_id: str,
+    server_build_mode: str,
+    requested_server_image: str,
+    image_inspect_path: Path,
+    output_path: Path,
+    require_tested_git_sha: bool,
+) -> None:
+    if require_tested_git_sha and not GIT_SHA.fullmatch(tested_git_sha):
+        raise ValueError("A full tested Honua git SHA is required")
+    if tested_git_sha != "unknown" and not GIT_SHA.fullmatch(tested_git_sha):
+        raise ValueError("Tested Honua git SHA must be full-length or 'unknown'")
+    if checkout_git_sha != "unknown" and not GIT_SHA.fullmatch(checkout_git_sha):
+        raise ValueError("Checked-out Honua git SHA must be full-length or 'unknown'")
+    if tested_git_sha != "unknown" and tested_git_sha != checkout_git_sha:
+        raise ValueError("Tested Honua git SHA does not match the checked-out commit")
+    if not re.fullmatch(r"^[0-9a-fA-F]{64}$", server_container_id):
+        raise ValueError("Honua Server container ID must be a full Docker identifier")
+    if not IMAGE_ID.fullmatch(server_image_id):
+        raise ValueError("Honua Server image ID must be an immutable sha256 identifier")
+    if server_build_mode not in {"source-build", "prebuilt", "local-existing"}:
+        raise ValueError("Honua Server build mode is invalid")
+    if require_tested_git_sha and server_build_mode == "local-existing":
+        raise ValueError("CI provenance cannot use an untracked local-existing image")
+    if server_build_mode == "prebuilt" and not requested_server_image:
+        raise ValueError("A requested image reference is required for a prebuilt image")
+
+    inspected = json.loads(image_inspect_path.read_text(encoding="utf-8"))
+    if not isinstance(inspected, list) or len(inspected) != 1:
+        raise ValueError("Honua Server image inspection must contain exactly one image")
+    if inspected[0].get("Id") != server_image_id:
+        raise ValueError("Running Honua Server image ID does not match its image inspection")
+
+    payload = {
+        "schemaVersion": 1,
+        "testedHonuaGitSha": tested_git_sha,
+        "checkedOutHonuaGitSha": checkout_git_sha,
+        "serverBuildMode": server_build_mode,
+        "requestedServerImage": requested_server_image or None,
+        "serverContainerId": server_container_id,
+        "serverImageId": server_image_id,
+        "serverImageRepoDigests": inspected[0].get("RepoDigests") or [],
+        "serverImageReference": "honua-server:latest",
+        "serverImageInspectFile": image_inspect_path.name,
+    }
+    temporary_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    temporary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    temporary_path.replace(output_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tested-git-sha", required=True)
+    parser.add_argument("--checkout-git-sha", required=True)
+    parser.add_argument("--server-container-id", required=True)
+    parser.add_argument("--server-image-id", required=True)
+    parser.add_argument("--server-build-mode", choices=("source-build", "prebuilt", "local-existing"), required=True)
+    parser.add_argument("--requested-server-image", default="")
+    parser.add_argument("--image-inspect", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--require-tested-git-sha", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        write_provenance(
+            args.tested_git_sha,
+            args.checkout_git_sha,
+            args.server_container_id,
+            args.server_image_id,
+            args.server_build_mode,
+            args.requested_server_image,
+            args.image_inspect,
+            args.output,
+            args.require_tested_git_sha,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Related to #2933

## What changed

- records the exact checked-out Honua git SHA in WPS 2.0 CITE result artifacts
- resolves the actual Compose server container to its immutable Docker image ID
- archives the matching full image inspection and validated provenance metadata, including build mode, requested prebuilt reference, and registry digests
- fails closed in GitHub Actions when required source or image provenance is missing or inconsistent
- preserves practical local behavior with an explicit warned Git fallback and `local-existing` mode for `--skip-build`
- documents the retained WPS evidence contract

## Why

The post-merge WPS CITE run passed 22/22, but its downloadable artifact only proved ETS identity. It did not identify the Honua source revision or immutable server image actually exercised, so it could not close the retained-evidence acceptance criterion.

## Validation

- `python -m unittest scripts.conformance.cite.tests.test_write_wps20_provenance` (6 passed)
- `bash scripts/conformance/cite/tests/test-wps20-runner-provenance-policy.sh`
- `python -m py_compile scripts/conformance/cite/write_wps20_provenance.py scripts/conformance/cite/tests/test_write_wps20_provenance.py`
- `bash -n scripts/conformance/cite/run-cite-wps20-tests.sh scripts/conformance/cite/tests/test-wps20-runner-provenance-policy.sh`
- `bash scripts/ci/validate-ci-router.sh`
- `docker compose -f docker/cite/wps20/compose.yml config --quiet`

## Review

Independent review: GO. No blocking findings remain.