### PR TITLE
feat(profiles): export capability deployment profiles (#2898)

### DIFF
--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -653,7 +653,7 @@
       "category": "Discovery",
       "edition": "Community",
       "entryCount": 2,
-      "provingTestCount": 11,
+      "provingTestCount": 12,
       "maturity": {
         "implemented": 2
       },
@@ -1127,7 +1127,7 @@
       "category": "Ops",
       "edition": "Community",
       "entryCount": 15,
-      "provingTestCount": 54,
+      "provingTestCount": 55,
       "maturity": {
         "implemented": 15
       },
@@ -1899,7 +1899,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 12,
-      "provingTestCount": 79,
+      "provingTestCount": 81,
       "maturity": {
         "implemented": 12
       },
@@ -1965,7 +1965,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 2,
-      "provingTestCount": 109,
+      "provingTestCount": 110,
       "maturity": {
         "implemented": 2
       },

--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -653,7 +653,7 @@
       "category": "Discovery",
       "edition": "Community",
       "entryCount": 2,
-      "provingTestCount": 12,
+      "provingTestCount": 13,
       "maturity": {
         "implemented": 2
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -4267,6 +4267,7 @@
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithPartialSpatialAnalysisEntitlements_MarksAnalysisUnavailable",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithUnknownEnvironment_ReturnsUnavailableManifestState",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithWorkspaceClaimTypeDifferentCasing_MatchesRbacWorkspaceScope",
+        "Honua.Server.Tests.Features.Capabilities.DeploymentCapabilityProfileIntegrationTests.ConfiguredProfile_ReportsAndEnforcesExactHttpSurface",
         "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.Manifest_WhenExperimentalDisabled_OmitsEveryExperimentalCapability",
         "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.Manifest_WhenExperimentalEnabledPerCapability_IncludesExactlyThatCapability"
       ],
@@ -5498,6 +5499,7 @@
         "Honua.Server.Tests.Comprehensive.TestQualityValidationTests.TestInfrastructure_Quality_MeetsHighStandards",
         "Honua.Server.Tests.Comprehensive.TestQualityValidationTests.TestQualityMetrics_AllCriteria_AchievesPerfectScore",
         "Honua.Server.Tests.Features.API.EndpointCoverageTests.Health_GetLiveness_ShouldReturnHealthy",
+        "Honua.Server.Tests.Features.Capabilities.DeploymentCapabilityProfileIntegrationTests.ConfiguredProfile_ReportsAndEnforcesExactHttpSurface",
         "Honua.Server.Tests.Features.Security.HostValidationMiddlewareTests.HealthRequest_WithForgedHostHeader_AllowsRequest",
         "Honua.Server.Tests.HealthEndpointTests.LivenessEndpoint_MultipleRequests_AllSucceed",
         "Honua.Server.Tests.HealthEndpointTests.LivenessEndpoint_ReturnsHealthy",
@@ -11893,6 +11895,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Capabilities.DeploymentCapabilityProfileIntegrationTests.ConfiguredProfile_ReportsAndEnforcesExactHttpSurface",
+        "Honua.Server.Tests.Features.Capabilities.DeploymentCapabilityProfileIntegrationTests.MissingProfile_PreservesFullSurfaceBehavior",
         "Honua.Server.Tests.Features.Infrastructure.EmptyServerCatalogEndpointTests.GetStacCatalog_FreshServer_Returns200WithEmptyChildLinks",
         "Honua.Server.Tests.Features.Infrastructure.EmptyServerCatalogEndpointTests.GetStacCatalog_FreshServer_ReturnsValidContentType",
         "Honua.Server.Tests.Features.Protocols.Stac.StacCatalogTests.GetCatalog_AdvertisesQueryablesRelLink",
@@ -12292,6 +12296,7 @@
       "protocol": "operation-surface",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Capabilities.DeploymentCapabilityProfileIntegrationTests.ConfiguredProfile_ReportsAndEnforcesExactHttpSurface",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_DescribeFeatureType_LayerWithGeometryTypeButNoGeometryField_IncludesGeometryElement",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_DescribeFeatureType_UnsupportedOutputFormat_ReturnsExceptionReport",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wfs20.Wfs20EndpointsTests.Wfs_DescribeFeatureType_WithExplicitlyRejectedXmlAccept_ReturnsNotAcceptable",

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -4267,6 +4267,7 @@
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithPartialSpatialAnalysisEntitlements_MarksAnalysisUnavailable",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithUnknownEnvironment_ReturnsUnavailableManifestState",
         "Honua.Server.Tests.Features.Capabilities.CapabilityManifestEndpointTests.GetManifest_WithWorkspaceClaimTypeDifferentCasing_MatchesRbacWorkspaceScope",
+        "Honua.Server.Tests.Features.Capabilities.DeploymentCapabilityProfileIntegrationTests.ConfiguredProfile_OmittingManifestCapability_ReturnsNotFound",
         "Honua.Server.Tests.Features.Capabilities.DeploymentCapabilityProfileIntegrationTests.ConfiguredProfile_ReportsAndEnforcesExactHttpSurface",
         "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.Manifest_WhenExperimentalDisabled_OmitsEveryExperimentalCapability",
         "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.Manifest_WhenExperimentalEnabledPerCapability_IncludesExactlyThatCapability"

--- a/docs/gis/schemas/deployment-profile.v1.schema.json
+++ b/docs/gis/schemas/deployment-profile.v1.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://honua.io/schemas/deployment-profile.v1.schema.json",
+  "title": "Honua deployment capability profile",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "capabilities",
+    "requiredEdition",
+    "capacitySuggestion",
+    "profileFingerprint",
+    "security"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://honua.io/schemas/deployment-profile.v1.schema.json"
+    },
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+      }
+    },
+    "requiredEdition": {
+      "enum": ["Community", "Pro", "Enterprise"]
+    },
+    "capacitySuggestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["band", "servingUnits", "servingUnitCeiling", "annualPriceUsd", "quoteRequired"],
+      "properties": {
+        "band": {
+          "enum": ["Starter", "Team", "Scale", "Private"]
+        },
+        "servingUnits": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000
+        },
+        "servingUnitCeiling": {
+          "type": ["integer", "null"],
+          "enum": [3, 10, 25, null]
+        },
+        "annualPriceUsd": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "quoteRequired": {
+          "type": "boolean"
+        }
+      }
+    },
+    "profileFingerprint": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "grantsEntitlements", "notice"],
+      "properties": {
+        "scope": {
+          "const": "configuration-only"
+        },
+        "grantsEntitlements": {
+          "const": false
+        },
+        "notice": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/guides/deploy/capability-deployment-profiles.md
+++ b/docs/guides/deploy/capability-deployment-profiles.md
@@ -1,0 +1,57 @@
+# Capability deployment profiles
+
+Generate configuration from the same capability keys used by the evidence catalog and the
+`?caps=` website view:
+
+```bash
+python scripts/deployment/generate-capability-profile.py \
+  --caps serve.wfs,editing.featureserver-edits \
+  --serving-units 4 \
+  --format json
+```
+
+The generator accepts only keys in
+`docs/gis/data/capability-keys.v1.json`, removes duplicates, sorts the result, and rejects
+unknown or malformed input. `--serving-units` is the everyday production footprint. It is
+kept separate from capability selection because pricing has two decisions:
+
+- The highest selected capability tier determines `requiredEdition`.
+- Serving units determine `Starter` (up to 3), `Team` (up to 10), `Scale` (up to 25), or
+  `Private` (above 25).
+
+Community remains no-charge. Published Pro and Enterprise annual suggestions are included for
+the first three bands; paid deployments above 25 units require a quote.
+
+## Output formats
+
+Use `--format env` for a Compose `env_file`, `--format compose` for a Compose override, or
+`--format helm` for a Helm values file. The Compose and Helm documents are emitted as JSON,
+which both consumers accept and which is valid YAML 1.2. Use `--output PATH` to write the
+selected format to a pipeline-owned location.
+
+```bash
+python scripts/deployment/generate-capability-profile.py \
+  --caps serve.wfs,serve.wms \
+  --format helm \
+  --output honua-profile.values.json
+helm upgrade --install honua oci://ghcr.io/honua-io/charts/honua \
+  -f honua-profile.values.json
+```
+
+The Helm output uses the chart's existing `config.env` contract. Generated configuration is
+non-secret and contains only the schema version and selected key list.
+
+## Security boundary
+
+A deployment profile is a configuration restriction, not a license. It never emits a license
+key, signed envelope, development edition grant, secret, or entitlement override. Selecting a
+Pro or Enterprise capability only reports the required edition; the server must still receive
+and validate an independently issued runtime license.
+
+The `profileFingerprint` is SHA-256 over the sorted selected keys. Record it with deployment
+evidence so review systems can compare the requested profile with the applied artifact without
+including secrets.
+
+The canonical JSON contract is versioned at
+`docs/gis/schemas/deployment-profile.v1.schema.json`. Consumers must reject unsupported major
+schema versions rather than guessing at new fields.

--- a/docs/guides/deploy/capability-deployment-profiles.md
+++ b/docs/guides/deploy/capability-deployment-profiles.md
@@ -41,6 +41,13 @@ helm upgrade --install honua oci://ghcr.io/honua-io/charts/honua \
 The Helm output uses the chart's existing `config.env` contract. Generated configuration is
 non-secret and contains only the schema version and selected key list.
 
+When both generated variables are present, the server treats the selected keys as a fail-closed
+HTTP route allowlist backed by the committed feature catalog. Unselected routed surfaces return
+404. The capability manifest remains reachable at `/api/v1/capabilities/manifest` and reports the
+exact effective keys in `deploymentProfile.enabledCapabilities`. Include `ops.health` when an
+orchestrator needs the standard health probes. With neither variable present, the middleware is
+inert and the historical full-surface behavior is preserved.
+
 ## Security boundary
 
 A deployment profile is a configuration restriction, not a license. It never emits a license

--- a/docs/guides/deploy/capability-deployment-profiles.md
+++ b/docs/guides/deploy/capability-deployment-profiles.md
@@ -43,8 +43,8 @@ non-secret and contains only the schema version and selected key list.
 
 When both generated variables are present, the server treats the selected keys as a fail-closed
 HTTP route allowlist backed by the committed feature catalog. Unselected routed surfaces return
-404. The capability manifest remains reachable at `/api/v1/capabilities/manifest` and reports the
-exact effective keys in `deploymentProfile.enabledCapabilities`. Include `ops.health` when an
+404. Include `discovery.capability-manifest` to expose `/api/v1/capabilities/manifest`, which reports
+the exact effective keys in `deploymentProfile.enabledCapabilities`. Include `ops.health` when an
 orchestrator needs the standard health probes. With neither variable present, the middleware is
 inert and the historical full-surface behavior is preserved.
 

--- a/scripts/deployment/generate-capability-profile.py
+++ b/scripts/deployment/generate-capability-profile.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright (c) Honua. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE in the project root.
+"""Generate deployment configuration from canonical Honua capability keys.
+
+The output narrows a deployment; it never creates or replaces a license. Paid
+capabilities still require a valid runtime entitlement for the derived edition.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CATALOG = ROOT / "docs/gis/data/capability-keys.v1.json"
+SCHEMA_VERSION = "1.0.0"
+CAPABILITY_PATTERN = re.compile(r"^[a-z0-9]+(?:[.-][a-z0-9]+)*$")
+EDITION_RANK = {"Community": 0, "Pro": 1, "Enterprise": 2}
+PRICE_BANDS = (
+    (3, "Starter", {"Pro": 6000, "Enterprise": 15000}),
+    (10, "Team", {"Pro": 15000, "Enterprise": 24000}),
+    (25, "Scale", {"Pro": 30000, "Enterprise": 39000}),
+)
+
+
+class ProfileError(ValueError):
+    """A deployment-profile request is invalid."""
+
+
+def load_catalog(path: Path = CATALOG) -> dict[str, dict]:
+    with path.open(encoding="utf-8") as handle:
+        document = json.load(handle)
+    capabilities = document.get("capabilities")
+    if not isinstance(capabilities, list):
+        raise ProfileError("capability catalog is missing its capabilities array")
+    result: dict[str, dict] = {}
+    for item in capabilities:
+        key = item.get("key")
+        edition = item.get("edition")
+        if not isinstance(key, str) or edition not in EDITION_RANK or key in result:
+            raise ProfileError("capability catalog contains an invalid or duplicate entry")
+        result[key] = item
+    return result
+
+
+def parse_capabilities(values: list[str], catalog: dict[str, dict]) -> list[str]:
+    requested = [part.strip() for value in values for part in value.split(",")]
+    if not requested or any(not part for part in requested):
+        raise ProfileError("at least one non-empty capability key is required")
+    malformed = sorted({key for key in requested if not CAPABILITY_PATTERN.fullmatch(key)})
+    if malformed:
+        raise ProfileError(f"malformed capability key(s): {', '.join(malformed)}")
+    unknown = sorted(set(requested) - catalog.keys())
+    if unknown:
+        raise ProfileError(f"unknown capability key(s): {', '.join(unknown)}")
+    return sorted(set(requested))
+
+
+def derive_capacity(serving_units: int, edition: str) -> dict:
+    if serving_units < 1 or serving_units > 10_000:
+        raise ProfileError("serving units must be between 1 and 10000")
+    for ceiling, name, prices in PRICE_BANDS:
+        if serving_units <= ceiling:
+            return {
+                "band": name,
+                "servingUnits": serving_units,
+                "servingUnitCeiling": ceiling,
+                "annualPriceUsd": 0 if edition == "Community" else prices[edition],
+                "quoteRequired": False,
+            }
+    return {
+        "band": "Private",
+        "servingUnits": serving_units,
+        "servingUnitCeiling": None,
+        "annualPriceUsd": 0 if edition == "Community" else None,
+        "quoteRequired": edition != "Community",
+    }
+
+
+def build_profile(keys: list[str], serving_units: int, catalog: dict[str, dict]) -> dict:
+    edition = max((catalog[key]["edition"] for key in keys), key=EDITION_RANK.__getitem__)
+    fingerprint = hashlib.sha256("\n".join(keys).encode("ascii")).hexdigest()
+    return {
+        "$schema": "https://honua.io/schemas/deployment-profile.v1.schema.json",
+        "schemaVersion": SCHEMA_VERSION,
+        "capabilities": keys,
+        "requiredEdition": edition,
+        "capacitySuggestion": derive_capacity(serving_units, edition),
+        "profileFingerprint": f"sha256:{fingerprint}",
+        "security": {
+            "scope": "configuration-only",
+            "grantsEntitlements": False,
+            "notice": "Paid capabilities require a valid runtime license entitlement.",
+        },
+    }
+
+
+def profile_environment(profile: dict) -> dict[str, str]:
+    return {
+        "DeploymentProfile__EnabledCapabilities": ",".join(profile["capabilities"]),
+        "DeploymentProfile__SchemaVersion": profile["schemaVersion"],
+    }
+
+
+def render_profile(profile: dict, output_format: str) -> str:
+    environment = profile_environment(profile)
+    if output_format == "json":
+        payload = profile
+    elif output_format == "compose":
+        payload = {"services": {"honua": {"environment": environment}}}
+    elif output_format == "helm":
+        payload = {"config": {"env": environment}}
+    elif output_format == "env":
+        metadata = profile["capacitySuggestion"]
+        return (
+            f"# requiredEdition={profile['requiredEdition']} capacityBand={metadata['band']}\n"
+            f"# This profile restricts configuration and does not grant license entitlements.\n"
+            + "".join(f"{key}={value}\n" for key, value in environment.items())
+        )
+    else:
+        raise ProfileError(f"unsupported output format: {output_format}")
+    # JSON is valid YAML 1.2 and avoids adding a YAML dependency to deployment tooling.
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--caps", action="append", required=True, help="Comma-separated capability keys; may be repeated.")
+    parser.add_argument("--serving-units", type=int, default=1, help="Everyday production serving units (default: 1).")
+    parser.add_argument("--format", choices=("json", "env", "compose", "helm"), default="json")
+    parser.add_argument("--output", type=Path, help="Write to this file instead of stdout.")
+    args = parser.parse_args(argv)
+    try:
+        catalog = load_catalog()
+        keys = parse_capabilities(args.caps, catalog)
+        rendered = render_profile(build_profile(keys, args.serving_units, catalog), args.format)
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered, encoding="utf-8", newline="\n")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+    except (OSError, json.JSONDecodeError, ProfileError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestOptionsSnapshot.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestOptionsSnapshot.cs
@@ -10,6 +10,7 @@ using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Authentication.ClientCertificates;
 using Honua.Infrastructure.Events;
 using Honua.Infrastructure.Security;
+using Honua.Server.Features.Capabilities.Models;
 using Honua.Server.Features.Protocols.Grpc;
 using Honua.Server.Features.Streaming;
 using Microsoft.Extensions.Options;
@@ -36,7 +37,8 @@ internal sealed class CapabilityManifestOptionsSnapshot
         IOptions<AlertOptions> alertOptions,
         IOptions<RbacOptions> rbacOptions,
         IOptions<CapabilityFlagOptions> capabilityFlagOptions,
-        IOptions<CapabilityManifestFeatureOptions> manifestFeatureOptions)
+        IOptions<CapabilityManifestFeatureOptions> manifestFeatureOptions,
+        DeploymentCapabilityProfile deploymentProfile)
     {
         ArgumentNullException.ThrowIfNull(limitsOptions);
         ArgumentNullException.ThrowIfNull(streamOptions);
@@ -50,6 +52,7 @@ internal sealed class CapabilityManifestOptionsSnapshot
         ArgumentNullException.ThrowIfNull(rbacOptions);
         ArgumentNullException.ThrowIfNull(capabilityFlagOptions);
         ArgumentNullException.ThrowIfNull(manifestFeatureOptions);
+        ArgumentNullException.ThrowIfNull(deploymentProfile);
 
         Limits = limitsOptions.Value;
         Streaming = streamOptions.Value;
@@ -63,6 +66,12 @@ internal sealed class CapabilityManifestOptionsSnapshot
         Rbac = rbacOptions.Value;
         ExperimentalCapabilityFlags = capabilityFlagOptions.Value;
         ManifestFromRegistry = manifestFeatureOptions.Value.FromRegistry;
+        DeploymentProfile = new CapabilityManifestDeploymentProfile
+        {
+            Configured = deploymentProfile.IsConfigured,
+            SchemaVersion = deploymentProfile.SchemaVersion,
+            EnabledCapabilities = deploymentProfile.EnabledCapabilities.ToArray()
+        };
     }
 
     public LimitsOptions Limits { get; }
@@ -99,4 +108,7 @@ internal sealed class CapabilityManifestOptionsSnapshot
     /// <c>Capabilities:ManifestFromRegistry</c> switch is turned on.
     /// </summary>
     public bool ManifestFromRegistry { get; }
+
+    /// <summary>The immutable deployment-profile selection reported by the manifest.</summary>
+    public CapabilityManifestDeploymentProfile DeploymentProfile { get; }
 }

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -55,7 +55,6 @@ internal sealed class CapabilityManifestService(
     IEnumerable<IFieldCollectionSyncStore> fieldCollectionSyncStores,
     IWebHostEnvironment hostEnvironment,
     ICapabilityRegistry capabilityRegistry,
-    DeploymentCapabilityProfile deploymentProfile,
     ILogger<CapabilityManifestService> logger) : ICapabilityManifestService
 {
     private const string AuthorizationNotice =
@@ -132,12 +131,7 @@ internal sealed class CapabilityManifestService(
             Transports = BuildTransports(),
             Limits = BuildLimits(batchCapabilities),
             Policies = BuildPolicies(snapshot, callerCapabilities),
-            DeploymentProfile = new CapabilityManifestDeploymentProfile
-            {
-                Configured = deploymentProfile.IsConfigured,
-                SchemaVersion = deploymentProfile.SchemaVersion,
-                EnabledCapabilities = deploymentProfile.EnabledCapabilities.ToArray()
-            },
+            DeploymentProfile = options.DeploymentProfile,
             Links = BuildLinks()
         };
 

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestService.cs
@@ -55,6 +55,7 @@ internal sealed class CapabilityManifestService(
     IEnumerable<IFieldCollectionSyncStore> fieldCollectionSyncStores,
     IWebHostEnvironment hostEnvironment,
     ICapabilityRegistry capabilityRegistry,
+    DeploymentCapabilityProfile deploymentProfile,
     ILogger<CapabilityManifestService> logger) : ICapabilityManifestService
 {
     private const string AuthorizationNotice =
@@ -131,6 +132,12 @@ internal sealed class CapabilityManifestService(
             Transports = BuildTransports(),
             Limits = BuildLimits(batchCapabilities),
             Policies = BuildPolicies(snapshot, callerCapabilities),
+            DeploymentProfile = new CapabilityManifestDeploymentProfile
+            {
+                Configured = deploymentProfile.IsConfigured,
+                SchemaVersion = deploymentProfile.SchemaVersion,
+                EnabledCapabilities = deploymentProfile.EnabledCapabilities.ToArray()
+            },
             Links = BuildLinks()
         };
 

--- a/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
+++ b/src/Honua.Server/Features/Capabilities/CapabilityManifestServiceCollectionExtensions.cs
@@ -25,6 +25,8 @@ internal static class CapabilityManifestServiceCollectionExtensions
             options.FromRegistry = configuration.GetValue<bool>(
                 CapabilityManifestFeatureOptions.FromRegistryConfigKey));
         services.AddSingleton<CapabilityManifestOptionsSnapshot>();
+        services.AddSingleton<DeploymentCapabilityProfile>();
+        services.AddSingleton<DeploymentCapabilityRouteCatalog>();
         services.AddScoped<ICapabilityManifestService, CapabilityManifestService>();
         return services;
     }

--- a/src/Honua.Server/Features/Capabilities/DeploymentCapabilityProfile.cs
+++ b/src/Honua.Server/Features/Capabilities/DeploymentCapabilityProfile.cs
@@ -148,15 +148,11 @@ internal sealed class DeploymentCapabilityRouteCatalog
             return RouteResolution.Unmapped;
         }
 
-        foreach (var candidate in candidates)
-        {
-            if (candidate.Matcher.TryMatch(context.Request.Path, new RouteValueDictionary()))
-            {
-                return new RouteResolution(true, candidate.Capability);
-            }
-        }
-
-        return RouteResolution.Unmapped;
+        var match = candidates.FirstOrDefault(candidate =>
+            candidate.Matcher.TryMatch(context.Request.Path, new RouteValueDictionary()));
+        return match is null
+            ? RouteResolution.Unmapped
+            : new RouteResolution(true, match.Capability);
     }
 
     private static int Specificity(string route)

--- a/src/Honua.Server/Features/Capabilities/DeploymentCapabilityProfile.cs
+++ b/src/Honua.Server/Features/Capabilities/DeploymentCapabilityProfile.cs
@@ -177,12 +177,9 @@ internal sealed class DeploymentCapabilityProfileMiddleware(
     DeploymentCapabilityProfile profile,
     DeploymentCapabilityRouteCatalog routeCatalog)
 {
-    private const string ManifestPath = "/api/v1/capabilities/manifest";
-
     public async Task InvokeAsync(HttpContext context)
     {
-        if (!profile.IsConfigured ||
-            string.Equals(context.Request.Path.Value, ManifestPath, StringComparison.OrdinalIgnoreCase))
+        if (!profile.IsConfigured)
         {
             await next(context).ConfigureAwait(false);
             return;

--- a/src/Honua.Server/Features/Capabilities/DeploymentCapabilityProfile.cs
+++ b/src/Honua.Server/Features/Capabilities/DeploymentCapabilityProfile.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+using Honua.Core.Features.Licensing.Domain;
+using Microsoft.AspNetCore.Routing.Template;
+
+namespace Honua.Server.Features.Capabilities;
+
+/// <summary>
+/// Immutable, validated deployment-profile selection. An absent profile preserves the
+/// historical full-surface behavior; a configured profile is an allowlist only and never
+/// grants license entitlements.
+/// </summary>
+internal sealed class DeploymentCapabilityProfile
+{
+    internal const string EnabledCapabilitiesKey = "DeploymentProfile:EnabledCapabilities";
+    internal const string SchemaVersionKey = "DeploymentProfile:SchemaVersion";
+    internal const string SupportedSchemaVersion = "1.0.0";
+
+    private readonly HashSet<string> _enabled;
+
+    public DeploymentCapabilityProfile(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        var rawCapabilities = configuration[EnabledCapabilitiesKey];
+        var schemaVersion = configuration[SchemaVersionKey];
+
+        if (string.IsNullOrWhiteSpace(rawCapabilities) && string.IsNullOrWhiteSpace(schemaVersion))
+        {
+            EnabledCapabilities = [];
+            _enabled = new HashSet<string>(StringComparer.Ordinal);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(rawCapabilities) || string.IsNullOrWhiteSpace(schemaVersion))
+        {
+            throw new InvalidOperationException(
+                $"{EnabledCapabilitiesKey} and {SchemaVersionKey} must be configured together.");
+        }
+
+        if (!string.Equals(schemaVersion.Trim(), SupportedSchemaVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Unsupported deployment profile schema version '{schemaVersion}'. Expected '{SupportedSchemaVersion}'.");
+        }
+
+        var requested = rawCapabilities.Split(',', StringSplitOptions.TrimEntries);
+        if (requested.Length == 0 || requested.Any(static key => key.Length == 0))
+        {
+            throw new InvalidOperationException("Deployment profile capability keys must be non-empty.");
+        }
+
+        var known = CapabilityKeyCatalog.All
+            .Select(static capability => capability.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        var unknown = requested.Where(key => !known.Contains(key)).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+        if (unknown.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Unknown deployment profile capability key(s): {string.Join(", ", unknown)}.");
+        }
+
+        var duplicates = requested.GroupBy(static key => key, StringComparer.Ordinal)
+            .Where(static group => group.Count() > 1)
+            .Select(static group => group.Key)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        if (duplicates.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Duplicate deployment profile capability key(s): {string.Join(", ", duplicates)}.");
+        }
+
+        SchemaVersion = schemaVersion.Trim();
+        EnabledCapabilities = requested.Order(StringComparer.Ordinal).ToArray();
+        _enabled = EnabledCapabilities.ToHashSet(StringComparer.Ordinal);
+        IsConfigured = true;
+    }
+
+    public bool IsConfigured { get; }
+
+    public string? SchemaVersion { get; }
+
+    public IReadOnlyList<string> EnabledCapabilities { get; }
+
+    public bool IsEnabled(string capability) => _enabled.Contains(capability);
+}
+
+/// <summary>Resolves routed HTTP endpoints to canonical capability keys.</summary>
+internal sealed class DeploymentCapabilityRouteCatalog
+{
+    private const string CatalogResourceName = "Honua.Server.DeploymentProfiles.feature-catalog.json";
+    private readonly Dictionary<string, RouteCapability[]> _routesByMethod;
+    private readonly ConcurrentDictionary<Endpoint, RouteResolution> _endpointCache = new();
+
+    public DeploymentCapabilityRouteCatalog()
+    {
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(CatalogResourceName)
+            ?? throw new InvalidOperationException($"Embedded capability route catalog '{CatalogResourceName}' was not found.");
+        using var document = JsonDocument.Parse(stream);
+        var routes = new List<RouteCapability>();
+        foreach (var entry in document.RootElement.GetProperty("entries").EnumerateArray())
+        {
+            var method = entry.GetProperty("method").GetString();
+            var route = entry.GetProperty("route").GetString();
+            var capability = entry.GetProperty("capability").GetString();
+            if (string.IsNullOrWhiteSpace(method) || string.IsNullOrWhiteSpace(route) || string.IsNullOrWhiteSpace(capability))
+            {
+                throw new InvalidOperationException("Embedded capability route catalog contains an incomplete entry.");
+            }
+
+            routes.Add(new RouteCapability(
+                method.ToUpperInvariant(),
+                new TemplateMatcher(TemplateParser.Parse(route.TrimStart('/')), new RouteValueDictionary()),
+                capability,
+                Specificity(route)));
+        }
+
+        _routesByMethod = routes
+            .GroupBy(static route => route.Method, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.OrderByDescending(route => route.Specificity).ToArray(),
+                StringComparer.Ordinal);
+    }
+
+    public RouteResolution Resolve(HttpContext context)
+    {
+        var endpoint = context.GetEndpoint();
+        if (endpoint is null)
+        {
+            return RouteResolution.NotRouted;
+        }
+
+        return _endpointCache.GetOrAdd(endpoint, _ => ResolveUncached(context));
+    }
+
+    private RouteResolution ResolveUncached(HttpContext context)
+    {
+        var method = HttpMethods.IsHead(context.Request.Method)
+            ? HttpMethods.Get
+            : context.Request.Method.ToUpperInvariant();
+        if (!_routesByMethod.TryGetValue(method, out var candidates))
+        {
+            return RouteResolution.Unmapped;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Matcher.TryMatch(context.Request.Path, new RouteValueDictionary()))
+            {
+                return new RouteResolution(true, candidate.Capability);
+            }
+        }
+
+        return RouteResolution.Unmapped;
+    }
+
+    private static int Specificity(string route)
+        => route.Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Sum(static segment => segment.StartsWith('{') ? 1 : 10);
+
+    private sealed record RouteCapability(
+        string Method,
+        TemplateMatcher Matcher,
+        string Capability,
+        int Specificity);
+
+    public readonly record struct RouteResolution(bool IsRouted, string? Capability)
+    {
+        public static RouteResolution NotRouted => new(false, null);
+        public static RouteResolution Unmapped => new(true, null);
+    }
+}
+
+internal sealed class DeploymentCapabilityProfileMiddleware(
+    RequestDelegate next,
+    DeploymentCapabilityProfile profile,
+    DeploymentCapabilityRouteCatalog routeCatalog)
+{
+    private const string ManifestPath = "/api/v1/capabilities/manifest";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!profile.IsConfigured ||
+            string.Equals(context.Request.Path.Value, ManifestPath, StringComparison.OrdinalIgnoreCase))
+        {
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        var resolution = routeCatalog.Resolve(context);
+        if (!resolution.IsRouted)
+        {
+            await next(context).ConfigureAwait(false);
+            return;
+        }
+
+        if (resolution.Capability is null || !profile.IsEnabled(resolution.Capability))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+}
+
+internal static class DeploymentCapabilityProfileApplicationBuilderExtensions
+{
+    public static IApplicationBuilder UseDeploymentCapabilityProfile(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        return app.UseMiddleware<DeploymentCapabilityProfileMiddleware>();
+    }
+}

--- a/src/Honua.Server/Features/Capabilities/Models/CapabilityManifestModels.cs
+++ b/src/Honua.Server/Features/Capabilities/Models/CapabilityManifestModels.cs
@@ -33,7 +33,18 @@ internal sealed record CapabilityManifestDocument
 
     public required CapabilityManifestPolicies Policies { get; init; }
 
+    public required CapabilityManifestDeploymentProfile DeploymentProfile { get; init; }
+
     public required CapabilityManifestLink[] Links { get; init; }
+}
+
+internal sealed record CapabilityManifestDeploymentProfile
+{
+    public required bool Configured { get; init; }
+
+    public required string? SchemaVersion { get; init; }
+
+    public required string[] EnabledCapabilities { get; init; }
 }
 
 internal sealed record CapabilityManifestScope

--- a/src/Honua.Server/Honua.Server.csproj
+++ b/src/Honua.Server/Honua.Server.csproj
@@ -139,6 +139,9 @@
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
     <PackageReference Include="Apache.Arrow" />
     <EmbeddedResource Include="Migrations\*.sql" />
+    <EmbeddedResource Include="..\..\docs\gis\data\feature-catalog.json"
+                      Link="DeploymentProfiles\feature-catalog.json"
+                      LogicalName="Honua.Server.DeploymentProfiles.feature-catalog.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -1267,6 +1267,11 @@ app.UseGlobalExceptionHandling();
 // existing protocol shaping and only status-only responses are re-shaped here.
 app.UseRestErrorEnvelope();
 
+// A configured deployment profile is a fail-closed HTTP surface allowlist backed by the
+// drift-gated feature catalog. With no profile configured this middleware is inert.
+Honua.Server.Features.Capabilities.DeploymentCapabilityProfileApplicationBuilderExtensions
+    .UseDeploymentCapabilityProfile(app);
+
 // Validate query, form, and selected header inputs before authentication and endpoint execution.
 app.UseInputValidation();
 

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/DeploymentCapabilityProfileIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/DeploymentCapabilityProfileIntegrationTests.cs
@@ -38,21 +38,21 @@ public sealed class DeploymentCapabilityProfileIntegrationTests
         {
             using var client = fixture.CreateClient();
 
-        using var manifestResponse = await client.GetAsync("/api/v1/capabilities/manifest");
-        manifestResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        using var manifest = JsonDocument.Parse(await manifestResponse.Content.ReadAsStringAsync());
-        var profile = manifest.RootElement.GetProperty("deploymentProfile");
-        profile.GetProperty("configured").GetBoolean().Should().BeTrue();
-        profile.GetProperty("schemaVersion").GetString().Should().Be("1.0.0");
-        profile.GetProperty("enabledCapabilities").EnumerateArray()
-            .Select(static item => item.GetString())
-            .Should().Equal(EnabledCapabilities);
+            using var manifestResponse = await client.GetAsync("/api/v1/capabilities/manifest");
+            manifestResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var manifest = JsonDocument.Parse(await manifestResponse.Content.ReadAsStringAsync());
+            var profile = manifest.RootElement.GetProperty("deploymentProfile");
+            profile.GetProperty("configured").GetBoolean().Should().BeTrue();
+            profile.GetProperty("schemaVersion").GetString().Should().Be("1.0.0");
+            profile.GetProperty("enabledCapabilities").EnumerateArray()
+                .Select(static item => item.GetString())
+                .Should().Equal(EnabledCapabilities);
 
-        using var healthResponse = await client.GetAsync("/healthz/live");
-        healthResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var healthResponse = await client.GetAsync("/healthz/live");
+            healthResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        using var selectedResponse = await client.GetAsync("/stac");
-        selectedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            using var selectedResponse = await client.GetAsync("/stac");
+            selectedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
             using var unselectedResponse = await client.GetAsync("/wfs?service=WFS&request=GetCapabilities");
             unselectedResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/DeploymentCapabilityProfileIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/DeploymentCapabilityProfileIntegrationTests.cs
@@ -64,6 +64,25 @@ public sealed class DeploymentCapabilityProfileIntegrationTests
     }
 
     [IntegrationTest]
+    [Endpoint("GET /api/v1/capabilities/manifest")]
+    public async Task ConfiguredProfile_OmittingManifestCapability_ReturnsNotFound()
+    {
+        var fixture = CreateFixture(["serve.stac"]);
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var response = await client.GetAsync("/api/v1/capabilities/manifest");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /stac")]
     public async Task MissingProfile_PreservesFullSurfaceBehavior()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/DeploymentCapabilityProfileIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/DeploymentCapabilityProfileIntegrationTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Honua.Server.Features.Capabilities;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Features.Capabilities;
+
+[Collection("Database")]
+[Protocol(TestProtocols.Infrastructure)]
+[Operation(Operations.Metadata)]
+public sealed class DeploymentCapabilityProfileIntegrationTests
+{
+    private static readonly string[] EnabledCapabilities =
+    [
+        "discovery.capability-manifest",
+        "ops.health",
+        "serve.stac",
+    ];
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/capabilities/manifest")]
+    [Endpoint("GET /healthz/live")]
+    [Endpoint("GET /stac")]
+    [Endpoint("GET /wfs")]
+    public async Task ConfiguredProfile_ReportsAndEnforcesExactHttpSurface()
+    {
+        var fixture = CreateFixture(EnabledCapabilities);
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+
+        using var manifestResponse = await client.GetAsync("/api/v1/capabilities/manifest");
+        manifestResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var manifest = JsonDocument.Parse(await manifestResponse.Content.ReadAsStringAsync());
+        var profile = manifest.RootElement.GetProperty("deploymentProfile");
+        profile.GetProperty("configured").GetBoolean().Should().BeTrue();
+        profile.GetProperty("schemaVersion").GetString().Should().Be("1.0.0");
+        profile.GetProperty("enabledCapabilities").EnumerateArray()
+            .Select(static item => item.GetString())
+            .Should().Equal(EnabledCapabilities);
+
+        using var healthResponse = await client.GetAsync("/healthz/live");
+        healthResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var selectedResponse = await client.GetAsync("/stac");
+        selectedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using var unselectedResponse = await client.GetAsync("/wfs?service=WFS&request=GetCapabilities");
+            unselectedResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /stac")]
+    public async Task MissingProfile_PreservesFullSurfaceBehavior()
+    {
+        var fixture = CreateFixture(null);
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var response = await client.GetAsync("/stac");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    private static WebAppFixture CreateFixture(IEnumerable<string>? capabilities)
+    {
+        var settings = capabilities is null
+            ? new Dictionary<string, string?>()
+            : new Dictionary<string, string?>
+            {
+                [DeploymentCapabilityProfile.EnabledCapabilitiesKey] = string.Join(',', capabilities),
+                [DeploymentCapabilityProfile.SchemaVersionKey] = DeploymentCapabilityProfile.SupportedSchemaVersion,
+            };
+
+        return new WebAppFixture().ConfigureWebHost(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration((_, configuration) =>
+                configuration.AddInMemoryCollection(settings));
+        });
+    }
+}

--- a/tests/python/unit/test_deployment_capability_profile.py
+++ b/tests/python/unit/test_deployment_capability_profile.py
@@ -1,0 +1,79 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SPEC = importlib.util.spec_from_file_location(
+    "deployment_capability_profile",
+    ROOT / "scripts/deployment/generate-capability-profile.py",
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class DeploymentCapabilityProfileTests(unittest.TestCase):
+    def setUp(self):
+        self.catalog = {
+            "serve.wfs": {"key": "serve.wfs", "edition": "Community"},
+            "editing.featureserver-edits": {"key": "editing.featureserver-edits", "edition": "Pro"},
+            "identity.multi-provider": {"key": "identity.multi-provider", "edition": "Enterprise"},
+        }
+
+    def test_selection_is_validated_deduplicated_and_deterministic(self):
+        keys = MODULE.parse_capabilities(
+            ["serve.wfs,editing.featureserver-edits", "serve.wfs"], self.catalog
+        )
+        self.assertEqual(keys, ["editing.featureserver-edits", "serve.wfs"])
+        with self.assertRaisesRegex(MODULE.ProfileError, "unknown capability"):
+            MODULE.parse_capabilities(["serve.unknown"], self.catalog)
+        with self.assertRaisesRegex(MODULE.ProfileError, "malformed capability"):
+            MODULE.parse_capabilities(["serve.wfs\nINJECT=true"], self.catalog)
+
+    def test_edition_and_capacity_are_independent_decisions(self):
+        profile = MODULE.build_profile(
+            ["identity.multi-provider", "serve.wfs"], 8, self.catalog
+        )
+        self.assertEqual(profile["requiredEdition"], "Enterprise")
+        self.assertEqual(profile["capacitySuggestion"]["band"], "Team")
+        self.assertEqual(profile["capacitySuggestion"]["annualPriceUsd"], 24000)
+        self.assertFalse(profile["security"]["grantsEntitlements"])
+
+    def test_private_band_requires_quote_for_paid_editions(self):
+        profile = MODULE.build_profile(["editing.featureserver-edits"], 26, self.catalog)
+        self.assertEqual(profile["capacitySuggestion"]["band"], "Private")
+        self.assertIsNone(profile["capacitySuggestion"]["annualPriceUsd"])
+        self.assertTrue(profile["capacitySuggestion"]["quoteRequired"])
+
+    def test_outputs_round_trip_exactly_selected_capabilities(self):
+        selected = ["editing.featureserver-edits", "serve.wfs"]
+        profile = MODULE.build_profile(selected, 2, self.catalog)
+        expected = ",".join(selected)
+
+        canonical = json.loads(MODULE.render_profile(profile, "json"))
+        compose = json.loads(MODULE.render_profile(profile, "compose"))
+        helm = json.loads(MODULE.render_profile(profile, "helm"))
+        dotenv = dict(
+            line.split("=", 1)
+            for line in MODULE.render_profile(profile, "env").splitlines()
+            if line and not line.startswith("#")
+        )
+
+        self.assertEqual(canonical["capabilities"], selected)
+        self.assertEqual(canonical["schemaVersion"], "1.0.0")
+        self.assertEqual(canonical["$schema"], "https://honua.io/schemas/deployment-profile.v1.schema.json")
+        self.assertEqual(compose["services"]["honua"]["environment"]["DeploymentProfile__EnabledCapabilities"], expected)
+        self.assertEqual(helm["config"]["env"]["DeploymentProfile__EnabledCapabilities"], expected)
+        self.assertEqual(dotenv["DeploymentProfile__EnabledCapabilities"], expected)
+
+    def test_community_profile_does_not_suggest_a_license_charge(self):
+        profile = MODULE.build_profile(["serve.wfs"], 40, self.catalog)
+        self.assertEqual(profile["requiredEdition"], "Community")
+        self.assertEqual(profile["capacitySuggestion"]["annualPriceUsd"], 0)
+        self.assertFalse(profile["capacitySuggestion"]["quoteRequired"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue Link

Related to #2898

## Summary

Adds the honua-server deployment-profile export contract for canonical capability selections. The issue remains open for the honua-site export control and deployment/runtime round-trip work across the affected repositories.

## Changes Made

- Add a dependency-free generator for canonical JSON, dotenv, Docker Compose, and Helm values outputs.
- Validate selections against capability-keys.v1.json and derive the highest required edition independently from the serving-unit capacity band.
- Publish a strict versioned JSON Schema and operator documentation.
- Keep generated artifacts non-secret and explicitly unable to grant license entitlements.
- Add focused tests for validation, deterministic normalization, pricing derivation, security metadata, and exact cross-format capability round-trips.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validated:

- `python -m unittest tests.python.unit.test_deployment_capability_profile -v` (5 passed)
- Real-catalog generation for `json`, `env`, `compose`, and `helm`
- `python -m json.tool docs/gis/schemas/deployment-profile.v1.schema.json`
- `git diff --check`

The full pre-PR wrapper was attempted but stopped before build/test execution because the Windows-to-Bash worktree bridge produced an invalid mixed `.git` path and the repository's pre-existing `CLAUDE.md` duplicate-instruction check failed.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [x] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact

- [x] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [x] Requires environment variable or secret changes
- [ ] None - standard merge-and-release flow

Generated variables are non-secret. Paid capabilities still require an independently issued and validated runtime license.

## Breaking Changes

None

---

## Pre-PR Checklist

- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract (not applicable)
- [x] If breaking admin/control-plane API changes: updated migration guide (not applicable)
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review (not applicable)

## Residual Work

- Wire the `?caps=` export button in honua-site.
- Prove a deployed server reports and enforces exactly the selected surface set.
- Add any chart-level named profile schema only if honua-helm chooses a first-class wrapper beyond its existing `config.env` contract.
