### PR TITLE
fix(security): allow opaque admin hub connection IDs (#2954)

### DIFF
--- a/src/Honua.Server/Features/Infrastructure/Security/InputValidationMiddleware.cs
+++ b/src/Honua.Server/Features/Infrastructure/Security/InputValidationMiddleware.cs
@@ -353,7 +353,19 @@ internal sealed class InputValidationMiddleware
 
     private static bool ShouldSkipSqlInspection(HttpRequest request, string paramType, string name)
         => IsFeatureEditPayloadField(request, paramType, name)
-           || IsOAuth2CredentialParameter(request, paramType, name);
+           || IsOAuth2CredentialParameter(request, paramType, name)
+           || IsAdminSignalRConnectionId(request, paramType, name);
+
+    private static bool IsAdminSignalRConnectionId(HttpRequest request, string paramType, string name)
+    {
+        // SignalR supplies this opaque, base64url connection token after negotiation. It is
+        // consumed only by the hub transport and can legitimately contain SQL-looking byte
+        // sequences such as "--"; it never reaches a SQL context. Keep the exemption exact
+        // to the admin hub transport route and parameter so every other input remains checked.
+        return paramType.Equals("query", StringComparison.Ordinal)
+            && name.Equals("id", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(request.Path.Value, "/hubs/admin", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static bool IsOAuth2CredentialParameter(HttpRequest request, string paramType, string name)
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Security/InputValidationIntegrationTests.cs
@@ -161,6 +161,36 @@ public sealed class InputValidationIntegrationTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Endpoint("GET /hubs/admin")]
+    public async Task AdminHub_WithSqlLikeOpaqueConnectionId_ReachesSignalR()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "/hubs/admin?id=opaque--connection-token");
+        request.Headers.Add("X-API-Key", AdminPassword);
+
+        using var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await response.Content.ReadAsStringAsync()).Should().NotContain("SQL injection attempt detected");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /hubs/admin")]
+    public async Task AdminHub_WithSqlInjectionInNonTransportParameter_ReturnsBadRequest()
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "/hubs/admin?where=1%3D1--");
+        request.Headers.Add("X-API-Key", AdminPassword);
+
+        using var response = await _fixture.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("SQL injection attempt detected");
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/query")]
     public async Task Query_WithSqlKeywordInsideOpaqueCredentialHeader_IsNotRejectedByInputValidation()
     {


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Fixes #2954

## Summary
Prevents legitimate admin SignalR LongPolling connections from being rejected when a framework-generated opaque connection token contains SQL-looking text such as `--`. Batch CI run 29801020239 exposed the false positive with token `BH8I--t7jhpwT-DyN4Ny3Q`.

## Changes Made
- Exempt only query parameter `id` on the exact `/hubs/admin` transport route from SQL-injection content inspection.
- Preserve SQL-injection inspection for every other parameter and route.
- Add deterministic regressions proving the opaque token reaches SignalR `404` semantics while a malicious `where` value still returns the validation `400`.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Focused validation passed 17/17:

`dotnet test tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj --configuration Release --filter "FullyQualifiedName~Honua.Server.Tests.Features.Security.InputValidationIntegrationTests|FullyQualifiedName~Honua.Server.Tests.Admin.AdminRealtimeGroupsTests" --logger "console;verbosity=normal"`

`git diff --check` passed.

Independent review: no findings.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
