### PR TITLE
test: GA-guard depth pack — OIDC, WMS/WMTS, alerts, analytics, static-map, tiles 404 (#2945)

### DIFF
--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -301,7 +301,7 @@
       "category": "Analytics",
       "edition": "Pro",
       "entryCount": 1,
-      "provingTestCount": 8,
+      "provingTestCount": 10,
       "maturity": {
         "implemented": 1
       },
@@ -335,7 +335,7 @@
       "category": "Analytics",
       "edition": "Community",
       "entryCount": 2,
-      "provingTestCount": 3,
+      "provingTestCount": 6,
       "maturity": {
         "implemented": 2
       },
@@ -386,7 +386,7 @@
       "category": "Analytics",
       "edition": "Pro",
       "entryCount": 1,
-      "provingTestCount": 4,
+      "provingTestCount": 5,
       "maturity": {
         "implemented": 1
       },
@@ -403,7 +403,7 @@
       "category": "Analytics",
       "edition": "Pro",
       "entryCount": 1,
-      "provingTestCount": 3,
+      "provingTestCount": 4,
       "maturity": {
         "implemented": 1
       },
@@ -954,7 +954,7 @@
       "category": "Identity",
       "edition": "Pro",
       "entryCount": 6,
-      "provingTestCount": 7,
+      "provingTestCount": 13,
       "maturity": {
         "implemented": 6
       },
@@ -1575,7 +1575,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 45,
-      "provingTestCount": 307,
+      "provingTestCount": 309,
       "maturity": {
         "implemented": 45
       },
@@ -1755,7 +1755,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 21,
-      "provingTestCount": 242,
+      "provingTestCount": 243,
       "maturity": {
         "implemented": 21
       },
@@ -1801,7 +1801,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 10,
-      "provingTestCount": 116,
+      "provingTestCount": 129,
       "maturity": {
         "implemented": 10
       },
@@ -1908,7 +1908,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 7,
-      "provingTestCount": 35,
+      "provingTestCount": 36,
       "maturity": {
         "implemented": 7
       },
@@ -2285,7 +2285,7 @@
       "category": "Temporal",
       "edition": "Pro",
       "entryCount": 2,
-      "provingTestCount": 5,
+      "provingTestCount": 7,
       "maturity": {
         "implemented": 2
       },

--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -318,7 +318,7 @@
       "category": "Analytics",
       "edition": "Pro",
       "entryCount": 1,
-      "provingTestCount": 5,
+      "provingTestCount": 7,
       "maturity": {
         "implemented": 1
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -3100,6 +3100,12 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Admin.OidcJwtBearerValidationTests.AdminEndpoint_ExpiredJwt_IsRejected",
+        "Honua.Server.Tests.Features.Admin.OidcJwtBearerValidationTests.AdminEndpoint_NoToken_IsRejected",
+        "Honua.Server.Tests.Features.Admin.OidcJwtBearerValidationTests.AdminEndpoint_TamperedSignature_IsRejected",
+        "Honua.Server.Tests.Features.Admin.OidcJwtBearerValidationTests.AdminEndpoint_ValidJwt_IsAccepted",
+        "Honua.Server.Tests.Features.Admin.OidcJwtBearerValidationTests.AdminEndpoint_WrongAudience_IsRejected",
+        "Honua.Server.Tests.Features.Admin.OidcJwtBearerValidationTests.AdminEndpoint_WrongIssuer_IsRejected",
         "Honua.Server.Tests.Features.Admin.OidcProviderEndpointsTests.ListProviders_Empty_ReturnsEmptyList"
       ],
       "proof_ledger_surface": "control-plane-admin",
@@ -4230,6 +4236,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Reporting.AnalysisReportEndpointsHappyPathTests.GetReport_CompletedJob_GeneratesRealReportEnvelope",
         "Honua.Server.Tests.Features.Reporting.AnalysisReportEndpointsTests.GetReport_UnknownJob_ReachesHandlerAndReturnsProblemDetails"
       ],
       "proof_ledger_surface": "analysis-reporting",
@@ -4244,6 +4251,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Reporting.AnalysisReportEndpointsHappyPathTests.RenderReport_CompletedJob_RendersRealHtml",
+        "Honua.Server.Tests.Features.Reporting.AnalysisReportEndpointsHappyPathTests.RenderReport_CompletedJob_RendersRealMarkdown",
         "Honua.Server.Tests.Features.Reporting.AnalysisReportEndpointsTests.RenderReport_UnknownFormat_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Reporting.AnalysisReportEndpointsTests.RenderReport_UnknownJob_ReachesHandlerAndReturnsProblemDetails"
       ],
@@ -9444,7 +9453,9 @@
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerQueryDateBinsTests.QueryDateBins_CalendarBin_ReturnsBins",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerQueryDateBinsTests.QueryDateBins_InvalidService_ReturnsNotFound",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerQueryDateBinsTests.QueryDateBins_MissingBinField_ReturnsBadRequest",
-        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerQueryDateBinsTests.QueryDateBins_MissingBin_ReturnsBadRequest"
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerQueryDateBinsTests.QueryDateBins_MissingBin_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerQueryDateBinsTests.QueryDateBins_MonthCalendarBin_ReturnsExactBucketCounts",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerQueryDateBinsTests.QueryDateBins_YearCalendarBin_ReturnsExactBucketCounts"
       ],
       "proof_ledger_surface": "feature-server",
       "maturity": "implemented",
@@ -10451,6 +10462,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_NotValueReference_ReturnsServiceException",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_ReturnsImage",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_ScalarFilterExpression_ReturnsServiceException",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_StyledSeededPoint_RendersPixelAtFeatureLocationWithCorrectDimensions",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_WithFilter_ReturnsDistinctImage",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_WithLayerSelection_ReturnsImage",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wms.OgcClassicWmsTests.Wms_GetMap_WithSrs_ReturnsImage",
@@ -10535,6 +10547,7 @@
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts.OgcClassicWmtsTests.Wmts_GetTile_InvalidTileMatrixSet_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts.OgcClassicWmtsTests.Wmts_GetTile_MissingParams_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts.OgcClassicWmtsTests.Wmts_GetTile_ReturnsPngImage",
+        "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts.OgcClassicWmtsTests.Wmts_GetTile_StyledSeededPoint_RendersPixelAtFeatureLocationWithCorrectDimensions",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts.OgcClassicWmtsTests.Wmts_GetTile_UpperBoundTileMatrixSetLimit_ReturnsPng",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts.OgcClassicWmtsTests.Wmts_GetTile_WebMercatorQuad_StillReturnsPngImage",
         "Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts.OgcClassicWmtsTests.Wmts_GetTile_WorldCrs84Quad_ReturnsPngImage",
@@ -12141,6 +12154,13 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_CommunityEdition_DimensionAboveCommunityMax_ReturnsPaymentRequired",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_CommunityEdition_DimensionAtCommunityMax_ReturnsImage",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_CommunityEdition_HighDpi_ReturnsPaymentRequired",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_CommunityEdition_MarkersAboveCommunityLimit_ReturnsPaymentRequired",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_CommunityEdition_MarkersWithinCommunityLimit_ReturnsImage",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_CommunityEdition_PathAboveCommunityLimit_ReturnsPaymentRequired",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_CommunityEdition_PathWithinCommunityLimit_ReturnsImage",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ExceedsProMaxDimension_ReturnsBadRequest",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_IfNoneMatch_Returns304WhenUnmodified",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_InvalidCenter_ReturnsBadRequest",
@@ -12149,6 +12169,12 @@
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_Jpeg_ReturnsJpeg",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_Png_ReturnsImage",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ProEditionAllowsHighDpi_ReturnsImage",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ProEditionHighDpi_ScalesOutputResolution",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ProEdition_DimensionWithinEntitlementBand_ReturnsImage",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ProEdition_ExceedsHardCap_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ProEdition_MarkersAboveCommunityLimit_ReturnsImage",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ProEdition_MarkersExceedProHardCap_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ProEdition_PathAboveCommunityLimit_ReturnsImage",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_ReturnsETag",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_UnsupportedDpiFallsToDefault_ReturnsImage",
         "Honua.Server.Tests.Features.StaticMap.StaticMapEndpointTests.CenterZoom_Webp_ReturnsWebp",
@@ -12241,6 +12267,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerH3TileTests.H3Tile_InvalidCoords_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerH3TileTests.H3Tile_InvalidResolution_ReturnsBadRequest",
+        "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerH3TileTests.H3Tile_NonExistentLayer_ReturnsRealNotFound",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerH3TileTests.H3Tile_ValidCoords_ReturnsOkOrCapabilityError",
         "Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer.FeatureServerH3TileTests.H3Tile_WithExplicitResolution_ReturnsOkOrCapabilityError"
       ],
@@ -12258,6 +12285,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Infrastructure.LayerEnablementIntegrationTests.DisabledLayer_ReturnsNotFoundAcrossProtocols",
         "Honua.Server.Tests.Features.Protocols.Tiles.TileJsonEndpointTests.GetTileJson_FeatureServerProtocolDisabled_ReturnsNotFound",
+        "Honua.Server.Tests.Features.Protocols.Tiles.TileJsonEndpointTests.GetTileJson_NonExistentLayer_ReturnsRealNotFoundWithProblemJson",
         "Honua.Server.Tests.Features.Protocols.Tiles.TileJsonEndpointTests.GetTileJson_ReturnsTileJsonMetadata",
         "Honua.Server.Tests.Features.Protocols.Tiles.TileJsonEndpointTests.GetTileJson_ValidatesAgainstSchema"
       ],
@@ -16264,6 +16292,8 @@
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_EndpointOutsideCoverage_ReturnsNotFoundAndNotVisible",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_MissingCoordinates_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_ObserverEqualsTarget_ReturnsUnprocessableEntity",
+        "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_TargetBeyondRidgeRing_IsBlockedByIntervalRidge",
+        "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_TargetInsideRidgeRing_IsVisible",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_WithCoveredFlatTerrain_ReportsVisible",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_WithMixedResolutionMosaic_ReturnsActionableUnprocessableEntity"
       ],
@@ -16297,6 +16327,7 @@
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSunShadow_DaytimeSun_CastsShadowOverSurface",
+        "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSunShadow_KnownInput_MatchesIndependentlyComputedNoaaSolarPosition",
         "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSunShadow_MissingTimestamp_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSunShadow_SunBelowHorizon_ReportsNoShadow",
         "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSunShadow_WithoutProLicense_ReturnsPaymentRequired"
@@ -16315,6 +16346,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostViewshed_MissingObserver_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostViewshed_NonPositiveRadius_ReturnsUnprocessableEntity",
+        "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostViewshed_RidgeRingTerrain_OccludesFarSamplesButNotNearSamples",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostViewshed_WithCoveredFlatTerrain_ReturnsVisibleSamples"
       ],
       "proof_ledger_surface": "elevation-query-profile",
@@ -18238,10 +18270,12 @@
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_CellSizeBelowMinimum_ReturnsBadRequest",
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_DoesNotLeakInputCountIntoProperties",
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_HexGrid_ReturnsCellsWithCounts",
+        "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_HexGrid_TotalFeatureCountMatchesSeededPointCount",
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_InvalidMode_ReturnsBadRequest",
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_InvalidService_ReturnsNotFound",
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_MissingCellSize_ReturnsBadRequest",
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_SquareGrid_ReturnsCellsWithCounts",
+        "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_SquareGrid_ReturnsExactCellCountForSeededPoints",
         "Honua.Server.Tests.Features.SpatialAnalytics.SpatialAnalyticsRestTests.QueryDensity_WithTimeFilter_FlowsThroughTemporalBuilder"
       ],
       "proof_ledger_surface": "feature-server",

--- a/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
@@ -47,7 +47,16 @@ internal static class LayerValidationHelpers
     internal enum ValidationProtocol
     {
         OData,
-        OgcFeatures
+        OgcFeatures,
+
+        /// <summary>
+        /// RFC 7807 <c>application/problem+json</c> formatting with a real HTTP status
+        /// code, bypassing the path-classified <see cref="StandardErrorResponseFormatter"/>
+        /// (which treats every <c>/tiles</c> path as GeoServices and wraps errors in a
+        /// 200-envelope). Used by the tiles surface (tile.json / .mvt / h3 .mvt), which is
+        /// not an Esri protocol and must return real error status codes (honua-server#2945).
+        /// </summary>
+        ProblemJson
     }
 
     /// <summary>
@@ -104,6 +113,22 @@ internal static class LayerValidationHelpers
         };
     }
 
+    /// <summary>
+    /// Creates an RFC 7807 problem+json error response with the real HTTP status code,
+    /// independent of <see cref="StandardErrorResponseFormatter"/>'s path-based protocol
+    /// classification. See <see cref="ValidationProtocol.ProblemJson"/>.
+    /// </summary>
+    private static IResult CreateProblemJsonError(HttpContext context, string message, int statusCode)
+    {
+        var title = statusCode switch
+        {
+            StatusCodes.Status400BadRequest => "Bad Request",
+            StatusCodes.Status404NotFound => "Not Found",
+            _ => "Error"
+        };
+        return ProblemDetailsHelpers.CreateProblem(context, "about:blank", statusCode, title, message);
+    }
+
     // ---- Metadata v2 validation. Resolves a (publication, resource, service) triple
     // from the V2 graph snapshot for the given layer id (or collection id) and applies
     // the same access-policy + protocol-enablement checks as the v1 methods above.
@@ -134,6 +159,7 @@ internal static class LayerValidationHelpers
             {
                 ValidationProtocol.OData => CreateODataError(context, msg, StatusCodes.Status404NotFound),
                 ValidationProtocol.OgcFeatures => CreateOgcError(context, msg, StatusCodes.Status404NotFound),
+                ValidationProtocol.ProblemJson => CreateProblemJsonError(context, msg, StatusCodes.Status404NotFound),
                 _ => StandardErrorHelpers.CreateNotFound(context, msg),
             };
             return new MetadataV2ValidationResult(false, null, null, null, error);
@@ -159,6 +185,7 @@ internal static class LayerValidationHelpers
             {
                 ValidationProtocol.OData => CreateODataError(context, msg, StatusCodes.Status404NotFound),
                 ValidationProtocol.OgcFeatures => CreateOgcError(context, msg, StatusCodes.Status404NotFound),
+                ValidationProtocol.ProblemJson => CreateProblemJsonError(context, msg, StatusCodes.Status404NotFound),
                 _ => StandardErrorHelpers.CreateNotFound(context, msg),
             };
             return new MetadataV2ValidationResult(false, publication, resource, service, error);

--- a/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
+++ b/src/Honua.Hosting/Features/Validation/LayerValidationHelpers.cs
@@ -123,10 +123,42 @@ internal static class LayerValidationHelpers
         var title = statusCode switch
         {
             StatusCodes.Status400BadRequest => "Bad Request",
+            StatusCodes.Status401Unauthorized => "Unauthorized",
+            StatusCodes.Status403Forbidden => "Forbidden",
             StatusCodes.Status404NotFound => "Not Found",
             _ => "Error"
         };
         return ProblemDetailsHelpers.CreateProblem(context, "about:blank", statusCode, title, message);
+    }
+
+    /// <summary>
+    /// Evaluates resource access and formats a denial as RFC 7807 problem+json with the
+    /// real 401/403 status, bypassing <see cref="AccessPolicyHelpers.RequireResourceAccessAsync(HttpContext, MetadataV2Resource, MetadataV2Service?, AccessScope, CancellationToken)"/>'s
+    /// use of <see cref="StandardErrorHelpers"/> (which the path-classified
+    /// <see cref="StandardErrorResponseFormatter"/> would otherwise wrap as a GeoServices
+    /// 200-envelope for <c>/tiles</c> paths). See <see cref="ValidationProtocol.ProblemJson"/>.
+    /// </summary>
+    private static async Task<IResult?> RequireResourceAccessAsProblemJsonAsync(
+        HttpContext context,
+        MetadataV2Resource resource,
+        MetadataV2Service? service,
+        AccessScope scope,
+        CancellationToken cancellationToken)
+    {
+        var decision = await AccessPolicyHelpers.EvaluateResourceAccessAsync(
+            context,
+            resource,
+            service,
+            AccessPolicyHelpers.DefaultOperationForScope(scope),
+            cancellationToken).ConfigureAwait(false);
+        if (decision.IsAllowed)
+        {
+            return null;
+        }
+
+        return decision.RequiresAuthentication
+            ? CreateProblemJsonError(context, AccessPolicyHelpers.AuthRequiredMessage, StatusCodes.Status401Unauthorized)
+            : CreateProblemJsonError(context, AccessPolicyHelpers.AccessForbiddenMessage, StatusCodes.Status403Forbidden);
     }
 
     // ---- Metadata v2 validation. Resolves a (publication, resource, service) triple
@@ -170,8 +202,15 @@ internal static class LayerValidationHelpers
         // validator is the enforcement point for OData / OGC API Features / WFS /
         // tiles / STAC layer reads & mutations, so wiring it here re-routes those
         // adapters through the resolver consistently.
-        var accessError = await AccessPolicyHelpers.RequireResourceAccessAsync(
-            context, resource, service, scope, effectiveToken).ConfigureAwait(false);
+        // /tiles' ProblemJson opt-in must also govern authorization failures, not just
+        // not-found: AccessPolicyHelpers.RequireResourceAccessAsync formats denials via
+        // StandardErrorHelpers, which the path-classified StandardErrorResponseFormatter
+        // would otherwise wrap as a GeoServices 200-envelope for /tiles (honua-server#2945
+        // review). Evaluate the decision directly and format it as problem+json here.
+        var accessError = protocol == ValidationProtocol.ProblemJson
+            ? await RequireResourceAccessAsProblemJsonAsync(context, resource, service, scope, effectiveToken).ConfigureAwait(false)
+            : await AccessPolicyHelpers.RequireResourceAccessAsync(
+                context, resource, service, scope, effectiveToken).ConfigureAwait(false);
         if (accessError != null)
         {
             return new MetadataV2ValidationResult(false, publication, resource, service, accessError);

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.H3.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.H3.cs
@@ -358,10 +358,14 @@ internal static partial class FeatureServerEndpoints
 
         activity?.SetTag("h3.resolution", resolution);
 
-        // Validate layer access before checking server capabilities
+        // Validate layer access before checking server capabilities. /tiles is not an Esri
+        // protocol surface (honua-server#2945): layer-not-found must be a real HTTP 404 with
+        // a problem+json body, not the GeoServices 200-envelope path-based classification
+        // would otherwise apply to any /tiles/* route.
         var layerValidation = await LayerValidationHelpers.ValidateLayerWithAccessV2Async(
             context,
             layerId,
+            LayerValidationHelpers.ValidationProtocol.ProblemJson,
             requiredProtocol: FeatureServerProtocolName,
             cancellationToken: cancellationToken);
         if (!layerValidation.IsValid)
@@ -378,8 +382,11 @@ internal static partial class FeatureServerEndpoints
             ?? snapshot.ResolveStorageLayerId(resource);
         if (storageLayerId is null)
         {
-            return StandardErrorHelpers.CreateNotFound(
+            return ProblemDetailsHelpers.CreateProblem(
                 context,
+                "about:blank",
+                StatusCodes.Status404NotFound,
+                "Not Found",
                 $"Layer '{resource.Metadata.Name ?? layerId.ToString(CultureInfo.InvariantCulture)}' is not bound to a storage layer.");
         }
 

--- a/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Tiles.cs
+++ b/src/Honua.Protocols.GeoServices/FeatureServer/FeatureServerRequestHandlers.Tiles.cs
@@ -55,9 +55,13 @@ internal static partial class FeatureServerEndpoints
                 $"Invalid tile coordinates: x={x}, y={y}, z={z}");
         }
 
+        // /tiles is not an Esri protocol surface: unlike GeoServices /rest, layer-not-found
+        // must be a real HTTP 404 with a problem+json body, not a 200-wrapped GeoServices
+        // error envelope (honua-server#2945).
         var layerValidation = await LayerValidationHelpers.ValidateLayerWithAccessV2Async(
             context,
             layerId,
+            LayerValidationHelpers.ValidationProtocol.ProblemJson,
             requiredProtocol: FeatureServerProtocolName,
             cancellationToken: cancellationToken);
         if (!layerValidation.IsValid)
@@ -76,8 +80,13 @@ internal static partial class FeatureServerEndpoints
         var storageLayerId = publication.LayerIndex ?? snapshot.ResolveStorageLayerId(publication);
         if (storageLayerId is null)
         {
-            return StandardErrorHelpers.CreateNotFound(
+            // /tiles is not an Esri protocol surface (honua-server#2945): a real 404, not
+            // the GeoServices 200-envelope that path-based classification would otherwise apply.
+            return ProblemDetailsHelpers.CreateProblem(
                 context,
+                "about:blank",
+                StatusCodes.Status404NotFound,
+                "Not Found",
                 $"Layer '{resource.Metadata.Name ?? layerId.ToString(System.Globalization.CultureInfo.InvariantCulture)}' is not bound to a storage layer.");
         }
 

--- a/src/Honua.Server/Features/Protocols/Tiles/TileJsonEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Tiles/TileJsonEndpoints.cs
@@ -48,9 +48,13 @@ internal static class TileJsonEndpoints
         [FromServices] IOptions<LimitsOptions> limitsOptions,
         CancellationToken cancellationToken)
     {
+        // Tiles is not an Esri protocol surface: unlike GeoServices /rest, layer-not-found
+        // must be a real HTTP 404 with a problem+json body, not a 200-wrapped GeoServices
+        // error envelope (honua-server#2945).
         var layerValidation = await LayerValidationHelpers.ValidateLayerWithAccessV2Async(
             context,
             layerId,
+            LayerValidationHelpers.ValidationProtocol.ProblemJson,
             requiredProtocol: FeatureServerProtocolName,
             cancellationToken: cancellationToken);
         if (!layerValidation.IsValid)

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerH3TileTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerH3TileTests.cs
@@ -77,4 +77,18 @@ public sealed class FeatureServerH3TileTests : IClassFixture<WebAppFixture>
         // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /tiles/{layerId}/h3/{z}/{x}/{y}.mvt")]
+    public async Task H3Tile_NonExistentLayer_ReturnsRealNotFound()
+    {
+        // Regression test for honua-server#2945: /tiles is not an Esri protocol surface,
+        // so layer-not-found must be a real HTTP 404 + problem+json, not the GeoServices
+        // 200-envelope.
+        var response = await _fixture.Client.GetAsync("/tiles/999999/h3/5/16/11.mvt");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+    }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryDateBinsTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/FeatureServerQueryDateBinsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -107,6 +108,98 @@ public sealed class FeatureServerQueryDateBinsTests : IClassFixture<FeatureServe
 
         // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryDateBins)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryDateBins")]
+    public async Task QueryDateBins_MonthCalendarBin_ReturnsExactBucketCounts()
+    {
+        // Regression for honua-server#2945: previous proving tests only checked that
+        // "features" is a JSON array, never that the bucket counts reflect the seeded
+        // timestamps. tests/seed/server.yaml layer 0 has 5 features with `timestamp`:
+        //   2022-12-31T23:00:00Z (objectid 4)             -> 2022-12 bucket
+        //   2023-01-02T00:00:00Z, 2023-01-05T12:00:00Z,
+        //   2023-01-20T00:00:00Z (objectids 1, 2, 5)       -> 2023-01 bucket (count 3)
+        //   2023-02-10T00:00:00Z (objectid 3, NULL geometry) -> 2023-02 bucket
+        // queryDateBins groups on the raw timestamp attribute with no geometry filter,
+        // so the NULL-geometry feature (objectid 3) still counts.
+        var bin = JsonSerializer.Serialize(new { calendarBin = new { unit = "month" } });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryDateBins?binField=timestamp&bin={Uri.EscapeDataString(bin)}&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var features = document.RootElement.GetProperty("features");
+
+        var countsByMonth = ExtractCountsByYearMonth(features);
+
+        countsByMonth.Should().BeEquivalentTo(new Dictionary<string, long>
+        {
+            ["2022-12"] = 1,
+            ["2023-01"] = 3,
+            ["2023-02"] = 1,
+        });
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryDateBins)]
+    [Endpoint("GET /rest/services/{serviceId}/FeatureServer/{layerId}/queryDateBins")]
+    public async Task QueryDateBins_YearCalendarBin_ReturnsExactBucketCounts()
+    {
+        var bin = JsonSerializer.Serialize(new { calendarBin = new { unit = "year" } });
+
+        var response = await _fixture.Client.GetAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryDateBins?binField=timestamp&bin={Uri.EscapeDataString(bin)}&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(content);
+        var features = document.RootElement.GetProperty("features");
+
+        var countsByYear = ExtractCountsByYearMonth(features, yearOnly: true);
+
+        countsByYear.Should().BeEquivalentTo(new Dictionary<string, long>
+        {
+            ["2022"] = 1,
+            ["2023"] = 4,
+        });
+    }
+
+    /// <summary>
+    /// Groups queryDateBins response features by the "boundary" attribute's year (or
+    /// year-month), keyed off the "count" attribute. Tolerates the "boundary" value being
+    /// serialized either as an ISO-8601 string or an epoch-millisecond number, since the
+    /// wire representation of a boxed <c>DateTime</c>/<c>DateTimeOffset</c> attribute value
+    /// is an internal serialization detail this test should not hard-code.
+    /// </summary>
+    private static Dictionary<string, long> ExtractCountsByYearMonth(JsonElement features, bool yearOnly = false)
+    {
+        var result = new Dictionary<string, long>();
+        foreach (var feature in features.EnumerateArray())
+        {
+            var attributes = feature.GetProperty("attributes");
+            var boundary = attributes.GetProperty("boundary");
+            var count = attributes.GetProperty("count").GetInt64();
+
+            var timestamp = boundary.ValueKind switch
+            {
+                JsonValueKind.String => DateTimeOffset.Parse(boundary.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                JsonValueKind.Number => DateTimeOffset.FromUnixTimeMilliseconds(boundary.GetInt64()),
+                _ => throw new InvalidOperationException($"Unexpected boundary value kind: {boundary.ValueKind}")
+            };
+
+            var key = yearOnly
+                ? timestamp.Year.ToString(CultureInfo.InvariantCulture)
+                : timestamp.ToString("yyyy-MM", CultureInfo.InvariantCulture);
+            result[key] = count;
+        }
+
+        return result;
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileEndpointTests.cs
@@ -82,8 +82,9 @@ public class MvtTileEndpointTests : IClassFixture<WebAppFixture>
         var response = await _fixture.Client.GetAsync("/tiles/99999/1/0/0.mvt");
 
         // Assert
-        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // honua-server#2945: /tiles is not an Esri protocol surface; layer-not-found is
+        // a real HTTP 404 + problem+json, not the GeoServices 200-envelope.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
@@ -128,23 +128,24 @@ public class MvtTileErrorHandlingTests : IClassFixture<WebAppFixture>
     }
 
     [Fact]
-    public async Task GetTile_NonExistentLayer_ReturnsGeoServicesNotFoundError()
+    public async Task GetTile_NonExistentLayer_ReturnsRealNotFoundWithProblemJson()
     {
         // Act
         var response = await _fixture.Client.GetAsync("/tiles/99999/1/0/0.mvt");
 
         // Assert
-        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // honua-server#2945: /tiles is not an Esri protocol surface, so unlike
+        // /rest/services it must return a real HTTP 404 with an RFC 7807
+        // problem+json body rather than the GeoServices 200-envelope.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
 
         var content = await response.Content.ReadAsStringAsync();
-        var error = JsonSerializer.Deserialize<ApiErrorResponse>(content);
+        var problem = JsonSerializer.Deserialize<JsonElement>(content);
 
-        error.Should().NotBeNull();
-        error!.Error.Code.Should().Be(404);
-        error.Error.Message.Should().Be("Not Found");
-        error.Error.Details.Should().NotBeNull();
-        error.Error.Details.Should().Contain(detail => detail.Contains("Layer 99999 not found"));
+        problem.GetProperty("title").GetString().Should().Be("Not Found");
+        problem.GetProperty("status").GetInt32().Should().Be(404);
+        problem.GetProperty("detail").GetString().Should().Contain("Layer 99999 not found");
     }
 
     [Fact]
@@ -154,40 +155,35 @@ public class MvtTileErrorHandlingTests : IClassFixture<WebAppFixture>
         var response = await _fixture.Client.GetAsync("/tiles/99999/1/0/0.mvt");
 
         // Assert
-        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
 
-        // Should include correlation ID header for request tracing
+        // Should include correlation ID header for request tracing regardless of
+        // the response body format (added by the shared correlation-id middleware).
         response.Headers.Should().ContainKey("X-Correlation-ID");
         var correlationId = response.Headers.GetValues("X-Correlation-ID").First();
         correlationId.Should().NotBeNullOrEmpty();
     }
 
     [Fact]
-    public async Task GetTile_ErrorResponseFormat_ConsistentWithOtherFeatureServerEndpoints()
+    public async Task GetTile_ErrorResponseFormat_DivergesFromGeoServicesRestByDesign()
     {
-        // Act - Get error from MVT endpoint
+        // honua-server#2945: the /tiles surface is a real HTTP-status protocol, not an
+        // Esri GeoServices surface, so its 404 must NOT match the GeoServices REST
+        // 200-envelope shape — this test locks in the intentional divergence (the
+        // opposite of the old "ConsistentWith..." assertion this replaces).
+
+        // Act - Get error from MVT endpoint (tiles surface)
         var mvtResponse = await _fixture.Client.GetAsync("/tiles/99999/1/0/0.mvt");
 
-        // Act - Get error from FeatureServer query endpoint for comparison
+        // Act - Get error from FeatureServer query endpoint (GeoServices REST surface)
         var queryResponse = await _fixture.Client.GetAsync("/rest/services/99999/FeatureServer/0/query");
 
-        // Assert - Both should return the same error response format
-        await mvtResponse.AssertGeoServicesErrorAsync(404);
+        // Assert - the tiles surface returns a real 404 problem+json response...
+        mvtResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        mvtResponse.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        // ...while the GeoServices REST surface keeps its 200-wrapped error envelope.
         await queryResponse.AssertGeoServicesErrorAsync(404);
-
-        var mvtContent = await mvtResponse.Content.ReadAsStringAsync();
-        var queryContent = await queryResponse.Content.ReadAsStringAsync();
-
-        var mvtError = JsonSerializer.Deserialize<ApiErrorResponse>(mvtContent);
-        var queryError = JsonSerializer.Deserialize<ApiErrorResponse>(queryContent);
-
-        // Both should use the same error response structure
-        mvtError.Should().NotBeNull();
-        queryError.Should().NotBeNull();
-
-        mvtError!.Error.Code.Should().Be(queryError!.Error.Code);
-        mvtError.Error.Should().BeEquivalentTo(queryError.Error, options =>
-            options.Excluding(e => e.Message).Excluding(e => e.Details)); // Message content may differ
+        queryResponse.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileErrorHandlingTests.cs
@@ -4,11 +4,13 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Honua.Core.Features.Security.Domain;
 using Honua.Infrastructure.Models;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
 using Honua.TestKit.Extensions;
+using Honua.TestKit.Helpers;
 
 namespace Honua.Server.Tests.Features.Protocols.GeoServices.FeatureServer;
 
@@ -185,5 +187,53 @@ public class MvtTileErrorHandlingTests : IClassFixture<WebAppFixture>
         // ...while the GeoServices REST surface keeps its 200-wrapped error envelope.
         await queryResponse.AssertGeoServicesErrorAsync(404);
         queryResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetTile_AnonymousOnAuthRequiredLayer_ReturnsRealUnauthorizedWithProblemJson()
+    {
+        // honua-server#2960 review: the ProblemJson opt-in must also govern
+        // authorization failures, not just layer-not-found — an unauthenticated
+        // request against a layer that requires authentication must get a real
+        // HTTP 401 problem+json response, not the GeoServices 200-envelope that
+        // path-based classification would otherwise apply to /tiles.
+        using var factory = ServiceRbacTestFixture.CreateFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync(
+            $"/tiles/{ServiceRbacTestFixture.AlphaLayerId}/1/0/0.mvt");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var problem = JsonSerializer.Deserialize<JsonElement>(content);
+
+        problem.GetProperty("title").GetString().Should().Be("Unauthorized");
+        problem.GetProperty("status").GetInt32().Should().Be(401);
+    }
+
+    [Fact]
+    public async Task GetTile_AuthenticatedWithoutRequiredRole_ReturnsRealForbiddenWithProblemJson()
+    {
+        // honua-server#2960 review: a role-denied (but authenticated) request
+        // must also bypass the GeoServices envelope on /tiles and get a real
+        // HTTP 403 problem+json response.
+        using var factory = ServiceRbacTestFixture.CreateFactory(
+            layerCatalogFactory: static () => new RbacTestLayerCatalog(
+                alphaLayerMetadata: new AccessPolicy { AllowedRoles = ["editor"] }));
+        using var client = ServiceRbacTestFixture.CreateClient(factory, "reader");
+
+        var response = await client.GetAsync(
+            $"/tiles/{ServiceRbacTestFixture.AlphaLayerId}/1/0/0.mvt");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var problem = JsonSerializer.Deserialize<JsonElement>(content);
+
+        problem.GetProperty("title").GetString().Should().Be("Forbidden");
+        problem.GetProperty("status").GetInt32().Should().Be(403);
     }
 }

--- a/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileTemporalEndpointTests.cs
+++ b/tests/dotnet/Honua.Protocols.GeoServices.Tests/Source/FeatureServer/MvtTileTemporalEndpointTests.cs
@@ -148,8 +148,9 @@ public sealed class MvtTileTemporalEndpointTests : IAsyncLifetime
         var response = await _fixture.Client.GetAsync(
             $"/tiles/9999/1/0/0.mvt?time={start},{end}");
 
-        // PA-070/PA-117: GeoServices always returns HTTP 200; error code is in the JSON body.
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // honua-server#2945: /tiles is not an Esri protocol surface; layer-not-found is
+        // a real HTTP 404 + problem+json, not the GeoServices 200-envelope.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wms/OgcClassicWmsTests.cs
@@ -5,9 +5,12 @@ using System.Net;
 using System.Security.Cryptography;
 using FluentAssertions;
 using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Styling.Abstractions;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
 using Npgsql;
 using SkiaSharp;
 using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
@@ -830,5 +833,79 @@ public sealed class OgcClassicWmsTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.OK, $"Response body: {System.Text.Encoding.UTF8.GetString(content)}");
         response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
         content.Length.Should().BeGreaterThan(0);
+    }
+
+    // honua-server#2945: GetMap proving tests above only assert content-type/length; none
+    // exercised actual rendered pixel content. This binds a deterministic style to the
+    // seeded point layer and asserts a matching pixel appears at the feature's real-world
+    // location, plus that the response has the exact requested pixel dimensions.
+    [IntegrationTest]
+    [Operation(Operations.Wms)]
+    [InterfaceOperation(TestProtocols.Wms13, "GetMap")]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMS")]
+    public async Task Wms_GetMap_StyledSeededPoint_RendersPixelAtFeatureLocationWithCorrectDimensions()
+    {
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var catalog = fixture.GetService<ILayerStyleCatalog>();
+            await catalog.SetMapLibreStyleAsync(WebAppFixture.TestLayerId, CircleStyleJson("#ff0000"));
+
+            // Tight bbox around the seeded point at (lon=-122.5, lat=37.5) (tests/seed/server.yaml).
+            // WMS 1.3.0 + EPSG:4326 uses (lat,lon) axis order.
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMS?SERVICE=WMS&REQUEST=GetMap&VERSION=1.3.0&BBOX=37.4,-122.6,37.6,-122.4&WIDTH=256&HEIGHT=256&CRS=EPSG:4326&LAYERS={WebAppFixture.TestLayerId}&STYLES=&FORMAT=image/png");
+
+            var content = await response.Content.ReadAsByteArrayAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"Response body: {System.Text.Encoding.UTF8.GetString(content)}");
+            response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+
+            using var bitmap = SKBitmap.Decode(content);
+            bitmap.Should().NotBeNull();
+            bitmap!.Width.Should().Be(256);
+            bitmap.Height.Should().Be(256);
+
+            HasRedPixel(bitmap).Should().BeTrue(
+                "the styled point feature must be rendered at its seeded real-world location, not just produce a non-empty image");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    private static string CircleStyleJson(string hexColor) =>
+        $$"""
+        {
+          "version": 8,
+          "sources": {},
+          "layers": [
+            {
+              "id": "points",
+              "type": "circle",
+              "source": "features",
+              "paint": { "circle-color": "{{hexColor}}", "circle-radius": 12 }
+            }
+          ]
+        }
+        """;
+
+    private static bool HasRedPixel(SKBitmap bitmap)
+    {
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                if (pixel.Red > 150 && pixel.Green < 80 && pixel.Blue < 80)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/OgcClassicWmtsTests.cs
+++ b/tests/dotnet/Honua.Protocols.OgcClassic.Tests/Source/Wmts/OgcClassicWmtsTests.cs
@@ -5,14 +5,18 @@ using System.Net;
 using System.Text.Json;
 using System.Xml.Linq;
 using FluentAssertions;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Core.Features.Metadata.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Styling.Abstractions;
 using Honua.TestKit.Infrastructure;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Honua.TestKit.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using SkiaSharp;
 
 namespace Honua.Server.Tests.Features.Protocols.Ogc.Classic.Wmts;
 
@@ -879,5 +883,78 @@ public sealed class OgcClassicWmtsTests : IAsyncLifetime
         var content = await response.Content.ReadAsStringAsync();
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest, content);
         content.Should().Contain("exceptionCode=\"InvalidParameterValue\"");
+    }
+
+    // honua-server#2945: GetTile proving tests above only assert content-type/length; none
+    // exercised actual rendered tile content. This binds a deterministic style to the
+    // seeded point layer and asserts a matching pixel appears in the WebMercatorQuad z=0
+    // tile (a single tile spanning the whole globe, so it always contains the seeded point),
+    // plus that the decoded tile has the expected pixel dimensions.
+    [IntegrationTest]
+    [Operation(Operations.Wmts)]
+    [Endpoint("GET /rest/services/{serviceId}/MapServer/WMTS")]
+    [InterfaceOperation(TestProtocols.Wmts10, "GetTile")]
+    public async Task Wmts_GetTile_StyledSeededPoint_RendersPixelAtFeatureLocationWithCorrectDimensions()
+    {
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var catalog = fixture.GetService<ILayerStyleCatalog>();
+            await catalog.SetMapLibreStyleAsync(WebAppFixture.TestLayerId, CircleStyleJson("#ff0000"));
+
+            var response = await fixture.Client.GetAsync(
+                $"/rest/services/{WebAppFixture.TestServiceId}/MapServer/WMTS?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER={WebAppFixture.TestLayerId}&STYLE=default&FORMAT=image/png&TILEMATRIXSET=WebMercatorQuad&TILEMATRIX=0&TILEROW=0&TILECOL=0");
+
+            var content = await response.Content.ReadAsByteArrayAsync();
+            response.StatusCode.Should().Be(HttpStatusCode.OK, $"Response body: {System.Text.Encoding.UTF8.GetString(content)}");
+            response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+
+            using var bitmap = SKBitmap.Decode(content);
+            bitmap.Should().NotBeNull();
+            bitmap!.Width.Should().Be(256);
+            bitmap.Height.Should().Be(256);
+
+            HasRedPixel(bitmap).Should().BeTrue(
+                "the styled point feature must be rendered at its seeded real-world location within the tile, not just produce a non-empty image");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    private static string CircleStyleJson(string hexColor) =>
+        $$"""
+        {
+          "version": 8,
+          "sources": {},
+          "layers": [
+            {
+              "id": "points",
+              "type": "circle",
+              "source": "features",
+              "paint": { "circle-color": "{{hexColor}}", "circle-radius": 12 }
+            }
+          ]
+        }
+        """;
+
+    private static bool HasRedPixel(SKBitmap bitmap)
+    {
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                var pixel = bitmap.GetPixel(x, y);
+                if (pixel.Red > 150 && pixel.Green < 80 && pixel.Blue < 80)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/OidcJwtBearerValidationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/OidcJwtBearerValidationTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using FluentAssertions;
+using Honua.Infrastructure.Authentication;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Honua.Server.Tests.Features.Admin;
+
+/// <summary>
+/// End-to-end OIDC bearer-token validation (honua-server#2945). Every previous "proving" test
+/// for identity.oidc only exercised CRUD on <c>InMemoryOidcProviderStore</c> — no test signed a
+/// real JWT or drove it through the actual JwtBearer pipeline, so a broken/no-op validator would
+/// ship undetected. This stands up a fake in-process IdP (WireMock discovery document + JWKS
+/// endpoint, RSA-signed tokens) and drives real bearer tokens through a protected admin endpoint
+/// (<c>GET /api/v1/admin/oidc/providers</c>, gated by <c>AuthenticationExtensions.AdminPolicy</c>,
+/// which <see cref="Honua.Infrastructure.Authentication.OidcAuthenticationExtensions.AddOidcAuthorization"/>
+/// extends to accept the Composite/JwtBearer scheme once OIDC is enabled) to prove accept-valid /
+/// reject-expired / reject-wrong-issuer / reject-wrong-audience / reject-tampered-signature.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.IdentityManagement)]
+public sealed class OidcJwtBearerValidationTests : IAsyncLifetime
+{
+    private const string ClientId = "test-client";
+    private const string AdminRoute = "/api/v1/admin/oidc/providers";
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly RsaSecurityKey _signingKey;
+    private readonly WireMockServer _idp;
+    private readonly string _issuer;
+    private readonly WebAppFixture _fixture;
+
+    public OidcJwtBearerValidationTests()
+    {
+        _signingKey = new RsaSecurityKey(_rsa) { KeyId = "test-key-1" };
+
+        _idp = WireMockServer.Start();
+        _issuer = _idp.Urls[0];
+
+        _idp.Given(Request.Create().WithPath("/.well-known/openid-configuration").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""
+                {
+                  "issuer": "{{_issuer}}",
+                  "jwks_uri": "{{_issuer}}/jwks",
+                  "authorization_endpoint": "{{_issuer}}/authorize",
+                  "token_endpoint": "{{_issuer}}/token",
+                  "response_types_supported": ["code"],
+                  "subject_types_supported": ["public"],
+                  "id_token_signing_alg_values_supported": ["RS256"]
+                }
+                """));
+
+        _idp.Given(Request.Create().WithPath("/jwks").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(BuildJwksJson()));
+
+        _fixture = new WebAppFixture()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                // Point the real JwtBearer pipeline at the fake IdP: discovery + JWKS come from
+                // WireMock, so signature/issuer/audience/expiry validation runs against real
+                // RSA-signed tokens rather than a stub.
+                builder.UseSetting("Oidc:Enabled", "true");
+                builder.UseSetting("Oidc:RequireHttps", "false");
+                builder.UseSetting("Oidc:Generic:Enabled", "true");
+                builder.UseSetting("Oidc:Generic:Authority", _issuer);
+                builder.UseSetting("Oidc:Generic:ClientId", ClientId);
+            })
+            .ConfigureServices(services =>
+            {
+                // OidcAuthenticationOptionsValidator hard-fails startup unless Authority is
+                // HTTPS (a real production hardening rule). This test intentionally exercises
+                // the JwtBearer trust chain (issuer/audience/expiry/signature) against a
+                // lightweight in-process fake IdP over plain HTTP, so the production validator
+                // is removed here — the JWT validation logic under test is untouched.
+                services.RemoveAll<IValidateOptions<OidcAuthenticationOptions>>();
+            });
+    }
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+        _idp.Stop();
+        _rsa.Dispose();
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/oidc/providers")]
+    public async Task AdminEndpoint_ValidJwt_IsAccepted()
+    {
+        // Assert on the authentication/authorization boundary these tests exist to prove
+        // (401 = the JwtBearer trust chain rejected the token) rather than a literal 200:
+        // AdminPolicy's role assertion is a separate RBAC concern from token *validity*, and
+        // 403 here (reached only for an authenticated principal) already proves the token's
+        // signature/issuer/audience/expiry were all accepted by the real JwtBearer pipeline —
+        // exactly what "accept-valid" needs to demonstrate, without conflating it with the
+        // (correctly independent) admin-role authorization gate.
+        var response = await SendWithTokenAsync(CreateToken());
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized,
+            "a correctly signed, non-expired token with the right issuer/audience must be accepted by the JwtBearer pipeline. Body: {0}", body);
+        response.StatusCode.Should().BeOneOf(
+            [HttpStatusCode.OK, HttpStatusCode.Forbidden],
+            "the request must reach authorization (not fail at authentication) for a fully valid token. Body: {0}", body);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/oidc/providers")]
+    public async Task AdminEndpoint_ExpiredJwt_IsRejected()
+    {
+        var token = CreateToken(
+            notBefore: DateTime.UtcNow.AddMinutes(-20),
+            expires: DateTime.UtcNow.AddMinutes(-10));
+
+        var response = await SendWithTokenAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "an expired token must be rejected even though its signature/issuer/audience are valid");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/oidc/providers")]
+    public async Task AdminEndpoint_WrongIssuer_IsRejected()
+    {
+        // Still signed with the fake IdP's real key, but claims an issuer the server never
+        // configured as valid — proves issuer validation is enforced, not merely signature checks.
+        var token = CreateToken(issuer: "https://not-the-configured-idp.example.com");
+
+        var response = await SendWithTokenAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "a token from an unrecognized issuer must be rejected");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/oidc/providers")]
+    public async Task AdminEndpoint_WrongAudience_IsRejected()
+    {
+        var token = CreateToken(audience: "some-other-client-id");
+
+        var response = await SendWithTokenAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "a token issued for a different audience/client must be rejected");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/oidc/providers")]
+    public async Task AdminEndpoint_TamperedSignature_IsRejected()
+    {
+        var token = CreateToken(tamperSignature: true);
+
+        var response = await SendWithTokenAsync(token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "a token whose signature bytes were altered after signing must fail signature validation");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/oidc/providers")]
+    public async Task AdminEndpoint_NoToken_IsRejected()
+    {
+        var response = await _fixture.Client.GetAsync(AdminRoute);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "an unauthenticated request must not reach the admin endpoint");
+    }
+
+    private async Task<HttpResponseMessage> SendWithTokenAsync(string token)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, AdminRoute);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await _fixture.Client.SendAsync(request);
+    }
+
+    /// <summary>
+    /// Mints an RSA-signed JWT. Defaults describe a fully valid token (correct issuer/audience,
+    /// live validity window, real signature, an "admin" role claim so accept-valid isolates JWT
+    /// trust-chain validation from the separate role/authorization check) — callers override only
+    /// the dimension under test.
+    /// </summary>
+    private string CreateToken(
+        string? issuer = null,
+        string? audience = null,
+        DateTime? notBefore = null,
+        DateTime? expires = null,
+        bool tamperSignature = false)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, "test-user-1"),
+            // Emitted under both the configured Oidc:ClaimsMapping:RoleClaimType ("roles")
+            // and the canonical ClaimTypes.Role URI so the admin-policy role check passes
+            // regardless of which claim type name the validated identity's RoleClaimType
+            // ends up using — the dimension these tests isolate is JWT trust-chain
+            // validation (signature/issuer/audience/expiry), not role-claim mapping.
+            new("roles", "admin"),
+            new(ClaimTypes.Role, "admin"),
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: issuer ?? _issuer,
+            audience: audience ?? ClientId,
+            claims: claims,
+            notBefore: notBefore ?? DateTime.UtcNow.AddMinutes(-5),
+            expires: expires ?? DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256));
+
+        var jwt = handler.WriteToken(token);
+
+        if (!tamperSignature)
+        {
+            return jwt;
+        }
+
+        var segments = jwt.Split('.');
+        var signatureBytes = Base64UrlEncoder.DecodeBytes(segments[2]);
+        signatureBytes[0] ^= 0xFF;
+        segments[2] = Base64UrlEncoder.Encode(signatureBytes);
+        return string.Join('.', segments);
+    }
+
+    private string BuildJwksJson()
+    {
+        var parameters = _rsa.ExportParameters(false);
+        var modulus = Base64UrlEncoder.Encode(parameters.Modulus);
+        var exponent = Base64UrlEncoder.Encode(parameters.Exponent);
+
+        return $$"""
+        {
+          "keys": [
+            {
+              "kty": "RSA",
+              "use": "sig",
+              "kid": "{{_signingKey.KeyId}}",
+              "alg": "RS256",
+              "n": "{{modulus}}",
+              "e": "{{exponent}}"
+            }
+          ]
+        }
+        """;
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Alerts/DefaultAlertEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Alerts/DefaultAlertEvaluatorTests.cs
@@ -55,7 +55,326 @@ public sealed class DefaultAlertEvaluatorTests
         result.UpdatedState!.Inside.Should().BeTrue();
     }
 
-    private static AlertRuleDefinition CreateRule(AlertTriggerType triggerType) =>
+    // ---- Threshold trigger: fires only on the below->above (Started) and
+    // above->below (Ended/"threshold_resolved") transition edges; re-evaluating
+    // while already breached must NOT re-fire (honua-server#2945).
+
+    [UnitTest]
+    public async Task EvaluateAsync_ThresholdRule_BelowToAboveTransition_EmitsStartedEvent()
+    {
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Threshold, conditionsJson: """{"field":"speed","operator":">","value":50}""");
+        var feature = CreateFeatureWithAttributes(100, ("speed", 65.0));
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt),
+            feature,
+            rule,
+            zone: null,
+            currentState: null,
+            evaluatedAt);
+
+        result.Events.Should().ContainSingle();
+        var evt = result.Events[0];
+        evt.TriggerType.Should().Be(AlertTriggerType.Threshold);
+        evt.IncidentStatus.Should().Be(AlertIncidentStatus.Started);
+        evt.IncidentDurationMs.Should().Be(0);
+        evt.PayloadJson.Should().Contain("\"transition\":\"threshold\"");
+        result.UpdatedState!.ThresholdStateJson.Should().Contain("\"breached\":true");
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_ThresholdRule_StaysAboveOnSubsequentEvaluation_DoesNotReFire()
+    {
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Threshold, conditionsJson: """{"field":"speed","operator":">","value":50}""");
+        var feature = CreateFeatureWithAttributes(100, ("speed", 70.0));
+        var breachedSince = evaluatedAt.AddMinutes(-10);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = false,
+            LastAlertAt = breachedSince,
+            LastGeneration = 1,
+            ThresholdStateJson = $$"""{"breached":true,"breachedSince":"{{breachedSince:O}}"}"""
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt, generation: 2),
+            feature,
+            rule,
+            zone: null,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().BeEmpty("a rule already breached must not re-fire on every evaluation");
+        result.UpdatedState!.ThresholdStateJson.Should().Contain("\"breached\":true");
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_ThresholdRule_AboveToBelowTransition_EmitsResolvedEventWithDuration()
+    {
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Threshold, conditionsJson: """{"field":"speed","operator":">","value":50}""");
+        var feature = CreateFeatureWithAttributes(100, ("speed", 10.0));
+        var breachedSince = evaluatedAt.AddMinutes(-10);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = false,
+            LastAlertAt = breachedSince,
+            LastGeneration = 1,
+            ThresholdStateJson = $$"""{"breached":true,"breachedSince":"{{breachedSince:O}}"}"""
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt, generation: 2),
+            feature,
+            rule,
+            zone: null,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().ContainSingle();
+        var evt = result.Events[0];
+        evt.IncidentStatus.Should().Be(AlertIncidentStatus.Ended);
+        evt.PayloadJson.Should().Contain("\"transition\":\"threshold_resolved\"");
+        ((double)evt.IncidentDurationMs).Should().BeApproximately(
+            (evaluatedAt - breachedSince).TotalMilliseconds, 1000);
+        result.UpdatedState!.ThresholdStateJson.Should().Contain("\"breached\":false");
+    }
+
+    // ---- Dwell trigger: fires once elapsed time inside >= dwellSeconds, and
+    // (unlike Threshold) keeps firing on every subsequent evaluation once the
+    // cooldown elapses (an "Ongoing" incident, not a single edge).
+
+    [UnitTest]
+    public async Task EvaluateAsync_DwellRule_InsideBelowDwellDuration_DoesNotEmitEvent()
+    {
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Dwell, conditionsJson: """{"dwellSeconds":300}""");
+        var zone = CreateZone();
+        var feature = CreateFeature(100);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = true,
+            EnteredAt = evaluatedAt.AddSeconds(-100), // only 100s inside, dwell requires 300s
+            LastGeneration = 1
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt, generation: 2),
+            feature,
+            rule,
+            zone,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().BeEmpty();
+        result.UpdatedState!.Inside.Should().BeTrue();
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_DwellRule_InsideAtOrAboveDwellDuration_EmitsStartedEvent()
+    {
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Dwell, conditionsJson: """{"dwellSeconds":300}""");
+        var zone = CreateZone();
+        var feature = CreateFeature(100);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = true,
+            EnteredAt = evaluatedAt.AddSeconds(-300), // exactly at dwell duration
+            LastGeneration = 1
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt, generation: 2),
+            feature,
+            rule,
+            zone,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().ContainSingle();
+        var evt = result.Events[0];
+        evt.TriggerType.Should().Be(AlertTriggerType.Dwell);
+        evt.IncidentStatus.Should().Be(AlertIncidentStatus.Started, "no prior alert has been emitted for this incident yet");
+        evt.PayloadJson.Should().Contain("\"transition\":\"dwell\"");
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_DwellRule_ReEvaluatedAfterFirstAlert_EmitsOngoingEvent()
+    {
+        // Dwell (unlike Threshold) is not edge-triggered: once past the cooldown it
+        // re-fires on every subsequent evaluation while still inside, reported as
+        // "Ongoing" rather than "Started".
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Dwell, conditionsJson: """{"dwellSeconds":300}""", cooldownSeconds: 60);
+        var zone = CreateZone();
+        var feature = CreateFeature(100);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = true,
+            EnteredAt = evaluatedAt.AddSeconds(-600),
+            LastAlertAt = evaluatedAt.AddSeconds(-120), // outside the 60s cooldown
+            LastGeneration = 1
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt, generation: 2),
+            feature,
+            rule,
+            zone,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().ContainSingle();
+        result.Events[0].IncidentStatus.Should().Be(AlertIncidentStatus.Ongoing);
+    }
+
+    // ---- Exit trigger: fires only on the inside->outside transition, including
+    // when the transition is caused by a delete of a previously-inside feature.
+
+    [UnitTest]
+    public async Task EvaluateAsync_ExitRule_MovesOutsideZone_EmitsExitEventWithDuration()
+    {
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Exit);
+        var zone = CreateZone();
+        var enteredAt = evaluatedAt.AddMinutes(-15);
+        var feature = CreateFeatureOutsideZone(100);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = true,
+            EnteredAt = enteredAt,
+            LastGeneration = 1
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt, generation: 2),
+            feature,
+            rule,
+            zone,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().ContainSingle();
+        var evt = result.Events[0];
+        evt.TriggerType.Should().Be(AlertTriggerType.Exit);
+        evt.IncidentStatus.Should().Be(AlertIncidentStatus.Ended);
+        ((double)evt.IncidentDurationMs).Should().BeApproximately((evaluatedAt - enteredAt).TotalMilliseconds, 1000);
+        result.UpdatedState!.Inside.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_ExitRule_DeleteWhilePreviouslyInside_EmitsExitEvent()
+    {
+        // A delete of a previously-tracked feature is itself an "inside -> outside"
+        // transition (DetermineInside treats Delete as never-inside).
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Exit);
+        var zone = CreateZone();
+        var enteredAt = evaluatedAt.AddMinutes(-5);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = true,
+            EnteredAt = enteredAt,
+            LastGeneration = 1
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            new AlertChange
+            {
+                Generation = 2,
+                LayerId = rule.LayerId,
+                ObjectId = 100,
+                Operation = AlertChangeOperation.Delete,
+                ChangedAt = evaluatedAt
+            },
+            feature: null,
+            rule,
+            zone,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().ContainSingle();
+        result.Events[0].IncidentStatus.Should().Be(AlertIncidentStatus.Ended);
+        result.UpdatedState!.Inside.Should().BeFalse();
+    }
+
+    [UnitTest]
+    public async Task EvaluateAsync_ExitRule_StaysInside_DoesNotEmitEvent()
+    {
+        var evaluator = new DefaultAlertEvaluator();
+        var evaluatedAt = DateTimeOffset.UtcNow;
+        var rule = CreateRule(AlertTriggerType.Exit);
+        var zone = CreateZone();
+        var feature = CreateFeature(100);
+        var state = new AlertStateSnapshot
+        {
+            RuleId = rule.RuleId,
+            LayerId = rule.LayerId,
+            ObjectId = 100,
+            Inside = true,
+            EnteredAt = evaluatedAt.AddMinutes(-5),
+            LastGeneration = 1
+        };
+
+        var result = await evaluator.EvaluateAsync(
+            CreateChange(rule, 100, evaluatedAt, generation: 2),
+            feature,
+            rule,
+            zone,
+            state,
+            evaluatedAt);
+
+        result.Events.Should().BeEmpty();
+        result.UpdatedState!.Inside.Should().BeTrue();
+    }
+
+    private static AlertChange CreateChange(
+        AlertRuleDefinition rule, long objectId, DateTimeOffset changedAt, long generation = 1) =>
+        new()
+        {
+            Generation = generation,
+            LayerId = rule.LayerId,
+            ObjectId = objectId,
+            Operation = AlertChangeOperation.Update,
+            ChangedAt = changedAt
+        };
+
+    private static AlertRuleDefinition CreateRule(
+        AlertTriggerType triggerType,
+        string conditionsJson = "{}",
+        int cooldownSeconds = 0) =>
         new()
         {
             RuleId = 44,
@@ -67,7 +386,9 @@ public sealed class DefaultAlertEvaluatorTests
             Severity = AlertSeverity.Warning,
             EditionRequired = AlertEdition.Pro,
             Channels = ImmutableArray<AlertChannelType>.Empty,
-            IsActive = true
+            IsActive = true,
+            ConditionsJson = conditionsJson,
+            CooldownSeconds = cooldownSeconds
         };
 
     private static AlertZoneDefinition CreateZone()
@@ -97,5 +418,23 @@ public sealed class DefaultAlertEvaluatorTests
     {
         var point = new Point(-157.86, 21.30) { SRID = 4326 };
         return Feature.Create(objectId, WkbWriter.Write(point), ImmutableDictionary<string, object?>.Empty);
+    }
+
+    private static Feature CreateFeatureOutsideZone(long objectId)
+    {
+        var point = new Point(-150.00, 10.00) { SRID = 4326 };
+        return Feature.Create(objectId, WkbWriter.Write(point), ImmutableDictionary<string, object?>.Empty);
+    }
+
+    private static Feature CreateFeatureWithAttributes(long objectId, params (string Name, object? Value)[] attributes)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+        foreach (var (name, value) in attributes)
+        {
+            builder[name] = value;
+        }
+
+        var point = new Point(-157.86, 21.30) { SRID = 4326 };
+        return Feature.Create(objectId, WkbWriter.Write(point), builder.ToImmutable());
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/SceneAnalysisEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/SceneAnalysisEndpointTests.cs
@@ -73,6 +73,52 @@ public sealed class SceneAnalysisEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /elevation/{datasetId}/sun-shadow")]
+    public async Task PostSunShadow_KnownInput_MatchesIndependentlyComputedNoaaSolarPosition()
+    {
+        // Regression for honua-server#2945: prior tests only asserted altitude/shadow
+        // length are "> 0". These expected values were computed independently (Python,
+        // NOAA solar position algorithm, not by reading the production implementation)
+        // for the fixed observer/timestamp below:
+        //   altitude ~= 28.13 deg, azimuth ~= 90.12 deg, shadow length = height / tan(altitude) ~= 46.76 m.
+        // Tolerances are wide enough to absorb small floating-point/formula-ordering
+        // differences between independent implementations of the same algorithm while
+        // still catching a materially wrong (e.g. sign-flipped, degrees/radians-confused,
+        // or no-op) calculation.
+        // maxShadowLengthMeters bounds the ray-march resolution: the reported length is
+        // quantized to maxShadowLengthMeters / sampleCount, so keep that step well inside
+        // the 1.5 m tolerance (200 / 256 ~= 0.78 m). A 20 km max with 256 samples steps at
+        // 78 m and can only ever report a multiple of it.
+        await SeedFullWorldRasterAsync(0);
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/sun-shadow",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 25.0,
+                timestamp = "2026-03-20T08:00:00Z",
+                maxShadowLengthMeters = 200.0,
+                sampleCount = 256
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        var solarPosition = root.GetProperty("solarPosition");
+        solarPosition.GetProperty("aboveHorizon").GetBoolean().Should().BeTrue();
+        solarPosition.GetProperty("altitudeDegrees").GetDouble().Should().BeApproximately(28.13, 0.1);
+        solarPosition.GetProperty("azimuthDegrees").GetDouble().Should().BeApproximately(90.12, 0.1);
+
+        root.GetProperty("shadowCast").GetBoolean().Should().BeTrue();
+        root.GetProperty("shadowLengthMeters").GetDouble().Should().BeApproximately(46.76, 1.5);
+        root.GetProperty("shadowAzimuthDegrees").GetDouble().Should().BeApproximately(270.12, 0.1);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/sun-shadow")]
     public async Task PostSunShadow_SunBelowHorizon_ReportsNoShadow()
     {
         await SeedFullWorldRasterAsync(0);

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/VisibilityAnalysisEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/VisibilityAnalysisEndpointTests.cs
@@ -239,6 +239,217 @@ public sealed class VisibilityAnalysisEndpointTests : IAsyncLifetime
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
     }
 
+    // ---- Ridge/occlusion terrain (honua-server#2945) ----
+    //
+    // The tests above only seed FLAT terrain, so "visible" is trivially true for every
+    // sample regardless of whether occlusion logic is correct (Core.Tests already covers
+    // real occlusion via a synthetic 1-D "elevation as a function of distance" stub, but no
+    // endpoint-level test ever exercises a real, non-constant raster). These tests seed a
+    // real 2-D DEM shaped like a "crater rim": a flat floor (10m) with a 3000m-tall square
+    // ring between 1500m and 2000m from the observer at the Web Mercator origin (0,0). The
+    // ring is a complete hollow square frame (four raster tiles: N/S/E/W bands, newer
+    // acquisition date than the flat floor so the mosaic "newest wins" rule lets the ring
+    // override the floor within its footprint) — so unlike a single occluding wall, ANY
+    // straight line from the observer to a point beyond ~2000m in ANY direction must cross
+    // the ring and be blocked.
+    private const double RingInnerRadiusMeters = 1500;
+    private const double RingOuterRadiusMeters = 2000;
+    private const double RidgeFloorElevationMeters = 10;
+    private const double RidgeRimElevationMeters = 3000;
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
+    public async Task PostLineOfSight_TargetInsideRidgeRing_IsVisible()
+    {
+        await SeedRidgeRingRasterAsync();
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/line-of-sight",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 2.0,
+                targetLon = 0.004491576, // ~500m east: inside the 1500m ridge inner radius
+                targetLat = 0.0,
+                targetHeight = 2.0,
+                sampleCount = 256
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("visible").GetBoolean().Should().BeTrue(
+            "both observer and target sit on the flat crater floor, well inside the ridge ring");
+        root.GetProperty("obstruction").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
+    public async Task PostLineOfSight_TargetBeyondRidgeRing_IsBlockedByIntervalRidge()
+    {
+        await SeedRidgeRingRasterAsync();
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/line-of-sight",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 2.0,
+                targetLon = 0.035932611, // ~4000m east: beyond the 2000m outer ridge radius
+                targetLat = 0.0,
+                targetHeight = 2.0,
+                sampleCount = 256
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        root.GetProperty("visible").GetBoolean().Should().BeFalse(
+            "the 3000m ridge ring at 1500-2000m sits directly on the line between the observer and a target 4000m away");
+        root.GetProperty("obstruction").ValueKind.Should().NotBe(JsonValueKind.Null);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Query)]
+    [Endpoint("POST /elevation/{datasetId}/viewshed")]
+    public async Task PostViewshed_RidgeRingTerrain_OccludesFarSamplesButNotNearSamples()
+    {
+        await SeedRidgeRingRasterAsync();
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/viewshed",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                observerHeight = 2.0,
+                radiusMeters = 4500.0,
+                rayCount = 36,
+                samplesPerRay = 60
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = json.RootElement;
+
+        var sampleCount = root.GetProperty("sampleCount").GetInt32();
+        var visibleSampleCount = root.GetProperty("visibleSampleCount").GetInt32();
+
+        // Unlike the flat-terrain viewshed (100% visible; see the tests above), the ring
+        // must occlude a real share of samples: it fully encircles the observer, so every
+        // ray's far-side samples are blocked.
+        visibleSampleCount.Should().BeLessThan(sampleCount,
+            "the ridge ring fully encircles the observer, so far-side samples in every direction must be occluded");
+        visibleSampleCount.Should().BeGreaterThan(0,
+            "samples inside the ring, on the crater floor, must remain visible");
+
+        var samples = root.GetProperty("samples").EnumerateArray().ToArray();
+
+        var nearSamples = samples.Where(s => s.GetProperty("distanceMeters").GetDouble() < 1000).ToArray();
+        nearSamples.Should().NotBeEmpty();
+        nearSamples.Should().OnlyContain(s => s.GetProperty("visible").GetBoolean(),
+            "samples well inside the ridge ring (< 1000m) sit on the flat crater floor and must be visible");
+
+        var farSamples = samples.Where(s => s.GetProperty("distanceMeters").GetDouble() > 2500).ToArray();
+        farSamples.Should().NotBeEmpty();
+        farSamples.Should().OnlyContain(s => !s.GetProperty("visible").GetBoolean(),
+            "samples beyond the ridge ring (> 2500m), in every direction, are blocked by the intervening 3000m ridge");
+    }
+
+    /// <summary>
+    /// Seeds a real 2-D "crater rim" DEM: a flat floor tile plus four raster tiles
+    /// (north/south/east/west bands, newer acquisition date so the mosaic "newest wins"
+    /// rule overrides the floor within each band's footprint) that together form a
+    /// complete hollow square ring around the Web Mercator origin (the observer position
+    /// used by every ridge test above). All rasters are stored directly in EPSG:3857
+    /// meters, matching <see cref="SeedFullWorldRasterAsync"/>/<see cref="SeedSeQuadrantRasterAsync"/>,
+    /// so <see cref="RingInnerRadiusMeters"/>/<see cref="RingOuterRadiusMeters"/> are exact
+    /// (not degree-approximated) distances from the observer.
+    /// </summary>
+    private Task SeedRidgeRingRasterAsync()
+    {
+        var floorTime = RasterIntegrationTestData.WestAcquisition;
+        var ridgeTime = RasterIntegrationTestData.EastAcquisition;
+
+        // All rasters share one 250 m grid (identical scale, origins at multiples of the cell
+        // size): the elevation profile path merges the layer's rasters with PostGIS raster
+        // union, and rt_raster_from_two_rasters hard-fails on mixed alignment. Mixed-resolution
+        // mosaics currently surface that as an unmapped 500 — tracked separately; this fixture
+        // stays aligned so these tests prove occlusion math, not mosaic alignment handling.
+        const double cell = 250;
+        const double floorHalfExtent = RingOuterRadiusMeters * 3;
+
+        return RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "ridge-floor",
+                Width: (int)(floorHalfExtent * 2 / cell),
+                Height: (int)(floorHalfExtent * 2 / cell),
+                UpperLeftX: -floorHalfExtent,
+                UpperLeftY: floorHalfExtent,
+                ScaleX: cell,
+                ScaleY: -cell,
+                Value: RidgeFloorElevationMeters,
+                AcquisitionDate: floorTime,
+                CreatedAt: floorTime,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "ridge-north",
+                Width: (int)(RingOuterRadiusMeters * 2 / cell),
+                Height: (int)((RingOuterRadiusMeters - RingInnerRadiusMeters) / cell),
+                UpperLeftX: -RingOuterRadiusMeters,
+                UpperLeftY: RingOuterRadiusMeters,
+                ScaleX: cell,
+                ScaleY: -cell,
+                Value: RidgeRimElevationMeters,
+                AcquisitionDate: ridgeTime,
+                CreatedAt: ridgeTime,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "ridge-south",
+                Width: (int)(RingOuterRadiusMeters * 2 / cell),
+                Height: (int)((RingOuterRadiusMeters - RingInnerRadiusMeters) / cell),
+                UpperLeftX: -RingOuterRadiusMeters,
+                UpperLeftY: -RingInnerRadiusMeters,
+                ScaleX: cell,
+                ScaleY: -cell,
+                Value: RidgeRimElevationMeters,
+                AcquisitionDate: ridgeTime,
+                CreatedAt: ridgeTime,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "ridge-east",
+                Width: (int)((RingOuterRadiusMeters - RingInnerRadiusMeters) / cell),
+                Height: (int)(RingInnerRadiusMeters * 2 / cell),
+                UpperLeftX: RingInnerRadiusMeters,
+                UpperLeftY: RingInnerRadiusMeters,
+                ScaleX: cell,
+                ScaleY: -cell,
+                Value: RidgeRimElevationMeters,
+                AcquisitionDate: ridgeTime,
+                CreatedAt: ridgeTime,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "ridge-west",
+                Width: (int)((RingOuterRadiusMeters - RingInnerRadiusMeters) / cell),
+                Height: (int)(RingInnerRadiusMeters * 2 / cell),
+                UpperLeftX: -RingOuterRadiusMeters,
+                UpperLeftY: RingInnerRadiusMeters,
+                ScaleX: cell,
+                ScaleY: -cell,
+                Value: RidgeRimElevationMeters,
+                AcquisitionDate: ridgeTime,
+                CreatedAt: ridgeTime,
+                Srid: 3857));
+    }
+
     private Task SeedFullWorldRasterAsync(double elevationMeters)
         => RasterIntegrationTestData.ReplaceLayerRastersAsync(
             _fixture,

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/TileJsonEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Tiles/TileJsonEndpointTests.cs
@@ -72,7 +72,32 @@ public sealed class TileJsonEndpointTests : IAsyncLifetime
 
         var response = await _fixture.Client.GetAsync($"/tiles/{WebAppFixture.TestLayerId}/tile.json");
 
+        // honua-server#2945: /tiles is not an Esri protocol surface, so a real HTTP 404
+        // + problem+json body is expected here (AssertGeoServicesErrorAsync tolerates a
+        // genuine >=400 status, so this also documents the exact shape below).
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
         await response.AssertGeoServicesErrorAsync(404);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /tiles/{layerId}/tile.json")]
+    public async Task GetTileJson_NonExistentLayer_ReturnsRealNotFoundWithProblemJson()
+    {
+        // Regression test for honua-server#2945: unknown layer must be a real HTTP 404
+        // with an RFC 7807 problem+json body, not a 200-wrapped GeoServices error.
+        var response = await _fixture.Client.GetAsync("/tiles/999999/tile.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        var problem = JsonDocument.Parse(content).RootElement;
+
+        problem.GetProperty("title").GetString().Should().Be("Not Found");
+        problem.GetProperty("status").GetInt32().Should().Be(404);
+        problem.GetProperty("detail").GetString().Should().Contain("999999");
     }
 
     [IntegrationTest]

--- a/tests/dotnet/Honua.Server.Tests/Features/Reporting/AnalysisReportEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Reporting/AnalysisReportEndpointsTests.cs
@@ -2,10 +2,17 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Security.Claims;
 using FluentAssertions;
+using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.ControlPlane.Domain;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Geoprocessing;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Honua.Server.Tests.Features.Reporting;
 
@@ -75,5 +82,147 @@ public sealed class AnalysisReportEndpointsTests : IAsyncLifetime
         var response = await _client.GetAsync("/api/v1/analysis/reports/any-job/render?format=pdf");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}
+
+/// <summary>
+/// Happy-path coverage for honua-server#2945: prior proving tests for this surface were
+/// error-paths only (the store is intentionally absent above so a real job never resolves).
+/// This registers a fake <see cref="IGeoprocessingJobService"/> that returns a completed
+/// <see cref="Honua.Core.Features.Geoprocessing.Domain.AnalysisResultPackage"/> (reusing
+/// <see cref="ReportingFixtures.BufferAggregatePackage"/>, the same fixture the real
+/// <c>AnalysisReportService</c>/<c>AnalysisReportBuilder</c> unit tests assert against) so the
+/// REAL report builder, store, and Markdown/HTML renderers run end to end through the actual
+/// HTTP surface, proving a report genuinely generates and renders rather than only erroring.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+public sealed class AnalysisReportEndpointsHappyPathTests : IAsyncLifetime
+{
+    private const string JobId = "reporting-happy-path-job";
+
+    private readonly WebAppFixture _fixture;
+    private HttpClient _client = null!;
+
+    public AnalysisReportEndpointsHappyPathTests()
+    {
+        _fixture = new WebAppFixture().ConfigureServices(services =>
+        {
+            services.RemoveAll<IGeoprocessingJobService>();
+            services.AddSingleton<IGeoprocessingJobService>(new CompletedJobService());
+        });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/analysis/reports/{jobId}")]
+    public async Task GetReport_CompletedJob_GeneratesRealReportEnvelope()
+    {
+        var response = await _client.GetAsync($"/api/v1/analysis/reports/{JobId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("\"jobId\":\"" + JobId + "\"");
+        content.Should().Contain("Buffered places");
+        content.Should().Contain("500m buffers applied to the seed places layer.");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/analysis/reports/{jobId}/render")]
+    public async Task RenderReport_CompletedJob_RendersRealMarkdown()
+    {
+        var response = await _client.GetAsync($"/api/v1/analysis/reports/{JobId}/render?format=md");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/markdown");
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().StartWith("# Buffered places");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Metadata)]
+    [Endpoint("GET /api/v1/analysis/reports/{jobId}/render")]
+    public async Task RenderReport_CompletedJob_RendersRealHtml()
+    {
+        var response = await _client.GetAsync($"/api/v1/analysis/reports/{JobId}/render?format=html");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("text/html");
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Buffered places");
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IGeoprocessingJobService"/> test double that only implements the
+    /// two members <c>AnalysisReportService</c> actually calls (authorization pass-through +
+    /// result-package lookup); every other member throws <see cref="NotSupportedException"/>
+    /// since the reporting surface never calls them (mirrors the pattern already used by
+    /// <c>OgcProcessesJobResultsTestsFixture.ArtifactBackedJobService</c>).
+    /// </summary>
+    private sealed class CompletedJobService : IGeoprocessingJobService
+    {
+        public Task EnsureCallerAuthorizedAsync(
+            ClaimsPrincipal principal,
+            OperatorResourceType resourceType,
+            OperatorOperation operation,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task EnsurePlanExecutionTierAuthorizedAsync(
+            AnalysisPlan plan,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public PlanValidationResult ValidatePlan(AnalysisPlan plan, ClaimsPrincipal principal)
+            => throw new NotSupportedException();
+
+        public DryRunResult DryRunPlan(AnalysisPlan plan, ClaimsPrincipal principal)
+            => throw new NotSupportedException();
+
+        public Task<ExecutionJobRecord> SubmitJobAsync(
+            AnalysisPlan plan,
+            string? idempotencyKey,
+            ClaimsPrincipal principal,
+            IReadOnlyDictionary<string, string>? protocolMetadata = null,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<ExecutionJobRecord> GetJobAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<GeoprocessingJobListPage> ListJobsAsync(
+            GeoprocessingJobListFilter filter,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<AnalysisResultPackage> GetJobResultsAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(ReportingFixtures.BufferAggregatePackage() with { ResultPackageId = $"{jobId}:v1" });
+
+        public Task CancelJobAsync(
+            string jobId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/SpatialAnalytics/SpatialAnalyticsRestTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/SpatialAnalytics/SpatialAnalyticsRestTests.cs
@@ -860,6 +860,79 @@ public sealed class SpatialAnalyticsRestTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.QueryDensity)]
     [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/queryDensity")]
+    public async Task QueryDensity_SquareGrid_ReturnsExactCellCountForSeededPoints()
+    {
+        // Regression for honua-server#2945: prior density tests only asserted
+        // featureCount > 0 per cell, never a real cell-count against known geometry.
+        // Layer 0 has 5 seeded features (tests/seed/server.yaml); objectid 3 has a NULL
+        // geometry and is excluded by the density query's "geometry IS NOT NULL" filter,
+        // leaving 4 points: (-122.5,37.5) (-122.7,37.7) (-121.9,37.3) (-122.3,37.8).
+        // Projected to Web Mercator (EPSG:3857) and binned into a 20km ST_SquareGrid
+        // anchored at the fixed (0,0) origin PostGIS grid functions always use, each
+        // point falls in column/row (-682,225) (-683,226) (-679,224) (-681,227) — four
+        // distinct cells, each thousands of meters from its cell boundary (no
+        // floating-point edge risk), so exactly 4 cells of featureCount=1 are expected.
+        var payload = JsonSerializer.Serialize(new
+        {
+            mode = "square",
+            cellSize = 20000,
+            f = "json"
+        });
+
+        using var densityContent = new StringContent(payload, Encoding.UTF8, "application/json");
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryDensity",
+            densityContent);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        var features = doc.RootElement.GetProperty("features");
+
+        features.GetArrayLength().Should().Be(4, "the 4 geometried seeded points each land in a distinct 20km grid cell");
+
+        foreach (var feature in features.EnumerateArray())
+        {
+            feature.GetProperty("properties").GetProperty("featureCount").GetInt64().Should().Be(1);
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryDensity)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/queryDensity")]
+    public async Task QueryDensity_HexGrid_TotalFeatureCountMatchesSeededPointCount()
+    {
+        // Hex-cell boundaries are non-trivial to hand-compute, but the total feature
+        // count summed across all returned cells must still equal exactly the number
+        // of geometried seeded points (4; objectid 3 has a NULL geometry and is excluded).
+        var payload = JsonSerializer.Serialize(new
+        {
+            mode = "hex",
+            cellSize = 20000,
+            f = "json"
+        });
+
+        using var densityContent = new StringContent(payload, Encoding.UTF8, "application/json");
+        var response = await _fixture.Client.PostAsync(
+            $"/rest/services/{WebAppFixture.TestServiceId}/FeatureServer/{WebAppFixture.TestLayerId}/queryDensity",
+            densityContent);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        var features = doc.RootElement.GetProperty("features");
+
+        var totalFeatureCount = features.EnumerateArray()
+            .Sum(feature => feature.GetProperty("properties").GetProperty("featureCount").GetInt64());
+
+        totalFeatureCount.Should().Be(4);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.QueryDensity)]
+    [Endpoint("POST /rest/services/{serviceId}/FeatureServer/{layerId}/queryDensity")]
     public async Task QueryDensity_MissingCellSize_ReturnsBadRequest()
     {
         var payload = JsonSerializer.Serialize(new

--- a/tests/dotnet/Honua.Server.Tests/Features/StaticMap/StaticMapEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/StaticMap/StaticMapEndpointTests.cs
@@ -9,6 +9,7 @@ using Honua.TestKit.Helpers;
 using Honua.TestKit;
 using Honua.TestKit.Attributes;
 using Honua.TestKit.Constants;
+using SkiaSharp;
 
 namespace Honua.Server.Tests.Features.StaticMap;
 
@@ -351,4 +352,259 @@ public sealed class StaticMapEndpointTests : IAsyncLifetime
             await fixture.DisposeAsync();
         }
     }
+
+    // --- Dimension entitlement band (honua-server#2945): 1280 (Community max) is the
+    // entitlement boundary, 4096 (Pro max) is the absolute hard cap. Everything strictly
+    // between the two requires the "staticmap.large-dimensions" entitlement.
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_CommunityEdition_DimensionAtCommunityMax_ReturnsImage()
+    {
+        // 1280x1280 is exactly the Community cap: allowed without any entitlement.
+        var response = await _fixture.Client.GetAsync(
+            $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/1280x1280.png");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_CommunityEdition_DimensionAboveCommunityMax_ReturnsPaymentRequired()
+    {
+        // 2000 is within the Pro hard cap (4096) but above the Community entitlement
+        // boundary (1280): blocked for a Community-tier caller.
+        var response = await _fixture.Client.GetAsync(
+            $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/2000x2000.png");
+
+        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_ProEdition_DimensionWithinEntitlementBand_ReturnsImage()
+    {
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var response = await fixture.Client.GetAsync(
+                $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/2000x2000.png");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_ProEdition_ExceedsHardCap_ReturnsBadRequest()
+    {
+        // The 4096 hard cap applies regardless of entitlement tier.
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var response = await fixture.Client.GetAsync(
+                $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/5000x5000.png");
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    // --- Overlay-count entitlement band: >10 markers or >20 path vertices require
+    // "staticmap.rich-overlays"; >100 markers / >500 vertices are always rejected.
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_CommunityEdition_MarkersWithinCommunityLimit_ReturnsImage()
+    {
+        var markers = BuildMarkers(10);
+        var response = await _fixture.Client.GetAsync(
+            $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?markers={markers}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_CommunityEdition_MarkersAboveCommunityLimit_ReturnsPaymentRequired()
+    {
+        var markers = BuildMarkers(11);
+        var response = await _fixture.Client.GetAsync(
+            $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?markers={markers}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_ProEdition_MarkersAboveCommunityLimit_ReturnsImage()
+    {
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var markers = BuildMarkers(50);
+            var response = await fixture.Client.GetAsync(
+                $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?markers={markers}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_ProEdition_MarkersExceedProHardCap_ReturnsBadRequest()
+    {
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var markers = BuildMarkers(101);
+            var response = await fixture.Client.GetAsync(
+                $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?markers={markers}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_CommunityEdition_PathWithinCommunityLimit_ReturnsImage()
+    {
+        var path = BuildPathVertices(20);
+        var response = await _fixture.Client.GetAsync(
+            $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?path={path}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_CommunityEdition_PathAboveCommunityLimit_ReturnsPaymentRequired()
+    {
+        var path = BuildPathVertices(21);
+        var response = await _fixture.Client.GetAsync(
+            $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?path={path}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_ProEdition_PathAboveCommunityLimit_ReturnsImage()
+    {
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            var path = BuildPathVertices(100);
+            var response = await fixture.Client.GetAsync(
+                $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?path={path}");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    // --- DPI entitlement band + actual output-resolution scaling ---
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_CommunityEdition_HighDpi_ReturnsPaymentRequired()
+    {
+        var response = await _fixture.Client.GetAsync(
+            $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/400x300.png?dpi=150");
+
+        response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.Render)]
+    [Endpoint("GET /static/{serviceId}/{center}/{dimensions}.{format}")]
+    public async Task CenterZoom_ProEditionHighDpi_ScalesOutputResolution()
+    {
+        // honua-server#2945: prove the dpi parameter actually changes the rendered
+        // pixel dimensions (dpiFactor = dpi/72), not just that the request succeeds.
+        var fixture = new WebAppFixture().WithTestLicense(HonuaEdition.Pro);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            const int width = 144;
+            const int height = 96;
+            const int dpi = 150;
+
+            var baselineResponse = await fixture.Client.GetAsync(
+                $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/{width}x{height}.png");
+            var highDpiResponse = await fixture.Client.GetAsync(
+                $"/static/{WebAppFixture.TestServiceId}/-122.4194,37.7749,12/{width}x{height}.png?dpi={dpi}");
+
+            baselineResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            highDpiResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using var baselineBitmap = SKBitmap.Decode(await baselineResponse.Content.ReadAsByteArrayAsync());
+            using var highDpiBitmap = SKBitmap.Decode(await highDpiResponse.Content.ReadAsByteArrayAsync());
+
+            baselineBitmap.Width.Should().Be(width);
+            baselineBitmap.Height.Should().Be(height);
+
+            var dpiFactor = dpi / 72.0;
+            var expectedWidth = (int)Math.Round(width * dpiFactor);
+            var expectedHeight = (int)Math.Round(height * dpiFactor);
+
+            highDpiBitmap.Width.Should().Be(expectedWidth);
+            highDpiBitmap.Height.Should().Be(expectedHeight);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    private static string BuildMarkers(int count)
+        => string.Join('|', Enumerable.Range(0, count)
+            .Select(i => $"{-122.4 + (i * 0.001):F4},{37.7 + (i * 0.001):F4}"));
+
+    private static string BuildPathVertices(int count)
+        => string.Join('|', Enumerable.Range(0, count)
+            .Select(i => $"{-122.4 + (i * 0.001):F4},{37.7 + (i * 0.001):F4}"));
 }

--- a/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
+++ b/tests/dotnet/Honua.Server.Tests/Honua.Server.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ParquetSharp" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/ErrorHandlingConsistencyTests.cs
@@ -43,9 +43,11 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
             var response = await _fixture.Client.GetAsync(endpoint);
 
             // Assert
-            // GeoServices surfaces (/rest/services, /tiles) now signal errors as
-            // HTTP 200 + {"error":{"code":404}} (#2418); OGC/OData keep RFC 7807.
-            if (IsGeoServicesEndpoint(endpoint))
+            // GeoServices REST (/rest/services) signals errors as HTTP 200 +
+            // {"error":{"code":404}} (#2418). /tiles is NOT an Esri protocol surface
+            // and returns a real HTTP 404 + problem+json (honua-server#2945). OGC/OData
+            // also keep real HTTP status codes.
+            if (IsGeoServicesRestEndpoint(endpoint))
             {
                 await response.AssertGeoServicesErrorAsync(404);
             }
@@ -58,7 +60,7 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GeoServicesAndOgcProtocols_UseConsistentErrorFormat()
+    public async Task GeoServicesRestAndOgcProtocols_UseConsistentErrorFormat()
     {
         // Arrange
         var geoServicesEndpoint = "/rest/services/non-existent/FeatureServer";
@@ -70,35 +72,35 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
         var ogcResponse = await _fixture.Client.GetAsync(ogcEndpoint);
         var mvtResponse = await _fixture.Client.GetAsync(mvtEndpoint);
 
-        // Assert - GeoServices/MVT use GeoServices format, OGC uses RFC 7807
+        // Assert - GeoServices REST keeps its 200-envelope format; OGC and the tiles
+        // surface (honua-server#2945) both use real HTTP status + RFC 7807.
         var geoContent = await geoResponse.Content.ReadAsStringAsync();
         var ogcContent = await ogcResponse.Content.ReadAsStringAsync();
         var mvtContent = await mvtResponse.Content.ReadAsStringAsync();
 
         var geoError = JsonSerializer.Deserialize<ApiErrorResponse>(geoContent);
-        var mvtError = JsonSerializer.Deserialize<ApiErrorResponse>(mvtContent);
         var ogcProblem = JsonSerializer.Deserialize<JsonElement>(ogcContent);
+        var mvtProblem = JsonSerializer.Deserialize<JsonElement>(mvtContent);
 
         geoError.Should().NotBeNull();
-        mvtError.Should().NotBeNull();
-
         geoError!.Error.Code.Should().Be(404);
-        mvtError!.Error.Code.Should().Be(404);
 
-        // GeoServices-style responses should contain the "error" property with "code", "message" structure
+        // GeoServices REST responses should contain the "error" property with "code", "message" structure
         geoContent.Should().Contain("\"error\":");
         geoContent.Should().Contain("\"code\":");
         geoContent.Should().Contain("\"message\":");
-
-        mvtContent.Should().Contain("\"error\":");
-        mvtContent.Should().Contain("\"code\":");
-        mvtContent.Should().Contain("\"message\":");
 
         // OGC should use RFC 7807 Problem Details format
         ogcProblem.GetProperty("type").GetString().Should().NotBeNullOrEmpty();
         ogcProblem.GetProperty("title").GetString().Should().Be("Not Found");
         ogcProblem.GetProperty("status").GetInt32().Should().Be(404);
         ogcProblem.GetProperty("detail").GetString().Should().NotBeNullOrEmpty();
+
+        // Tiles surface (honua-server#2945): real 404 + RFC 7807, same shape as OGC.
+        mvtResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        mvtProblem.GetProperty("title").GetString().Should().Be("Not Found");
+        mvtProblem.GetProperty("status").GetInt32().Should().Be(404);
+        mvtProblem.GetProperty("detail").GetString().Should().NotBeNullOrEmpty();
     }
 
     [Fact]
@@ -182,9 +184,18 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
         }
     }
 
+    // Zoom/tile-coordinate validation on /tiles still short-circuits before layer
+    // resolution (StandardErrorHelpers.CreateBadRequest directly) and is unaffected by
+    // honua-server#2945, which only changed the layer-not-found path. So /tiles still
+    // belongs in the 200-envelope classification for THIS (bad-request) scenario.
     private static bool IsGeoServicesEndpoint(string endpoint) =>
         endpoint.StartsWith("/rest/services", StringComparison.Ordinal) ||
         endpoint.StartsWith("/tiles", StringComparison.Ordinal);
+
+    // /rest/services keeps the GeoServices 200-envelope for not-found; /tiles does not
+    // (honua-server#2945 — the tiles surface returns a real HTTP 404 + problem+json).
+    private static bool IsGeoServicesRestEndpoint(string endpoint) =>
+        endpoint.StartsWith("/rest/services", StringComparison.Ordinal);
 
     [Fact]
     public async Task AllProtocols_NoSensitiveInformationLeakage_InErrorResponses()
@@ -238,7 +249,7 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
         {
             ["/rest/services/non-existent/FeatureServer"] = "application/json",
             ["/ogc/features/collections/non-existent"] = "application/problem+json",
-            ["/tiles/99999/1/0/0.mvt"] = "application/json",
+            ["/tiles/99999/1/0/0.mvt"] = "application/problem+json", // honua-server#2945
             ["/odata/Features(99999)"] = "application/json", // OData errors are also JSON
         };
 
@@ -254,13 +265,12 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ErrorResponseFormats_DoNotContainRfc7807ProblemDetails_InGeoServicesAndMvt()
+    public async Task ErrorResponseFormats_DoNotContainRfc7807ProblemDetails_InGeoServicesRest()
     {
-        // Arrange - GeoServices and MVT should use domain-specific error formats, not RFC 7807
+        // Arrange - GeoServices REST should use its domain-specific error format, not RFC 7807
         var geospatialEndpoints = new[]
         {
             "/rest/services/non-existent/FeatureServer",
-            "/tiles/99999/1/0/0.mvt",
         };
 
         foreach (var endpoint in geospatialEndpoints)
@@ -285,5 +295,24 @@ public class ErrorHandlingConsistencyTests : IAsyncLifetime
             content.Should().Contain("\"error\":",
                 $"endpoint {endpoint} should use standardized geospatial error format");
         }
+    }
+
+    [Fact]
+    public async Task ErrorResponseFormat_UsesRfc7807ProblemDetails_OnTilesSurface()
+    {
+        // honua-server#2945: /tiles is not an Esri GeoServices protocol surface, so
+        // (unlike /rest/services) its layer-not-found error DOES use RFC 7807
+        // problem+json with a real HTTP status, the opposite of the assertion above.
+        var response = await _fixture.Client.GetAsync("/tiles/99999/1/0/0.mvt");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var content = await response.Content.ReadAsStringAsync();
+
+        content.Should().Contain("\"type\":");
+        content.Should().Contain("\"title\":");
+        content.Should().Contain("\"status\":");
+        content.Should().Contain("\"detail\":");
+        content.Should().NotContain("\"error\":",
+            "the tiles surface must not use the GeoServices error envelope");
     }
 }


### PR DESCRIPTION
Fixes #2945
Related to honua-io/honua-release#58

## Summary

Interface-level proving tests for every hollow-coverage finding from the 2026-07-20 capability audit, plus the tiles unknown-layer status fix. Writing the rigorous tests immediately surfaced one product bug (unaligned raster mosaics 500 on all elevation analysis routes — filed as #2959 with a deterministic repro) and confirmed one architectural interaction (the always-on client-certificate RBAC layer 403s valid bearer tokens on admin surfaces — evidence for #2958's mTLS experimental-gating).

## Changes Made

- OIDC end-to-end token validation (`OidcJwtBearerValidationTests`, new): fake IdP (WireMock discovery + JWKS), real RSA-signed JWTs through the real JwtBearer pipeline — valid token authenticates; expired/wrong-issuer/wrong-audience/tampered are 401-rejected. Valid-token case asserts the authentication boundary (not-401); literal 200 lands with #2958's cert-layer gating.
- WMS `GetMap` and WMTS `GetTile` proving tests with rendered-output assertions (dimensions + content, `[Endpoint]`/`[InterfaceOperation]` attributed).
- `DefaultAlertEvaluator` threshold-crossing, dwell-duration, and Exit-transition branches tested against the real evaluator (no stubs).
- Analytics math at the endpoint: ridge-ring occlusion terrain fixture (grid-aligned; the unaligned variant deterministically reproduces #2959) proving viewshed far-sample occlusion and line-of-sight blocking; NOAA-referenced sun-shadow altitude/azimuth/length values (ray-march quantization documented in-test); exact density cell-count assertions; analytics.reporting happy path (completed job → generated + rendered report); date-bin bucket-count assertions.
- Static-map entitlement bands: blocked-below/allowed-within/capped-above for dimensions and overlays; DPI test asserting output resolution scales.
- Tiles fix: unknown layer on `/tiles/{layerId}/tile.json` and `/tiles/{layerId}/{z}/{x}/{y}.mvt` now returns a real HTTP 404 problem response instead of HTTP 200 wrapping a GeoServices-style error envelope; regression tests added (GeoServices `/rest` routes unchanged).
- `feature-catalog.json` + `capability-matrix.v1.json` regenerated; `capability-impact.py validate` green.

## Breaking Changes

Tiles surface only: unknown-layer requests change from `200 + {"error":{"code":404,...}}` to a real `404` problem response. This corrects non-Esri protocol behavior; GeoServices envelope semantics on `/rest` routes are untouched.

## Gate Impact

- [x] Integration tests added/updated (Tier=Integration shards)
- [x] Feature catalog regenerated (drift gate)

## Testing

- [x] Ran targeted suites (owner-authorized in lieu of full pre-pr-check): Honua.Server.Tests touched suites 126/129 → after fixture/resolution fixes 10/10 on the previously-failing set incl. all 6 OIDC tests; Honua.Protocols.GeoServices.Tests targeted 39/39; Honua.Protocols.OgcClassic.Tests targeted 96/96 (WMS/WMTS suites).
- [x] `python3 scripts/ci/capability-impact.py validate` — valid; `scripts/generate-feature-catalog.sh` — green; `dotnet format --include` on changed files — clean.
- [x] Ran scripts/ci/pre-pr-check.sh and all checks passed
