### PR TITLE
fix(query): use resource primary id for default ordering

### DIFF
--- a/src/Honua.Core/Features/Query/QueryProcessor.cs
+++ b/src/Honua.Core/Features/Query/QueryProcessor.cs
@@ -479,10 +479,11 @@ public sealed class QueryProcessor : IQueryProcessor
         var orderBy = query.OrderBy;
         if (orderBy?.IsDefaultOrEmpty != false)
         {
+            var primaryIdField = resource.FindPrimaryIdField();
             orderBy = ImmutableArray.Create(new OrderByClause(
-                FieldNames.ObjectId,
+                primaryIdField?.Name ?? FieldNames.ObjectId,
                 ascending: true,
-                MetadataV2FieldType.BigInteger));
+                primaryIdField?.Type ?? MetadataV2FieldType.BigInteger));
         }
 
         // Optimize field selection

--- a/tests/dotnet/Honua.Core.Tests/Features/Query/QueryProcessorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Query/QueryProcessorTests.cs
@@ -191,4 +191,46 @@ public sealed class QueryProcessorTests
 
         featureQuery.IncludeNullGeometry.Should().BeTrue();
     }
+
+    [Fact]
+    public void OptimizeQuery_PagedQueryWithoutOrdering_UsesResourcePrimaryIdForProviderOrdering()
+    {
+        var resource = _resource with
+        {
+            SchemaFields =
+            [
+                new MetadataV2Field
+                {
+                    Name = "feature_id",
+                    Type = MetadataV2FieldType.Integer,
+                    Nullable = false,
+                    SemanticRoles = ["id.primary"]
+                },
+                new MetadataV2Field { Name = "shape", Type = MetadataV2FieldType.Geometry, Nullable = false },
+                new MetadataV2Field { Name = "name", Type = MetadataV2FieldType.String }
+            ]
+        };
+        var query = new UnifiedQuery { Limit = 2 };
+
+        var optimized = _processor.OptimizeQuery(query, resource);
+        var providerQuery = _processor.ToFeatureQuery(optimized, resource);
+
+        providerQuery.OrderBy.Should().NotBeNull();
+        providerQuery.OrderBy.Value.Should().ContainSingle()
+            .Which.Should().Be(new OrderByClause("feature_id", ascending: true, MetadataV2FieldType.Integer));
+    }
+
+    [Fact]
+    public void OptimizeQuery_PagedQueryWithConventionalObjectId_PreservesObjectIdOrdering()
+    {
+        var query = new UnifiedQuery { Limit = 2 };
+
+        var optimized = _processor.OptimizeQuery(query, _resource);
+        var providerQuery = _processor.ToFeatureQuery(optimized, _resource);
+
+        providerQuery.OrderBy.Should().NotBeNull();
+        providerQuery.OrderBy.Value.Should().ContainSingle()
+            .Which.Field.Should().Be(FieldNames.ObjectId);
+        providerQuery.OrderBy.Value[0].Ascending.Should().BeTrue();
+    }
 }

--- a/tests/dotnet/Honua.Core.Tests/Features/Query/QueryProcessorTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Query/QueryProcessorTests.cs
@@ -216,7 +216,7 @@ public sealed class QueryProcessorTests
         var providerQuery = _processor.ToFeatureQuery(optimized, resource);
 
         providerQuery.OrderBy.Should().NotBeNull();
-        providerQuery.OrderBy.Value.Should().ContainSingle()
+        providerQuery.OrderBy!.Value.Should().ContainSingle()
             .Which.Should().Be(new OrderByClause("feature_id", ascending: true, MetadataV2FieldType.Integer));
     }
 
@@ -229,7 +229,7 @@ public sealed class QueryProcessorTests
         var providerQuery = _processor.ToFeatureQuery(optimized, _resource);
 
         providerQuery.OrderBy.Should().NotBeNull();
-        providerQuery.OrderBy.Value.Should().ContainSingle()
+        providerQuery.OrderBy!.Value.Should().ContainSingle()
             .Which.Field.Should().Be(FieldNames.ObjectId);
         providerQuery.OrderBy.Value[0].Ascending.Should().BeTrue();
     }

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureStoreIntegrationTests.cs
@@ -5,6 +5,9 @@ using System.Collections.Immutable;
 using System.Globalization;
 using DuckDB.NET.Data;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Query;
+using Honua.Core.Queries.Filters;
 using Honua.DuckDB.Features.FeatureStore;
 using Honua.DuckDB.Features.FeatureStore.Services;
 using Honua.DuckDB.Features.Infrastructure;
@@ -53,7 +56,8 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
             )
             """);
 
-        for (var i = 1; i <= 10; i++)
+        int[] insertionOrder = [5, 1, 9, 2, 8, 3, 10, 4, 7, 6];
+        foreach (var i in insertionOrder)
         {
             var lon = -122.0 + i * 0.01;
             var lat = 37.0 + i * 0.01;
@@ -125,6 +129,49 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
 
         Assert.Equal(3, result.Items.Length);
         Assert.True(result.HasMoreResults);
+    }
+
+    [Fact]
+    public async Task QueryAsync_PagedUnifiedQueryWithNonObjectIdPrimaryKey_ReturnsPrimaryKeyOrder()
+    {
+        var resource = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "res.parcels", Name = "parcels" },
+            Type = MetadataV2ResourceType.FeatureDataset,
+            SchemaFields =
+            [
+                new MetadataV2Field
+                {
+                    Name = "id",
+                    Type = MetadataV2FieldType.BigInteger,
+                    Nullable = false,
+                    SemanticRoles = ["id.primary"]
+                },
+                new MetadataV2Field
+                {
+                    Name = "geom",
+                    Type = MetadataV2FieldType.Geometry,
+                    Nullable = false,
+                    SemanticRoles = ["geometry.primary"]
+                },
+                new MetadataV2Field { Name = "name", Type = MetadataV2FieldType.String }
+            ],
+            Spatial = new MetadataV2ResourceSpatial
+            {
+                GeometryType = MetadataV2GeometryType.Point,
+                SpatialReference = MetadataV2SpatialReference.Wgs84
+            }
+        };
+        var processor = new QueryProcessor(
+            new UnusedFilterExpressionTranslator(),
+            _store,
+            NullLogger<QueryProcessor>.Instance);
+        var optimized = processor.OptimizeQuery(new UnifiedQuery { Limit = 3 }, resource);
+        var providerQuery = processor.ToFeatureQuery(optimized, resource);
+
+        var result = await _store.QueryAsync(LayerId, providerQuery);
+
+        Assert.Equal([1L, 2L, 3L], result.Items.Select(feature => feature.Id));
     }
 
     [Fact]
@@ -352,6 +399,15 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = sql;
         await cmd.ExecuteNonQueryAsync();
+    }
+
+    private sealed class UnusedFilterExpressionTranslator : IFilterExpressionTranslator
+    {
+        public FilterExpression Normalize(FilterExpression expression, MetadataV2Resource resource)
+            => throw new InvalidOperationException("The ordering regression does not use filters.");
+
+        public SqlFragment Translate(FilterExpression expression, MetadataV2Resource resource)
+            => throw new InvalidOperationException("The ordering regression does not use filters.");
     }
 
     /// <summary>


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Fixes #2964

## Summary
Resolve default pagination ordering from the resource's semantic primary-id field instead of assuming every provider column is named `objectid`.

## Changes Made
- Resolve the default order field with `FindPrimaryIdField()`, retaining the existing `objectid` fallback.
- Carry the resolved primary-id field type into the provider-facing order clause.
- Add focused regressions for a non-`objectid` primary key and the conventional `objectid` path.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

`dotnet test tests/dotnet/Honua.Core.Tests/Honua.Core.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Honua.Core.Tests.Features.Query.QueryProcessorTests" --logger "console;verbosity=minimal"` (12 passed).

`scripts/ci/pre-pr-check.sh` could not complete locally: WSL Bash rejected the Windows worktree metadata; Git for Windows Bash accepted it but could not resolve `origin/trunk`, expanded to the full server matrix, and was stopped after more than 13 minutes in unrelated shards. CI remains authoritative for the full gate.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
