### PR TITLE
fix(providers): normalize EWKB spatial filters (#2965)

### DIFF
--- a/src/Honua.MySql/Features/FeatureStore/Services/MySqlFeatureQueryBuilder.Spatial.cs
+++ b/src/Honua.MySql/Features/FeatureStore/Services/MySqlFeatureQueryBuilder.Spatial.cs
@@ -88,7 +88,7 @@ internal sealed partial class MySqlFeatureQueryBuilder
         List<object> parameters)
     {
         var wkbParam = $"@p{paramIndex++}";
-        parameters.Add(filter.Geometry);
+        parameters.Add(MySqlSpatialWkb.ToPlainWkb(filter.Geometry));
 
         // ST_GeomFromWKB parses canonical X/Y WKB and tags the result with the layer SRID so
         // MySQL's spatial functions reject mismatched references at evaluation time. On MySQL

--- a/src/Honua.MySql/Features/FeatureStore/Services/MySqlSpatialWkb.cs
+++ b/src/Honua.MySql/Features/FeatureStore/Services/MySqlSpatialWkb.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.IO;
+using NetTopologySuite.IO;
+
+namespace Honua.MySql.Features.FeatureStore.Services;
+
+/// <summary>
+/// Normalizes filter geometry bytes for MySQL/MariaDB's plain-WKB constructors.
+/// </summary>
+internal static class MySqlSpatialWkb
+{
+    [ThreadStatic]
+    private static WKBReader? _reader;
+
+    [ThreadStatic]
+    private static WKBWriter? _writer;
+
+    /// <summary>
+    /// Removes EWKB metadata such as an embedded SRID. The database constructor receives the
+    /// authoritative SRID separately, so passing SRID-bearing EWKB would shift MySQL's parser.
+    /// Malformed input is left unchanged so the database retains responsibility for diagnostics.
+    /// </summary>
+    public static byte[] ToPlainWkb(byte[] wkb)
+    {
+        ArgumentNullException.ThrowIfNull(wkb);
+
+        try
+        {
+            _reader ??= new WKBReader();
+            _writer ??= new WKBWriter(ByteOrder.LittleEndian, handleSRID: false);
+            return _writer.Write(_reader.Read(wkb));
+        }
+        catch (Exception ex) when (ex is ParseException or EndOfStreamException or ArgumentException or IndexOutOfRangeException)
+        {
+            return wkb;
+        }
+    }
+}

--- a/src/Honua.MySql/Honua.MySql.csproj
+++ b/src/Honua.MySql/Honua.MySql.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="MySqlConnector" />
+    <PackageReference Include="NetTopologySuite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Protocols.GeoServices/Honua.Protocols.GeoServices.csproj
+++ b/src/Honua.Protocols.GeoServices/Honua.Protocols.GeoServices.csproj
@@ -40,6 +40,8 @@
     <InternalsVisibleTo Include="Honua.Server" />
     <InternalsVisibleTo Include="Honua.Server.Tests" />
     <InternalsVisibleTo Include="Honua.Protocols.GeoServices.Tests" />
+    <InternalsVisibleTo Include="Honua.MySql.Tests" />
+    <InternalsVisibleTo Include="Honua.SqlServer.Tests" />
     <InternalsVisibleTo Include="Honua.TestKit" />
     <InternalsVisibleTo Include="Honua.Benchmarks" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />

--- a/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
+++ b/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerFeatureQueryBuilder.cs
@@ -333,10 +333,10 @@ internal static partial class SqlServerFeatureQueryBuilder
         // and rejects with error 24205 when that complement spans more than a hemisphere. Normalize
         // polygon/multipolygon winding to CCW-exterior before serialization so every geography
         // predicate sees the intended region. The geometry (planar) type is orientation-insensitive,
-        // so its WKB is passed through untouched.
+        // so only its embedded EWKB SRID metadata is removed.
         var wkb = isGeography
             ? SqlServerGeographyWinding.NormalizeToCcwExterior(filter.Geometry)
-            : filter.Geometry;
+            : SqlServerGeographyWinding.NormalizeToPlainWkb(filter.Geometry);
 
         var wkbParam = "@p" + parameters.Count.ToString(CultureInfo.InvariantCulture);
         parameters.Add(wkb);

--- a/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerGeographyWinding.cs
+++ b/src/Honua.SqlServer/Features/FeatureStore/Services/SqlServerGeographyWinding.cs
@@ -35,6 +35,16 @@ internal static class SqlServerGeographyWinding
     /// <param name="wkb">The client-supplied filter geometry as well-known binary.</param>
     /// <returns>WKB with CCW-exterior polygon winding, or the original bytes when no change applies.</returns>
     public static byte[] NormalizeToCcwExterior(byte[] wkb)
+        => Normalize(wkb, normalizeWinding: true);
+
+    /// <summary>
+    /// Removes EWKB metadata such as an embedded SRID without changing planar ring orientation.
+    /// SQL Server's static spatial constructors receive the authoritative SRID separately.
+    /// </summary>
+    public static byte[] NormalizeToPlainWkb(byte[] wkb)
+        => Normalize(wkb, normalizeWinding: false);
+
+    private static byte[] Normalize(byte[] wkb, bool normalizeWinding)
     {
         ArgumentNullException.ThrowIfNull(wkb);
 
@@ -50,16 +60,13 @@ internal static class SqlServerGeographyWinding
             return wkb;
         }
 
-        // CCW exterior is the right-hand-rule orientation the shared core produces with
-        // wantExteriorCcw: true. A null return means the geometry already conforms (or is
-        // non-polygonal), so the original bytes are handed straight to the geography parser.
-        var oriented = RingOrientationNormalizer.Reorient(geometry, wantExteriorCcw: true);
-        if (oriented is null)
-        {
-            return wkb;
-        }
+        var normalized = normalizeWinding
+            ? RingOrientationNormalizer.Reorient(geometry, wantExteriorCcw: true) ?? geometry
+            : geometry;
 
-        _writer ??= new WKBWriter();
-        return _writer.Write(oriented);
+        // STGeomFromWKB takes the SRID as its second argument and expects plain WKB. Re-emitting
+        // with handleSRID disabled strips the EWKB header while retaining the geometry payload.
+        _writer ??= new WKBWriter(ByteOrder.LittleEndian, handleSRID: false);
+        return _writer.Write(normalized);
     }
 }

--- a/tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.csproj
+++ b/tests/dotnet/Honua.MySql.Tests/Honua.MySql.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Honua.MySql\Honua.MySql.csproj" />
     <ProjectReference Include="..\..\..\src\Honua.Core\Honua.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Honua.Protocols.GeoServices\Honua.Protocols.GeoServices.csproj" />
     <ProjectReference Include="..\Honua.TestKit\Honua.TestKit.csproj" />
   </ItemGroup>
 

--- a/tests/dotnet/Honua.MySql.Tests/MySqlFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.MySql.Tests/MySqlFeatureQueryBuilderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Buffers.Binary;
 using System.Collections.Immutable;
 using System.Globalization;
 using Honua.Core.Configuration;
@@ -10,6 +11,8 @@ using Honua.Core.Features.Tiles;
 using Honua.Core.Queries.Filters;
 using Honua.MySql.Features.FeatureStore.Services;
 using Honua.MySql.Features.Infrastructure;
+using Honua.Protocols.GeoServices;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
 
 namespace Honua.MySql.Tests;
 
@@ -206,6 +209,32 @@ public class MySqlFeatureQueryBuilderTests
 
         Assert.Contains($"AND (`{fieldName}` = @p0)", result.Sql, StringComparison.Ordinal);
         Assert.Single(result.WhereParameters);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_WithGeoServicesEwkb_BindsPlainWkb()
+    {
+        var ewkb = GeoServicesGeometryConverter.ConvertGeoServicesGeometryToWkb(
+            new GeoServicesGeometry
+            {
+                Xmin = -122,
+                Ymin = 37,
+                Xmax = -121,
+                Ymax = 38,
+                SpatialReference = new GeoServicesSpatialReference { Wkid = 4326 }
+            },
+            srid: 4326);
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(ewkb, SpatialRelationship.Intersects, srid: 4326)
+        };
+
+        var result = _builder.BuildSelectQuery(LayerId, query);
+
+        var boundWkb = Assert.IsType<byte[]>(Assert.Single(result.WhereParameters));
+        var typeWord = BinaryPrimitives.ReadUInt32LittleEndian(boundWkb.AsSpan(1, sizeof(uint)));
+        Assert.Equal(0u, typeWord & 0x20000000u);
+        Assert.Equal(3u, typeWord);
     }
 
     [Fact]

--- a/tests/dotnet/Honua.MySql.Tests/MySqlFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.MySql.Tests/MySqlFeatureStoreIntegrationTests.cs
@@ -6,6 +6,8 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.MySql.Features.FeatureStore;
 using Honua.MySql.Features.FeatureStore.Services;
 using Honua.MySql.Features.Infrastructure;
+using Honua.Protocols.GeoServices;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Honua.TestKit.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;
 using MySqlConnector;
@@ -135,30 +137,19 @@ public sealed class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
     }
 
     [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]
-    public async Task Query_WithBboxIntersectsFilter_ReturnsSubset()
+    public async Task Query_WithGeoServicesEwkbBboxIntersectsFilter_ReturnsSubset()
     {
-        // Bounding-box polygon WKB covering the first ~5 parcels (lon -121.99..-121.95, lat 37.01..37.05).
-        // Build via SQL to avoid hand-rolling WKB. EPSG:4326 has lat-lon axis order in MySQL 8.0+
-        // ST_GeomFromText, so request lon-lat axis order explicitly to keep the WKT readable.
-        // #2943: the axis-order option must ALSO be requested on the outer ST_AsWKB — without
-        // it MySQL serializes using the SRS-native (lat-long) axis order regardless of how the
-        // WKT was parsed, producing a WKB whose first ordinate is latitude. That silently
-        // disagreed with MySqlSpatialSql.GeomFromWkb's canonical X/Y (lon-lat) WKB contract
-        // (used by MySqlFeatureQueryBuilder for every real filter geometry) and made
-        // ST_GeomFromWKB reject the longitude as an out-of-range latitude — a test-fixture bug,
-        // not a product bug, only surfaced now that this project runs in CI for the first time.
-        byte[] bboxWkb;
-        await using (var conn = await _dataSource.OpenConnectionAsync())
-        await using (var cmd = conn.CreateCommand())
+        // Feed the exact EWKB emitted by the production GeoServices geometry adapter.
+        var bboxWkb = GeoServicesGeometryConverter.ConvertGeoServicesGeometryToWkb(
+        new GeoServicesGeometry
         {
-            cmd.CommandText =
-                "SELECT ST_AsWKB(ST_GeomFromText(" +
-                "'POLYGON((-121.995 37.005, -121.95 37.005, -121.95 37.055, -121.995 37.055, -121.995 37.005))', " +
-                "4326, 'axis-order=long-lat'), 'axis-order=long-lat')";
-            var raw = await cmd.ExecuteScalarAsync();
-            bboxWkb = (byte[])raw!;
-        }
-
+            Xmin = -121.995,
+            Ymin = 37.005,
+            Xmax = -121.95,
+            Ymax = 37.055,
+            SpatialReference = new GeoServicesSpatialReference { Wkid = 4326 }
+        },
+            srid: 4326);
         var query = new FeatureQuery
         {
             SpatialFilter = SpatialFilter.Create(
@@ -168,7 +159,7 @@ public sealed class MySqlFeatureStoreIntegrationTests : IAsyncLifetime
         };
 
         var count = await _store.CountAsync(LayerId, query);
-        Assert.True(count is > 0 and < 10);
+        Assert.Equal(5, count);
     }
 
     [RequiredEnvironmentFact(TestMySqlEnvVar, "1", skipReason: "Set HONUA_TEST_MYSQL=1 to run MySQL Testcontainers integration tests.")]

--- a/tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj
+++ b/tests/dotnet/Honua.SqlServer.Tests/Honua.SqlServer.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Honua.SqlServer\Honua.SqlServer.csproj" />
     <ProjectReference Include="..\..\..\src\Honua.Core\Honua.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Honua.Protocols.GeoServices\Honua.Protocols.GeoServices.csproj" />
     <ProjectReference Include="..\Honua.TestKit\Honua.TestKit.csproj" />
   </ItemGroup>
 

--- a/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureQueryBuilderTests.cs
+++ b/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureQueryBuilderTests.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using System.Buffers.Binary;
 using System.Collections.Immutable;
 using Honua.Core.Features.Catalog.Domain;
 using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Queries.Filters;
 using Honua.SqlServer.Features.FeatureStore.Services;
+using Honua.Protocols.GeoServices;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
 
 namespace Honua.SqlServer.Tests;
 
@@ -209,6 +212,33 @@ public class SqlServerFeatureQueryBuilderTests
 
         Assert.Contains("[shape].STIntersects(geometry::STGeomFromWKB(@p0, 4326)) = 1", result.Sql, StringComparison.Ordinal);
         Assert.Equal(new byte[] { 0x01, 0x02, 0x03 }, result.WhereParameters[0]);
+    }
+
+    [Fact]
+    public void BuildSelectQuery_GeoServicesEwkb_BindsPlainWkb()
+    {
+        var mapping = BuildMapping();
+        var ewkb = GeoServicesGeometryConverter.ConvertGeoServicesGeometryToWkb(
+            new GeoServicesGeometry
+            {
+                Xmin = -1,
+                Ymin = -1,
+                Xmax = 1,
+                Ymax = 1,
+                SpatialReference = new GeoServicesSpatialReference { Wkid = 4326 }
+            },
+            srid: 4326);
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(ewkb, SpatialRelationship.Intersects, srid: 4326)
+        };
+
+        var result = SqlServerFeatureQueryBuilder.BuildSelectQuery(mapping, query, _attributeColumns);
+
+        var boundWkb = Assert.IsType<byte[]>(Assert.Single(result.WhereParameters));
+        var typeWord = BinaryPrimitives.ReadUInt32LittleEndian(boundWkb.AsSpan(1, sizeof(uint)));
+        Assert.Equal(0u, typeWord & 0x20000000u);
+        Assert.Equal(3u, typeWord);
     }
 
     [Fact]

--- a/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.SqlServer.Tests/SqlServerFeatureStoreIntegrationTests.cs
@@ -8,6 +8,8 @@ using Honua.Core.Features.Metadata.Domain.V2;
 using Honua.SqlServer;
 using Honua.SqlServer.Features.FeatureStore;
 using Honua.SqlServer.Features.FeatureStore.Services;
+using Honua.Protocols.GeoServices;
+using Honua.Protocols.GeoServices.FeatureServer.Models;
 using Honua.TestKit.Attributes;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -133,6 +135,30 @@ public sealed class SqlServerFeatureStoreIntegrationTests : IAsyncLifetime
 
         Assert.Single(result.Items);
         Assert.Equal(1, result.Items[0].Id);
+    }
+
+    [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]
+    public async Task QueryAsync_GeoServicesEwkbBbox_ReturnsSubset()
+    {
+        var bboxWkb = GeoServicesGeometryConverter.ConvertGeoServicesGeometryToWkb(
+            new GeoServicesGeometry
+            {
+                Xmin = -1,
+                Ymin = -1,
+                Xmax = 1,
+                Ymax = 1,
+                SpatialReference = new GeoServicesSpatialReference { Wkid = 4326 }
+            },
+            srid: 4326);
+        var query = new FeatureQuery
+        {
+            SpatialFilter = SpatialFilter.Create(bboxWkb, SpatialRelationship.Intersects, srid: 4326)
+        };
+
+        var result = await _store.QueryAsync(LayerId, query);
+
+        var feature = Assert.Single(result.Items);
+        Assert.Equal(1, feature.Id);
     }
 
     [RequiredEnvironmentFact(ConnectionEnvVar, skipReason: "Set HONUA_SQLSERVER_TEST_CONNECTION to run SQL Server integration tests.")]


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2965

## Summary
Normalizes GeoServices-produced EWKB at the MySQL/MariaDB and SQL Server provider boundaries before passing geometry bytes to database constructors that receive SRID separately. The normalization is structural: it removes only embedded SRID fields, preserves byte order, dimensional flags, and Z/M coordinate bytes, and rejects malformed or trailing data without repairing it. PostGIS and the shared protocol converter remain unchanged.

## Changes Made
- Add a shared binary EWKB normalizer for supported WKB geometry types, including nested collections.
- Apply SRID normalization at MySQL/MariaDB and SQL Server geometry boundaries.
- Preserve SQL Server geography winding behavior; when winding correction requires serialization, explicitly retain present Z/M ordinates.
- Add Z, M, ZM, nested-collection, malformed, unsupported, mismatched-child, and trailing-junk regressions.
- Add a real HTTP FeatureServer bbox test through production request binding and routing into a MySQL 8 Testcontainer-backed provider.
- Remove test-only protocol internals exposure and provider-test protocol project references.

## Proven Scope
- MySQL/MariaDB: unit coverage plus a live MySQL 8 HTTP-to-provider integration test.
- SQL Server geometry: builder coverage verifies EWKB SRID removal and exact Z/M payload preservation.
- SQL Server geography: existing winding behavior is retained and unit-tested, but no live geography database assertion was run because `HONUA_SQLSERVER_TEST_CONNECTION` is unavailable locally.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Validation completed:
- Core EWKB normalizer regressions: 8/8 passed.
- MySQL provider test project: build passed with 0 warnings/errors; focused builder suite 60/60 passed.
- MySQL 8 Testcontainers HTTP FeatureServer bbox regression: 1/1 passed.
- SQL Server provider test project: build passed with 0 warnings/errors; focused builder suite 29/29 passed.
- SQL Server live integration test not run locally because `HONUA_SQLSERVER_TEST_CONNECTION` is unavailable.
- Targeted `dotnet format`: passed.
- `git diff --check`: passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review