### PR TITLE
fix(elevation): map misaligned raster mosaics

### DIFF
--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -318,7 +318,7 @@
       "category": "Analytics",
       "edition": "Pro",
       "entryCount": 1,
-      "provingTestCount": 4,
+      "provingTestCount": 5,
       "maturity": {
         "implemented": 1
       },

--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -352,7 +352,7 @@
       "category": "Analytics",
       "edition": "Pro",
       "entryCount": 1,
-      "provingTestCount": 3,
+      "provingTestCount": 4,
       "maturity": {
         "implemented": 1
       },
@@ -1438,7 +1438,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 2,
-      "provingTestCount": 28,
+      "provingTestCount": 29,
       "maturity": {
         "implemented": 2
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5454,6 +5454,7 @@
         "Honua.Server.Tests.Features.Protocols.Elevation.ElevationEndpointTests.GetElevationProfile_WithIntervalOnly_DerivesSampleCountFromLineLength",
         "Honua.Server.Tests.Features.Protocols.Elevation.ElevationEndpointTests.GetElevationProfile_WithInvalidWkt_ReturnsUnprocessableEntity",
         "Honua.Server.Tests.Features.Protocols.Elevation.ElevationEndpointTests.GetElevationProfile_WithLineOutsideCoverage_ReturnsAllNoDataSamples",
+        "Honua.Server.Tests.Features.Protocols.Elevation.ElevationEndpointTests.GetElevationProfile_WithMixedResolutionMosaic_ReturnsActionableUnprocessableEntity",
         "Honua.Server.Tests.Features.Protocols.Elevation.ElevationEndpointTests.GetElevationProfile_WithNonLineStringGeometry_ReturnsUnprocessableEntity",
         "Honua.Server.Tests.Features.Protocols.Elevation.ElevationEndpointTests.GetElevationProfile_WithProjectedSrid_ReturnsValidGeodesicLength"
       ],
@@ -16274,6 +16275,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSlice_DegeneratePlane_ReturnsUnprocessableEntity",
         "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSlice_OverSurface_ReturnsIntersectionMetadata",
+        "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSlice_WithMixedResolutionMosaic_ReturnsActionableUnprocessableEntity",
         "Honua.Server.Tests.Features.Protocols.Elevation.SceneAnalysisEndpointTests.PostSlice_WithoutProLicense_ReturnsPaymentRequired"
       ],
       "proof_ledger_surface": "elevation-query-profile",

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -16257,7 +16257,8 @@
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_EndpointOutsideCoverage_ReturnsNotFoundAndNotVisible",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_MissingCoordinates_ReturnsBadRequest",
         "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_ObserverEqualsTarget_ReturnsUnprocessableEntity",
-        "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_WithCoveredFlatTerrain_ReportsVisible"
+        "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_WithCoveredFlatTerrain_ReportsVisible",
+        "Honua.Server.Tests.Features.Protocols.Elevation.VisibilityAnalysisEndpointTests.PostLineOfSight_WithMixedResolutionMosaic_ReturnsActionableUnprocessableEntity"
       ],
       "proof_ledger_surface": "elevation-query-profile",
       "maturity": "implemented",

--- a/src/Honua.Core/Features/Raster/Domain/ElevationDomain.cs
+++ b/src/Honua.Core/Features/Raster/Domain/ElevationDomain.cs
@@ -223,7 +223,13 @@ public enum ElevationFailureKind
     /// <summary>
     /// The supplied geometry is invalid or not the expected type.
     /// </summary>
-    InvalidGeometry = 2
+    InvalidGeometry = 2,
+
+    /// <summary>
+    /// The selected source rasters do not share a pixel-grid alignment and
+    /// therefore cannot be combined safely for profile-based analysis.
+    /// </summary>
+    MisalignedMosaic = 3
 }
 
 /// <summary>

--- a/src/Honua.Postgres/Features/Raster/PostgresElevationService.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresElevationService.cs
@@ -421,10 +421,16 @@ internal sealed class PostgresElevationService : IElevationService
         command.AddParameter("@maxSampleCount", options.MaxSampleCount);
     }
 
-    private static bool IsRasterAlignmentFailure(PostgresException exception)
-        => exception.SqlState == PostgresErrorCodes.InternalError &&
-           (string.Equals(exception.Routine, "rt_raster_from_two_rasters", StringComparison.Ordinal) ||
-            exception.MessageText.Contains("do not have the same alignment", StringComparison.OrdinalIgnoreCase));
+    internal static bool IsRasterAlignmentFailure(PostgresException exception)
+    {
+        const string routine = "rt_raster_from_two_rasters";
+        const string alignmentInvariant = "The two rasters provided do not have the same alignment";
+
+        return exception.SqlState == PostgresErrorCodes.InternalError &&
+               exception.MessageText.Contains(alignmentInvariant, StringComparison.Ordinal) &&
+               (string.Equals(exception.Routine, routine, StringComparison.Ordinal) ||
+                exception.MessageText.StartsWith($"{routine}:", StringComparison.Ordinal));
+    }
 
     /// <summary>
     /// SQL fragment that resolves the effective sample count from explicit

--- a/src/Honua.Postgres/Features/Raster/PostgresElevationService.cs
+++ b/src/Honua.Postgres/Features/Raster/PostgresElevationService.cs
@@ -6,6 +6,7 @@ using Honua.Core.Features.Raster.Abstractions;
 using Honua.Core.Features.Raster.Domain;
 using Honua.Postgres.Features.Infrastructure;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Honua.Postgres.Features.Raster;
 
@@ -341,8 +342,9 @@ internal sealed class PostgresElevationService : IElevationService
         command.AddParameter("@layerId", layerId);
         command.AddParameter("@rasterIds", rasterIds);
 
-        await using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        try
         {
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 var dist = reader.IsDBNull(1) ? 0.0 : reader.GetDouble(1);
@@ -364,6 +366,12 @@ internal sealed class PostgresElevationService : IElevationService
                     NoData = !elev.HasValue
                 });
             }
+        }
+        catch (PostgresException exception) when (IsRasterAlignmentFailure(exception))
+        {
+            throw new ElevationQueryException(
+                ElevationFailureKind.MisalignedMosaic,
+                "Elevation analysis cannot combine the selected rasters because their pixel grids are not aligned. Reproject or resample the dataset to a common pixel size, origin, and skew before retrying.");
         }
 
         if (samples.Count == 0)
@@ -412,6 +420,11 @@ internal sealed class PostgresElevationService : IElevationService
         command.AddParameter("@defaultSampleCount", options.DefaultSampleCount);
         command.AddParameter("@maxSampleCount", options.MaxSampleCount);
     }
+
+    private static bool IsRasterAlignmentFailure(PostgresException exception)
+        => exception.SqlState == PostgresErrorCodes.InternalError &&
+           (string.Equals(exception.Routine, "rt_raster_from_two_rasters", StringComparison.Ordinal) ||
+            exception.MessageText.Contains("do not have the same alignment", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// SQL fragment that resolves the effective sample count from explicit

--- a/src/Honua.Scene/Grpc/HonuaElevationGrpcService.cs
+++ b/src/Honua.Scene/Grpc/HonuaElevationGrpcService.cs
@@ -285,11 +285,13 @@ internal sealed partial class HonuaElevationGrpcService : Proto.ElevationService
     /// Maps an <see cref="ElevationFailureKind"/> to the gRPC status that mirrors
     /// the canonical HTTP mapping (ElevationEndpoints.MapElevationException), so a
     /// failure surfaces with consistent semantics across protocols. gRPC has no
-    /// 422 equivalent, so the HTTP UnprocessableEntity cases (UnsupportedCrs /
-    /// InvalidGeometry) collapse to <see cref="StatusCode.InvalidArgument"/>, which
+    /// 422 equivalent, so client-input cases (UnsupportedCrs / InvalidGeometry)
+    /// collapse to <see cref="StatusCode.InvalidArgument"/>, which
     /// carries the same "client supplied an unacceptable request" meaning. A
-    /// missing source maps to <see cref="StatusCode.NotFound"/> (HTTP 404) and any
-    /// future/unknown kind maps to the safe default
+    /// source mosaic that cannot be combined maps to
+    /// <see cref="StatusCode.FailedPrecondition"/> because the request is valid but
+    /// the configured dataset is not analysis-ready. A missing source maps to
+    /// <see cref="StatusCode.NotFound"/> (HTTP 404) and any future/unknown kind maps to the safe default
     /// <see cref="StatusCode.InvalidArgument"/> (HTTP 400 BadRequest).
     /// </summary>
     private static StatusCode MapFailureKind(ElevationFailureKind failureKind)
@@ -298,7 +300,7 @@ internal sealed partial class HonuaElevationGrpcService : Proto.ElevationService
             ElevationFailureKind.SourceUnavailable => StatusCode.NotFound,
             ElevationFailureKind.UnsupportedCrs => StatusCode.InvalidArgument,
             ElevationFailureKind.InvalidGeometry => StatusCode.InvalidArgument,
-            ElevationFailureKind.MisalignedMosaic => StatusCode.InvalidArgument,
+            ElevationFailureKind.MisalignedMosaic => StatusCode.FailedPrecondition,
             _ => StatusCode.InvalidArgument
         };
 

--- a/src/Honua.Scene/Grpc/HonuaElevationGrpcService.cs
+++ b/src/Honua.Scene/Grpc/HonuaElevationGrpcService.cs
@@ -298,6 +298,7 @@ internal sealed partial class HonuaElevationGrpcService : Proto.ElevationService
             ElevationFailureKind.SourceUnavailable => StatusCode.NotFound,
             ElevationFailureKind.UnsupportedCrs => StatusCode.InvalidArgument,
             ElevationFailureKind.InvalidGeometry => StatusCode.InvalidArgument,
+            ElevationFailureKind.MisalignedMosaic => StatusCode.InvalidArgument,
             _ => StatusCode.InvalidArgument
         };
 

--- a/src/Honua.Server/Features/Protocols/Elevation/ElevationEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/ElevationEndpoints.cs
@@ -380,6 +380,7 @@ internal static class ElevationEndpoints
             ElevationFailureKind.SourceUnavailable => StandardErrorHelpers.CreateNotFound(context, exception.Message),
             ElevationFailureKind.UnsupportedCrs => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
             ElevationFailureKind.InvalidGeometry => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
+            ElevationFailureKind.MisalignedMosaic => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
             _ => StandardErrorHelpers.CreateBadRequest(context, exception.Message)
         };
 

--- a/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/SceneAnalysisEndpoints.cs
@@ -416,6 +416,7 @@ internal static partial class SceneAnalysisEndpoints
             ElevationFailureKind.SourceUnavailable => StandardErrorHelpers.CreateNotFound(context, exception.Message),
             ElevationFailureKind.UnsupportedCrs => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
             ElevationFailureKind.InvalidGeometry => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
+            ElevationFailureKind.MisalignedMosaic => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
             _ => StandardErrorHelpers.CreateBadRequest(context, exception.Message)
         };
 

--- a/src/Honua.Server/Features/Protocols/Elevation/VisibilityAnalysisEndpoints.cs
+++ b/src/Honua.Server/Features/Protocols/Elevation/VisibilityAnalysisEndpoints.cs
@@ -404,6 +404,7 @@ internal static partial class VisibilityAnalysisEndpoints
             ElevationFailureKind.SourceUnavailable => StandardErrorHelpers.CreateNotFound(context, exception.Message),
             ElevationFailureKind.UnsupportedCrs => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
             ElevationFailureKind.InvalidGeometry => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
+            ElevationFailureKind.MisalignedMosaic => StandardErrorHelpers.CreateUnprocessableEntity(context, exception.Message),
             _ => StandardErrorHelpers.CreateBadRequest(context, exception.Message)
         };
 

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresElevationServiceTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Raster/PostgresElevationServiceTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Postgres.Features.Raster;
+using Npgsql;
+
+namespace Honua.Postgres.Tests.Features.Raster;
+
+public sealed class PostgresElevationServiceTests
+{
+    [Fact]
+    public void IsRasterAlignmentFailure_ExactPostgisInvariant_ReturnsTrue()
+    {
+        var exception = CreateInternalError(
+            "rt_raster_from_two_rasters: The two rasters provided do not have the same alignment",
+            "rt_raster_from_two_rasters");
+
+        PostgresElevationService.IsRasterAlignmentFailure(exception).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRasterAlignmentFailure_UnrelatedInternalErrorFromSameRoutine_ReturnsFalse()
+    {
+        var exception = CreateInternalError(
+            "rt_raster_from_two_rasters: raster dimensions are invalid",
+            "rt_raster_from_two_rasters");
+
+        PostgresElevationService.IsRasterAlignmentFailure(exception).Should().BeFalse();
+    }
+
+    private static PostgresException CreateInternalError(string message, string? routine)
+        => new(
+            messageText: message,
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: PostgresErrorCodes.InternalError,
+            detail: null,
+            hint: null,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null,
+            where: null,
+            schemaName: null,
+            tableName: null,
+            columnName: null,
+            dataTypeName: null,
+            constraintName: null,
+            file: null,
+            line: null,
+            routine: routine);
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/ElevationEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/ElevationEndpointTests.cs
@@ -619,6 +619,22 @@ public sealed class ElevationEndpointTests : IAsyncLifetime
         json.RootElement.GetProperty("sampleCount").GetInt32().Should().Be(12);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("GET /elevation/{datasetId}/profile")]
+    public async Task GetElevationProfile_WithMixedResolutionMosaic_ReturnsActionableUnprocessableEntity()
+    {
+        await SeedMixedResolutionMosaicAsync();
+
+        var line = "LINESTRING(0 0, 0.1 0)";
+        var response = await _fixture.Client.GetAsync(
+            $"/elevation/0/profile?line={Uri.EscapeDataString(line)}&sampleCount=8");
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        (await response.Content.ReadAsStringAsync()).Should().Contain("pixel grids are not aligned");
+    }
+
     private Task SeedFullWorldRasterAsync(double elevationMeters)
         => RasterIntegrationTestData.ReplaceLayerRastersAsync(
             _fixture,
@@ -652,6 +668,35 @@ public sealed class ElevationEndpointTests : IAsyncLifetime
                 AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
                 CreatedAt: RasterIntegrationTestData.WestAcquisition,
                 Srid: srid));
+
+    private Task SeedMixedResolutionMosaicAsync()
+        => RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "coarse-world-dem",
+                Width: 2,
+                Height: 2,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent,
+                ScaleY: -WebMercatorExtent,
+                Value: 100,
+                AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
+                CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "fine-world-dem",
+                Width: 4,
+                Height: 4,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent / 2,
+                ScaleY: -WebMercatorExtent / 2,
+                Value: 125,
+                AcquisitionDate: RasterIntegrationTestData.EastAcquisition,
+                CreatedAt: RasterIntegrationTestData.EastAcquisition,
+                Srid: 3857));
 
     private async Task ClearLayerRastersAsync()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/SceneAnalysisEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/SceneAnalysisEndpointTests.cs
@@ -228,6 +228,29 @@ public sealed class SceneAnalysisEndpointTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.PaymentRequired);
     }
 
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/slice")]
+    public async Task PostSlice_WithMixedResolutionMosaic_ReturnsActionableUnprocessableEntity()
+    {
+        await SeedMixedResolutionMosaicAsync();
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/slice",
+            new
+            {
+                startLon = 0.0,
+                startLat = 0.0,
+                endLon = 0.1,
+                endLat = 0.0,
+                sampleCount = 8
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        (await response.Content.ReadAsStringAsync()).Should().Contain("pixel grids are not aligned");
+    }
+
     private Task SeedFullWorldRasterAsync(double elevationMeters)
         => RasterIntegrationTestData.ReplaceLayerRastersAsync(
             _fixture,
@@ -243,5 +266,34 @@ public sealed class SceneAnalysisEndpointTests : IAsyncLifetime
                 Value: elevationMeters,
                 AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
                 CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857));
+
+    private Task SeedMixedResolutionMosaicAsync()
+        => RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "coarse-world-dem",
+                Width: 2,
+                Height: 2,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent,
+                ScaleY: -WebMercatorExtent,
+                Value: 100,
+                AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
+                CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "fine-world-dem",
+                Width: 4,
+                Height: 4,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent / 2,
+                ScaleY: -WebMercatorExtent / 2,
+                Value: 125,
+                AcquisitionDate: RasterIntegrationTestData.EastAcquisition,
+                CreatedAt: RasterIntegrationTestData.EastAcquisition,
                 Srid: 3857));
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/VisibilityAnalysisEndpointTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Elevation/VisibilityAnalysisEndpointTests.cs
@@ -113,6 +113,31 @@ public sealed class VisibilityAnalysisEndpointTests : IAsyncLifetime
     [IntegrationTest]
     [Operation(Operations.ErrorHandling)]
     [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
+    public async Task PostLineOfSight_WithMixedResolutionMosaic_ReturnsActionableUnprocessableEntity()
+    {
+        await SeedMixedResolutionMosaicAsync();
+
+        var response = await _fixture.Client.PostAsJsonAsync(
+            "/elevation/0/line-of-sight",
+            new
+            {
+                observerLon = 0.0,
+                observerLat = 0.0,
+                targetLon = 0.1,
+                targetLat = 0.0,
+                sampleCount = 8
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("pixel grids are not aligned");
+        body.Should().Contain("Reproject or resample");
+    }
+
+    [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /elevation/{datasetId}/line-of-sight")]
     public async Task PostLineOfSight_EndpointOutsideCoverage_ReturnsNotFoundAndNotVisible()
     {
         // Regression: an observer/target ground sample that resolves to no-data
@@ -246,5 +271,34 @@ public sealed class VisibilityAnalysisEndpointTests : IAsyncLifetime
                 Value: elevationMeters,
                 AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
                 CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857));
+
+    private Task SeedMixedResolutionMosaicAsync()
+        => RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "coarse-world-dem",
+                Width: 2,
+                Height: 2,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent,
+                ScaleY: -WebMercatorExtent,
+                Value: 100,
+                AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
+                CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "fine-world-dem",
+                Width: 4,
+                Height: 4,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent / 2,
+                ScaleY: -WebMercatorExtent / 2,
+                Value: 125,
+                AcquisitionDate: RasterIntegrationTestData.EastAcquisition,
+                CreatedAt: RasterIntegrationTestData.EastAcquisition,
                 Srid: 3857));
 }

--- a/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/SceneGrpcIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Protocols/Grpc/SceneGrpcIntegrationTests.cs
@@ -1711,6 +1711,37 @@ public sealed class ElevationGrpcAuthorizationTests : IAsyncLifetime
     }
 
     [IntegrationTest]
+    [Operation(Operations.ErrorHandling)]
+    [Endpoint("POST /geospatial.v1.ElevationService/GetElevationProfile")]
+    public async Task GetElevationProfile_MisalignedMosaic_ThrowsFailedPrecondition()
+    {
+        _fixture.UpdateV2ServiceMetadata(
+            WebAppFixture.TestServiceId,
+            accessPolicy: new AccessPolicy { AllowAnonymous = true });
+        await SeedMixedResolutionMosaicAsync();
+
+        var line = new Proto.PolylineGeometry();
+        var path = new Proto.CoordinateSequence();
+        path.Coords.Add(new Proto.Coordinate { X = 0, Y = 0 });
+        path.Coords.Add(new Proto.Coordinate { X = 1000, Y = 0 });
+        line.Paths.Add(path);
+
+        var request = new Proto.GetElevationProfileRequest
+        {
+            LayerId = WebAppFixture.TestLayerId,
+            SampleCount = 8,
+            SpatialReference = new Proto.SpatialReference { Wkid = 3857, LatestWkid = 3857 },
+            Line = line,
+        };
+
+        var act = async () => await _elevationClient!.GetElevationProfileAsync(request, _headers);
+
+        var exception = (await act.Should().ThrowAsync<RpcException>()).Which;
+        exception.StatusCode.Should().Be(StatusCode.FailedPrecondition);
+        exception.Status.Detail.Should().Contain("pixel grids are not aligned");
+    }
+
+    [IntegrationTest]
     [Operation(Operations.Query)]
     [Endpoint("POST /geospatial.v1.ElevationService/GetElevation")]
     [InterfaceOperation(TestProtocols.Grpc, "geospatial.v1.ElevationService/GetElevation")]
@@ -1806,5 +1837,34 @@ public sealed class ElevationGrpcAuthorizationTests : IAsyncLifetime
                 Value: elevationMeters,
                 AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
                 CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857));
+
+    private Task SeedMixedResolutionMosaicAsync()
+        => RasterIntegrationTestData.ReplaceLayerRastersAsync(
+            _fixture,
+            WebAppFixture.TestLayerId,
+            new RasterSeed(
+                Name: "coarse-world-dem",
+                Width: 2,
+                Height: 2,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent,
+                ScaleY: -WebMercatorExtent,
+                Value: 100,
+                AcquisitionDate: RasterIntegrationTestData.WestAcquisition,
+                CreatedAt: RasterIntegrationTestData.WestAcquisition,
+                Srid: 3857),
+            new RasterSeed(
+                Name: "fine-world-dem",
+                Width: 4,
+                Height: 4,
+                UpperLeftX: -WebMercatorExtent,
+                UpperLeftY: WebMercatorExtent,
+                ScaleX: WebMercatorExtent / 2,
+                ScaleY: -WebMercatorExtent / 2,
+                Value: 125,
+                AcquisitionDate: RasterIntegrationTestData.EastAcquisition,
+                CreatedAt: RasterIntegrationTestData.EastAcquisition,
                 Srid: 3857));
 }


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Fixes #2959

## Summary
Maps PostGIS raster-alignment failures from elevation profile mosaics to an actionable domain error instead of allowing an internal database exception to escape as HTTP 500. Automatic resampling is deliberately avoided because selecting a high-resolution reference raster can expand a large mosaic without a reliable memory bound and silently changes elevation resolution semantics.

## Changes Made
- Add `MisalignedMosaic` to the canonical elevation failure model and map it to HTTP 422 / gRPC `InvalidArgument`.
- Translate only Postgres `XX000` alignment failures from `rt_raster_from_two_rasters` at the profile mosaic boundary; unrelated database failures remain unhandled and observable.
- Add a real PostGIS endpoint regression with overlapping 2x2 and 4x4 rasters covering the same extent.
- Regenerate the feature catalog and capability matrix evidence projections.
- Audit sibling raster unions: dataset-map rendering already aligns inputs before union; import validation enforces SRID/band compatibility but intentionally permits differing grids; `PostgresRasterStore` has additional mosaic unions outside the profile-analysis call path and is unchanged by this narrowly scoped domain contract.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [x] Manual testing performed

Validation:
- Mixed-grid endpoint regression: 1 passed, 0 failed against real PostGIS.
- Architecture suite: 174 passed, 0 failed.
- Release solution build with warnings as errors: 0 warnings, 0 errors.
- `dotnet format Honua.sln --verify-no-changes --no-restore`: passed.
- Feature catalog emitter and capability-matrix drift check: passed.
- `scripts/ci/pre-pr-check.sh` was attempted, but WSL cannot resolve this Windows worktree's absolute `.git/worktrees` pointer and treats the Windows `CLAUDE.md` link as a duplicate. The equivalent PowerShell checks above completed successfully.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (wrapper limitation documented above; equivalent checks passed)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review
