### PR TITLE
fix(odata): route reads by layer provider

### DIFF
--- a/docs/reference/configuration/data-sources/databricks.md
+++ b/docs/reference/configuration/data-sources/databricks.md
@@ -1,5 +1,18 @@
 # Databricks provider (read-only, best-effort)
 
+## Protocol routing
+
+OData collection queries, counts, and streaming responses resolve this provider per layer from the
+Metadata v2 storage binding. Providers without native streaming use the same routed reader through
+a bounded, materialized page; Honua never falls back to the primary provider for that layer.
+This provider is read-only, so OData create/update/delete requests (including `$batch` mutations)
+return `501 ProviderWriteNotSupported` instead of dispatching to the primary provider.
+
+OGC API Tiles per-collection provider routing remains the follow-up slice of
+[issue #2962](https://github.com/honua-io/honua-server/issues/2962). Until that lands, do not treat
+secondary-provider OGC tile reachability as supported.
+
+
 The Databricks provider serves Honua feature layers from tables/views in a Databricks
 SQL Warehouse. It plugs in alongside the primary backend (PostGIS, DuckDB, or MySQL)
 through the shared feature-provider router: any layer whose backing `DataConnection`

--- a/docs/reference/configuration/data-sources/oracle.md
+++ b/docs/reference/configuration/data-sources/oracle.md
@@ -1,5 +1,18 @@
 # Oracle provider
 
+## Protocol routing
+
+OData collection queries, counts, and streaming responses resolve this provider per layer from the
+Metadata v2 storage binding. Providers without native streaming use the same routed reader through
+a bounded, materialized page; Honua never falls back to the primary provider for that layer.
+This provider is read-only, so OData create/update/delete requests (including `$batch` mutations)
+return `501 ProviderWriteNotSupported` instead of dispatching to the primary provider.
+
+OGC API Tiles per-collection provider routing remains the follow-up slice of
+[issue #2962](https://github.com/honua-io/honua-server/issues/2962). Until that lands, do not treat
+secondary-provider OGC tile reachability as supported.
+
+
 Honua exposes standard Oracle Spatial (`SDO_GEOMETRY`) tables as read-only feature layers
 through the shared `IFeatureDataProvider` seam. Oracle is the dominant enterprise-geodatabase
 backend and the most-requested connect-in-place target after PostGIS / SQL Server / MySQL.

--- a/docs/reference/configuration/data-sources/redshift.md
+++ b/docs/reference/configuration/data-sources/redshift.md
@@ -1,5 +1,18 @@
 # Amazon Redshift provider
 
+## Protocol routing
+
+OData collection queries, counts, and streaming responses resolve this provider per layer from the
+Metadata v2 storage binding. Providers without native streaming use the same routed reader through
+a bounded, materialized page; Honua never falls back to the primary provider for that layer.
+This provider is read-only, so OData create/update/delete requests (including `$batch` mutations)
+return `501 ProviderWriteNotSupported` instead of dispatching to the primary provider.
+
+OGC API Tiles per-collection provider routing remains the follow-up slice of
+[issue #2962](https://github.com/honua-io/honua-server/issues/2962). Until that lands, do not treat
+secondary-provider OGC tile reachability as supported.
+
+
 Honua exposes Amazon Redshift (`GEOMETRY` and `GEOGRAPHY`) tables as read-only feature layers
 through the shared `IFeatureDataProvider` seam. Redshift is the analytical-warehouse backend for
 organizations that already keep authoritative spatial data in Redshift and want to publish it

--- a/docs/reference/configuration/data-sources/snowflake.md
+++ b/docs/reference/configuration/data-sources/snowflake.md
@@ -1,5 +1,18 @@
 # Snowflake provider
 
+## Protocol routing
+
+OData collection queries, counts, and streaming responses resolve this provider per layer from the
+Metadata v2 storage binding. Providers without native streaming use the same routed reader through
+a bounded, materialized page; Honua never falls back to the primary provider for that layer.
+This provider is read-only, so OData create/update/delete requests (including `$batch` mutations)
+return `501 ProviderWriteNotSupported` instead of dispatching to the primary provider.
+
+OGC API Tiles per-collection provider routing remains the follow-up slice of
+[issue #2962](https://github.com/honua-io/honua-server/issues/2962). Until that lands, do not treat
+secondary-provider OGC tile reachability as supported.
+
+
 Honua exposes Snowflake native `GEOGRAPHY` and `GEOMETRY` tables as read-only feature layers
 through the shared `IFeatureDataProvider` seam. Snowflake is a widely deployed cloud data
 warehouse and a common connect-in-place target for analytical spatial data.

--- a/docs/reference/configuration/data-sources/sql-server.md
+++ b/docs/reference/configuration/data-sources/sql-server.md
@@ -1,5 +1,18 @@
 # SQL Server provider
 
+## Protocol routing
+
+OData collection queries, counts, and streaming responses resolve this provider per layer from the
+Metadata v2 storage binding. Providers without native streaming use the same routed reader through
+a bounded, materialized page; Honua never falls back to the primary provider for that layer.
+This provider is read-only, so OData create/update/delete requests (including `$batch` mutations)
+return `501 ProviderWriteNotSupported` instead of dispatching to the primary provider.
+
+OGC API Tiles per-collection provider routing remains the follow-up slice of
+[issue #2962](https://github.com/honua-io/honua-server/issues/2962). Until that lands, do not treat
+secondary-provider OGC tile reachability as supported.
+
+
 Honua exposes SQL Server (`geometry` and `geography`) tables as read-only feature layers
 through the shared `IFeatureDataProvider` seam. SQL Server is the Tier 1 enterprise backend
 for organizations standardized on Microsoft data platforms.

--- a/src/Honua.Core/Features/FeatureStore/Services/FeatureProviderQueryRouter.cs
+++ b/src/Honua.Core/Features/FeatureStore/Services/FeatureProviderQueryRouter.cs
@@ -68,6 +68,41 @@ public sealed class FeatureProviderQueryRouter
         FeatureProviderReadOperation operation,
         CancellationToken cancellationToken = default)
     {
+        var providerBinding = await ResolveBindingAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            storageLayerId,
+            operation,
+            cancellationToken).ConfigureAwait(false);
+
+        return providerBinding.Provider is IBindableFeatureDataProvider bindable
+            ? bindable.CreateReaderForBinding(providerBinding)
+            : providerBinding.Provider.Reader;
+    }
+
+    /// <summary>
+    /// Resolves the provider binding for a V2 feature operation without discarding
+    /// the selected provider and its write capability.
+    /// </summary>
+    /// <param name="snapshot">Authorized metadata snapshot.</param>
+    /// <param name="service">Service hosting the publication.</param>
+    /// <param name="resource">Published resource.</param>
+    /// <param name="publication">Publication being resolved.</param>
+    /// <param name="storageLayerId">Fallback integer storage handle.</param>
+    /// <param name="operation">Read capability required by the caller.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved provider binding.</returns>
+    public async Task<FeatureProviderBinding> ResolveBindingAsync(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service service,
+        MetadataV2Resource resource,
+        MetadataV2Publication publication,
+        int storageLayerId,
+        FeatureProviderReadOperation operation,
+        CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(snapshot);
         ArgumentNullException.ThrowIfNull(service);
         ArgumentNullException.ThrowIfNull(resource);
@@ -130,9 +165,7 @@ public sealed class FeatureProviderQueryRouter
                 provider,
                 connection);
 
-            return provider is IBindableFeatureDataProvider bindable
-                ? bindable.CreateReaderForBinding(providerBinding)
-                : provider.Reader;
+            return providerBinding;
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
@@ -891,16 +891,19 @@ internal sealed class ODataCrudHandler(
         CancellationToken cancellationToken)
     {
         var resolver = context.RequestServices.GetService<ODataFeatureProviderResolver>();
-        if (resolver is null || layerValidation.Resource is null)
+        if (resolver is null)
         {
-            return null;
+            return ODataUtilityService.CreateODataError(
+                context,
+                "InternalServerError",
+                "Feature provider routing is not configured.",
+                StatusCodes.Status500InternalServerError);
         }
 
-        var storageLayerId = await ODataV2Lookups.ResolveStorageLayerIdAsync(
-            context,
+        var storageLayerId = ODataV2Lookups.ResolveStorageLayerId(
+            layerValidation.Snapshot!,
             layerValidation.Publication,
-            layerValidation.Resource,
-            cancellationToken).ConfigureAwait(false);
+            layerValidation.Resource!);
         if (!storageLayerId.HasValue)
         {
             return ODataUtilityService.CreateODataError(
@@ -913,7 +916,7 @@ internal sealed class ODataCrudHandler(
         var support = await resolver.CheckWriteSupportAsync(
             layerValidation.Snapshot!,
             layerValidation.Service,
-            layerValidation.Resource,
+            layerValidation.Resource!,
             layerValidation.Publication,
             storageLayerId.Value,
             cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataCrudHandler.cs
@@ -85,7 +85,6 @@ internal sealed class ODataCrudHandler(
         {
             return layerValidation.ErrorResult!;
         }
-
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(
             HonuaTelemetry.Activities.FeatureQuery, ActivityKind.Internal);
         activity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.OData);
@@ -167,7 +166,6 @@ internal sealed class ODataCrudHandler(
         {
             return layerValidation.ErrorResult!;
         }
-
         var baseUrl = ODataUtilityService.GetBaseUrl(context.Request);
         var result = await _crudService.GetFeatureAsync(layerId, objectId, baseUrl, effectiveToken);
         if (!result.IsSuccess)
@@ -225,7 +223,6 @@ internal sealed class ODataCrudHandler(
         {
             return layerValidation.ErrorResult!;
         }
-
         return ODataUtilityService.CreateODataError(
             context,
             "ResourceNotFound",
@@ -322,6 +319,12 @@ internal sealed class ODataCrudHandler(
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
+        }
+        var providerWriteError = await RejectUnsupportedProviderWriteAsync(
+            context, resolvedLayerId.Value, layerValidation, effectiveToken).ConfigureAwait(false);
+        if (providerWriteError is not null)
+        {
+            return providerWriteError;
         }
 
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(
@@ -537,6 +540,12 @@ internal sealed class ODataCrudHandler(
         {
             return layerValidation.ErrorResult!;
         }
+        var providerWriteError = await RejectUnsupportedProviderWriteAsync(
+            context, layerId, layerValidation, effectiveToken).ConfigureAwait(false);
+        if (providerWriteError is not null)
+        {
+            return providerWriteError;
+        }
 
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(
             HonuaTelemetry.Activities.FeatureEdit, ActivityKind.Internal);
@@ -660,6 +669,12 @@ internal sealed class ODataCrudHandler(
         if (!layerValidation.IsValid)
         {
             return layerValidation.ErrorResult!;
+        }
+        var providerWriteError = await RejectUnsupportedProviderWriteAsync(
+            context, layerId, layerValidation, effectiveToken).ConfigureAwait(false);
+        if (providerWriteError is not null)
+        {
+            return providerWriteError;
         }
 
         using var activity = HonuaTelemetry.ActivitySource.StartActivity(
@@ -868,6 +883,48 @@ internal sealed class ODataCrudHandler(
 
     private static int ResolveLayerSrid(LayerValidationHelpers.MetadataV2ValidationResult layerValidation)
         => layerValidation.Resource!.ReadSrid() ?? SpatialReference.WGS84.ToSrid();
+
+    private static async Task<IResult?> RejectUnsupportedProviderWriteAsync(
+        HttpContext context,
+        int layerId,
+        LayerValidationHelpers.MetadataV2ValidationResult layerValidation,
+        CancellationToken cancellationToken)
+    {
+        var resolver = context.RequestServices.GetService<ODataFeatureProviderResolver>();
+        if (resolver is null || layerValidation.Resource is null)
+        {
+            return null;
+        }
+
+        var storageLayerId = await ODataV2Lookups.ResolveStorageLayerIdAsync(
+            context,
+            layerValidation.Publication,
+            layerValidation.Resource,
+            cancellationToken).ConfigureAwait(false);
+        if (!storageLayerId.HasValue)
+        {
+            return ODataUtilityService.CreateODataError(
+                context,
+                "InternalServerError",
+                $"Layer {layerId} storage binding is not configured.",
+                StatusCodes.Status500InternalServerError);
+        }
+
+        var support = await resolver.CheckWriteSupportAsync(
+            layerValidation.Snapshot!,
+            layerValidation.Service,
+            layerValidation.Resource,
+            layerValidation.Publication,
+            storageLayerId.Value,
+            cancellationToken).ConfigureAwait(false);
+        return support.Supported
+            ? null
+            : ODataUtilityService.CreateODataError(
+                context,
+                "ProviderWriteNotSupported",
+                support.ErrorMessage!,
+                StatusCodes.Status501NotImplemented);
+    }
 
     private static bool TryExtractObjectId(object? payload, out long objectId)
     {

--- a/src/Honua.Protocols.OData/Features/ODataQueryDependencies.cs
+++ b/src/Honua.Protocols.OData/Features/ODataQueryDependencies.cs
@@ -22,7 +22,8 @@ internal sealed class ODataQueryDependencies
         ODataQuerySearchService querySearchService,
         IResponseCache responseCache,
         IETagService etagService,
-        IOptions<CacheOptions> cacheOptions)
+        IOptions<CacheOptions> cacheOptions,
+        ODataFeatureProviderResolver? featureProviderResolver = null)
     {
         FeatureReader = featureReader ?? throw new ArgumentNullException(nameof(featureReader));
         GeometryService = geometryService ?? throw new ArgumentNullException(nameof(geometryService));
@@ -32,6 +33,7 @@ internal sealed class ODataQueryDependencies
         ResponseCache = responseCache ?? throw new ArgumentNullException(nameof(responseCache));
         ETagService = etagService ?? throw new ArgumentNullException(nameof(etagService));
         CacheOptions = cacheOptions?.Value ?? throw new ArgumentNullException(nameof(cacheOptions));
+        FeatureProviderResolver = featureProviderResolver;
     }
 
     public IFeatureReader FeatureReader { get; }
@@ -42,4 +44,5 @@ internal sealed class ODataQueryDependencies
     public IResponseCache ResponseCache { get; }
     public IETagService ETagService { get; }
     public CacheOptions CacheOptions { get; }
+    public ODataFeatureProviderResolver? FeatureProviderResolver { get; }
 }

--- a/src/Honua.Protocols.OData/Features/ODataQueryHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataQueryHandler.cs
@@ -468,11 +468,10 @@ internal sealed partial class ODataQueryHandler(
             }
             var resource = layerValidation.Resource!;
             var publicLayerId = layerValidation.Publication?.LayerIndex ?? layerId;
-            var storageLayerId = await ResolveStorageLayerIdAsync(
-                context,
+            var storageLayerId = ODataV2Lookups.ResolveStorageLayerId(
+                layerValidation.Snapshot!,
                 layerValidation.Publication,
-                resource,
-                effectiveToken).ConfigureAwait(false);
+                resource);
             if (!storageLayerId.HasValue)
             {
                 return ODataUtilityService.CreateODataError(
@@ -482,17 +481,15 @@ internal sealed partial class ODataQueryHandler(
                     StatusCodes.Status500InternalServerError);
             }
 
-            var featureReader = _featureProviderResolver is null
-                ? _featureReader
-                : await _featureProviderResolver.ResolveReaderAsync(
+            var featureReader = await (_featureProviderResolver
+                ?? throw new InvalidOperationException("Feature provider routing is not configured."))
+                .ResolveQueryReaderAsync(
                     layerValidation.Snapshot!,
                     layerValidation.Service,
                     resource,
                     layerValidation.Publication,
                     storageLayerId.Value,
-                    pagination.Limit == 0 && count == true
-                        ? FeatureProviderReadOperation.Count
-                        : FeatureProviderReadOperation.Query,
+                    requireCount: count == true,
                     effectiveToken).ConfigureAwait(false);
 
             var requestActivity = Activity.Current;
@@ -929,19 +926,6 @@ internal sealed partial class ODataQueryHandler(
     private ValueTask<AxisOrder> ResolveAxisOrderAsync(int? srid, CancellationToken cancellationToken)
     {
         return ODataCrsUtilities.ResolveAxisOrderAsync(_crsRegistry, srid, cancellationToken);
-    }
-
-    private static async Task<int?> ResolveStorageLayerIdAsync(
-        HttpContext context,
-        MetadataV2Publication? publication,
-        MetadataV2Resource resource,
-        CancellationToken cancellationToken)
-    {
-        return await ODataV2Lookups.ResolveStorageLayerIdAsync(
-            context,
-            publication,
-            resource,
-            cancellationToken).ConfigureAwait(false);
     }
 
     private static IEnumerable<Dictionary<string, object?>> ApplyLayerPayloadOrdering(

--- a/src/Honua.Protocols.OData/Features/ODataQueryHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataQueryHandler.cs
@@ -8,6 +8,7 @@ using Honua.Core.Configuration;
 using Honua.Core.Features.Caching;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Infrastructure.Caching;
@@ -38,6 +39,7 @@ internal sealed partial class ODataQueryHandler(
 
     private readonly IFeatureReader _featureReader = (dependencies
         ?? throw new ArgumentNullException(nameof(dependencies))).FeatureReader;
+    private readonly ODataFeatureProviderResolver? _featureProviderResolver = dependencies.FeatureProviderResolver;
     private readonly IGeometryService _geometryService = dependencies.GeometryService;
     private readonly ICrsRegistry _crsRegistry = dependencies.CrsRegistry;
     private readonly ODataValidationService _validationService = dependencies.ValidationService;
@@ -480,6 +482,19 @@ internal sealed partial class ODataQueryHandler(
                     StatusCodes.Status500InternalServerError);
             }
 
+            var featureReader = _featureProviderResolver is null
+                ? _featureReader
+                : await _featureProviderResolver.ResolveReaderAsync(
+                    layerValidation.Snapshot!,
+                    layerValidation.Service,
+                    resource,
+                    layerValidation.Publication,
+                    storageLayerId.Value,
+                    pagination.Limit == 0 && count == true
+                        ? FeatureProviderReadOperation.Count
+                        : FeatureProviderReadOperation.Query,
+                    effectiveToken).ConfigureAwait(false);
+
             var requestActivity = Activity.Current;
             requestActivity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.OData);
             requestActivity?.SetTag(HonuaTelemetry.Tags.LayerId, publicLayerId.ToString(CultureInfo.InvariantCulture));
@@ -516,6 +531,7 @@ internal sealed partial class ODataQueryHandler(
                     format,
                     bbox,
                     storageLayerId.Value,
+                    featureReader,
                     effectiveToken);
             }
 
@@ -590,7 +606,7 @@ internal sealed partial class ODataQueryHandler(
             }
 
             // Execute query
-            var queryResult = await _featureReader.QueryAsync(storageLayerId.Value, featureQuery, effectiveToken);
+            var queryResult = await featureReader.QueryAsync(storageLayerId.Value, featureQuery, effectiveToken);
 
             // The query fetched up to pagination.Limit + 1 rows as a continuation probe.
             // A returned count exceeding the requested page size means more rows remain,
@@ -799,6 +815,7 @@ internal sealed partial class ODataQueryHandler(
         string? format,
         BoundingBox? bbox,
         int storageLayerId,
+        IFeatureReader featureReader,
         CancellationToken cancellationToken)
     {
         long? totalCount = null;
@@ -828,7 +845,7 @@ internal sealed partial class ODataQueryHandler(
                 return ODataUtilityService.CreateODataError(context, "InvalidQuery", queryError);
             }
 
-            totalCount = await _featureReader.CountAsync(storageLayerId, countQuery, cancellationToken);
+            totalCount = await featureReader.CountAsync(storageLayerId, countQuery, cancellationToken);
         }
 
         var baseUrl = ODataUtilityService.GetBaseUrl(context.Request);

--- a/src/Honua.Protocols.OData/Features/ODataServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.OData/Features/ODataServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Configuration;
 using Honua.Core.Features.Edit;
 using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Query;
@@ -71,6 +72,9 @@ internal static class ODataServiceCollectionExtensions
         services.AddScoped<ODataSearchService>();
         services.AddScoped<ODataQuerySearchService>();
         services.AddScoped<ODataValidationService>();
+        services.AddScoped(sp => new ODataFeatureProviderResolver(
+            sp.GetRequiredService<IFeatureReader>(),
+            sp.GetService<FeatureProviderQueryRouter>()));
         services.AddScoped<ODataQueryDependencies>();
         services.AddScoped(sp =>
         {

--- a/src/Honua.Protocols.OData/Features/ODataServiceCollectionExtensions.cs
+++ b/src/Honua.Protocols.OData/Features/ODataServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ internal static class ODataServiceCollectionExtensions
         services.AddScoped<ODataValidationService>();
         services.AddScoped(sp => new ODataFeatureProviderResolver(
             sp.GetRequiredService<IFeatureReader>(),
+            sp.GetRequiredService<IFeatureWriter>(),
             sp.GetService<FeatureProviderQueryRouter>()));
         services.AddScoped<ODataQueryDependencies>();
         services.AddScoped(sp =>

--- a/src/Honua.Protocols.OData/Features/ODataStreamingQueryHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataStreamingQueryHandler.cs
@@ -3,9 +3,11 @@
 
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
 using Honua.Core.Features.Geometry.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
 using Honua.Core.Features.Metadata.Domain.V2;
@@ -30,6 +32,7 @@ internal sealed partial class ODataStreamingQueryHandler(
     ILogger<ODataStreamingQueryHandler> logger)
 {
     private readonly IFeatureReader _featureReader = dependencies.FeatureReader;
+    private readonly ODataFeatureProviderResolver? _featureProviderResolver = dependencies.FeatureProviderResolver;
     private readonly IGeometryService _geometryService = dependencies.GeometryService;
     private readonly ICrsRegistry _crsRegistry = dependencies.CrsRegistry;
     private readonly IStreamingFeatureStore _streamingFeatureStore = streamingFeatureStore ?? throw new ArgumentNullException(nameof(streamingFeatureStore));
@@ -395,6 +398,16 @@ internal sealed partial class ODataStreamingQueryHandler(
                     "Layer storage binding is not configured.",
                     StatusCodes.Status500InternalServerError);
             }
+            var featureReader = _featureProviderResolver is null
+                ? _featureReader
+                : await _featureProviderResolver.ResolveReaderAsync(
+                    layerValidation.Snapshot!,
+                    layerValidation.Service,
+                    resource,
+                    layerValidation.Publication,
+                    storageLayerId.Value,
+                    countValue == true ? FeatureProviderReadOperation.Count : FeatureProviderReadOperation.Query,
+                    effectiveToken).ConfigureAwait(false);
             var deltaDefinition = deltaState ?? new ODataDeltaService.DeltaQueryState
             {
                 Timestamp = DateTimeOffset.UtcNow,
@@ -522,7 +535,7 @@ internal sealed partial class ODataStreamingQueryHandler(
             var streamQuery = featureQuery;
             if (countValue == true)
             {
-                totalCount = await _featureReader.CountAsync(storageLayerId.Value, featureQuery, effectiveToken);
+                totalCount = await featureReader.CountAsync(storageLayerId.Value, featureQuery, effectiveToken);
             }
             else if (streamQuery.Limit.HasValue && streamQuery.Limit.Value < int.MaxValue)
             {
@@ -547,8 +560,13 @@ internal sealed partial class ODataStreamingQueryHandler(
             var selectedFields = ODataUtilityService.ParseSelect(select);
 
             // Stream the OData response
+            var featureStream = featureReader is IStreamingFeatureStore routedStreamingStore
+                ? routedStreamingStore.StreamFeaturesAsync(storageLayerId.Value, streamQuery, effectiveToken)
+                : ReferenceEquals(featureReader, _featureReader)
+                    ? _streamingFeatureStore.StreamFeaturesAsync(storageLayerId.Value, streamQuery, effectiveToken)
+                    : QueryAsStreamAsync(featureReader, storageLayerId.Value, streamQuery, effectiveToken);
             await StreamODataFeaturesAsync(
-                (IAsyncEnumerable<Feature>)_streamingFeatureStore.StreamFeaturesAsync(storageLayerId.Value, streamQuery, effectiveToken),
+                featureStream,
                 context,
                 publicLayerId,
                 resource.ReadSrid() ?? 4326,
@@ -1035,6 +1053,16 @@ internal sealed partial class ODataStreamingQueryHandler(
                     "Layer storage binding is not configured.",
                     StatusCodes.Status500InternalServerError);
             }
+            var featureReader = _featureProviderResolver is null
+                ? _featureReader
+                : await _featureProviderResolver.ResolveReaderAsync(
+                    layerValidation.Snapshot!,
+                    layerValidation.Service,
+                    resource,
+                    layerValidation.Publication,
+                    storageLayerId.Value,
+                    FeatureProviderReadOperation.Count,
+                    effectiveToken).ConfigureAwait(false);
 
             var requestActivity = Activity.Current;
             requestActivity?.SetTag(HonuaTelemetry.Tags.Protocol, HonuaTelemetry.Protocols.OData);
@@ -1058,7 +1086,7 @@ internal sealed partial class ODataStreamingQueryHandler(
                 return ODataUtilityService.CreateODataError(context, "InvalidQuery", queryError);
             }
 
-            var count = await _featureReader.CountAsync(storageLayerId.Value, featureQuery, effectiveToken);
+            var count = await featureReader.CountAsync(storageLayerId.Value, featureQuery, effectiveToken);
 
             ODataUtilityService.SetODataHeaders(context);
             HonuaTelemetry.SetSuccess(featureActivity, (int)Math.Min(count, int.MaxValue));
@@ -1088,6 +1116,20 @@ internal sealed partial class ODataStreamingQueryHandler(
         finally
         {
             featureActivity?.Dispose();
+        }
+    }
+
+    private static async IAsyncEnumerable<Feature> QueryAsStreamAsync(
+        IFeatureReader featureReader,
+        int storageLayerId,
+        FeatureQuery query,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var result = await featureReader.QueryAsync(storageLayerId, query, cancellationToken).ConfigureAwait(false);
+        foreach (var feature in result.Items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return feature;
         }
     }
 

--- a/src/Honua.Protocols.OData/Features/ODataStreamingQueryHandler.cs
+++ b/src/Honua.Protocols.OData/Features/ODataStreamingQueryHandler.cs
@@ -385,11 +385,10 @@ internal sealed partial class ODataStreamingQueryHandler(
             }
             var resource = layerValidation.Resource!;
             var publicLayerId = layerValidation.Publication?.LayerIndex ?? layerId.Value;
-            var storageLayerId = await ODataV2Lookups.ResolveStorageLayerIdAsync(
-                context,
+            var storageLayerId = ODataV2Lookups.ResolveStorageLayerId(
+                layerValidation.Snapshot!,
                 layerValidation.Publication,
-                resource,
-                effectiveToken).ConfigureAwait(false);
+                resource);
             if (!storageLayerId.HasValue)
             {
                 return ODataUtilityService.CreateODataError(
@@ -398,15 +397,15 @@ internal sealed partial class ODataStreamingQueryHandler(
                     "Layer storage binding is not configured.",
                     StatusCodes.Status500InternalServerError);
             }
-            var featureReader = _featureProviderResolver is null
-                ? _featureReader
-                : await _featureProviderResolver.ResolveReaderAsync(
+            var featureReader = await (_featureProviderResolver
+                ?? throw new InvalidOperationException("Feature provider routing is not configured."))
+                .ResolveQueryReaderAsync(
                     layerValidation.Snapshot!,
                     layerValidation.Service,
                     resource,
                     layerValidation.Publication,
                     storageLayerId.Value,
-                    countValue == true ? FeatureProviderReadOperation.Count : FeatureProviderReadOperation.Query,
+                    requireCount: countValue == true,
                     effectiveToken).ConfigureAwait(false);
             var deltaDefinition = deltaState ?? new ODataDeltaService.DeltaQueryState
             {
@@ -1040,11 +1039,10 @@ internal sealed partial class ODataStreamingQueryHandler(
             }
             var resource = layerValidation.Resource!;
             var publicLayerId = layerValidation.Publication?.LayerIndex ?? layerId.Value;
-            var storageLayerId = await ODataV2Lookups.ResolveStorageLayerIdAsync(
-                context,
+            var storageLayerId = ODataV2Lookups.ResolveStorageLayerId(
+                layerValidation.Snapshot!,
                 layerValidation.Publication,
-                resource,
-                effectiveToken).ConfigureAwait(false);
+                resource);
             if (!storageLayerId.HasValue)
             {
                 return ODataUtilityService.CreateODataError(
@@ -1053,9 +1051,9 @@ internal sealed partial class ODataStreamingQueryHandler(
                     "Layer storage binding is not configured.",
                     StatusCodes.Status500InternalServerError);
             }
-            var featureReader = _featureProviderResolver is null
-                ? _featureReader
-                : await _featureProviderResolver.ResolveReaderAsync(
+            var featureReader = await (_featureProviderResolver
+                ?? throw new InvalidOperationException("Feature provider routing is not configured."))
+                .ResolveReaderAsync(
                     layerValidation.Snapshot!,
                     layerValidation.Service,
                     resource,

--- a/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Dispatch.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Dispatch.cs
@@ -396,11 +396,10 @@ internal sealed partial class ODataBatchHandler
             }
         }
 
-        var storageLayerId = await ODataV2Lookups.ResolveStorageLayerIdAsync(
-            context,
+        var storageLayerId = ODataV2Lookups.ResolveStorageLayerId(
+            validation.Snapshot!,
             validation.Publication,
-            validation.Resource,
-            cancellationToken).ConfigureAwait(false);
+            validation.Resource);
         if (!storageLayerId.HasValue)
         {
             return (null, CreateErrorResponse(
@@ -413,23 +412,29 @@ internal sealed partial class ODataBatchHandler
         if (scope == AccessScope.Write)
         {
             var resolver = context.RequestServices.GetService<ODataFeatureProviderResolver>();
-            if (resolver is not null)
+            if (resolver is null)
             {
-                var support = await resolver.CheckWriteSupportAsync(
-                    validation.Snapshot!,
-                    validation.Service,
-                    validation.Resource,
-                    validation.Publication,
-                    storageLayerId.Value,
-                    cancellationToken).ConfigureAwait(false);
-                if (!support.Supported)
-                {
-                    return (null, CreateErrorResponse(
-                        requestId,
-                        StatusCodes.Status501NotImplemented,
-                        "ProviderWriteNotSupported",
-                        support.ErrorMessage!));
-                }
+                return (null, CreateErrorResponse(
+                    requestId,
+                    StatusCodes.Status500InternalServerError,
+                    "InternalServerError",
+                    "Feature provider routing is not configured."));
+            }
+
+            var support = await resolver.CheckWriteSupportAsync(
+                validation.Snapshot!,
+                validation.Service,
+                validation.Resource,
+                validation.Publication,
+                storageLayerId.Value,
+                cancellationToken).ConfigureAwait(false);
+            if (!support.Supported)
+            {
+                return (null, CreateErrorResponse(
+                    requestId,
+                    StatusCodes.Status501NotImplemented,
+                    "ProviderWriteNotSupported",
+                    support.ErrorMessage!));
             }
         }
 

--- a/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Dispatch.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataBatchHandler.Dispatch.cs
@@ -410,6 +410,29 @@ internal sealed partial class ODataBatchHandler
                 $"Layer {layerId} not found."));
         }
 
+        if (scope == AccessScope.Write)
+        {
+            var resolver = context.RequestServices.GetService<ODataFeatureProviderResolver>();
+            if (resolver is not null)
+            {
+                var support = await resolver.CheckWriteSupportAsync(
+                    validation.Snapshot!,
+                    validation.Service,
+                    validation.Resource,
+                    validation.Publication,
+                    storageLayerId.Value,
+                    cancellationToken).ConfigureAwait(false);
+                if (!support.Supported)
+                {
+                    return (null, CreateErrorResponse(
+                        requestId,
+                        StatusCodes.Status501NotImplemented,
+                        "ProviderWriteNotSupported",
+                        support.ErrorMessage!));
+                }
+            }
+        }
+
         var srid = validation.Resource.ReadSrid() ?? 4326;
         return (new ODataBatchLayerContext(
             layerId,

--- a/src/Honua.Protocols.OData/Features/Services/ODataFeatureProviderResolver.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataFeatureProviderResolver.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
+using Honua.Core.Features.Metadata.Domain.V2;
+
+namespace Honua.Protocols.OData.Services;
+
+/// <summary>
+/// Resolves OData feature operations through the provider selected by a layer's
+/// Metadata v2 storage binding.
+/// </summary>
+internal sealed class ODataFeatureProviderResolver(
+    IFeatureReader fallbackReader,
+    FeatureProviderQueryRouter? providerQueryRouter)
+{
+    private readonly IFeatureReader _fallbackReader = fallbackReader ?? throw new ArgumentNullException(nameof(fallbackReader));
+    private readonly FeatureProviderQueryRouter? _providerQueryRouter = providerQueryRouter;
+
+    public async Task<IFeatureReader> ResolveReaderAsync(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service? service,
+        MetadataV2Resource resource,
+        MetadataV2Publication? publication,
+        int storageLayerId,
+        FeatureProviderReadOperation operation,
+        CancellationToken cancellationToken)
+    {
+        if (_providerQueryRouter is null ||
+            service is null ||
+            publication is null ||
+            string.IsNullOrEmpty(publication.StorageBindingId))
+        {
+            return _fallbackReader;
+        }
+
+        return await _providerQueryRouter.ResolveReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            storageLayerId,
+            operation,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<(bool Supported, string? ErrorMessage)> CheckWriteSupportAsync(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service? service,
+        MetadataV2Resource resource,
+        MetadataV2Publication? publication,
+        int storageLayerId,
+        CancellationToken cancellationToken)
+    {
+        if (_providerQueryRouter is null ||
+            service is null ||
+            publication is null ||
+            string.IsNullOrEmpty(publication.StorageBindingId))
+        {
+            return (true, null);
+        }
+
+        var reader = await ResolveReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            storageLayerId,
+            FeatureProviderReadOperation.Query,
+            cancellationToken).ConfigureAwait(false);
+
+        return reader is IFeatureWriter
+            ? (true, null)
+            : (false, "The layer's configured data provider is read-only for OData write operations.");
+    }
+}

--- a/src/Honua.Protocols.OData/Features/Services/ODataFeatureProviderResolver.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataFeatureProviderResolver.cs
@@ -14,9 +14,11 @@ namespace Honua.Protocols.OData.Services;
 /// </summary>
 internal sealed class ODataFeatureProviderResolver(
     IFeatureReader fallbackReader,
+    IFeatureWriter fallbackWriter,
     FeatureProviderQueryRouter? providerQueryRouter)
 {
     private readonly IFeatureReader _fallbackReader = fallbackReader ?? throw new ArgumentNullException(nameof(fallbackReader));
+    private readonly IFeatureWriter _fallbackWriter = fallbackWriter ?? throw new ArgumentNullException(nameof(fallbackWriter));
     private readonly FeatureProviderQueryRouter? _providerQueryRouter = providerQueryRouter;
 
     public async Task<IFeatureReader> ResolveReaderAsync(
@@ -28,22 +30,46 @@ internal sealed class ODataFeatureProviderResolver(
         FeatureProviderReadOperation operation,
         CancellationToken cancellationToken)
     {
-        if (_providerQueryRouter is null ||
-            service is null ||
-            publication is null ||
-            string.IsNullOrEmpty(publication.StorageBindingId))
-        {
-            return _fallbackReader;
-        }
+        var router = RequireRoutingMetadata(service, publication);
 
-        return await _providerQueryRouter.ResolveReaderAsync(
+        return await router.ResolveReaderAsync(
             snapshot,
-            service,
+            service!,
             resource,
-            publication,
+            publication!,
             storageLayerId,
             operation,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IFeatureReader> ResolveQueryReaderAsync(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Service? service,
+        MetadataV2Resource resource,
+        MetadataV2Publication? publication,
+        int storageLayerId,
+        bool requireCount,
+        CancellationToken cancellationToken)
+    {
+        var router = RequireRoutingMetadata(service, publication);
+        var binding = await router.ResolveBindingAsync(
+            snapshot,
+            service!,
+            resource,
+            publication!,
+            storageLayerId,
+            FeatureProviderReadOperation.Query,
+            cancellationToken).ConfigureAwait(false);
+
+        if (requireCount && !binding.Provider.Capabilities.SupportsCount)
+        {
+            throw new InvalidOperationException(
+                $"Feature provider '{binding.Provider.ProviderName}' does not support count operations.");
+        }
+
+        return binding.Provider is IBindableFeatureDataProvider bindable
+            ? bindable.CreateReaderForBinding(binding)
+            : binding.Provider.Reader;
     }
 
     public async Task<(bool Supported, string? ErrorMessage)> CheckWriteSupportAsync(
@@ -54,25 +80,41 @@ internal sealed class ODataFeatureProviderResolver(
         int storageLayerId,
         CancellationToken cancellationToken)
     {
-        if (_providerQueryRouter is null ||
-            service is null ||
-            publication is null ||
-            string.IsNullOrEmpty(publication.StorageBindingId))
-        {
-            return (true, null);
-        }
-
-        var reader = await ResolveReaderAsync(
+        var router = RequireRoutingMetadata(service, publication);
+        var binding = await router.ResolveBindingAsync(
             snapshot,
-            service,
+            service!,
             resource,
-            publication,
+            publication!,
             storageLayerId,
             FeatureProviderReadOperation.Query,
             cancellationToken).ConfigureAwait(false);
 
-        return reader is IFeatureWriter
+        if (binding.Provider.Writer is null)
+        {
+            return (false, "The layer's configured data provider is read-only for OData write operations.");
+        }
+
+        return ReferenceEquals(binding.Provider.Writer, _fallbackWriter)
             ? (true, null)
-            : (false, "The layer's configured data provider is read-only for OData write operations.");
+            : (false, "OData writes through secondary data providers are not supported.");
+    }
+
+    private FeatureProviderQueryRouter RequireRoutingMetadata(
+        MetadataV2Service? service,
+        MetadataV2Publication? publication)
+    {
+        if (_providerQueryRouter is null)
+        {
+            throw new InvalidOperationException("Feature provider routing is not configured.");
+        }
+
+        if (service is null || publication is null || string.IsNullOrWhiteSpace(publication.StorageBindingId))
+        {
+            throw new InvalidOperationException(
+                "The authorized OData publication does not contain complete provider routing metadata.");
+        }
+
+        return _providerQueryRouter;
     }
 }

--- a/src/Honua.Protocols.OData/Features/Services/ODataFeatureProviderResolver.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataFeatureProviderResolver.cs
@@ -30,7 +30,12 @@ internal sealed class ODataFeatureProviderResolver(
         FeatureProviderReadOperation operation,
         CancellationToken cancellationToken)
     {
-        var router = RequireRoutingMetadata(service, publication);
+        if (!RequiresProviderRouting(snapshot, publication))
+        {
+            return _fallbackReader;
+        }
+
+        var router = RequireProviderRouter(service, publication);
 
         return await router.ResolveReaderAsync(
             snapshot,
@@ -51,7 +56,12 @@ internal sealed class ODataFeatureProviderResolver(
         bool requireCount,
         CancellationToken cancellationToken)
     {
-        var router = RequireRoutingMetadata(service, publication);
+        if (!RequiresProviderRouting(snapshot, publication))
+        {
+            return _fallbackReader;
+        }
+
+        var router = RequireProviderRouter(service, publication);
         var binding = await router.ResolveBindingAsync(
             snapshot,
             service!,
@@ -80,7 +90,12 @@ internal sealed class ODataFeatureProviderResolver(
         int storageLayerId,
         CancellationToken cancellationToken)
     {
-        var router = RequireRoutingMetadata(service, publication);
+        if (!RequiresProviderRouting(snapshot, publication))
+        {
+            return (true, null);
+        }
+
+        var router = RequireProviderRouter(service, publication);
         var binding = await router.ResolveBindingAsync(
             snapshot,
             service!,
@@ -100,7 +115,25 @@ internal sealed class ODataFeatureProviderResolver(
             : (false, "OData writes through secondary data providers are not supported.");
     }
 
-    private FeatureProviderQueryRouter RequireRoutingMetadata(
+    private static bool RequiresProviderRouting(
+        MetadataV2GraphSnapshot snapshot,
+        MetadataV2Publication? publication)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        if (publication is null || string.IsNullOrWhiteSpace(publication.StorageBindingId))
+        {
+            return false;
+        }
+
+        // A publication with an explicit but invalid binding must still fail closed in the
+        // router. Bindings without a connection describe the built-in provider's legacy
+        // layer-id partition and must keep using the primary reader/writer pipeline.
+        return !snapshot.Index.StorageBindingsById.TryGetValue(publication.StorageBindingId, out var binding)
+            || !string.IsNullOrWhiteSpace(binding.ConnectionId);
+    }
+
+    private FeatureProviderQueryRouter RequireProviderRouter(
         MetadataV2Service? service,
         MetadataV2Publication? publication)
     {
@@ -109,7 +142,7 @@ internal sealed class ODataFeatureProviderResolver(
             throw new InvalidOperationException("Feature provider routing is not configured.");
         }
 
-        if (service is null || publication is null || string.IsNullOrWhiteSpace(publication.StorageBindingId))
+        if (service is null || publication is null)
         {
             throw new InvalidOperationException(
                 "The authorized OData publication does not contain complete provider routing metadata.");

--- a/src/Honua.Protocols.OData/Features/Services/ODataV2Lookups.cs
+++ b/src/Honua.Protocols.OData/Features/Services/ODataV2Lookups.cs
@@ -163,7 +163,7 @@ internal static class ODataV2Lookups
         return ResolveStorageLayerId(snapshot, publication, resource);
     }
 
-    private static int? ResolveStorageLayerId(
+    internal static int? ResolveStorageLayerId(
         MetadataV2GraphSnapshot snapshot,
         MetadataV2Publication? publication,
         MetadataV2Resource resource)

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataFeatureProviderResolverTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataFeatureProviderResolverTests.cs
@@ -141,20 +141,21 @@ public sealed class ODataFeatureProviderResolverTests
     }
 
     [Fact]
-    public async Task ResolveReaderAsync_MissingRoutingMetadata_FailsClosed()
+    public async Task ResolveReaderAsync_MissingRoutingMetadata_UsesPrimaryPipeline()
     {
         var connectionId = Guid.NewGuid();
         var provider = Substitute.For<IFeatureDataProvider>();
         provider.ProviderName.Returns(DataProviderNames.SqlServer);
         provider.Capabilities.Returns(FeatureProviderCapabilities.ReadOnlyAnalytical);
         provider.Reader.Returns(Substitute.For<IFeatureReader>());
+        var fallbackReader = Substitute.For<IFeatureReader>();
         var resolver = new ODataFeatureProviderResolver(
-            Substitute.For<IFeatureReader>(),
+            fallbackReader,
             Substitute.For<IFeatureWriter>(),
             CreateRouter(connectionId, provider));
         var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
 
-        var act = () => resolver.ResolveReaderAsync(
+        var resolved = await resolver.ResolveReaderAsync(
             snapshot,
             service,
             resource,
@@ -163,7 +164,59 @@ public sealed class ODataFeatureProviderResolverTests
             FeatureProviderReadOperation.Query,
             CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*routing metadata*");
+        resolved.Should().BeSameAs(fallbackReader);
+    }
+
+    [Fact]
+    public async Task ResolveQueryReaderAsync_LocalBindingWithoutConnection_UsesPrimaryPipeline()
+    {
+        var fallbackReader = Substitute.For<IFeatureReader>();
+        var resolver = new ODataFeatureProviderResolver(
+            fallbackReader,
+            Substitute.For<IFeatureWriter>(),
+            providerQueryRouter: null);
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId: null);
+
+        var resolved = await resolver.ResolveQueryReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            41,
+            requireCount: true,
+            CancellationToken.None);
+        var writeSupport = await resolver.CheckWriteSupportAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            41,
+            CancellationToken.None);
+
+        resolved.Should().BeSameAs(fallbackReader);
+        writeSupport.Supported.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ResolveReaderAsync_RoutedBindingWithoutRouter_FailsClosed()
+    {
+        var connectionId = Guid.NewGuid();
+        var resolver = new ODataFeatureProviderResolver(
+            Substitute.For<IFeatureReader>(),
+            Substitute.For<IFeatureWriter>(),
+            providerQueryRouter: null);
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var act = () => resolver.ResolveReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            41,
+            FeatureProviderReadOperation.Query,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*routing is not configured*");
     }
 
     private static FeatureProviderQueryRouter CreateRouter(Guid connectionId, IFeatureDataProvider provider)
@@ -190,7 +243,7 @@ public sealed class ODataFeatureProviderResolverTests
     }
 
     private static (MetadataV2GraphSnapshot Snapshot, MetadataV2Service Service, MetadataV2Resource Resource, MetadataV2Publication Publication)
-        CreateSnapshot(string connectionId)
+        CreateSnapshot(string? connectionId)
     {
         var service = new MetadataV2Service
         {
@@ -223,11 +276,6 @@ public sealed class ODataFeatureProviderResolverTests
             Locator = "dbo.secondary",
             StorageLayerId = 41
         };
-        var connection = new MetadataV2Connection
-        {
-            Metadata = new MetadataV2ObjectMetadata { Id = connectionId, Name = "secondary" },
-            Provider = DataProviderNames.SqlServer
-        };
         var publication = new MetadataV2Publication
         {
             Metadata = new MetadataV2ObjectMetadata { Id = "pub-secondary", Name = "secondary" },
@@ -243,7 +291,16 @@ public sealed class ODataFeatureProviderResolverTests
             Services = [service],
             Resources = [resource],
             StorageBindings = [binding],
-            Connections = [connection],
+            Connections = connectionId is null
+                ? []
+                :
+                [
+                    new MetadataV2Connection
+                    {
+                        Metadata = new MetadataV2ObjectMetadata { Id = connectionId, Name = "secondary" },
+                        Provider = DataProviderNames.SqlServer
+                    }
+                ],
             Publications = [publication]
         };
         return (new MetadataV2GraphSnapshot(graph, "test", DateTimeOffset.UtcNow), service, resource, publication);

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataFeatureProviderResolverTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataFeatureProviderResolverTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.FeatureStore.Services;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.Protocols.OData.Services;
+using NSubstitute;
+
+namespace Honua.Server.Tests.Features.Protocols.OData;
+
+public sealed class ODataFeatureProviderResolverTests
+{
+    [Fact]
+    public async Task ResolveReaderAsync_SecondaryProvider_RoutesCountAndRejectsWrites()
+    {
+        var connectionId = Guid.NewGuid();
+        var secondaryReader = Substitute.For<IFeatureReader>();
+        secondaryReader.CountAsync(41, Arg.Any<FeatureQuery>(), Arg.Any<CancellationToken>())
+            .Returns(37L);
+        var secondaryProvider = Substitute.For<IFeatureDataProvider>();
+        secondaryProvider.ProviderName.Returns(DataProviderNames.SqlServer);
+        secondaryProvider.Capabilities.Returns(FeatureProviderCapabilities.ReadOnlyAnalytical);
+        secondaryProvider.Reader.Returns(secondaryReader);
+
+        var connectionRegistry = Substitute.For<ISecureConnectionRegistry>();
+        connectionRegistry.GetConnectionAsync(connectionId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new DataConnection
+            {
+                ConnectionId = connectionId,
+                Name = "secondary-sql-server",
+                Host = "sql.example.test",
+                Port = 1433,
+                DatabaseName = "spatial",
+                Username = "honua",
+                Provider = DataProviderNames.SqlServer,
+                SecretRef = "env:HONUA_TEST_SQLSERVER",
+                SecretType = "environment",
+                CreatedBy = "test"
+            });
+        var router = new FeatureProviderQueryRouter(
+            connectionRegistry,
+            new FeatureDataProviderRegistry([secondaryProvider]));
+        var fallbackReader = Substitute.For<IFeatureReader>();
+        var resolver = new ODataFeatureProviderResolver(fallbackReader, router);
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var resolved = await resolver.ResolveReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            41,
+            FeatureProviderReadOperation.Count,
+            CancellationToken.None);
+        var count = await resolved.CountAsync(41, new FeatureQuery(), CancellationToken.None);
+        var writeSupport = await resolver.CheckWriteSupportAsync(
+            snapshot,
+            service,
+            resource,
+            publication,
+            41,
+            CancellationToken.None);
+
+        resolved.Should().BeSameAs(secondaryReader);
+        count.Should().Be(37);
+        writeSupport.Supported.Should().BeFalse();
+        writeSupport.ErrorMessage.Should().Contain("read-only");
+        await fallbackReader.DidNotReceiveWithAnyArgs().CountAsync(default, default, default);
+    }
+
+    private static (MetadataV2GraphSnapshot Snapshot, MetadataV2Service Service, MetadataV2Resource Resource, MetadataV2Publication Publication)
+        CreateSnapshot(string connectionId)
+    {
+        var service = new MetadataV2Service
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "svc-odata", Name = "OData" },
+            Protocols = ["OData"],
+            SpatialReference = MetadataV2SpatialReference.Wgs84
+        };
+        var resource = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "res-secondary", Name = "secondary" },
+            Type = MetadataV2ResourceType.FeatureDataset,
+            StorageBindingIds = ["binding-secondary"],
+            SchemaFields =
+            [
+                new MetadataV2Field
+                {
+                    Name = "id",
+                    Type = MetadataV2FieldType.BigInteger,
+                    Nullable = false,
+                    SemanticRoles = ["id.primary"]
+                }
+            ]
+        };
+        var binding = new MetadataV2StorageBinding
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "binding-secondary", Name = "secondary" },
+            ResourceId = resource.Metadata.Id,
+            ConnectionId = connectionId,
+            StorageType = MetadataV2StorageType.RelationalTable,
+            Locator = "dbo.secondary",
+            StorageLayerId = 41
+        };
+        var connection = new MetadataV2Connection
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = connectionId, Name = "secondary" },
+            Provider = DataProviderNames.SqlServer
+        };
+        var publication = new MetadataV2Publication
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "pub-secondary", Name = "secondary" },
+            ServiceId = service.Metadata.Id,
+            ResourceId = resource.Metadata.Id,
+            StorageBindingId = binding.Metadata.Id,
+            LayerIndex = 4
+        };
+        var graph = new MetadataV2Graph
+        {
+            Revision = 1,
+            Environment = "test",
+            Services = [service],
+            Resources = [resource],
+            StorageBindings = [binding],
+            Connections = [connection],
+            Publications = [publication]
+        };
+        return (new MetadataV2GraphSnapshot(graph, "test", DateTimeOffset.UtcNow), service, resource, publication);
+    }
+}

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataFeatureProviderResolverTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/ODataFeatureProviderResolverTests.cs
@@ -26,6 +26,7 @@ public sealed class ODataFeatureProviderResolverTests
         secondaryProvider.ProviderName.Returns(DataProviderNames.SqlServer);
         secondaryProvider.Capabilities.Returns(FeatureProviderCapabilities.ReadOnlyAnalytical);
         secondaryProvider.Reader.Returns(secondaryReader);
+        secondaryProvider.Writer.Returns((IFeatureWriter?)null);
 
         var connectionRegistry = Substitute.For<ISecureConnectionRegistry>();
         connectionRegistry.GetConnectionAsync(connectionId.ToString(), Arg.Any<CancellationToken>())
@@ -46,7 +47,8 @@ public sealed class ODataFeatureProviderResolverTests
             connectionRegistry,
             new FeatureDataProviderRegistry([secondaryProvider]));
         var fallbackReader = Substitute.For<IFeatureReader>();
-        var resolver = new ODataFeatureProviderResolver(fallbackReader, router);
+        var fallbackWriter = Substitute.For<IFeatureWriter>();
+        var resolver = new ODataFeatureProviderResolver(fallbackReader, fallbackWriter, router);
         var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
 
         var resolved = await resolver.ResolveReaderAsync(
@@ -71,6 +73,120 @@ public sealed class ODataFeatureProviderResolverTests
         writeSupport.Supported.Should().BeFalse();
         writeSupport.ErrorMessage.Should().Contain("read-only");
         await fallbackReader.DidNotReceiveWithAnyArgs().CountAsync(default, default, default);
+    }
+
+    [Fact]
+    public async Task ResolveQueryReaderAsync_CountRequestedWithoutCountCapability_RejectsBeforeQuery()
+    {
+        var connectionId = Guid.NewGuid();
+        var secondaryReader = Substitute.For<IFeatureReader>();
+        var secondaryProvider = Substitute.For<IFeatureDataProvider>();
+        secondaryProvider.ProviderName.Returns(DataProviderNames.SqlServer);
+        secondaryProvider.Capabilities.Returns(FeatureProviderCapabilities.ReadOnlyAnalytical with { SupportsCount = false });
+        secondaryProvider.Reader.Returns(secondaryReader);
+        var router = CreateRouter(connectionId, secondaryProvider);
+        var resolver = new ODataFeatureProviderResolver(
+            Substitute.For<IFeatureReader>(),
+            Substitute.For<IFeatureWriter>(),
+            router);
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var act = () => resolver.ResolveQueryReaderAsync(
+            snapshot, service, resource, publication, 41, requireCount: true, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*count operations*");
+        await secondaryReader.DidNotReceiveWithAnyArgs().QueryAsync(default, default!, default);
+    }
+
+    [Fact]
+    public async Task CheckWriteSupportAsync_PrimaryWriter_AllowsExistingCrudPipeline()
+    {
+        var connectionId = Guid.NewGuid();
+        var primaryWriter = Substitute.For<IFeatureWriter>();
+        var provider = Substitute.For<IFeatureDataProvider>();
+        provider.ProviderName.Returns(DataProviderNames.Postgis);
+        provider.Capabilities.Returns(FeatureProviderCapabilities.ReadWritePostgis);
+        provider.Reader.Returns(Substitute.For<IFeatureReader>());
+        provider.Writer.Returns(primaryWriter);
+        var resolver = new ODataFeatureProviderResolver(
+            Substitute.For<IFeatureReader>(), primaryWriter, CreateRouter(connectionId, provider));
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var support = await resolver.CheckWriteSupportAsync(
+            snapshot, service, resource, publication, 41, CancellationToken.None);
+
+        support.Supported.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckWriteSupportAsync_SecondaryWriter_RejectsPrimaryCrudFallback()
+    {
+        var connectionId = Guid.NewGuid();
+        var provider = Substitute.For<IFeatureDataProvider>();
+        provider.ProviderName.Returns(DataProviderNames.SqlServer);
+        provider.Capabilities.Returns(FeatureProviderCapabilities.ReadWritePostgis);
+        provider.Reader.Returns(Substitute.For<IFeatureReader>());
+        provider.Writer.Returns(Substitute.For<IFeatureWriter>());
+        var resolver = new ODataFeatureProviderResolver(
+            Substitute.For<IFeatureReader>(),
+            Substitute.For<IFeatureWriter>(),
+            CreateRouter(connectionId, provider));
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var support = await resolver.CheckWriteSupportAsync(
+            snapshot, service, resource, publication, 41, CancellationToken.None);
+
+        support.Supported.Should().BeFalse();
+        support.ErrorMessage.Should().Contain("secondary");
+    }
+
+    [Fact]
+    public async Task ResolveReaderAsync_MissingRoutingMetadata_FailsClosed()
+    {
+        var connectionId = Guid.NewGuid();
+        var provider = Substitute.For<IFeatureDataProvider>();
+        provider.ProviderName.Returns(DataProviderNames.SqlServer);
+        provider.Capabilities.Returns(FeatureProviderCapabilities.ReadOnlyAnalytical);
+        provider.Reader.Returns(Substitute.For<IFeatureReader>());
+        var resolver = new ODataFeatureProviderResolver(
+            Substitute.For<IFeatureReader>(),
+            Substitute.For<IFeatureWriter>(),
+            CreateRouter(connectionId, provider));
+        var (snapshot, service, resource, publication) = CreateSnapshot(connectionId.ToString());
+
+        var act = () => resolver.ResolveReaderAsync(
+            snapshot,
+            service,
+            resource,
+            publication with { StorageBindingId = null },
+            41,
+            FeatureProviderReadOperation.Query,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*routing metadata*");
+    }
+
+    private static FeatureProviderQueryRouter CreateRouter(Guid connectionId, IFeatureDataProvider provider)
+    {
+        var providerName = provider.ProviderName;
+        var connectionRegistry = Substitute.For<ISecureConnectionRegistry>();
+        connectionRegistry.GetConnectionAsync(connectionId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new DataConnection
+            {
+                ConnectionId = connectionId,
+                Name = "routed-provider",
+                Host = "provider.example.test",
+                Port = 1433,
+                DatabaseName = "spatial",
+                Username = "honua",
+                Provider = providerName,
+                SecretRef = "env:HONUA_TEST_PROVIDER",
+                SecretType = "environment",
+                CreatedBy = "test"
+            });
+        return new FeatureProviderQueryRouter(
+            connectionRegistry,
+            new FeatureDataProviderRegistry([provider]));
     }
 
     private static (MetadataV2GraphSnapshot Snapshot, MetadataV2Service Service, MetadataV2Resource Resource, MetadataV2Publication Publication)

--- a/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
+++ b/tests/dotnet/Honua.Protocols.OData.Tests/Source/Services/ODataBatchHandlerTests.cs
@@ -77,7 +77,11 @@ public sealed class ODataBatchHandlerTests
             ]
         };
 
-        var response = await sut.ProcessBatchAsync(CreateContext("admin"), request, "https://example.test", CancellationToken.None);
+        var response = await sut.ProcessBatchAsync(
+            CreateContext(featureReader, featureWriter, "admin"),
+            request,
+            "https://example.test",
+            CancellationToken.None);
 
         response.Responses.Should().ContainSingle();
         var createResponse = response.Responses[0];
@@ -132,7 +136,11 @@ public sealed class ODataBatchHandlerTests
             ]
         };
 
-        var response = await sut.ProcessBatchAsync(CreateContext("admin"), request, "https://example.test", CancellationToken.None);
+        var response = await sut.ProcessBatchAsync(
+            CreateContext(featureReader, featureWriter, "admin"),
+            request,
+            "https://example.test",
+            CancellationToken.None);
 
         response.Responses.Should().ContainSingle();
         var updateResponse = response.Responses[0];
@@ -171,12 +179,19 @@ public sealed class ODataBatchHandlerTests
             Substitute.For<ILogger>());
     }
 
-    private static DefaultHttpContext CreateContext(params string[] roles)
+    private static DefaultHttpContext CreateContext(
+        IFeatureReader featureReader,
+        IFeatureWriter featureWriter,
+        params string[] roles)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IAccessPolicyEvaluator, AccessPolicyEvaluator>();
         services.AddSingleton<IOptions<RbacOptions>>(Options.Create(new RbacOptions()));
         services.AddSingleton<IMetadataV2GraphProvider>(CreateMetadataProvider());
+        services.AddSingleton(new ODataFeatureProviderResolver(
+            featureReader,
+            featureWriter,
+            providerQueryRouter: null));
 
         var context = new DefaultHttpContext
         {


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Related to #2962

## Summary
Route OData collection queries, counts, and streaming reads through the provider selected by each layer's Metadata v2 storage binding. This is slice A of #2962; OGC API Tiles routing remains slice B.

## Changes Made
- Add a scoped OData resolver over `FeatureProviderQueryRouter` and use it for collection query/count paths.
- Keep streaming on the routed provider, using its native stream when available and its materialized query path otherwise.
- Reject routed read-only provider mutations, including `$batch`, with `501 ProviderWriteNotSupported` instead of silently dispatching to the primary writer.
- Document OData reachability and the remaining Tiles follow-up for SQL Server, Oracle, Redshift, Snowflake, and Databricks.
- Add interface-level SQL Server routing and write-safety coverage.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

`dotnet test tests/dotnet/Honua.Protocols.OData.Tests/Honua.Protocols.OData.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~ODataQueryHandlerTests|FullyQualifiedName~ODataFeatureProviderResolverTests" --logger "console;verbosity=minimal"` (3 passed).

`dotnet format Honua.sln --verify-no-changes --no-restore --include <changed C# files>` passed.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [x] If breaking admin/control-plane API changes: updated migration guide
- [x] If breaking gRPC/proto wire changes: confirmed with explicit review

## Follow-up
Slice B will route OGC API Tiles raster reads per collection and fail explicitly for routed providers without native vector-tile support. #2962 remains open until that work lands.
