### PR TITLE
feat(duckdb): support CQL2 spatial predicates (#2963)

### DIFF
--- a/docs/reference/configuration/data-sources/duckdb.md
+++ b/docs/reference/configuration/data-sources/duckdb.md
@@ -219,7 +219,7 @@ the `GEOMETRY` type.
 | Capability | Status |
 |-----------|--------|
 | Feature queries (select, count, object IDs) | Supported |
-| Spatial filters (intersects, within, contains, etc.) | Supported |
+| Spatial filters (including CQL2 intersects, within, contains, and distance predicates) | Supported; cross-SRID CQL2 geometry literals must be pre-transformed to the layer CRS using `always_xy` axis order |
 | Statistics and aggregation (sum, avg, count, group by) | Supported |
 | GeoJSON export | Supported |
 | Object-store Parquet / GeoParquet scans | Supported for read-only analytical layers via DuckDB temporary views |

--- a/src/Honua.Core.Abstractions/Queries/Filters/SqlFilterExpressionVisitorBase.cs
+++ b/src/Honua.Core.Abstractions/Queries/Filters/SqlFilterExpressionVisitorBase.cs
@@ -74,7 +74,10 @@ public abstract class SqlFilterExpressionVisitorBase
         _parameters.Clear();
 
         var sql = TranslateExpression(filter, context);
-        return new SqlFragment(sql, _parameters);
+        // The scoped translator can translate more than one independent fragment in a
+        // request (for example enforced and caller filters). Snapshot the parameters so
+        // resetting this visitor for the next translation cannot mutate an earlier result.
+        return new SqlFragment(sql, _parameters.ToArray());
     }
 
     /// <summary>

--- a/src/Honua.Core.Abstractions/Queries/Filters/SqlFragmentHelpers.cs
+++ b/src/Honua.Core.Abstractions/Queries/Filters/SqlFragmentHelpers.cs
@@ -14,7 +14,7 @@ public static class SqlFragmentHelpers
 {
     /// <summary>
     /// Combines two SQL fragments with a logical <c>AND</c>, renumbering the right fragment's
-    /// <c>@pN</c> parameter placeholders so they follow the left fragment's parameters without
+    /// <c>@pN</c> or DuckDB <c>$N</c> parameter placeholders so they follow the left fragment's parameters without
     /// collision. Returns the non-null fragment when the other side is <see langword="null"/>,
     /// or <see langword="null"/> when both are <see langword="null"/>.
     /// </summary>
@@ -40,16 +40,24 @@ public static class SqlFragmentHelpers
     }
 
     /// <summary>
-    /// Shifts every <c>@pN</c> parameter placeholder in <paramref name="sql"/> by
+    /// Shifts every <c>@pN</c> or DuckDB <c>$N</c> parameter placeholder in <paramref name="sql"/> by
     /// <paramref name="offset"/> so it can be concatenated after an existing parameter list.
     /// </summary>
     /// <param name="sql">The SQL text whose placeholders should be renumbered.</param>
     /// <param name="offset">The number of leading parameters to skip past.</param>
     /// <returns>The SQL text with renumbered placeholders.</returns>
     public static string RenumberSqlFragmentParameters(string sql, int offset)
-        => Regex.Replace(
+    {
+        var namedSql = Regex.Replace(
             sql,
             @"@p(\d+)",
             match => "@p" + (int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture) + offset).ToString(CultureInfo.InvariantCulture),
             RegexOptions.CultureInvariant);
+
+        return Regex.Replace(
+            namedSql,
+            @"\$(\d+)",
+            match => "$" + (int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture) + offset).ToString(CultureInfo.InvariantCulture),
+            RegexOptions.CultureInvariant);
+    }
 }

--- a/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
+++ b/src/Honua.DuckDB/Features/FeatureStore/Services/DuckDBFeatureQueryBuilder.cs
@@ -1029,8 +1029,38 @@ internal sealed partial class DuckDBFeatureQueryBuilder : IFeatureQueryBuilder
     [GeneratedRegex(@"@p(\d+)", RegexOptions.CultureInvariant)]
     private static partial Regex NamedParameterRegex();
 
+    [GeneratedRegex(@"\$(\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex PositionalParameterRegex();
+
     private static string ConvertNamedParametersToPositional(string sql, ref int paramIndex)
     {
+        // DuckDB's native translator emits 1-based $N placeholders. Rebase them to the
+        // builder's current position so enforced filters, caller filters, object IDs, and
+        // temporal predicates cannot reuse the same parameter slots.
+        var positionalIndices = new SortedSet<int>();
+        foreach (Match match in PositionalParameterRegex().Matches(sql))
+        {
+            positionalIndices.Add(int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture));
+        }
+
+        if (positionalIndices.Count > 0)
+        {
+            var positionalStart = paramIndex;
+            var positionalMap = new Dictionary<int, int>(positionalIndices.Count);
+            var positionalRank = 0;
+            foreach (var sourceIndex in positionalIndices)
+            {
+                positionalMap[sourceIndex] = positionalStart + positionalRank++;
+            }
+
+            sql = PositionalParameterRegex().Replace(sql, match =>
+            {
+                var sourceIndex = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+                return $"${positionalMap[sourceIndex]}";
+            });
+            paramIndex = positionalStart + positionalIndices.Count;
+        }
+
         // Collect unique @pN indices in ascending order. SqlFragment.Parameters is always
         // ordered by @pN index, so sorting unique indices gives the correct Parameters[rank]
         // <-> positional-$index alignment. Using a dense mapping also prevents sparse

--- a/src/Honua.DuckDB/Queries/Filters/DuckDbSqlFilterTranslator.cs
+++ b/src/Honua.DuckDB/Queries/Filters/DuckDbSqlFilterTranslator.cs
@@ -1,0 +1,254 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Buffers.Binary;
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Shared.Models;
+using Honua.Core.Queries.Filters;
+
+namespace Honua.DuckDB.Queries.Filters;
+
+/// <summary>
+/// Translates the shared filter AST into parameterized DuckDB SQL.
+/// </summary>
+internal sealed class DuckDbSqlFilterTranslator : SqlFilterExpressionVisitorBase, ISqlFilterTranslator
+{
+    public DuckDbSqlFilterTranslator()
+        : base(DuckDbSqlDialect.Instance)
+    {
+    }
+
+    /// <inheritdoc />
+    public SqlFragment Translate(FilterExpression filter, MetadataV2Resource resource)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(resource);
+        return Translate(filter, FilterTranslationContext.FromResource(resource));
+    }
+
+    protected override string TranslateBinary(BinaryExpression binary, FilterTranslationContext context)
+    {
+        if (binary.Right is ValueList { Values.Count: 0 })
+        {
+            return binary.Operator switch
+            {
+                BinaryOperator.In => "FALSE",
+                BinaryOperator.NotIn => "TRUE",
+                _ => TranslateBinaryOperands(binary, context)
+            };
+        }
+
+        return TranslateBinaryOperands(binary, context);
+    }
+
+    private string TranslateBinaryOperands(BinaryExpression binary, FilterTranslationContext context)
+    {
+        var left = TranslateExpression(binary.Left, context);
+        var right = TranslateExpression(binary.Right, context);
+        var op = binary.Operator switch
+        {
+            BinaryOperator.And => "AND",
+            BinaryOperator.Or => "OR",
+            BinaryOperator.Equal => "=",
+            BinaryOperator.NotEqual => "<>",
+            BinaryOperator.LessThan => "<",
+            BinaryOperator.LessThanOrEqual => "<=",
+            BinaryOperator.GreaterThan => ">",
+            BinaryOperator.GreaterThanOrEqual => ">=",
+            BinaryOperator.Like => "LIKE",
+            BinaryOperator.NotLike => "NOT LIKE",
+            BinaryOperator.In => "IN",
+            BinaryOperator.NotIn => "NOT IN",
+            BinaryOperator.Add => "+",
+            BinaryOperator.Subtract => "-",
+            BinaryOperator.Multiply => "*",
+            BinaryOperator.Divide => "/",
+            BinaryOperator.Modulo => "%",
+            BinaryOperator.Div => "//",
+            BinaryOperator.Power => "^",
+            _ => throw Unsupported($"Binary operator '{binary.Operator}'")
+        };
+
+        return binary.Operator is BinaryOperator.And or BinaryOperator.Or or
+            BinaryOperator.Add or BinaryOperator.Subtract or BinaryOperator.Multiply or
+            BinaryOperator.Divide or BinaryOperator.Modulo or BinaryOperator.Div or BinaryOperator.Power
+            ? $"({left} {op} {right})"
+            : $"{left} {op} {right}";
+    }
+
+    protected override string TranslateUnary(UnaryExpression unary, FilterTranslationContext context)
+    {
+        var operand = TranslateExpression(unary.Operand, context);
+        return unary.Operator switch
+        {
+            UnaryOperator.Not => $"NOT ({operand})",
+            UnaryOperator.IsNull => $"{operand} IS NULL",
+            UnaryOperator.IsNotNull => $"{operand} IS NOT NULL",
+            UnaryOperator.Negate => $"-({operand})",
+            _ => throw Unsupported($"Unary operator '{unary.Operator}'")
+        };
+    }
+
+    protected override string TranslateProperty(PropertyReference property, FilterTranslationContext context)
+    {
+        var field = context.TryGetField(property.PropertyName);
+        if (field is not null)
+        {
+            return Dialect.QuoteIdentifier(field.Value.Name);
+        }
+
+        if (IsGeometryAlias(property.PropertyName))
+        {
+            return GetGeometryColumn(context);
+        }
+
+        throw new ArgumentException(
+            $"Field '{property.PropertyName}' is not defined on layer '{context.ResourceName}'.");
+    }
+
+    protected override string TranslateSpatial(SpatialPredicate spatial, FilterTranslationContext context)
+    {
+        var left = TranslateGeometryExpression(spatial.Left, context);
+        var right = TranslateGeometryExpression(spatial.Right, context);
+
+        // CQL2 defines these operators in AST operand order. In particular, do not apply the
+        // FeatureQuery.SpatialFilter Within/Contains inversion: that path models a feature
+        // geometry plus a separate filter geometry, while CQL2 permits either operand order.
+        return spatial.Operator switch
+        {
+            SpatialOperator.Intersects => $"ST_Intersects({left}, {right})",
+            SpatialOperator.Contains => $"ST_Contains({left}, {right})",
+            SpatialOperator.Within => $"ST_Within({left}, {right})",
+            SpatialOperator.Crosses => $"ST_Crosses({left}, {right})",
+            SpatialOperator.Touches => $"ST_Touches({left}, {right})",
+            SpatialOperator.Overlaps => $"ST_Overlaps({left}, {right})",
+            SpatialOperator.Disjoint => $"ST_Disjoint({left}, {right})",
+            SpatialOperator.Equals => $"ST_Equals({left}, {right})",
+            _ => throw Unsupported($"Spatial operator '{spatial.Operator}'")
+        };
+    }
+
+    protected override string TranslateSpatialDistance(
+        SpatialDistancePredicate spatial,
+        FilterTranslationContext context)
+    {
+        var left = TranslateGeometryExpression(spatial.Left, context);
+        var right = TranslateGeometryExpression(spatial.Right, context);
+        var distance = TranslateExpression(spatial.Distance, context);
+
+        if (DistanceConversions.IsGeographicSrid(context.Wkid))
+        {
+            if (context.GeometryType is not GeometryType.Point)
+            {
+                throw Unsupported(
+                    $"Geographic distance spatial filters for {context.GeometryType} layers; " +
+                    "DuckDB ST_Distance_Spheroid accepts point geometries only");
+            }
+
+            EnsurePointGeometryLiteral(spatial.Left);
+            EnsurePointGeometryLiteral(spatial.Right);
+
+            // DuckDB's spheroid function expects latitude/longitude, while Honua's axis
+            // contract is always X/Y (longitude/latitude).
+            var geodesicDistance =
+                $"ST_Distance_Spheroid(ST_FlipCoordinates({left}), ST_FlipCoordinates({right}))";
+            return spatial.Operator switch
+            {
+                SpatialOperator.DWithin => $"{geodesicDistance} <= {distance}",
+                SpatialOperator.Beyond => $"{geodesicDistance} > {distance}",
+                _ => throw Unsupported($"Spatial distance operator '{spatial.Operator}'")
+            };
+        }
+
+        if (context.Wkid is >= 4000 and <= 4999)
+        {
+            throw Unsupported(
+                $"Distance spatial filters for SRID {context.Wkid}; the CRS is in the EPSG geographic " +
+                "range but is not in the geodesic allowlist, so metre semantics cannot be established");
+        }
+
+        return spatial.Operator switch
+        {
+            SpatialOperator.DWithin => $"ST_DWithin({left}, {right}, {distance})",
+            SpatialOperator.Beyond => $"NOT ST_DWithin({left}, {right}, {distance})",
+            _ => throw Unsupported($"Spatial distance operator '{spatial.Operator}'")
+        };
+    }
+
+    private string TranslateGeometryExpression(FilterExpression expression, FilterTranslationContext context)
+    {
+        switch (expression)
+        {
+            case GeometryLiteral geometry:
+                if (geometry.Srid != 0 && geometry.Srid != context.Wkid)
+                {
+                    throw Unsupported(
+                        $"Cross-SRID geometry literals (layer SRID {context.Wkid}, literal SRID {geometry.Srid}); " +
+                        "pre-transform the literal to the layer CRS using an always_xy axis contract");
+                }
+
+                return $"ST_GeomFromWKB({AddParameter(geometry.Wkb)})";
+
+            case PropertyReference property:
+                var field = context.TryGetField(property.PropertyName);
+                if (field is null)
+                {
+                    if (IsGeometryAlias(property.PropertyName))
+                    {
+                        return GetGeometryColumn(context);
+                    }
+
+                    throw new ArgumentException($"Field '{property.PropertyName}' is not a geometry field.");
+                }
+
+                if (!field.Value.IsGeometry)
+                {
+                    throw new ArgumentException($"Field '{property.PropertyName}' is not a geometry field.");
+                }
+
+                return Dialect.QuoteIdentifier(field.Value.Name);
+
+            default:
+                throw Unsupported($"Geometry expression '{expression.GetType().Name}'");
+        }
+    }
+
+    private static void EnsurePointGeometryLiteral(FilterExpression expression)
+    {
+        if (expression is not GeometryLiteral geometry)
+        {
+            return;
+        }
+
+        var wkb = geometry.Wkb;
+        if (wkb.Length < 5 || wkb[0] is not (0 or 1))
+        {
+            throw Unsupported(
+                "Geographic distance geometry literal with an invalid WKB header; " +
+                "DuckDB ST_Distance_Spheroid accepts point geometries only");
+        }
+
+        var encodedType = wkb[0] == 1
+            ? BinaryPrimitives.ReadUInt32LittleEndian(wkb.AsSpan(1, 4))
+            : BinaryPrimitives.ReadUInt32BigEndian(wkb.AsSpan(1, 4));
+        var baseType = (encodedType & 0x1FFFFFFF) % 1000;
+        if (baseType != 1)
+        {
+            throw Unsupported(
+                "Geographic distance geometry literal that is not a point; " +
+                "DuckDB ST_Distance_Spheroid accepts point geometries only");
+        }
+    }
+
+    private string GetGeometryColumn(FilterTranslationContext context)
+        => Dialect.QuoteIdentifier(context.GeometryColumnName ?? "geometry");
+
+    private static bool IsGeometryAlias(string propertyName)
+        => propertyName.Equals("geom", StringComparison.OrdinalIgnoreCase) ||
+           propertyName.Equals("shape", StringComparison.OrdinalIgnoreCase) ||
+           propertyName.Equals("geometry", StringComparison.OrdinalIgnoreCase);
+
+    private static NotSupportedException Unsupported(string feature)
+        => new($"{feature} is not supported by the DuckDB provider.");
+}

--- a/src/Honua.DuckDB/Queries/Filters/DuckDbSqlFilterTranslator.cs
+++ b/src/Honua.DuckDB/Queries/Filters/DuckDbSqlFilterTranslator.cs
@@ -109,6 +109,20 @@ internal sealed class DuckDbSqlFilterTranslator : SqlFilterExpressionVisitorBase
 
     protected override string TranslateSpatial(SpatialPredicate spatial, FilterTranslationContext context)
     {
+        // Protocol-scoped geodesic routing (OData geo.intersects over Edm.Geography) asks for
+        // ellipsoidal intersects semantics so long edges and antimeridian-crossing geometries
+        // resolve correctly. DuckDB's spatial extension has no geography/ellipsoidal intersects
+        // equivalent to PostGIS's geography cast, so reject rather than silently downgrade to
+        // planar-in-degree ST_Intersects (see Honua.Postgres.Queries.Filters.
+        // PostgresSqlFilterTranslator.TranslateSpatial for the geography-backed implementation
+        // this provider does not have).
+        if (spatial.Geodesic)
+        {
+            throw Unsupported(
+                $"Geodesic spatial operator '{spatial.Operator}'; DuckDB has no geography-backed " +
+                "ellipsoidal intersects, so this would silently evaluate in planar degree space");
+        }
+
         var left = TranslateGeometryExpression(spatial.Left, context);
         var right = TranslateGeometryExpression(spatial.Right, context);
 

--- a/src/Honua.DuckDB/ServiceCollectionExtensions.cs
+++ b/src/Honua.DuckDB/ServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@ internal static class ServiceCollectionExtensions
             : $"Data Source={options.DatabasePath}";
 
         services.AddSingleton<ISqlDialect>(DuckDbSqlDialect.Instance);
+        services.AddScoped<ISqlFilterTranslator, DuckDbSqlFilterTranslator>();
 
         // Register infrastructure singletons
         services.AddSingleton<DuckDBSpatialBootstrap>(sp =>

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureStoreIntegrationTests.cs
@@ -262,6 +262,22 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public void Translate_GeodesicIntersects_RejectsRatherThanSilentlyEvaluatingPlanar()
+    {
+        var filter = new SpatialPredicate(
+            SpatialOperator.Intersects,
+            new PropertyReference("geom"),
+            GeometryLiteral(CreatePolygonWkb(-121.972, 37.028, -121.948, 37.052), 4326))
+        {
+            Geodesic = true
+        };
+
+        var exception = Assert.Throws<NotSupportedException>(() => _filterTranslator.Translate(filter, _resource));
+
+        Assert.Contains("Geodesic", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Translate_GeographicDistanceOnPolygonResource_RejectsPointOnlyFunction()
     {
         var polygonResource = _resource with

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureStoreIntegrationTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBFeatureStoreIntegrationTests.cs
@@ -4,10 +4,14 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using DuckDB.NET.Data;
+using Honua.Core.Features.FeatureStore.Abstractions;
 using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Queries.Filters;
 using Honua.DuckDB.Features.FeatureStore;
 using Honua.DuckDB.Features.FeatureStore.Services;
 using Honua.DuckDB.Features.Infrastructure;
+using Honua.DuckDB.Queries.Filters;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.DuckDB.Tests;
@@ -23,6 +27,8 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
     private DuckDBLayerRegistry _registry = null!;
     private string _connectionString = null!;
     private DuckDBSpatialBootstrap _spatialBootstrap = null!;
+    private DuckDbSqlFilterTranslator _filterTranslator = null!;
+    private MetadataV2Resource _resource = null!;
     private const int LayerId = 0;
 
     public async Task InitializeAsync()
@@ -93,6 +99,32 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
         var cacheManager = new DuckDBFeatureCacheManager(_registry);
 
         _store = new DuckDBFeatureStore(queryBuilder, dataAccess, cacheManager);
+        _filterTranslator = new DuckDbSqlFilterTranslator();
+        _resource = new MetadataV2Resource
+        {
+            Metadata = new MetadataV2ObjectMetadata { Id = "duckdb.parcels", Name = "parcels" },
+            Type = MetadataV2ResourceType.FeatureDataset,
+            Spatial = new MetadataV2ResourceSpatial
+            {
+                GeometryType = MetadataV2GeometryType.Point,
+                PrimaryGeometryField = "geom",
+                SpatialReference = MetadataV2SpatialReference.Wgs84
+            },
+            SchemaFields =
+            [
+                new MetadataV2Field
+                {
+                    Name = "id",
+                    Type = MetadataV2FieldType.BigInteger,
+                    Nullable = false,
+                    SemanticRoles = ["id.primary"]
+                },
+                new MetadataV2Field { Name = "geom", Type = MetadataV2FieldType.Geometry, Nullable = false },
+                new MetadataV2Field { Name = "name", Type = MetadataV2FieldType.String },
+                new MetadataV2Field { Name = "area", Type = MetadataV2FieldType.Double },
+                new MetadataV2Field { Name = "type", Type = MetadataV2FieldType.String }
+            ]
+        };
     }
 
     public Task DisposeAsync()
@@ -139,6 +171,147 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
 
         Assert.Equal(3, result.Items.Length);
         Assert.All(result.Items, f => Assert.Contains(f.Id, new long[] { 1, 3, 5 }));
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithCql2Intersects_ReturnsCorrectFeatureSet()
+    {
+        var polygon = GeometryLiteral(CreatePolygonWkb(-121.972, 37.028, -121.948, 37.052), 4326);
+        var filter = new SpatialPredicate(
+            SpatialOperator.Intersects,
+            new PropertyReference("geom"),
+            polygon);
+        var ids = await QueryIdsThroughInterfaceAsync(_store, QueryWithFilter(filter));
+
+        Assert.Equal([3L, 4L, 5L], ids);
+
+        // Exercise positional rebasing: the spatial WKB is $1 and the later object-id
+        // predicate must become $2 rather than aliasing the geometry parameter.
+        var narrowed = await QueryIdsThroughInterfaceAsync(_store, QueryWithFilter(filter) with
+        {
+            ObjectIds = ImmutableArray.Create(4L, 8L)
+        });
+        Assert.Equal([4L], narrowed);
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithCql2WithinAndContains_PreservesAsymmetricOperandOrder()
+    {
+        var polygon = GeometryLiteral(CreatePolygonWkb(-121.972, 37.028, -121.948, 37.052), 4326);
+        var within = await QueryIdsThroughInterfaceAsync(_store, QueryWithFilter(new SpatialPredicate(
+            SpatialOperator.Within,
+            new PropertyReference("geom"),
+            polygon)));
+        var containsWithReversedOperands = await QueryIdsThroughInterfaceAsync(_store, QueryWithFilter(new SpatialPredicate(
+            SpatialOperator.Contains,
+            polygon,
+            new PropertyReference("geom"))));
+
+        var expected = new long[] { 3, 4, 5 };
+        Assert.Equal(expected, within);
+        Assert.Equal(expected, containsWithReversedOperands);
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithCql2DWithin_UsesMetersAndAlwaysXyAxisOrder()
+    {
+        var filter = new SpatialDistancePredicate(
+            SpatialOperator.DWithin,
+            new PropertyReference("geom"),
+            GeometryLiteral(CreatePointWkb(-121.95, 37.05), 4326),
+            new Literal(1_600d, LiteralType.Number));
+        var ids = await QueryIdsThroughInterfaceAsync(_store, QueryWithFilter(filter));
+
+        Assert.Equal([4L, 5L, 6L], ids);
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithCombinedAttributeAndSpatialFragments_PreservesParameterBindings()
+    {
+        var attribute = _filterTranslator.Translate(
+            new BinaryExpression(
+                new PropertyReference("area"),
+                BinaryOperator.GreaterThan,
+                new Literal(0d, LiteralType.Number)),
+            _resource);
+        var spatial = _filterTranslator.Translate(
+            new SpatialPredicate(
+                SpatialOperator.Intersects,
+                new PropertyReference("geom"),
+                GeometryLiteral(CreatePolygonWkb(-121.972, 37.028, -121.948, 37.052), 4326)),
+            _resource);
+        var combined = SqlFragmentHelpers.CombineSqlFilters(attribute, spatial);
+
+        var ids = await QueryIdsThroughInterfaceAsync(_store, new FeatureQuery { SqlFilter = combined });
+
+        Assert.Equal([3L, 4L, 5L], ids);
+    }
+
+    [Fact]
+    public void Translate_CrossSridGeometryLiteral_RejectsWithAxisGuidance()
+    {
+        var filter = new SpatialPredicate(
+            SpatialOperator.Intersects,
+            new PropertyReference("geom"),
+            GeometryLiteral(CreatePointWkb(-121.95, 37.05), 3857));
+
+        var exception = Assert.Throws<NotSupportedException>(() => _filterTranslator.Translate(filter, _resource));
+
+        Assert.Contains("Cross-SRID", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("always_xy", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Translate_GeographicDistanceOnPolygonResource_RejectsPointOnlyFunction()
+    {
+        var polygonResource = _resource with
+        {
+            Spatial = _resource.Spatial! with { GeometryType = MetadataV2GeometryType.Polygon }
+        };
+        var filter = new SpatialDistancePredicate(
+            SpatialOperator.DWithin,
+            new PropertyReference("geom"),
+            GeometryLiteral(CreatePointWkb(-121.95, 37.05), 4326),
+            new Literal(1_600d, LiteralType.Number));
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _filterTranslator.Translate(filter, polygonResource));
+
+        Assert.Contains("point geometries only", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Translate_GeographicDistanceOnMultiPointResource_RejectsPointOnlyFunction()
+    {
+        var multiPointResource = _resource with
+        {
+            Spatial = _resource.Spatial! with { GeometryType = MetadataV2GeometryType.MultiPoint }
+        };
+        var filter = new SpatialDistancePredicate(
+            SpatialOperator.DWithin,
+            new PropertyReference("geom"),
+            GeometryLiteral(CreatePointWkb(-121.95, 37.05), 4326),
+            new Literal(1_600d, LiteralType.Number));
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _filterTranslator.Translate(filter, multiPointResource));
+
+        Assert.Contains("point geometries only", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Translate_GeographicDistanceWithPolygonLiteral_RejectsPointOnlyFunction()
+    {
+        var filter = new SpatialDistancePredicate(
+            SpatialOperator.DWithin,
+            new PropertyReference("geom"),
+            GeometryLiteral(CreatePolygonWkb(-121.96, 37.04, -121.94, 37.06), 4326),
+            new Literal(1_600d, LiteralType.Number));
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _filterTranslator.Translate(filter, _resource));
+
+        Assert.Contains("point geometries only", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -352,6 +525,58 @@ public class DuckDBFeatureStoreIntegrationTests : IAsyncLifetime
         await using var cmd = connection.CreateCommand();
         cmd.CommandText = sql;
         await cmd.ExecuteNonQueryAsync();
+    }
+
+    private FeatureQuery QueryWithFilter(FilterExpression filter)
+        => new() { SqlFilter = _filterTranslator.Translate(filter, _resource) };
+
+#pragma warning disable CA1859 // Deliberately exercise the provider through its public interface.
+    private static async Task<long[]> QueryIdsThroughInterfaceAsync(
+        IFeatureReader reader,
+        FeatureQuery query)
+    {
+        var result = await reader.QueryAsync(LayerId, query);
+        return result.Items.Select(feature => feature.Id).Order().ToArray();
+    }
+#pragma warning restore CA1859
+
+    private static GeometryLiteral GeometryLiteral(byte[] wkb, int srid)
+        => new(wkb, srid, "test-wkb");
+
+    private static byte[] CreatePointWkb(double x, double y)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        writer.Write((byte)1); // little-endian
+        writer.Write(1u); // Point
+        writer.Write(x);
+        writer.Write(y);
+        return stream.ToArray();
+    }
+
+    private static byte[] CreatePolygonWkb(double minX, double minY, double maxX, double maxY)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        writer.Write((byte)1); // little-endian
+        writer.Write(3u); // Polygon
+        writer.Write(1u); // one ring
+        writer.Write(5u); // closed shell
+        (double X, double Y)[] coordinates =
+        [
+            (minX, minY),
+            (maxX, minY),
+            (maxX, maxY),
+            (minX, maxY),
+            (minX, minY)
+        ];
+        foreach (var coordinate in coordinates)
+        {
+            writer.Write(coordinate.X);
+            writer.Write(coordinate.Y);
+        }
+
+        return stream.ToArray();
     }
 
     /// <summary>

--- a/tests/dotnet/Honua.DuckDB.Tests/DuckDBProviderResolutionTests.cs
+++ b/tests/dotnet/Honua.DuckDB.Tests/DuckDBProviderResolutionTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
 using Honua.Core.Features.HealthCheck.Abstractions;
+using Honua.Core.Queries.Filters;
+using Honua.DuckDB.Queries.Filters;
 using Honua.DuckDB.Features.HealthCheck;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,6 +55,17 @@ public sealed class DuckDBProviderResolutionTests
         Assert.NotNull(second);
         // Scoped instances across different scopes must be different objects.
         Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void AddDuckDBServices_RegistersSqlFilterTranslator()
+    {
+        using var provider = BuildDuckDbServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var translator = scope.ServiceProvider.GetRequiredService<ISqlFilterTranslator>();
+
+        Assert.IsType<DuckDbSqlFilterTranslator>(translator);
     }
 
     private static ServiceProvider BuildDuckDbServiceProvider()


### PR DESCRIPTION
﻿# Pull Request

## Issue Link
Fixes #2963

## Summary
Adds DuckDB SQL translation for attribute and CQL2 spatial predicates, preserving explicit CQL2 operand order and safe CRS/distance semantics. This also makes independent enforced and caller filter fragments safe to compose with DuckDB positional parameters.

## Changes Made
- Register a scoped DuckDB SQL filter translator with topological and distance predicates.
- Use spheroid distance with XY-axis correction for point data, planar `ST_DWithin` for projected CRSs, and explicit rejection for unsafe CRS or geometry combinations.
- Rebase DuckDB `$N` parameters, snapshot translator parameters, and add real `IFeatureReader` exact-set regressions for intersects, within/contains, dwithin, combined filters, and rejection contracts.
- Document DuckDB CQL2 spatial support and cross-SRID limitations.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None - no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None - no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None - standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Validation Details
- `Honua.DuckDB.Tests`: 104 passed
- Focused `Honua.Core.Tests` filter suite: 264 passed
- Scoped `dotnet format --verify-no-changes`: passed
- `git diff --check`: passed
