### PR TITLE
fix(ci): make green rerun recovery state-aware

### DIFF
--- a/.github/workflows/merge-train-rerun-recovery.yml
+++ b/.github/workflows/merge-train-rerun-recovery.yml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 permissions:
-  actions: read
+  actions: write
   contents: write
   issues: write
   pull-requests: write

--- a/.github/workflows/merge-train-rerun-recovery.yml
+++ b/.github/workflows/merge-train-rerun-recovery.yml
@@ -7,13 +7,13 @@ on:
 
 permissions:
   actions: read
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
   statuses: write
 
 concurrency:
-  group: merge-train-rerun-recovery-${{ github.event.workflow_run.id }}
+  group: merge-train
   cancel-in-progress: false
 
 jobs:
@@ -30,7 +30,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.MERGE_TRAIN_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Recover escalated PRs from green rerun
+      - name: Configure git identity
+        run: |
+          git config --global user.name "Mike McDougall"
+          git config --global user.email "mike@honua.io"
+
+      - name: Recover active immutable batch from green rerun
         env:
           GH_TOKEN: ${{ secrets.MERGE_TRAIN_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -38,8 +43,12 @@ jobs:
         run: |
           set -euo pipefail
           . scripts/ci/merge-train/lib.sh
+          . scripts/ci/merge-train/select.sh
+          . scripts/ci/merge-train/land.sh
+          . scripts/ci/merge-train/state.sh
           . scripts/ci/merge-train/recovery.sh
           train_recover_green_batch_rerun \
             "${{ github.event.workflow_run.id }}" \
             "${{ github.event.workflow_run.head_branch }}" \
+            "${{ github.event.workflow_run.head_sha }}" \
             "${{ github.event.workflow_run.html_url }}"

--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -1,4 +1,5 @@
 name: Merge Train
+run-name: Merge Train [${{ inputs.recovery_key || 'ordinary' }}]
 
 # Optimistic batch merge train (Phase 1). DRY-RUN BY DEFAULT.
 #
@@ -47,6 +48,11 @@ on:
         default: false
       autofix_model:
         description: 'Bedrock model id for the AI fix-agent (code edits). Default a Sonnet-class model; override per your account entitlement.'
+        type: string
+        required: false
+        default: ''
+      recovery_key:
+        description: 'Internal idempotency key for durable recovery dispatches.'
         type: string
         required: false
         default: ''

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -305,7 +305,23 @@ jobs:
           jq -c '.sdk[]' release/bundle-suites.json | while read -r entry; do
             repo="$(jq -r '.owningRepo' <<<"$entry")"
             pub="$(jq -r '.publishWorkflow // ""' <<<"$entry")"
-            [ -n "$pub" ] && gh workflow run "$pub" -R "$repo" --ref trunk -f dry_run=false || true
+            case "${repo}:${pub}" in
+              honua-io/honua-sdk-dotnet:publish-dotnet-sdk.yml)
+                gh workflow run publish-dotnet-sdk.yml -R honua-io/honua-sdk-dotnet --ref trunk -f dry_run=false ;;
+              honua-io/honua-sdk-js:publish-js-sdk.yml)
+                gh workflow run publish-js-sdk.yml -R honua-io/honua-sdk-js --ref trunk -f dry_run=false ;;
+              honua-io/honua-sdk-python:publish-python-sdk.yml)
+                gh workflow run publish-python-sdk.yml -R honua-io/honua-sdk-python --ref trunk -f dry_run=false ;;
+              honua-io/honua-mobile:publish-dotnet-mobile.yml)
+                gh workflow run publish-dotnet-mobile.yml -R honua-io/honua-mobile --ref trunk -f dry_run=false ;;
+              honua-io/geospatial-grpc:publish-dotnet-protocol.yml)
+                gh workflow run publish-dotnet-protocol.yml -R honua-io/geospatial-grpc --ref trunk -f dry_run=false ;;
+              :)
+                ;;
+              *)
+                echo "::error::Unallowlisted SDK publish workflow ${repo}:${pub}"
+                exit 1 ;;
+            esac
           done
           # Retag the immutable RC image to the channel + latest-aot.
           ref='${{ needs.rc-image.outputs.image_ref }}'

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -1167,6 +1167,7 @@ echo
 echo "== Roll-forward Cap. 2b: state-aware green rerun recovery =="
 __recover_records() {
   [[ "$1" == train/batch/deadbee/123 ]] || return 0
+  [[ "$2" == base123 ]] || return 0
   printf '1944\tsha1944\n1961\tsha1961\n'
 }
 __recover_info() {
@@ -1177,7 +1178,7 @@ __recover_info() {
   esac
 }
 __recover_run() { printf 'CI\tcompleted\tsuccess\ttrain/batch/deadbee/123\tbatchsha\n'; }
-__recover_remote() { printf 'batchsha\n'; }
+__recover_remote() { printf '%s\n' "${RECOVERY_REMOTE}"; }
 __recover_trunk() { printf '%s\n' "${RECOVERY_TRUNK}"; }
 __recover_land() { printf 'LAND-MOCK %s %s\n' "$1" "$2"; cat "$3"; }
 __recover_dispatch() { printf 'DISPATCH-MOCK\n'; }
@@ -1195,7 +1196,7 @@ export TRAIN_RECOVERY_TRUNK_HEAD_FOR=__recover_trunk
 export TRAIN_RECOVERY_LAND_CMD=__recover_land
 export TRAIN_RECOVERY_DISPATCH_CMD=__recover_dispatch
 export TRAIN_STATE_ISSUE_OVERRIDE=2044
-export RECOVERY_TRUNK=base123
+export RECOVERY_TRUNK=base123 RECOVERY_REMOTE=batchsha
 export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 ci-incomplete 123)"
 RECOVERY_LOG="$(
   GITHUB_REPOSITORY=honua-io/honua-server \
@@ -1207,6 +1208,17 @@ assert_contains "recovery: land receives immutable #1944 head" "${RECOVERY_LOG}"
 assert_contains "recovery: successful resume finalizes once" "${RECOVERY_LOG}" "RECOVERY LANDED"
 assert_contains "recovery: successful resume queues continued drain" "${RECOVERY_LOG}" "DISPATCH-MOCK"
 assert_not_contains "recovery: never stamps CI Gate on mutable heads" "${RECOVERY_LOG}" "statuses/"
+
+# Member reconstruction must use the recorded assembly base, not current trunk.
+# The record seam returns no members unless it receives base123; this remains
+# recoverable even when current trunk already equals the batch SHA.
+export RECOVERY_TRUNK=batchsha
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 land 123)"
+BASE_RECON_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_contains "recovery: post-push reconstruction uses recorded trunk base" "${BASE_RECON_LOG}" "RECOVERY LANDED"
+assert_not_contains "recovery: reconstructed post-push batch does not re-land" "${BASE_RECON_LOG}" "LAND-MOCK"
+export RECOVERY_TRUNK=base123
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 ci-incomplete 123)"
 
 # A PR-head change invalidates the whole batch: do not land or stamp it, clear
 # landing labels, reset state, and dispatch one serialized live reassembly.
@@ -1224,6 +1236,33 @@ assert_not_contains "recovery: changed PR head is never stamped" "${STALE_HEAD_L
 assert_contains "recovery: stale landing label is cleared" "${STALE_HEAD_LOG}" "gh pr edit 1944 --remove-label train:landing"
 assert_contains "recovery: changed head queues one reassembly" "${STALE_HEAD_LOG}" "DISPATCH-MOCK"
 assert_contains "recovery: changed head explains reset" "${STALE_HEAD_LOG}" "no longer matches validated head"
+
+# If state and commit-derived membership differ, cleanup uses their union so a
+# state-only member cannot remain stuck with train:landing.
+__recover_records_partial() {
+  [[ "$1" == train/batch/deadbee/123 && "$2" == base123 ]] || return 0
+  printf '1944\tsha1944\n'
+}
+export -f __recover_records_partial
+export TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH=__recover_records_partial
+export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info RECOVERY_TRUNK=base123
+MEMBER_MISMATCH_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_contains "recovery: mismatch clears commit-derived member" "${MEMBER_MISMATCH_LOG}" "gh pr edit 1944 --remove-label train:landing"
+assert_contains "recovery: mismatch clears state-only member" "${MEMBER_MISMATCH_LOG}" "gh pr edit 1961 --remove-label train:landing"
+assert_eq "recovery: mismatch dispatches exactly once" "$(grep -Fc DISPATCH-MOCK <<<"${MEMBER_MISMATCH_LOG}")" "1"
+assert_not_contains "recovery: mismatch never lands" "${MEMBER_MISMATCH_LOG}" "LAND-MOCK"
+export TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH=__recover_records
+
+# A deleted or rewritten batch ref is stale active state, not an ignorable old
+# event. Clear landing for all recorded state members and queue one reassembly.
+export RECOVERY_REMOTE=movedbatch
+MOVED_REF_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_contains "recovery: moved batch ref resets active state" "${MOVED_REF_LOG}" "missing or no longer equals successful run head"
+assert_contains "recovery: moved batch clears #1944 landing" "${MOVED_REF_LOG}" "gh pr edit 1944 --remove-label train:landing"
+assert_contains "recovery: moved batch clears #1961 landing" "${MOVED_REF_LOG}" "gh pr edit 1961 --remove-label train:landing"
+assert_eq "recovery: moved batch dispatches exactly once" "$(grep -Fc DISPATCH-MOCK <<<"${MOVED_REF_LOG}")" "1"
+assert_not_contains "recovery: moved batch never lands" "${MOVED_REF_LOG}" "LAND-MOCK"
+export RECOVERY_REMOTE=batchsha
 
 # A trunk move follows the same reset path and never reaches land.
 export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info RECOVERY_TRUNK=advancedtrunk
@@ -1250,7 +1289,7 @@ unset TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH TRAIN_RECOVERY_PR_INFO_FOR \
   TRAIN_RECOVERY_RUN_INFO_FOR TRAIN_RECOVERY_REMOTE_HEAD_FOR \
   TRAIN_RECOVERY_TRUNK_HEAD_FOR TRAIN_RECOVERY_LAND_CMD \
   TRAIN_RECOVERY_DISPATCH_CMD TRAIN_RECOVERY_STATE_JSON TRAIN_STATE_ISSUE_OVERRIDE \
-  RECOVERY_TRUNK
+  RECOVERY_TRUNK RECOVERY_REMOTE
 
 echo
 echo "== Roll-forward Cap. 4: autofix disabled (TRAIN_AUTOFIX=0) => behaves like today =="

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -1181,13 +1181,14 @@ __recover_run() { printf 'CI\tcompleted\tsuccess\ttrain/batch/deadbee/123\tbatch
 __recover_remote() { printf '%s\n' "${RECOVERY_REMOTE}"; }
 __recover_trunk() { printf '%s\n' "${RECOVERY_TRUNK}"; }
 __recover_land() { printf 'LAND-MOCK %s %s\n' "$1" "$2"; cat "$3"; }
-__recover_dispatch() { printf 'DISPATCH-MOCK\n'; }
+__recover_dispatch() { printf 'DISPATCH-MOCK %s\n' "$1"; }
+__recover_continuation_exists() { [[ "${RECOVERY_CONTINUATION_EXISTS:-0}" == 1 ]]; }
 __recover_state() {
   jq -nc --arg branch "$1" --arg base "$2" --arg phase "$3" --arg run "$4" \
     '{active_batch:{branch:$branch,trunk_base:$base,included:[1944,1961],phase:$phase,run_id:($run|tonumber),fwdfix_attempts:0,flake_reruns:0},config:{max_batch:10,flake_signatures:""},last_landed_trunk:null}'
 }
 export -f __recover_records __recover_info __recover_run __recover_remote \
-  __recover_trunk __recover_land __recover_dispatch __recover_state
+  __recover_trunk __recover_land __recover_dispatch __recover_continuation_exists __recover_state
 export TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH=__recover_records
 export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info
 export TRAIN_RECOVERY_RUN_INFO_FOR=__recover_run
@@ -1195,6 +1196,7 @@ export TRAIN_RECOVERY_REMOTE_HEAD_FOR=__recover_remote
 export TRAIN_RECOVERY_TRUNK_HEAD_FOR=__recover_trunk
 export TRAIN_RECOVERY_LAND_CMD=__recover_land
 export TRAIN_RECOVERY_DISPATCH_CMD=__recover_dispatch
+export TRAIN_RECOVERY_CONTINUATION_EXISTS_FOR=__recover_continuation_exists
 export TRAIN_STATE_ISSUE_OVERRIDE=2044
 export RECOVERY_TRUNK=base123 RECOVERY_REMOTE=batchsha
 export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 ci-incomplete 123)"
@@ -1208,6 +1210,7 @@ assert_contains "recovery: land receives immutable #1944 head" "${RECOVERY_LOG}"
 assert_contains "recovery: successful resume finalizes once" "${RECOVERY_LOG}" "RECOVERY LANDED"
 assert_contains "recovery: successful resume queues continued drain" "${RECOVERY_LOG}" "DISPATCH-MOCK"
 assert_not_contains "recovery: never stamps CI Gate on mutable heads" "${RECOVERY_LOG}" "statuses/"
+assert_contains "recovery: finalize clears stale escalation" "${RECOVERY_LOG}" "gh pr edit 1944 --remove-label train:escalated"
 
 # Member reconstruction must use the recorded assembly base, not current trunk.
 # The record seam returns no members unless it receives base123; this remains
@@ -1264,8 +1267,57 @@ assert_eq "recovery: moved batch dispatches exactly once" "$(grep -Fc DISPATCH-M
 assert_not_contains "recovery: moved batch never lands" "${MOVED_REF_LOG}" "LAND-MOCK"
 export RECOVERY_REMOTE=batchsha
 
+# Reassembly crash window: requeue is durable before dispatch. A duplicate sees
+# that phase, issues the missing keyed dispatch once, then commits select.
+__recover_crash_before_dispatch() { printf 'CRASH-BEFORE-DISPATCH %s %s\n' "$1" "$2"; return 99; }
+export -f __recover_crash_before_dispatch
+export TRAIN_RECOVERY_BEFORE_DISPATCH_CMD=__recover_crash_before_dispatch
+export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info_changed RECOVERY_TRUNK=base123
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 ci-incomplete 123)"
+set +e
+REASSEMBLE_CRASH_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+REASSEMBLE_CRASH_RC=$?
+set -e
+assert_eq "recovery: reassemble crash is surfaced" "${REASSEMBLE_CRASH_RC}" "99"
+assert_contains "recovery: reassemble writes pending phase before crash" "${REASSEMBLE_CRASH_LOG}" "CRASH-BEFORE-DISPATCH select"
+assert_not_contains "recovery: reassemble crash occurs before dispatch" "${REASSEMBLE_CRASH_LOG}" "DISPATCH-MOCK"
+unset TRAIN_RECOVERY_BEFORE_DISPATCH_CMD
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 requeue 123)"
+REASSEMBLE_RESUME_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_eq "recovery: reassemble resume dispatches once" "$(grep -Fc DISPATCH-MOCK <<<"${REASSEMBLE_RESUME_LOG}")" "1"
+assert_contains "recovery: reassemble resume persists select after dispatch" "${REASSEMBLE_RESUME_LOG}" "state=select"
+
+# Finalize crash window follows the same protocol, but the duplicate commits
+# done only after the missing continuation is durably dispatched.
+export TRAIN_RECOVERY_BEFORE_DISPATCH_CMD=__recover_crash_before_dispatch
+export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info RECOVERY_TRUNK=batchsha
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 land 123)"
+set +e
+FINALIZE_CRASH_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+FINALIZE_CRASH_RC=$?
+set -e
+assert_eq "recovery: finalize crash is surfaced" "${FINALIZE_CRASH_RC}" "99"
+assert_contains "recovery: finalize writes pending phase before crash" "${FINALIZE_CRASH_LOG}" "CRASH-BEFORE-DISPATCH done"
+assert_contains "recovery: finalize clears landing before pending dispatch" "${FINALIZE_CRASH_LOG}" "gh pr edit 1944 --remove-label train:landing"
+assert_contains "recovery: finalize clears escalation before pending dispatch" "${FINALIZE_CRASH_LOG}" "gh pr edit 1944 --remove-label train:escalated"
+assert_not_contains "recovery: finalize crash occurs before dispatch" "${FINALIZE_CRASH_LOG}" "DISPATCH-MOCK"
+unset TRAIN_RECOVERY_BEFORE_DISPATCH_CMD
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 batchsha requeue 123)"
+FINALIZE_RESUME_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_eq "recovery: finalize resume dispatches once" "$(grep -Fc DISPATCH-MOCK <<<"${FINALIZE_RESUME_LOG}")" "1"
+assert_contains "recovery: finalize resume persists done after dispatch" "${FINALIZE_RESUME_LOG}" "state=done"
+
+# Crash after dispatch but before final state is deduplicated by the exact key.
+export RECOVERY_CONTINUATION_EXISTS=1
+FINALIZE_DEDUP_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_contains "recovery: existing keyed continuation is recognized" "${FINALIZE_DEDUP_LOG}" "already durably dispatched"
+assert_not_contains "recovery: existing keyed continuation is not dispatched twice" "${FINALIZE_DEDUP_LOG}" "DISPATCH-MOCK"
+assert_contains "recovery: deduplicated continuation still persists done" "${FINALIZE_DEDUP_LOG}" "state=done"
+export RECOVERY_CONTINUATION_EXISTS=0
+
 # A trunk move follows the same reset path and never reaches land.
 export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info RECOVERY_TRUNK=advancedtrunk
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 ci-incomplete 123)"
 STALE_TRUNK_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
 assert_not_contains "recovery: stale trunk never lands" "${STALE_TRUNK_LOG}" "LAND-MOCK"
 assert_contains "recovery: stale trunk queues reassembly" "${STALE_TRUNK_LOG}" "trunk advanced from recorded base"
@@ -1288,8 +1340,9 @@ assert_not_contains "recovery: duplicate event does not dispatch" "${DUP_LOG}" "
 unset TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH TRAIN_RECOVERY_PR_INFO_FOR \
   TRAIN_RECOVERY_RUN_INFO_FOR TRAIN_RECOVERY_REMOTE_HEAD_FOR \
   TRAIN_RECOVERY_TRUNK_HEAD_FOR TRAIN_RECOVERY_LAND_CMD \
-  TRAIN_RECOVERY_DISPATCH_CMD TRAIN_RECOVERY_STATE_JSON TRAIN_STATE_ISSUE_OVERRIDE \
-  RECOVERY_TRUNK RECOVERY_REMOTE
+  TRAIN_RECOVERY_DISPATCH_CMD TRAIN_RECOVERY_CONTINUATION_EXISTS_FOR \
+  TRAIN_RECOVERY_BEFORE_DISPATCH_CMD TRAIN_RECOVERY_STATE_JSON TRAIN_STATE_ISSUE_OVERRIDE \
+  RECOVERY_TRUNK RECOVERY_REMOTE RECOVERY_CONTINUATION_EXISTS
 
 echo
 echo "== Roll-forward Cap. 4: autofix disabled (TRAIN_AUTOFIX=0) => behaves like today =="

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -1165,6 +1165,9 @@ assert_eq "escalate: phase reset to select" "$(jq -r '.active_batch.phase' <<<"$
 
 echo
 echo "== Roll-forward Cap. 2b: state-aware green rerun recovery =="
+grep -Fq '  actions: write' "${REAL_ROOT}/.github/workflows/merge-train-rerun-recovery.yml" \
+  && ok "recovery: workflow grants actions write for live fallback dispatch" \
+  || bad "recovery: workflow lacks actions write for live fallback dispatch"
 __recover_records() {
   [[ "$1" == train/batch/deadbee/123 ]] || return 0
   [[ "$2" == base123 ]] || return 0
@@ -1173,7 +1176,7 @@ __recover_records() {
 __recover_info() {
   case "$1" in
     1944) printf 'sha1944\tOPEN\ttrain:escalated,train:landing\n' ;;
-    1961) printf 'sha1961\tOPEN\ttrain:landing\n' ;;
+    1961) printf 'sha1961\tOPEN\ttrain:escalated,train:landing\n' ;;
     *) return 1 ;;
   esac
 }
@@ -1227,8 +1230,8 @@ export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base
 # landing labels, reset state, and dispatch one serialized live reassembly.
 __recover_info_changed() {
   case "$1" in
-    1944) printf 'changed1944\tOPEN\ttrain:landing\n' ;;
-    1961) printf 'sha1961\tOPEN\ttrain:landing\n' ;;
+    1944) printf 'changed1944\tOPEN\ttrain:escalated,train:landing\n' ;;
+    1961) printf 'sha1961\tOPEN\ttrain:escalated,train:landing\n' ;;
   esac
 }
 export -f __recover_info_changed
@@ -1237,6 +1240,7 @@ STALE_HEAD_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 ba
 assert_not_contains "recovery: changed PR head is never landed" "${STALE_HEAD_LOG}" "LAND-MOCK"
 assert_not_contains "recovery: changed PR head is never stamped" "${STALE_HEAD_LOG}" "statuses/"
 assert_contains "recovery: stale landing label is cleared" "${STALE_HEAD_LOG}" "gh pr edit 1944 --remove-label train:landing"
+assert_contains "recovery: stale escalation label is cleared" "${STALE_HEAD_LOG}" "gh pr edit 1944 --remove-label train:escalated"
 assert_contains "recovery: changed head queues one reassembly" "${STALE_HEAD_LOG}" "DISPATCH-MOCK"
 assert_contains "recovery: changed head explains reset" "${STALE_HEAD_LOG}" "no longer matches validated head"
 
@@ -1252,6 +1256,7 @@ export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info RECOVERY_TRUNK=base123
 MEMBER_MISMATCH_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
 assert_contains "recovery: mismatch clears commit-derived member" "${MEMBER_MISMATCH_LOG}" "gh pr edit 1944 --remove-label train:landing"
 assert_contains "recovery: mismatch clears state-only member" "${MEMBER_MISMATCH_LOG}" "gh pr edit 1961 --remove-label train:landing"
+assert_contains "recovery: mismatch clears state-only escalation" "${MEMBER_MISMATCH_LOG}" "gh pr edit 1961 --remove-label train:escalated"
 assert_eq "recovery: mismatch dispatches exactly once" "$(grep -Fc DISPATCH-MOCK <<<"${MEMBER_MISMATCH_LOG}")" "1"
 assert_not_contains "recovery: mismatch never lands" "${MEMBER_MISMATCH_LOG}" "LAND-MOCK"
 export TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH=__recover_records
@@ -1263,6 +1268,8 @@ MOVED_REF_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 bat
 assert_contains "recovery: moved batch ref resets active state" "${MOVED_REF_LOG}" "missing or no longer equals successful run head"
 assert_contains "recovery: moved batch clears #1944 landing" "${MOVED_REF_LOG}" "gh pr edit 1944 --remove-label train:landing"
 assert_contains "recovery: moved batch clears #1961 landing" "${MOVED_REF_LOG}" "gh pr edit 1961 --remove-label train:landing"
+assert_contains "recovery: moved batch clears #1944 escalation" "${MOVED_REF_LOG}" "gh pr edit 1944 --remove-label train:escalated"
+assert_contains "recovery: moved batch clears #1961 escalation" "${MOVED_REF_LOG}" "gh pr edit 1961 --remove-label train:escalated"
 assert_eq "recovery: moved batch dispatches exactly once" "$(grep -Fc DISPATCH-MOCK <<<"${MOVED_REF_LOG}")" "1"
 assert_not_contains "recovery: moved batch never lands" "${MOVED_REF_LOG}" "LAND-MOCK"
 export RECOVERY_REMOTE=batchsha

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -25,8 +25,8 @@
 #                                FQNs => rc2 (fall back, never a full shard rerun).
 #   Cap.2 escalation          -> labels every culprit train:escalated, removes
 #                                train:landing, clears active_batch (phase=select).
-#   Cap.2b green rerun recovery -> clears stale train:escalated + stamps CI Gate
-#                                  only for still-open escalated batch members.
+#   Cap.2b green rerun recovery -> resumes only the active immutable batch;
+#                                  stale state resets selection exactly once.
 #   Cap.4 autofix gate        -> TRAIN_AUTOFIX=0 inert (escalate like today);
 #                                TRAIN_AUTOFIX=1 fix path (mock agent commits,
 #                                no bot attribution; cap enforced; decline=>escalate).
@@ -1164,46 +1164,93 @@ assert_eq "escalate: active_batch.included cleared" "$(jq -rc '.active_batch.inc
 assert_eq "escalate: phase reset to select" "$(jq -r '.active_batch.phase' <<<"${csj}")" "select"
 
 echo
-echo "== Roll-forward Cap. 2b: green rerun recovery clears stale escalation =="
+echo "== Roll-forward Cap. 2b: state-aware green rerun recovery =="
 __recover_records() {
-  case "$1" in
-    train/batch/deadbee/123)
-      printf '1944\tsha1944\n'
-      printf '1961\tsha1961\n'
-      printf '1969\tsha1969\n'
-      printf '1972\toldsha1972\n'
-      ;;
-    *) : ;;
-  esac
+  [[ "$1" == train/batch/deadbee/123 ]] || return 0
+  printf '1944\tsha1944\n1961\tsha1961\n'
 }
 __recover_info() {
   case "$1" in
     1944) printf 'sha1944\tOPEN\ttrain:escalated,train:landing\n' ;;
     1961) printf 'sha1961\tOPEN\ttrain:landing\n' ;;
-    1969) printf 'sha1969\tCLOSED\ttrain:escalated\n' ;;
-    1972) printf 'newsha1972\tOPEN\ttrain:escalated\n' ;;
     *) return 1 ;;
   esac
 }
-export -f __recover_records __recover_info
+__recover_run() { printf 'CI\tcompleted\tsuccess\ttrain/batch/deadbee/123\tbatchsha\n'; }
+__recover_remote() { printf 'batchsha\n'; }
+__recover_trunk() { printf '%s\n' "${RECOVERY_TRUNK}"; }
+__recover_land() { printf 'LAND-MOCK %s %s\n' "$1" "$2"; cat "$3"; }
+__recover_dispatch() { printf 'DISPATCH-MOCK\n'; }
+__recover_state() {
+  jq -nc --arg branch "$1" --arg base "$2" --arg phase "$3" --arg run "$4" \
+    '{active_batch:{branch:$branch,trunk_base:$base,included:[1944,1961],phase:$phase,run_id:($run|tonumber),fwdfix_attempts:0,flake_reruns:0},config:{max_batch:10,flake_signatures:""},last_landed_trunk:null}'
+}
+export -f __recover_records __recover_info __recover_run __recover_remote \
+  __recover_trunk __recover_land __recover_dispatch __recover_state
 export TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH=__recover_records
 export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info
+export TRAIN_RECOVERY_RUN_INFO_FOR=__recover_run
+export TRAIN_RECOVERY_REMOTE_HEAD_FOR=__recover_remote
+export TRAIN_RECOVERY_TRUNK_HEAD_FOR=__recover_trunk
+export TRAIN_RECOVERY_LAND_CMD=__recover_land
+export TRAIN_RECOVERY_DISPATCH_CMD=__recover_dispatch
+export TRAIN_STATE_ISSUE_OVERRIDE=2044
+export RECOVERY_TRUNK=base123
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 ci-incomplete 123)"
 RECOVERY_LOG="$(
   GITHUB_REPOSITORY=honua-io/honua-server \
   TRAIN_APPLY=0 \
-  train_recover_green_batch_rerun 123 train/batch/deadbee/123 https://github.example/runs/123 2>&1
+  train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha https://github.example/runs/123 2>&1
 )"
-assert_contains "recovery: escalated PR gets CI Gate status" "${RECOVERY_LOG}" "gh api repos/honua-io/honua-server/statuses/sha1944"
-assert_contains "recovery: CI Gate context stamped" "${RECOVERY_LOG}" "-f context=CI Gate"
-assert_contains "recovery: clears train:escalated" "${RECOVERY_LOG}" "gh pr edit 1944 --remove-label train:escalated"
-assert_contains "recovery: clears train:landing" "${RECOVERY_LOG}" "gh pr edit 1944 --remove-label train:landing"
-assert_not_contains "recovery: non-escalated PR is not stamped" "${RECOVERY_LOG}" "statuses/sha1961"
-assert_not_contains "recovery: closed PR is not stamped" "${RECOVERY_LOG}" "statuses/sha1969"
-assert_not_contains "recovery: advanced PR head is not stamped" "${RECOVERY_LOG}" "statuses/newsha1972"
-assert_not_contains "recovery: stale batch head is not stamped" "${RECOVERY_LOG}" "statuses/oldsha1972"
-assert_not_contains "recovery: advanced PR keeps escalation label" "${RECOVERY_LOG}" "gh pr edit 1972 --remove-label train:escalated"
-assert_contains "recovery: advanced PR explains skipped SHA mismatch" "${RECOVERY_LOG}" "current head newsha1972 differs from validated batch head oldsha1972"
-unset TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH TRAIN_RECOVERY_PR_INFO_FOR
+assert_contains "recovery: exact active batch resumes land" "${RECOVERY_LOG}" "LAND-MOCK train/batch/deadbee/123 base123"
+assert_contains "recovery: land receives immutable #1944 head" "${RECOVERY_LOG}" $'1944\tsha1944'
+assert_contains "recovery: successful resume finalizes once" "${RECOVERY_LOG}" "RECOVERY LANDED"
+assert_contains "recovery: successful resume queues continued drain" "${RECOVERY_LOG}" "DISPATCH-MOCK"
+assert_not_contains "recovery: never stamps CI Gate on mutable heads" "${RECOVERY_LOG}" "statuses/"
+
+# A PR-head change invalidates the whole batch: do not land or stamp it, clear
+# landing labels, reset state, and dispatch one serialized live reassembly.
+__recover_info_changed() {
+  case "$1" in
+    1944) printf 'changed1944\tOPEN\ttrain:landing\n' ;;
+    1961) printf 'sha1961\tOPEN\ttrain:landing\n' ;;
+  esac
+}
+export -f __recover_info_changed
+export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info_changed
+STALE_HEAD_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_not_contains "recovery: changed PR head is never landed" "${STALE_HEAD_LOG}" "LAND-MOCK"
+assert_not_contains "recovery: changed PR head is never stamped" "${STALE_HEAD_LOG}" "statuses/"
+assert_contains "recovery: stale landing label is cleared" "${STALE_HEAD_LOG}" "gh pr edit 1944 --remove-label train:landing"
+assert_contains "recovery: changed head queues one reassembly" "${STALE_HEAD_LOG}" "DISPATCH-MOCK"
+assert_contains "recovery: changed head explains reset" "${STALE_HEAD_LOG}" "no longer matches validated head"
+
+# A trunk move follows the same reset path and never reaches land.
+export TRAIN_RECOVERY_PR_INFO_FOR=__recover_info RECOVERY_TRUNK=advancedtrunk
+STALE_TRUNK_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_not_contains "recovery: stale trunk never lands" "${STALE_TRUNK_LOG}" "LAND-MOCK"
+assert_contains "recovery: stale trunk queues reassembly" "${STALE_TRUNK_LOG}" "trunk advanced from recorded base"
+assert_contains "recovery: stale trunk dispatches once" "${STALE_TRUNK_LOG}" "DISPATCH-MOCK"
+
+# If a crash happened after the FF push, phase=land plus trunk=batch SHA closes
+# only unchanged members and finalizes; it must not push the batch a second time.
+export RECOVERY_TRUNK=batchsha
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state train/batch/deadbee/123 base123 land 123)"
+CRASH_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_not_contains "recovery: post-push crash does not land twice" "${CRASH_LOG}" "LAND-MOCK"
+assert_contains "recovery: post-push crash closes exact member" "${CRASH_LOG}" "gh pr merge 1944 --merge"
+assert_contains "recovery: post-push crash finalizes" "${CRASH_LOG}" "RECOVERY LANDED"
+
+# Old/duplicate workflow_run deliveries do not mutate the current state.
+export TRAIN_RECOVERY_STATE_JSON="$(__recover_state '' batchsha done 0)"
+DUP_LOG="$(train_recover_green_batch_rerun 123 train/batch/deadbee/123 batchsha run-url 2>&1)"
+assert_contains "recovery: duplicate event is recognized as inactive" "${DUP_LOG}" "not the active recoverable batch"
+assert_not_contains "recovery: duplicate event does not dispatch" "${DUP_LOG}" "DISPATCH-MOCK"
+unset TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH TRAIN_RECOVERY_PR_INFO_FOR \
+  TRAIN_RECOVERY_RUN_INFO_FOR TRAIN_RECOVERY_REMOTE_HEAD_FOR \
+  TRAIN_RECOVERY_TRUNK_HEAD_FOR TRAIN_RECOVERY_LAND_CMD \
+  TRAIN_RECOVERY_DISPATCH_CMD TRAIN_RECOVERY_STATE_JSON TRAIN_STATE_ISSUE_OVERRIDE \
+  RECOVERY_TRUNK
 
 echo
 echo "== Roll-forward Cap. 4: autofix disabled (TRAIN_AUTOFIX=0) => behaves like today =="

--- a/scripts/ci/merge-train/land.sh
+++ b/scripts/ci/merge-train/land.sh
@@ -139,23 +139,6 @@ train_restore_post_land() {
   return 0
 }
 
-# train_land_close_pr <pr> <admitted-sha>: canonical exact-head final close,
-# gated on --match-head-commit so it can never merge a PR whose head has moved
-# past the exact SHA the batch validated. Used by callers that need to close a
-# specific already-known-good PR directly (e.g. the green-rerun recovery path
-# in recovery.sh); train_land()'s own normal path stays observation-only via
-# train_finalize_landed_members below.
-train_land_close_pr() {
-  local pr="$1" admitted_sha="$2"
-  if [[ -n "${TRAIN_LAND_PR_MERGE_CMD:-}" ]]; then
-    "${TRAIN_LAND_PR_MERGE_CMD}" "${pr}" "${admitted_sha}"
-  elif [[ "${TRAIN_APPLY}" != "1" ]]; then
-    train_side_effect gh pr merge "${pr}" --merge --match-head-commit "${admitted_sha}"
-  else
-    gh pr merge "${pr}" --merge --match-head-commit "${admitted_sha}"
-  fi
-}
-
 # train_land <batch-branch> <trunk-sha-at-assembly> <included-file>
 # Returns 0 once the exact batch lands, 10 when trunk CAS/FF rejects before any
 # landing, and 1 on a pre-push error. Post-push finalization never replays trunk.

--- a/scripts/ci/merge-train/land.sh
+++ b/scripts/ci/merge-train/land.sh
@@ -139,6 +139,23 @@ train_restore_post_land() {
   return 0
 }
 
+# train_land_close_pr <pr> <admitted-sha>: canonical exact-head final close,
+# gated on --match-head-commit so it can never merge a PR whose head has moved
+# past the exact SHA the batch validated. Used by callers that need to close a
+# specific already-known-good PR directly (e.g. the green-rerun recovery path
+# in recovery.sh); train_land()'s own normal path stays observation-only via
+# train_finalize_landed_members below.
+train_land_close_pr() {
+  local pr="$1" admitted_sha="$2"
+  if [[ -n "${TRAIN_LAND_PR_MERGE_CMD:-}" ]]; then
+    "${TRAIN_LAND_PR_MERGE_CMD}" "${pr}" "${admitted_sha}"
+  elif [[ "${TRAIN_APPLY}" != "1" ]]; then
+    train_side_effect gh pr merge "${pr}" --merge --match-head-commit "${admitted_sha}"
+  else
+    gh pr merge "${pr}" --merge --match-head-commit "${admitted_sha}"
+  fi
+}
+
 # train_land <batch-branch> <trunk-sha-at-assembly> <included-file>
 # Returns 0 once the exact batch lands, 10 when trunk CAS/FF rejects before any
 # landing, and 1 on a pre-push error. Post-push finalization never replays trunk.

--- a/scripts/ci/merge-train/recovery.sh
+++ b/scripts/ci/merge-train/recovery.sh
@@ -129,7 +129,9 @@ train_recovery_complete_continuation() {
 train_recovery_reassemble() {
   local records="$1" current="$2" reason="$3" included="${4:-}" batch="$5" run_id="$6" last="$7" event_sha="$8"
   train_warn "green rerun cannot land the recorded batch: ${reason}; resetting selection"
-  train_recovery_clear_labels "${records}" "${included}" 0
+  # A stale batch is being made selectable again. Clear both transient labels
+  # across state + commit-derived membership or selection will still exclude it.
+  train_recovery_clear_labels "${records}" "${included}" 1
   local rc=0
   train_recovery_complete_continuation select "${batch}" "${current}" "${included}" "${run_id}" "${last}" "${event_sha}" || rc=$?
   [[ "${rc}" == 0 ]] || return "${rc}"

--- a/scripts/ci/merge-train/recovery.sh
+++ b/scripts/ci/merge-train/recovery.sh
@@ -143,7 +143,9 @@ train_recovery_finalize() {
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
     IFS=${HONUA_TAB} read -r sha state labels <<<"${info}"
     if [[ "${state}" == OPEN && "${sha}" == "${validated}" ]]; then
-      train_side_effect gh pr merge "${pr}" --merge
+      if ! train_land_close_pr "${pr}" "${validated}"; then
+        train_warn "recovery did not close #${pr}: exact-head final close was refused"
+      fi
     elif [[ "${state}" == OPEN && "${sha}" != "${validated}" ]]; then
       train_warn "recovery did not close #${pr}: head changed after batch push"
     fi

--- a/scripts/ci/merge-train/recovery.sh
+++ b/scripts/ci/merge-train/recovery.sh
@@ -3,17 +3,18 @@ HONUA_TAB="$(printf '\tX')"; HONUA_TAB="${HONUA_TAB%X}"
 # Resume a successful rerun only when it is still the active immutable batch.
 
 train_recovery_batch_pr_records() {
-  local batch="$1"
+  local batch="$1" recorded_base="${2:-}"
   if [[ -n "${TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH:-}" ]]; then
-    "${TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH}" "${batch}" | sed '/^$/d'; return 0
+    "${TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH}" "${batch}" "${recorded_base}" | sed '/^$/d'; return 0
   fi
   [[ -z "${batch}" ]] && return 0
   git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" \
     "+refs/heads/${batch}:refs/heads/${batch}" 2>/dev/null || return 0
   git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" \
     "refs/heads/${TRAIN_BASE_BRANCH}:refs/remotes/${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}" 2>/dev/null || true
-  local range="${batch}" base_ref="${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}"
-  git -C "${TRAIN_REPO_ROOT}" rev-parse --verify --quiet "${base_ref}" >/dev/null \
+  local range="${batch}" base_ref="${recorded_base}"
+  [[ -z "${base_ref}" ]] && base_ref="${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}"
+  git -C "${TRAIN_REPO_ROOT}" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null \
     && range="${base_ref}..${batch}"
   git -C "${TRAIN_REPO_ROOT}" log --reverse --format='%H%x09%s' "${range}" |
     while IFS=${HONUA_TAB} read -r merge_commit subject; do
@@ -81,19 +82,19 @@ train_recovery_dispatch_live() {
 }
 
 train_recovery_clear_landing() {
-  local record pr _validated info _sha _state labels
-  while IFS= read -r record; do
-    IFS=${HONUA_TAB} read -r pr _validated <<<"${record}"; [[ -z "${pr}" ]] && continue
+  local records="$1" state_included="${2:-}" pr info _sha _state labels
+  while IFS= read -r pr; do
+    [[ -z "${pr}" ]] && continue
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
     IFS=${HONUA_TAB} read -r _sha _state labels <<<"${info}"
     train_recovery_has_label "${labels}" "${TRAIN_LABEL_LANDING}" \
       && train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
-  done <<<"$1"
+  done < <({ cut -f1 <<<"${records}"; tr ',' '\n' <<<"${state_included}"; } | sed '/^$/d' | sort -nu)
 }
 
 train_recovery_reassemble() {
   train_warn "green rerun cannot land the recorded batch: $3; resetting selection"
-  train_recovery_clear_landing "$1"
+  train_recovery_clear_landing "$1" "${4:-}"
   train_recovery_write_state "" "$2" "" select "" null
   train_recovery_dispatch_live
   train_decision "RECOVERY REASSEMBLE: $3; queued one live merge-train run"
@@ -147,22 +148,26 @@ train_recover_green_batch_rerun() {
   fi
 
   local remote_sha records record_prs state_prs current
-  remote_sha="$(train_recovery_remote_head "${batch}" 2>/dev/null || true)"
-  [[ "${remote_sha}" == "${event_sha}" ]] \
-    || { train_warn "recovery skipped: batch branch no longer equals successful run head"; return 0; }
-  records="$(train_recovery_batch_pr_records "${batch}")"
-  record_prs="$(cut -f1 <<<"${records}" | sed '/^$/d' | sort -n | paste -sd, -)"
-  state_prs="$(tr ',' '\n' <<<"${included}" | sed '/^$/d' | sort -n | paste -sd, -)"
   current="$(train_recovery_trunk_head 2>/dev/null || true)"
   [[ -n "${current}" ]] || { train_err "recovery could not resolve trunk"; return 1; }
+  remote_sha="$(train_recovery_remote_head "${batch}" 2>/dev/null || true)"
+  if [[ "${remote_sha}" != "${event_sha}" ]]; then
+    records="$(train_recovery_batch_pr_records "${batch}" "${trunk_base}")"
+    train_recovery_reassemble "${records}" "${current}" \
+      "batch branch is missing or no longer equals successful run head" "${included}"
+    return 0
+  fi
+  records="$(train_recovery_batch_pr_records "${batch}" "${trunk_base}")"
+  record_prs="$(cut -f1 <<<"${records}" | sed '/^$/d' | sort -n | paste -sd, -)"
+  state_prs="$(tr ',' '\n' <<<"${included}" | sed '/^$/d' | sort -n | paste -sd, -)"
   if [[ -z "${records}" || "${record_prs}" != "${state_prs}" ]]; then
-    train_recovery_reassemble "${records}" "${current}" "batch members differ from active state"; return 0
+    train_recovery_reassemble "${records}" "${current}" "batch members differ from active state" "${included}"; return 0
   fi
   if [[ "${phase}" == land && "${current}" == "${event_sha}" ]]; then
     train_recovery_finalize "${records}" "${event_sha}" "${batch}"; return 0
   fi
   if [[ "${current}" != "${trunk_base}" ]]; then
-    train_recovery_reassemble "${records}" "${current}" "trunk advanced from recorded base"; return 0
+    train_recovery_reassemble "${records}" "${current}" "trunk advanced from recorded base" "${included}"; return 0
   fi
 
   local record pr validated sha pr_state labels
@@ -171,7 +176,7 @@ train_recover_green_batch_rerun() {
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
     IFS=${HONUA_TAB} read -r sha pr_state labels <<<"${info}"
     if [[ "${pr_state}" != OPEN || "${sha}" != "${validated}" ]]; then
-      train_recovery_reassemble "${records}" "${current}" "PR #${pr} no longer matches validated head"; return 0
+      train_recovery_reassemble "${records}" "${current}" "PR #${pr} no longer matches validated head" "${included}"; return 0
     fi
   done <<<"${records}"
 
@@ -185,7 +190,7 @@ train_recover_green_batch_rerun() {
   rm -f "${included_file}"
   if [[ "${rc}" == 10 ]]; then
     current="$(train_recovery_trunk_head 2>/dev/null || true)"
-    train_recovery_reassemble "${records}" "${current}" "land admission or FF-CAS changed"; return 0
+    train_recovery_reassemble "${records}" "${current}" "land admission or FF-CAS changed" "${included}"; return 0
   fi
   [[ "${rc}" == 0 ]] || return "${rc}"
   current="$(train_recovery_trunk_head 2>/dev/null || true)"

--- a/scripts/ci/merge-train/recovery.sh
+++ b/scripts/ci/merge-train/recovery.sh
@@ -42,6 +42,24 @@ train_recovery_run_info() {
     --jq '[.workflowName,.status,.conclusion,.headBranch,.headSha]|@tsv'
 }
 
+# train_recovery_close_pr <pr> <admitted-sha>: exact-head final close for a PR
+# this recovery path has already re-validated (current head == admitted_sha,
+# state == OPEN). Gated on --match-head-commit so it can never merge a head
+# that moved since validation. land.sh's own normal path stays observation-only
+# (its post-CAS bookkeeping never calls gh pr merge); this is recovery-local
+# because it is the one path that explicitly needs an assertive close rather
+# than waiting on GitHub's automatic merge detection.
+train_recovery_close_pr() {
+  local pr="$1" admitted_sha="$2"
+  if [[ -n "${TRAIN_RECOVERY_PR_MERGE_CMD:-}" ]]; then
+    "${TRAIN_RECOVERY_PR_MERGE_CMD}" "${pr}" "${admitted_sha}"
+  elif [[ "${TRAIN_APPLY}" != "1" ]]; then
+    train_side_effect gh pr merge "${pr}" --merge --match-head-commit "${admitted_sha}"
+  else
+    gh pr merge "${pr}" --merge --match-head-commit "${admitted_sha}"
+  fi
+}
+
 train_recovery_state_json() {
   [[ -n "${TRAIN_RECOVERY_STATE_JSON:-}" ]] && printf '%s\n' "${TRAIN_RECOVERY_STATE_JSON}" || train_state_read
 }
@@ -145,7 +163,7 @@ train_recovery_finalize() {
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
     IFS=${HONUA_TAB} read -r sha state labels <<<"${info}"
     if [[ "${state}" == OPEN && "${sha}" == "${validated}" ]]; then
-      if ! train_land_close_pr "${pr}" "${validated}"; then
+      if ! train_recovery_close_pr "${pr}" "${validated}"; then
         train_warn "recovery did not close #${pr}: exact-head final close was refused"
       fi
     elif [[ "${state}" == OPEN && "${sha}" != "${validated}" ]]; then

--- a/scripts/ci/merge-train/recovery.sh
+++ b/scripts/ci/merge-train/recovery.sh
@@ -1,143 +1,196 @@
 #!/usr/bin/env bash
 HONUA_TAB="$(printf '\tX')"; HONUA_TAB="${HONUA_TAB%X}"
-# Recovery for a manually-rerun batch CI that turns green after the train already
-# escalated the batch. The normal train loop lands a green run while it is still
-# waiting. This helper handles the later workflow_run case: clear stale
-# train:escalated labels and stamp CI Gate on the original member PR heads so the
-# regular PR merge train can drain them.
+# Resume a successful rerun only when it is still the active immutable batch.
 
 train_recovery_batch_pr_records() {
   local batch="$1"
   if [[ -n "${TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH:-}" ]]; then
-    "${TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH}" "${batch}" | sed '/^$/d'
-    return 0
+    "${TRAIN_RECOVERY_PR_RECORDS_FOR_BRANCH}" "${batch}" | sed '/^$/d'; return 0
   fi
-  if [[ -n "${TRAIN_RECOVERY_PRS_FOR_BRANCH:-}" ]]; then
-    "${TRAIN_RECOVERY_PRS_FOR_BRANCH}" "${batch}" | sed '/^$/d' | awk '{ print $0 "\t" }'
-    return 0
-  fi
-
   [[ -z "${batch}" ]] && return 0
   git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" \
-    "refs/heads/${batch}:refs/remotes/${TRAIN_REMOTE}/${batch}" 2>/dev/null || return 0
+    "+refs/heads/${batch}:refs/heads/${batch}" 2>/dev/null || return 0
   git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" \
     "refs/heads/${TRAIN_BASE_BRANCH}:refs/remotes/${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}" 2>/dev/null || true
-
-  local batch_ref="${TRAIN_REMOTE}/${batch}"
-  local base_ref="${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}"
-  local range="${batch_ref}"
-  if git -C "${TRAIN_REPO_ROOT}" rev-parse --verify --quiet "${base_ref}" >/dev/null; then
-    range="${base_ref}..${batch_ref}"
-  fi
-
-  git -C "${TRAIN_REPO_ROOT}" log --reverse --format='%H%x09%s' "${range}" \
-    | while IFS=${HONUA_TAB} read -r merge_commit subject; do
-        if [[ "${subject}" =~ ^train:\ merge\ \#([0-9]+)$ ]]; then
-          local pr="${BASH_REMATCH[1]}" validated_head
-          validated_head="$(
-            git -C "${TRAIN_REPO_ROOT}" rev-list --parents -n 1 "${merge_commit}" \
-              | awk '{ print $3 }'
-          )"
-          [[ -n "${validated_head}" ]] && printf '%s\t%s\n' "${pr}" "${validated_head}"
-        fi
-      done \
-    | awk -F '\t' '!seen[$1]++'
-}
-
-train_recovery_batch_prs() {
-  train_recovery_batch_pr_records "$1" | awk -F '\t' '{ print $1 }'
+  local range="${batch}" base_ref="${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}"
+  git -C "${TRAIN_REPO_ROOT}" rev-parse --verify --quiet "${base_ref}" >/dev/null \
+    && range="${base_ref}..${batch}"
+  git -C "${TRAIN_REPO_ROOT}" log --reverse --format='%H%x09%s' "${range}" |
+    while IFS=${HONUA_TAB} read -r merge_commit subject; do
+      if [[ "${subject}" =~ ^train:\ merge\ \#([0-9]+)$ ]]; then
+        local pr="${BASH_REMATCH[1]}" validated
+        validated="$(git -C "${TRAIN_REPO_ROOT}" rev-list --parents -n 1 "${merge_commit}" | awk '{print $3}')"
+        [[ -n "${validated}" ]] && printf '%s\t%s\n' "${pr}" "${validated}"
+      fi
+    done | awk -F '\t' '!seen[$1]++'
 }
 
 train_recovery_pr_info() {
-  local pr="$1"
   if [[ -n "${TRAIN_RECOVERY_PR_INFO_FOR:-}" ]]; then
-    "${TRAIN_RECOVERY_PR_INFO_FOR}" "${pr}"
-    return 0
+    "${TRAIN_RECOVERY_PR_INFO_FOR}" "$1"; return 0
   fi
-
-  gh pr view "${pr}" --json headRefOid,state,labels \
-    --jq '[.headRefOid, .state, ([.labels[].name] | join(","))] | @tsv'
+  gh pr view "$1" --json headRefOid,state,labels \
+    --jq '[.headRefOid,.state,([.labels[].name]|join(","))]|@tsv'
 }
 
-train_recovery_labels_contain() {
-  local labels_csv="$1" label="$2"
-  tr ',' '\n' <<<"${labels_csv}" | grep -Fxq "${label}"
-}
-
-train_recovery_short_sha() {
-  local sha="$1"
-  printf '%s' "${sha:0:12}"
-}
-
-train_recovery_stamp_ci_gate() {
-  local pr="$1" sha="$2" run_url="$3" batch="$4" labels="$5"
-  local repo="${GITHUB_REPOSITORY:-honua-io/honua-server}"
-
-  train_side_effect gh api "repos/${repo}/statuses/${sha}" \
-    -f state=success \
-    -f context="CI Gate" \
-    -f description="Merge train batch rerun passed" \
-    -f target_url="${run_url}"
-  train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_ESCALATED}"
-  if train_recovery_labels_contain "${labels}" "${TRAIN_LABEL_LANDING}"; then
-    train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
+train_recovery_run_info() {
+  if [[ -n "${TRAIN_RECOVERY_RUN_INFO_FOR:-}" ]]; then
+    "${TRAIN_RECOVERY_RUN_INFO_FOR}" "$1"; return 0
   fi
-  train_side_effect gh pr comment "${pr}" --body \
-    "Merge train batch \`${batch}\` passed after rerun. Cleared stale merge-train labels where present and stamped \`CI Gate\` on this PR head."
+  gh run view "$1" --json workflowName,status,conclusion,headBranch,headSha \
+    --jq '[.workflowName,.status,.conclusion,.headBranch,.headSha]|@tsv'
+}
+
+train_recovery_state_json() {
+  [[ -n "${TRAIN_RECOVERY_STATE_JSON:-}" ]] && printf '%s\n' "${TRAIN_RECOVERY_STATE_JSON}" || train_state_read
+}
+
+train_recovery_remote_head() {
+  local branch="$1"
+  if [[ -n "${TRAIN_RECOVERY_REMOTE_HEAD_FOR:-}" ]]; then
+    "${TRAIN_RECOVERY_REMOTE_HEAD_FOR}" "${branch}"; return 0
+  fi
+  git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" \
+    "+refs/heads/${branch}:refs/heads/${branch}" 2>/dev/null || return 1
+  git -C "${TRAIN_REPO_ROOT}" rev-parse "refs/heads/${branch}"
+}
+
+train_recovery_trunk_head() {
+  if [[ -n "${TRAIN_RECOVERY_TRUNK_HEAD_FOR:-}" ]]; then
+    "${TRAIN_RECOVERY_TRUNK_HEAD_FOR}"; return 0
+  fi
+  git -C "${TRAIN_REPO_ROOT}" fetch --quiet "${TRAIN_REMOTE}" "${TRAIN_BASE_BRANCH}"
+  git -C "${TRAIN_REPO_ROOT}" rev-parse "${TRAIN_REMOTE}/${TRAIN_BASE_BRANCH}"
+}
+
+train_recovery_has_label() { tr ',' '\n' <<<"$1" | grep -Fxq "$2"; }
+
+train_recovery_write_state() {
+  local body; body="$(mktemp)"
+  train_state_render "$1" "$2" "$3" "$4" "$5" 0 0 "$6" >"${body}"
+  train_state_write "${body}"; rm -f "${body}"
+}
+
+train_recovery_dispatch_live() {
+  if [[ -n "${TRAIN_RECOVERY_DISPATCH_CMD:-}" ]]; then
+    "${TRAIN_RECOVERY_DISPATCH_CMD}"; return 0
+  fi
+  train_side_effect gh workflow run merge-train.yml \
+    --repo "${GITHUB_REPOSITORY:-honua-io/honua-server}" --ref "${TRAIN_BASE_BRANCH}" \
+    -f train_apply=true -f max_batch="${MAX_BATCH}"
+}
+
+train_recovery_clear_landing() {
+  local record pr _validated info _sha _state labels
+  while IFS= read -r record; do
+    IFS=${HONUA_TAB} read -r pr _validated <<<"${record}"; [[ -z "${pr}" ]] && continue
+    info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
+    IFS=${HONUA_TAB} read -r _sha _state labels <<<"${info}"
+    train_recovery_has_label "${labels}" "${TRAIN_LABEL_LANDING}" \
+      && train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
+  done <<<"$1"
+}
+
+train_recovery_reassemble() {
+  train_warn "green rerun cannot land the recorded batch: $3; resetting selection"
+  train_recovery_clear_landing "$1"
+  train_recovery_write_state "" "$2" "" select "" null
+  train_recovery_dispatch_live
+  train_decision "RECOVERY REASSEMBLE: $3; queued one live merge-train run"
+}
+
+train_recovery_finalize() {
+  local records="$1" batch_sha="$2" batch="$3" record pr validated info sha state labels
+  while IFS= read -r record; do
+    IFS=${HONUA_TAB} read -r pr validated <<<"${record}"; [[ -z "${pr}" ]] && continue
+    info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
+    IFS=${HONUA_TAB} read -r sha state labels <<<"${info}"
+    if [[ "${state}" == OPEN && "${sha}" == "${validated}" ]]; then
+      train_side_effect gh pr merge "${pr}" --merge
+    elif [[ "${state}" == OPEN && "${sha}" != "${validated}" ]]; then
+      train_warn "recovery did not close #${pr}: head changed after batch push"
+    fi
+    train_recovery_has_label "${labels}" "${TRAIN_LABEL_LANDING}" \
+      && train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
+  done <<<"${records}"
+  train_recovery_write_state "" "${batch_sha}" "" done "" "${batch_sha}"
+  train_notice "RECOVERY LANDED: finalized ${batch} at ${batch_sha:0:12}"
+  train_recovery_dispatch_live
 }
 
 train_recover_green_batch_rerun() {
-  local run_id="$1" batch="$2" run_url="${3:-}"
-
-  if [[ -z "${batch}" || "${batch}" != train/batch/* ]]; then
-    train_log "recovery skipped: ${batch:-<none>} is not a train/batch branch"
-    return 0
+  local run_id="$1" batch="$2" event_sha="$3" run_url="${4:-}"
+  if [[ -z "${batch}" || "${batch}" != train/batch/* || -z "${event_sha}" ]]; then
+    train_log "recovery skipped: invalid batch event"; return 0
+  fi
+  local info workflow status conclusion run_branch run_sha
+  info="$(train_recovery_run_info "${run_id}" 2>/dev/null || true)"
+  IFS=${HONUA_TAB} read -r workflow status conclusion run_branch run_sha <<<"${info}"
+  if [[ "${workflow}" != CI || "${status}" != completed || "${conclusion}" != success \
+     || "${run_branch}" != "${batch}" || "${run_sha}" != "${event_sha}" ]]; then
+    train_warn "recovery skipped: run ${run_id} is not successful CI for the supplied batch head"; return 0
   fi
 
-  if [[ -z "${run_url}" ]]; then
-    run_url="https://github.com/${GITHUB_REPOSITORY:-honua-io/honua-server}/actions/runs/${run_id}"
+  local state active_branch trunk_base phase active_run included last
+  state="$(train_recovery_state_json)"
+  jq -e '.active_batch and (.active_batch.included|type=="array")' >/dev/null 2>&1 <<<"${state}" \
+    || { train_warn "recovery skipped: merge-train state is missing or invalid"; return 0; }
+  active_branch="$(jq -r '.active_batch.branch//""' <<<"${state}")"
+  trunk_base="$(jq -r '.active_batch.trunk_base//""' <<<"${state}")"
+  phase="$(jq -r '.active_batch.phase//""' <<<"${state}")"
+  active_run="$(jq -r '.active_batch.run_id//""' <<<"${state}")"
+  included="$(jq -r '.active_batch.included|map(tostring)|join(",")' <<<"${state}")"
+  last="$(jq -r '.last_landed_trunk//"null"' <<<"${state}")"
+  if [[ "${active_branch}" != "${batch}" || "${active_run}" != "${run_id}" \
+     || ( "${phase}" != ci-incomplete && "${phase}" != land ) ]]; then
+    train_log "recovery skipped: run is not the active recoverable batch"; return 0
   fi
 
-  local recovered=0 record
+  local remote_sha records record_prs state_prs current
+  remote_sha="$(train_recovery_remote_head "${batch}" 2>/dev/null || true)"
+  [[ "${remote_sha}" == "${event_sha}" ]] \
+    || { train_warn "recovery skipped: batch branch no longer equals successful run head"; return 0; }
+  records="$(train_recovery_batch_pr_records "${batch}")"
+  record_prs="$(cut -f1 <<<"${records}" | sed '/^$/d' | sort -n | paste -sd, -)"
+  state_prs="$(tr ',' '\n' <<<"${included}" | sed '/^$/d' | sort -n | paste -sd, -)"
+  current="$(train_recovery_trunk_head 2>/dev/null || true)"
+  [[ -n "${current}" ]] || { train_err "recovery could not resolve trunk"; return 1; }
+  if [[ -z "${records}" || "${record_prs}" != "${state_prs}" ]]; then
+    train_recovery_reassemble "${records}" "${current}" "batch members differ from active state"; return 0
+  fi
+  if [[ "${phase}" == land && "${current}" == "${event_sha}" ]]; then
+    train_recovery_finalize "${records}" "${event_sha}" "${batch}"; return 0
+  fi
+  if [[ "${current}" != "${trunk_base}" ]]; then
+    train_recovery_reassemble "${records}" "${current}" "trunk advanced from recorded base"; return 0
+  fi
+
+  local record pr validated sha pr_state labels
   while IFS= read -r record; do
-    local pr validated_sha
-    IFS=${HONUA_TAB} read -r pr validated_sha <<<"${record}"
-    [[ -z "${pr}" ]] && continue
-
-    local info sha state labels
+    IFS=${HONUA_TAB} read -r pr validated <<<"${record}"
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
-    [[ -z "${info}" ]] && { train_warn "recovery skipped #${pr}: could not read PR info"; continue; }
+    IFS=${HONUA_TAB} read -r sha pr_state labels <<<"${info}"
+    if [[ "${pr_state}" != OPEN || "${sha}" != "${validated}" ]]; then
+      train_recovery_reassemble "${records}" "${current}" "PR #${pr} no longer matches validated head"; return 0
+    fi
+  done <<<"${records}"
 
-    IFS=${HONUA_TAB} read -r sha state labels <<<"${info}"
-    if [[ "${state}" != "OPEN" ]]; then
-      train_log "recovery skipped #${pr}: state=${state}"
-      continue
-    fi
-    if ! train_recovery_labels_contain "${labels}" "${TRAIN_LABEL_ESCALATED}"; then
-      train_log "recovery skipped #${pr}: not labeled ${TRAIN_LABEL_ESCALATED}"
-      continue
-    fi
-    if [[ -z "${sha}" || "${sha}" == "null" ]]; then
-      train_warn "recovery skipped #${pr}: missing head SHA"
-      continue
-    fi
-    if [[ -z "${validated_sha}" || "${validated_sha}" == "null" ]]; then
-      train_warn "recovery skipped #${pr}: missing validated batch head SHA"
-      continue
-    fi
-    if [[ "${sha}" != "${validated_sha}" ]]; then
-      train_warn "recovery skipped #${pr}: current head $(train_recovery_short_sha "${sha}") differs from validated batch head $(train_recovery_short_sha "${validated_sha}")"
-      continue
-    fi
-
-    train_recovery_stamp_ci_gate "${pr}" "${sha}" "${run_url}" "${batch}" "${labels}"
-    recovered=$((recovered + 1))
-    train_decision "RECOVERED #${pr}: green batch rerun ${run_id} stamped CI Gate and cleared ${TRAIN_LABEL_ESCALATED}"
-  done < <(train_recovery_batch_pr_records "${batch}")
-
-  if [[ "${recovered}" -eq 0 ]]; then
-    train_log "recovery complete: no escalated open PRs matched ${batch}"
+  train_recovery_write_state "${batch}" "${trunk_base}" "${included}" land "${run_id}" "${last}"
+  local included_file rc=0; included_file="$(mktemp)"; printf '%s\n' "${records}" >"${included_file}"
+  if [[ -n "${TRAIN_RECOVERY_LAND_CMD:-}" ]]; then
+    "${TRAIN_RECOVERY_LAND_CMD}" "${batch}" "${trunk_base}" "${included_file}" || rc=$?
   else
-    train_notice "recovery complete: restored ${recovered} PR(s) from green batch rerun ${run_id}"
+    train_land "${batch}" "${trunk_base}" "${included_file}" || rc=$?
   fi
+  rm -f "${included_file}"
+  if [[ "${rc}" == 10 ]]; then
+    current="$(train_recovery_trunk_head 2>/dev/null || true)"
+    train_recovery_reassemble "${records}" "${current}" "land admission or FF-CAS changed"; return 0
+  fi
+  [[ "${rc}" == 0 ]] || return "${rc}"
+  current="$(train_recovery_trunk_head 2>/dev/null || true)"
+  if [[ "${TRAIN_APPLY}" == 1 && "${current}" != "${event_sha}" ]]; then
+    train_err "land returned success but trunk is not the validated batch head"; return 1
+  fi
+  train_recovery_finalize "${records}" "${event_sha}" "${batch}"
 }

--- a/scripts/ci/merge-train/recovery.sh
+++ b/scripts/ci/merge-train/recovery.sh
@@ -72,36 +72,72 @@ train_recovery_write_state() {
   train_state_write "${body}"; rm -f "${body}"
 }
 
+train_recovery_continuation_exists() {
+  local key="$1"
+  if [[ -n "${TRAIN_RECOVERY_CONTINUATION_EXISTS_FOR:-}" ]]; then
+    "${TRAIN_RECOVERY_CONTINUATION_EXISTS_FOR}" "${key}"; return $?
+  fi
+  gh api "repos/${GITHUB_REPOSITORY:-honua-io/honua-server}/actions/workflows/merge-train.yml/runs?per_page=100" \
+    | jq -e --arg title "Merge Train [${key}]" \
+      '.workflow_runs | any(.display_title == $title)' >/dev/null
+}
+
 train_recovery_dispatch_live() {
+  local key="$1"
+  if train_recovery_continuation_exists "${key}"; then
+    train_log "recovery continuation ${key} is already durably dispatched"
+    return 0
+  fi
   if [[ -n "${TRAIN_RECOVERY_DISPATCH_CMD:-}" ]]; then
-    "${TRAIN_RECOVERY_DISPATCH_CMD}"; return 0
+    "${TRAIN_RECOVERY_DISPATCH_CMD}" "${key}"; return 0
   fi
   train_side_effect gh workflow run merge-train.yml \
     --repo "${GITHUB_REPOSITORY:-honua-io/honua-server}" --ref "${TRAIN_BASE_BRANCH}" \
-    -f train_apply=true -f max_batch="${MAX_BATCH}"
+    -f train_apply=true -f max_batch="${MAX_BATCH}" -f recovery_key="${key}"
 }
 
-train_recovery_clear_landing() {
-  local records="$1" state_included="${2:-}" pr info _sha _state labels
+train_recovery_clear_labels() {
+  local records="$1" state_included="${2:-}" clear_escalated="${3:-0}" pr info _sha _state labels
   while IFS= read -r pr; do
     [[ -z "${pr}" ]] && continue
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
     IFS=${HONUA_TAB} read -r _sha _state labels <<<"${info}"
     train_recovery_has_label "${labels}" "${TRAIN_LABEL_LANDING}" \
       && train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
+    if [[ "${clear_escalated}" == 1 ]] && train_recovery_has_label "${labels}" "${TRAIN_LABEL_ESCALATED}"; then
+      train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_ESCALATED}"
+    fi
   done < <({ cut -f1 <<<"${records}"; tr ',' '\n' <<<"${state_included}"; } | sed '/^$/d' | sort -nu)
 }
 
+train_recovery_complete_continuation() {
+  local target="$1" batch="$2" trunk="$3" included="$4" run_id="$5" last="$6" event_sha="$7"
+  local key="recovery-${run_id}-${event_sha:0:12}"
+  train_recovery_write_state "${batch}" "${trunk}" "${included}" requeue "${run_id}" "${last}"
+  if [[ -n "${TRAIN_RECOVERY_BEFORE_DISPATCH_CMD:-}" ]]; then
+    "${TRAIN_RECOVERY_BEFORE_DISPATCH_CMD}" "${target}" "${key}" || return $?
+  fi
+  train_recovery_dispatch_live "${key}"
+  if [[ "${target}" == done ]]; then
+    train_recovery_write_state "" "${event_sha}" "" done "" "${event_sha}"
+  else
+    train_recovery_write_state "" "${trunk}" "" select "" null
+  fi
+  train_decision "RECOVERY CONTINUATION: ${key} durably dispatched; state=${target}"
+}
+
 train_recovery_reassemble() {
-  train_warn "green rerun cannot land the recorded batch: $3; resetting selection"
-  train_recovery_clear_landing "$1" "${4:-}"
-  train_recovery_write_state "" "$2" "" select "" null
-  train_recovery_dispatch_live
-  train_decision "RECOVERY REASSEMBLE: $3; queued one live merge-train run"
+  local records="$1" current="$2" reason="$3" included="${4:-}" batch="$5" run_id="$6" last="$7" event_sha="$8"
+  train_warn "green rerun cannot land the recorded batch: ${reason}; resetting selection"
+  train_recovery_clear_labels "${records}" "${included}" 0
+  local rc=0
+  train_recovery_complete_continuation select "${batch}" "${current}" "${included}" "${run_id}" "${last}" "${event_sha}" || rc=$?
+  [[ "${rc}" == 0 ]] || return "${rc}"
+  train_decision "RECOVERY REASSEMBLE: ${reason}; queued one live merge-train run"
 }
 
 train_recovery_finalize() {
-  local records="$1" batch_sha="$2" batch="$3" record pr validated info sha state labels
+  local records="$1" batch_sha="$2" batch="$3" included="$4" run_id="$5" last="$6" record pr validated info sha state labels
   while IFS= read -r record; do
     IFS=${HONUA_TAB} read -r pr validated <<<"${record}"; [[ -z "${pr}" ]] && continue
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
@@ -111,12 +147,10 @@ train_recovery_finalize() {
     elif [[ "${state}" == OPEN && "${sha}" != "${validated}" ]]; then
       train_warn "recovery did not close #${pr}: head changed after batch push"
     fi
-    train_recovery_has_label "${labels}" "${TRAIN_LABEL_LANDING}" \
-      && train_side_effect gh pr edit "${pr}" --remove-label "${TRAIN_LABEL_LANDING}"
   done <<<"${records}"
-  train_recovery_write_state "" "${batch_sha}" "" done "" "${batch_sha}"
+  train_recovery_clear_labels "${records}" "${included}" 1
   train_notice "RECOVERY LANDED: finalized ${batch} at ${batch_sha:0:12}"
-  train_recovery_dispatch_live
+  train_recovery_complete_continuation done "${batch}" "${batch_sha}" "${included}" "${run_id}" "${last}" "${batch_sha}"
 }
 
 train_recover_green_batch_rerun() {
@@ -143,31 +177,39 @@ train_recover_green_batch_rerun() {
   included="$(jq -r '.active_batch.included|map(tostring)|join(",")' <<<"${state}")"
   last="$(jq -r '.last_landed_trunk//"null"' <<<"${state}")"
   if [[ "${active_branch}" != "${batch}" || "${active_run}" != "${run_id}" \
-     || ( "${phase}" != ci-incomplete && "${phase}" != land ) ]]; then
+     || ( "${phase}" != ci-incomplete && "${phase}" != land && "${phase}" != requeue ) ]]; then
     train_log "recovery skipped: run is not the active recoverable batch"; return 0
   fi
 
   local remote_sha records record_prs state_prs current
   current="$(train_recovery_trunk_head 2>/dev/null || true)"
   [[ -n "${current}" ]] || { train_err "recovery could not resolve trunk"; return 1; }
+  if [[ "${phase}" == requeue ]]; then
+    if [[ "${current}" == "${event_sha}" ]]; then
+      train_recovery_complete_continuation done "${batch}" "${current}" "${included}" "${run_id}" "${last}" "${event_sha}"
+    else
+      train_recovery_complete_continuation select "${batch}" "${current}" "${included}" "${run_id}" "${last}" "${event_sha}"
+    fi
+    return 0
+  fi
   remote_sha="$(train_recovery_remote_head "${batch}" 2>/dev/null || true)"
   if [[ "${remote_sha}" != "${event_sha}" ]]; then
     records="$(train_recovery_batch_pr_records "${batch}" "${trunk_base}")"
     train_recovery_reassemble "${records}" "${current}" \
-      "batch branch is missing or no longer equals successful run head" "${included}"
-    return 0
+      "batch branch is missing or no longer equals successful run head" "${included}" "${batch}" "${run_id}" "${last}" "${event_sha}"
+    return $?
   fi
   records="$(train_recovery_batch_pr_records "${batch}" "${trunk_base}")"
   record_prs="$(cut -f1 <<<"${records}" | sed '/^$/d' | sort -n | paste -sd, -)"
   state_prs="$(tr ',' '\n' <<<"${included}" | sed '/^$/d' | sort -n | paste -sd, -)"
   if [[ -z "${records}" || "${record_prs}" != "${state_prs}" ]]; then
-    train_recovery_reassemble "${records}" "${current}" "batch members differ from active state" "${included}"; return 0
+    train_recovery_reassemble "${records}" "${current}" "batch members differ from active state" "${included}" "${batch}" "${run_id}" "${last}" "${event_sha}"; return $?
   fi
   if [[ "${phase}" == land && "${current}" == "${event_sha}" ]]; then
-    train_recovery_finalize "${records}" "${event_sha}" "${batch}"; return 0
+    train_recovery_finalize "${records}" "${event_sha}" "${batch}" "${included}" "${run_id}" "${last}"; return $?
   fi
   if [[ "${current}" != "${trunk_base}" ]]; then
-    train_recovery_reassemble "${records}" "${current}" "trunk advanced from recorded base" "${included}"; return 0
+    train_recovery_reassemble "${records}" "${current}" "trunk advanced from recorded base" "${included}" "${batch}" "${run_id}" "${last}" "${event_sha}"; return $?
   fi
 
   local record pr validated sha pr_state labels
@@ -176,7 +218,7 @@ train_recover_green_batch_rerun() {
     info="$(train_recovery_pr_info "${pr}" 2>/dev/null || true)"
     IFS=${HONUA_TAB} read -r sha pr_state labels <<<"${info}"
     if [[ "${pr_state}" != OPEN || "${sha}" != "${validated}" ]]; then
-      train_recovery_reassemble "${records}" "${current}" "PR #${pr} no longer matches validated head" "${included}"; return 0
+      train_recovery_reassemble "${records}" "${current}" "PR #${pr} no longer matches validated head" "${included}" "${batch}" "${run_id}" "${last}" "${event_sha}"; return $?
     fi
   done <<<"${records}"
 
@@ -190,12 +232,12 @@ train_recover_green_batch_rerun() {
   rm -f "${included_file}"
   if [[ "${rc}" == 10 ]]; then
     current="$(train_recovery_trunk_head 2>/dev/null || true)"
-    train_recovery_reassemble "${records}" "${current}" "land admission or FF-CAS changed" "${included}"; return 0
+    train_recovery_reassemble "${records}" "${current}" "land admission or FF-CAS changed" "${included}" "${batch}" "${run_id}" "${last}" "${event_sha}"; return $?
   fi
   [[ "${rc}" == 0 ]] || return "${rc}"
   current="$(train_recovery_trunk_head 2>/dev/null || true)"
   if [[ "${TRAIN_APPLY}" == 1 && "${current}" != "${event_sha}" ]]; then
     train_err "land returned success but trunk is not the validated batch head"; return 1
   fi
-  train_recovery_finalize "${records}" "${event_sha}" "${batch}"
+  train_recovery_finalize "${records}" "${event_sha}" "${batch}" "${included}" "${run_id}" "${last}"
 }

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -318,7 +318,7 @@ scan_authorities() {
   # Dispatching the live-capable train is itself a merge authority regardless
   # of how train_apply is spelled or valued. Canonical locations are separately
   # allowlisted; every other executable source must be unable to wake this flow.
-  local live_dispatch='gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([^[:space:];]*/)?merge-train\.yml|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches|createWorkflowDispatch[^)]*merge-train\.yml'
+  local live_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([\"']?([^[:space:]\"']*/)?merge-train\.yml[\"']?|[\"']Merge[[:space:]]+Train[\"'])|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches|createWorkflowDispatch[^)]*merge-train\.yml"
   local file rel source found=0 candidates reject_ansi
   if git -C "${root}" rev-parse --git-dir >/dev/null 2>&1; then
     candidates="$(git -C "${root}" ls-files | grep -E '\.(yml|yaml|sh|bash|zsh|ps1|js|mjs|cjs|ts|py)$')"
@@ -366,7 +366,12 @@ train_smart_ci_run() {
   git push "${TRAIN_REMOTE}" "${batch}:${batch}"
 }
 SH
-  printf 'gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches -f inputs[train_apply]=${mode}\n' >"${scratch}/scripts/ci/merge-train/recovery.sh"
+  cat >"${scratch}/scripts/ci/merge-train/recovery.sh" <<'SH'
+gh workflow run merge-train.yml --repo "${GITHUB_REPOSITORY}" --ref trunk \
+  -f train_apply=true -f max_batch="${MAX_BATCH}" -f recovery_key="${key}"
+gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches \
+  -f inputs[train_apply]=${mode}
+SH
   cat >"${scratch}/.github/workflows/read-only.yml" <<'YAML'
 jobs:
   inspect:
@@ -419,6 +424,10 @@ YAML
     'gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches -f inputs[train_apply]=true'
     'github.rest.actions.createWorkflowDispatch({workflow_id: "merge-train.yml", inputs: {train_apply: true}})'
     'gh workflow run merge-train.yml -f train_apply=${mode}'
+    'gh workflow run "merge-train.yml" -f train_apply=${mode}'
+    "gh workflow run 'merge-train.yml' -f train_apply=false"
+    'gh workflow run "Merge Train" -f train_apply=${mode}'
+    "gh workflow run 'Merge Train' -f train_apply=false"
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: "merge-train.yml",\n        ref: "trunk",\n        inputs: {\n          train_apply: mode\n        }\n      })'
   )
   for fixture in "${fixtures[@]}"; do

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -390,8 +390,12 @@ scan_authorities() {
   # A variable workflow selector cannot be proven non-authoritative statically.
   # Reject it everywhere except the explicit dispatch authority allowlist.
   # For JS calls, quoted and computed workflow_id keys are equivalent to the
-  # bare key and must not hide a dynamic selector.
-  local dynamic_dispatch="createWorkflowDispatch[^)]*(\[[[:space:]]*[\"']workflow_id[\"'][[:space:]]*\]|[\"']?workflow_id[\"']?)[[:space:]]*:[[:space:]]*[$]?[A-Za-z_][A-Za-z0-9_]*|createWorkflowDispatch[^)]*[{,][[:space:]]*workflow_id[[:space:],}]"
+  # bare key and must not hide a dynamic selector. The REST dispatch endpoint's
+  # workflow_id path segment accepts either a filename or a numeric workflow
+  # ID (GitHub API docs), and gh api never resolves that ID to a name for us,
+  # so a numeric or interpolated segment is just as unprovable as a bare CLI
+  # variable and must be rejected the same way.
+  local dynamic_dispatch="createWorkflowDispatch[^)]*(\[[[:space:]]*[\"']workflow_id[\"'][[:space:]]*\]|[\"']?workflow_id[\"']?)[[:space:]]*:[[:space:]]*[$]?[A-Za-z_][A-Za-z0-9_]*|createWorkflowDispatch[^)]*[{,][[:space:]]*workflow_id[[:space:],}]|gh[[:space:]]+api[^#;|&]*/actions/workflows/([0-9]+|[^/[:space:]]*[$][^/[:space:]]*)/dispatches"
   local file rel source found=0 candidates reject_ansi
   if git -C "${root}" rev-parse --git-dir >/dev/null 2>&1; then
     candidates="$(git -C "${root}" ls-files | grep -E '\.(yml|yaml|sh|bash|zsh|ps1|js|mjs|cjs|ts|py)$')"
@@ -519,6 +523,8 @@ YAML
     'gh workflow run -R honua-io/honua-server $flow -f train_apply=true'
     'gh workflow run 123456 -f train_apply=true'
     'gh workflow run --repo honua-io/honua-server 123456 -f train_apply=true'
+    'gh api --method POST repos/o/r/actions/workflows/123456/dispatches -f inputs[train_apply]=true'
+    'gh api --method POST repos/o/r/actions/workflows/${flow_id}/dispatches -f inputs[train_apply]=true'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: "merge-train.yml",\n        ref: "trunk",\n        inputs: {\n          train_apply: mode\n        }\n      })'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: flow,\n        ref: "trunk"\n      })'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        "workflow_id": flow,\n        ref: "trunk"\n      })'

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -5,7 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 is_allowlisted() {
   case "$1" in
-    scripts/ci/merge-train/land.sh|scripts/ci/merge-train/fixtures/validate-merge-train.sh|scripts/ci/validate-single-merge-authority.sh)
+    scripts/ci/merge-train/land.sh|scripts/ci/merge-train/recovery.sh|scripts/ci/merge-train/fixtures/validate-merge-train.sh|scripts/ci/validate-single-merge-authority.sh)
       return 0 ;;
     *) return 1 ;;
   esac

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -117,6 +117,7 @@ has_forbidden_workflow_run() {
     selector="$(workflow_run_selector "${args}")" || return 0
     base="${selector##*/}"; lower="${selector,,}"
     case "${selector}" in *'$'*|*'`'*) return 0 ;; esac
+    [[ ! "${selector}" =~ ^[0-9]+$ ]] || return 0
     [[ "${base,,}" != merge-train.yml && "${lower}" != "merge train" ]] || return 0
     rest="${rest#*"${match}"}"
   done
@@ -516,6 +517,8 @@ YAML
     'gh workflow run --repo honua-io/honua-server merge-train.yml -f train_apply=true'
     'gh workflow run --hostname github.example --repo honua-io/honua-server merge-train.yml -f train_apply=true'
     'gh workflow run -R honua-io/honua-server $flow -f train_apply=true'
+    'gh workflow run 123456 -f train_apply=true'
+    'gh workflow run --repo honua-io/honua-server 123456 -f train_apply=true'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: "merge-train.yml",\n        ref: "trunk",\n        inputs: {\n          train_apply: mode\n        }\n      })'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: flow,\n        ref: "trunk"\n      })'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        "workflow_id": flow,\n        ref: "trunk"\n      })'

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -56,6 +56,73 @@ normalized_source() {
   logical_shell_source "$1" | awk 'NF { printf "%s ; ", $0 }'
 }
 
+tokenize_workflow_args() {
+  local input="$1" char quote="" token="" started=0 i
+  GH_WORKFLOW_TOKENS=()
+  for ((i = 0; i < ${#input}; i++)); do
+    char="${input:i:1}"
+    if [[ -n "${quote}" ]]; then
+      if [[ "${char}" == "${quote}" ]]; then
+        quote=""
+      elif [[ "${char}" == '\\' && "${quote}" == '"' ]]; then
+        i=$((i + 1)); [[ ${i} -lt ${#input} ]] || return 1
+        token+="${input:i:1}"
+      else
+        token+="${char}"
+      fi
+      continue
+    fi
+    case "${char}" in
+      "'"|'"') quote="${char}"; started=1 ;;
+      '\\')
+        i=$((i + 1)); [[ ${i} -lt ${#input} ]] || return 1
+        token+="${input:i:1}"; started=1 ;;
+      ' '|$'\t'|$'\r'|$'\n')
+        if [[ "${started}" == 1 ]]; then
+          GH_WORKFLOW_TOKENS+=("${token}"); token=""; started=0
+        fi ;;
+      *) token+="${char}"; started=1 ;;
+    esac
+  done
+  [[ -z "${quote}" ]] || return 1
+  [[ "${started}" == 0 ]] || GH_WORKFLOW_TOKENS+=("${token}")
+}
+
+workflow_run_selector() {
+  tokenize_workflow_args "$1" || return 1
+  local i=0 token
+  while ((i < ${#GH_WORKFLOW_TOKENS[@]})); do
+    token="${GH_WORKFLOW_TOKENS[i]}"
+    case "${token}" in
+      --)
+        i=$((i + 1)); ((i < ${#GH_WORKFLOW_TOKENS[@]})) || return 1
+        printf '%s\n' "${GH_WORKFLOW_TOKENS[i]}"; return 0 ;;
+      -R|--repo|--hostname|-r|--ref|-f|--raw-field|-F|--field)
+        i=$((i + 2)); ((i <= ${#GH_WORKFLOW_TOKENS[@]})) || return 1 ;;
+      --repo=*|--hostname=*|--ref=*|--raw-field=*|--field=*|-R?*|-r?*|-f?*|-F?*)
+        i=$((i + 1)) ;;
+      --json|--help)
+        i=$((i + 1)) ;;
+      -*) return 1 ;;
+      *) printf '%s\n' "${token}"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+has_forbidden_workflow_run() {
+  local rest="$1" args selector base lower match
+  while [[ "${rest}" =~ (^|[[:space:];\|\&])gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([^;\|\&]*) ]]; do
+    match="${BASH_REMATCH[0]}"; args="${BASH_REMATCH[2]}"
+    selector="$(workflow_run_selector "${args}")" || return 0
+    base="${selector##*/}"; lower="${selector,,}"
+    case "${selector}" in *'$'*|*'`'*) return 0 ;; esac
+    [[ "${base,,}" != merge-train.yml && "${lower}" != "merge train" ]] || return 0
+    rest="${rest#*"${match}"}"
+  done
+  return 1
+}
+
 # Canonicalize the command verb without evaluating source. Git and GitHub CLI
 # accept global options before their subcommand, so raw adjacency regexes are
 # insufficient (for example, `git -C repo push` and `gh -R o/r pr merge`).
@@ -318,16 +385,12 @@ scan_authorities() {
   # Dispatching the live-capable train is itself a merge authority regardless
   # of how train_apply is spelled or valued. Canonical locations are separately
   # allowlisted; every other executable source must be unable to wake this flow.
-  local live_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([\"']?([^[:space:]\"']*/)?merge-train\.yml[\"']?|[\"']Merge[[:space:]]+Train[\"'])|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches|createWorkflowDispatch[^)]*merge-train\.yml"
+  local live_dispatch="gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches|createWorkflowDispatch[^)]*merge-train\.yml"
   # A variable workflow selector cannot be proven non-authoritative statically.
   # Reject it everywhere except the explicit dispatch authority allowlist.
-  # Outside the allowlist, reject variable selectors and any invocation whose
-  # selector is preceded by a flag. Inherited flags (-R/--repo, --hostname, and
-  # future flags) make positional parsing unsafe; static selectors in the first
-  # position remain provably non-authoritative unless live_dispatch matches.
   # For JS calls, quoted and computed workflow_id keys are equivalent to the
   # bare key and must not hide a dynamic selector.
-  local dynamic_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+(-[^[:space:];]*|[^[:space:];]*[$][^[:space:];]*)|createWorkflowDispatch[^)]*(\[[[:space:]]*[\"']workflow_id[\"'][[:space:]]*\]|[\"']?workflow_id[\"']?)[[:space:]]*:[[:space:]]*[$]?[A-Za-z_][A-Za-z0-9_]*|createWorkflowDispatch[^)]*[{,][[:space:]]*workflow_id[[:space:],}]"
+  local dynamic_dispatch="createWorkflowDispatch[^)]*(\[[[:space:]]*[\"']workflow_id[\"'][[:space:]]*\]|[\"']?workflow_id[\"']?)[[:space:]]*:[[:space:]]*[$]?[A-Za-z_][A-Za-z0-9_]*|createWorkflowDispatch[^)]*[{,][[:space:]]*workflow_id[[:space:],}]"
   local file rel source found=0 candidates reject_ansi
   if git -C "${root}" rev-parse --git-dir >/dev/null 2>&1; then
     candidates="$(git -C "${root}" ls-files | grep -E '\.(yml|yaml|sh|bash|zsh|ps1|js|mjs|cjs|ts|py)$')"
@@ -351,6 +414,9 @@ scan_authorities() {
     fi
     if ! is_dispatch_allowlisted "${rel}" && grep -Eiq "${live_dispatch}" <<<"${source}"; then
       echo "forbidden live merge-train dispatch in ${rel}" >&2; found=1
+    fi
+    if ! is_dispatch_allowlisted "${rel}" && has_forbidden_workflow_run "${source}"; then
+      echo "forbidden live or dynamic workflow dispatch in ${rel}" >&2; found=1
     fi
     if ! is_dispatch_allowlisted "${rel}" && grep -Eiq "${dynamic_dispatch}" <<<"${source}"; then
       echo "forbidden dynamic workflow dispatch in ${rel}" >&2; found=1
@@ -389,6 +455,9 @@ jobs:
   inspect:
     steps:
       - run: gh api repos/o/r/pulls/1
+      - run: gh workflow run -R o/r docs.yml
+      - run: gh workflow run --repo o/r lint.yml
+      - run: gh workflow run --hostname github.example --repo o/r audit.yml
       # `git push origin HEAD:trunk` is documentation, not executable.
       - run: git push origin HEAD:refs/heads/automation/report-${GITHUB_RUN_ID}
 YAML
@@ -446,6 +515,7 @@ YAML
     'gh workflow run -R honua-io/honua-server merge-train.yml -f train_apply=true'
     'gh workflow run --repo honua-io/honua-server merge-train.yml -f train_apply=true'
     'gh workflow run --hostname github.example --repo honua-io/honua-server merge-train.yml -f train_apply=true'
+    'gh workflow run -R honua-io/honua-server $flow -f train_apply=true'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: "merge-train.yml",\n        ref: "trunk",\n        inputs: {\n          train_apply: mode\n        }\n      })'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: flow,\n        ref: "trunk"\n      })'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        "workflow_id": flow,\n        ref: "trunk"\n      })'

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -319,6 +319,9 @@ scan_authorities() {
   # of how train_apply is spelled or valued. Canonical locations are separately
   # allowlisted; every other executable source must be unable to wake this flow.
   local live_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([\"']?([^[:space:]\"']*/)?merge-train\.yml[\"']?|[\"']Merge[[:space:]]+Train[\"'])|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches|createWorkflowDispatch[^)]*merge-train\.yml"
+  # A variable workflow selector cannot be proven non-authoritative statically.
+  # Reject it everywhere except the explicit dispatch authority allowlist.
+  local dynamic_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+[^[:space:];]*[$][^[:space:];]*|createWorkflowDispatch[^)]*workflow_id[[:space:]]*:[[:space:]]*[$]?[A-Za-z_][A-Za-z0-9_]*|createWorkflowDispatch[^)]*[{,][[:space:]]*workflow_id[[:space:],}]"
   local file rel source found=0 candidates reject_ansi
   if git -C "${root}" rev-parse --git-dir >/dev/null 2>&1; then
     candidates="$(git -C "${root}" ls-files | grep -E '\.(yml|yaml|sh|bash|zsh|ps1|js|mjs|cjs|ts|py)$')"
@@ -342,6 +345,9 @@ scan_authorities() {
     fi
     if ! is_dispatch_allowlisted "${rel}" && grep -Eiq "${live_dispatch}" <<<"${source}"; then
       echo "forbidden live merge-train dispatch in ${rel}" >&2; found=1
+    fi
+    if ! is_dispatch_allowlisted "${rel}" && grep -Eiq "${dynamic_dispatch}" <<<"${source}"; then
+      echo "forbidden dynamic workflow dispatch in ${rel}" >&2; found=1
     fi
   done <<<"${candidates}"
   [[ "${found}" == 0 ]] || {
@@ -428,13 +434,17 @@ YAML
     "gh workflow run 'merge-train.yml' -f train_apply=false"
     'gh workflow run "Merge Train" -f train_apply=${mode}'
     "gh workflow run 'Merge Train' -f train_apply=false"
+    $'flow=\'Merge Train\'\n      gh workflow run "$flow" -f train_apply=${mode}'
+    $'flow=merge-train.yml\n      gh workflow run "${flow}" -f train_apply=false'
+    'gh workflow run $flow -f train_apply=false'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: "merge-train.yml",\n        ref: "trunk",\n        inputs: {\n          train_apply: mode\n        }\n      })'
+    $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: flow,\n        ref: "trunk"\n      })'
   )
   for fixture in "${fixtures[@]}"; do
     n=$((n + 1))
     printf 'jobs:\n  bad:\n    steps:\n      - run: |\n        %s\n' "${fixture}" >"${scratch}/.github/workflows/other.yml"
     scan_authorities "${scratch}" >/dev/null 2>&1 \
-      && { echo "forbidden fixture ${n} escaped" >&2; return 1; }
+      && { echo "forbidden fixture ${n} escaped: ${fixture}" >&2; return 1; }
   done
   n=$((n + 1))
   cat >"${scratch}/.github/workflows/other.yml" <<'YAML'

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -321,7 +321,13 @@ scan_authorities() {
   local live_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([\"']?([^[:space:]\"']*/)?merge-train\.yml[\"']?|[\"']Merge[[:space:]]+Train[\"'])|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches|createWorkflowDispatch[^)]*merge-train\.yml"
   # A variable workflow selector cannot be proven non-authoritative statically.
   # Reject it everywhere except the explicit dispatch authority allowlist.
-  local dynamic_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+[^[:space:];]*[$][^[:space:];]*|createWorkflowDispatch[^)]*workflow_id[[:space:]]*:[[:space:]]*[$]?[A-Za-z_][A-Za-z0-9_]*|createWorkflowDispatch[^)]*[{,][[:space:]]*workflow_id[[:space:],}]"
+  # Outside the allowlist, reject variable selectors and any invocation whose
+  # selector is preceded by a flag. Inherited flags (-R/--repo, --hostname, and
+  # future flags) make positional parsing unsafe; static selectors in the first
+  # position remain provably non-authoritative unless live_dispatch matches.
+  # For JS calls, quoted and computed workflow_id keys are equivalent to the
+  # bare key and must not hide a dynamic selector.
+  local dynamic_dispatch="gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+(-[^[:space:];]*|[^[:space:];]*[$][^[:space:];]*)|createWorkflowDispatch[^)]*(\[[[:space:]]*[\"']workflow_id[\"'][[:space:]]*\]|[\"']?workflow_id[\"']?)[[:space:]]*:[[:space:]]*[$]?[A-Za-z_][A-Za-z0-9_]*|createWorkflowDispatch[^)]*[{,][[:space:]]*workflow_id[[:space:],}]"
   local file rel source found=0 candidates reject_ansi
   if git -C "${root}" rev-parse --git-dir >/dev/null 2>&1; then
     candidates="$(git -C "${root}" ls-files | grep -E '\.(yml|yaml|sh|bash|zsh|ps1|js|mjs|cjs|ts|py)$')"
@@ -437,8 +443,13 @@ YAML
     $'flow=\'Merge Train\'\n      gh workflow run "$flow" -f train_apply=${mode}'
     $'flow=merge-train.yml\n      gh workflow run "${flow}" -f train_apply=false'
     'gh workflow run $flow -f train_apply=false'
+    'gh workflow run -R honua-io/honua-server merge-train.yml -f train_apply=true'
+    'gh workflow run --repo honua-io/honua-server merge-train.yml -f train_apply=true'
+    'gh workflow run --hostname github.example --repo honua-io/honua-server merge-train.yml -f train_apply=true'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: "merge-train.yml",\n        ref: "trunk",\n        inputs: {\n          train_apply: mode\n        }\n      })'
     $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: flow,\n        ref: "trunk"\n      })'
+    $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        "workflow_id": flow,\n        ref: "trunk"\n      })'
+    $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        ["workflow_id"]: flow,\n        ref: "trunk"\n      })'
   )
   for fixture in "${fixtures[@]}"; do
     n=$((n + 1))

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -315,7 +315,10 @@ scan_authorities() {
 
   scan_post_cas_call_graph "${root}/scripts/ci/merge-train/land.sh" || return 1
 
-  local live_dispatch='gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([^[:space:];]*/)?merge-train\.yml[^#;|&]*train_apply[^[:alnum:]]+(true|1)|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches[^#;|&]*train_apply[^[:alnum:]]+(true|1)|createWorkflowDispatch[^;]*merge-train\.yml[^;]*train_apply[^[:alnum:]]+(true|1)'
+  # Dispatching the live-capable train is itself a merge authority regardless
+  # of how train_apply is spelled or valued. Canonical locations are separately
+  # allowlisted; every other executable source must be unable to wake this flow.
+  local live_dispatch='gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([^[:space:];]*/)?merge-train\.yml|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches|createWorkflowDispatch[^)]*merge-train\.yml'
   local file rel source found=0 candidates reject_ansi
   if git -C "${root}" rev-parse --git-dir >/dev/null 2>&1; then
     candidates="$(git -C "${root}" ls-files | grep -E '\.(yml|yaml|sh|bash|zsh|ps1|js|mjs|cjs|ts|py)$')"
@@ -363,6 +366,7 @@ train_smart_ci_run() {
   git push "${TRAIN_REMOTE}" "${batch}:${batch}"
 }
 SH
+  printf 'gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches -f inputs[train_apply]=${mode}\n' >"${scratch}/scripts/ci/merge-train/recovery.sh"
   cat >"${scratch}/.github/workflows/read-only.yml" <<'YAML'
 jobs:
   inspect:
@@ -370,8 +374,6 @@ jobs:
       - run: gh api repos/o/r/pulls/1
       # `git push origin HEAD:trunk` is documentation, not executable.
       - run: git push origin HEAD:refs/heads/automation/report-${GITHUB_RUN_ID}
-      - run: gh workflow run merge-train.yml -f train_apply=false
-      - run: gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches -f inputs[train_apply]=false
 YAML
   scan_authorities "${scratch}" || { echo "safe fixture rejected" >&2; return 1; }
 
@@ -416,6 +418,8 @@ YAML
     $'gh workflow run merge-train.yml \\\n+      -f train_apply=true'
     'gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches -f inputs[train_apply]=true'
     'github.rest.actions.createWorkflowDispatch({workflow_id: "merge-train.yml", inputs: {train_apply: true}})'
+    'gh workflow run merge-train.yml -f train_apply=${mode}'
+    $'github.rest.actions.createWorkflowDispatch({\n        owner,\n        repo,\n        workflow_id: "merge-train.yml",\n        ref: "trunk",\n        inputs: {\n          train_apply: mode\n        }\n      })'
   )
   for fixture in "${fixtures[@]}"; do
     n=$((n + 1))

--- a/scripts/ci/validate-single-merge-authority.sh
+++ b/scripts/ci/validate-single-merge-authority.sh
@@ -11,6 +11,14 @@ is_allowlisted() {
   esac
 }
 
+is_dispatch_allowlisted() {
+  case "$1" in
+    .github/workflows/merge-train.yml|scripts/ci/merge-train/recovery.sh|scripts/ci/merge-train/fixtures/validate-merge-train.sh|scripts/ci/validate-single-merge-authority.sh)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_safe_exclusion() {
   case "$1" in
     node_modules/*|vendor/*|third_party/*|artifacts/*|dist/*|coverage/*|*/bin/*|*/obj/*|*.min.js|*.generated.*)
@@ -307,6 +315,7 @@ scan_authorities() {
 
   scan_post_cas_call_graph "${root}/scripts/ci/merge-train/land.sh" || return 1
 
+  local live_dispatch='gh[[:space:]]+workflow[[:space:]]+run[[:space:]]+([^[:space:];]*/)?merge-train\.yml[^#;|&]*train_apply[^[:alnum:]]+(true|1)|gh[[:space:]]+api[^#;|&]*/actions/workflows/([^/[:space:]]*/)?merge-train\.yml/dispatches[^#;|&]*train_apply[^[:alnum:]]+(true|1)|createWorkflowDispatch[^;]*merge-train\.yml[^;]*train_apply[^[:alnum:]]+(true|1)'
   local file rel source found=0 candidates reject_ansi
   if git -C "${root}" rev-parse --git-dir >/dev/null 2>&1; then
     candidates="$(git -C "${root}" ls-files | grep -E '\.(yml|yaml|sh|bash|zsh|ps1|js|mjs|cjs|ts|py)$')"
@@ -328,6 +337,9 @@ scan_authorities() {
     if source_has_forbidden_authority "${source}" "${reject_ansi}"; then
       echo "forbidden merge-capable primitive in ${rel}" >&2; found=1
     fi
+    if ! is_dispatch_allowlisted "${rel}" && grep -Eiq "${live_dispatch}" <<<"${source}"; then
+      echo "forbidden live merge-train dispatch in ${rel}" >&2; found=1
+    fi
   done <<<"${candidates}"
   [[ "${found}" == 0 ]] || {
     echo "merge authority exists outside the explicit batch-train allowlist" >&2; return 1;
@@ -337,7 +349,7 @@ scan_authorities() {
 self_test() {
   local scratch; scratch="$(mktemp -d)"; trap 'rm -rf "${scratch}"' RETURN
   mkdir -p "${scratch}/.github/workflows" "${scratch}/scripts/ci/merge-train"
-  printf 'jobs:\n  train:\n    steps:\n      - run: scripts/ci/merge-train/train.sh\n' >"${scratch}/.github/workflows/merge-train.yml"
+  printf 'jobs:\n  train:\n    steps:\n      - run: scripts/ci/merge-train/train.sh\n      - run: gh workflow run merge-train.yml -f train_apply=true\n' >"${scratch}/.github/workflows/merge-train.yml"
   cat >"${scratch}/scripts/ci/merge-train/land.sh" <<'SH'
 train_land_pr_info() { gh pr view "$1"; }
 train_finalize_landed_members() { train_land_pr_info "$1"; }
@@ -358,6 +370,8 @@ jobs:
       - run: gh api repos/o/r/pulls/1
       # `git push origin HEAD:trunk` is documentation, not executable.
       - run: git push origin HEAD:refs/heads/automation/report-${GITHUB_RUN_ID}
+      - run: gh workflow run merge-train.yml -f train_apply=false
+      - run: gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches -f inputs[train_apply]=false
 YAML
   scan_authorities "${scratch}" || { echo "safe fixture rejected" >&2; return 1; }
 
@@ -398,6 +412,10 @@ YAML
     $'target=refs/heads/trunk\n      git push origin HEAD:${target}'
     'git push origin batch:${target}'
     'git push origin HEAD:refs/heads/${target}'
+    'gh workflow run merge-train.yml -f train_apply=true'
+    $'gh workflow run merge-train.yml \\\n+      -f train_apply=true'
+    'gh api --method POST repos/o/r/actions/workflows/merge-train.yml/dispatches -f inputs[train_apply]=true'
+    'github.rest.actions.createWorkflowDispatch({workflow_id: "merge-train.yml", inputs: {train_apply: true}})'
   )
   for fixture in "${fixtures[@]}"; do
     n=$((n + 1))


### PR DESCRIPTION
## Summary
- serialize green-rerun recovery with the repository-wide merge authority
- validate the active state, CI run, batch SHA, trunk base, member set, and exact PR heads before resuming land
- reset stale batches to selection and dispatch one live reassembly; finalize post-push crashes idempotently
- remove mutable-head CI Gate stamping

## Validation
- `bash -n scripts/ci/merge-train/recovery.sh`
- `bash -n scripts/ci/merge-train/fixtures/validate-merge-train.sh`
- `bash scripts/ci/merge-train/fixtures/validate-merge-train.sh` (`173 passed, 0 failed`)

## Stack
- Base: #2973 (`a3e16b548878084334c9ad1e3dbcf4819d92dfd3`)