### PR TITLE
ci: capability-scoped local pre-pr-check (#2951)

### DIFF
--- a/.github/workflows/capability-impact-comparison.yml
+++ b/.github/workflows/capability-impact-comparison.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Validate capability, proving-test, shard, and lane crosswalks
         run: python3 scripts/ci/capability-impact.py validate
       - name: Run focused selector tests
-        run: python3 -m unittest discover -s tests/python/unit -p 'test_capability_impact.py' -v
+        run: |
+          python3 -m unittest discover -s tests/python/unit -p 'test_capability_impact.py' -v
+          python3 -m unittest discover -s tests/python/unit -p 'test_pre_pr_scoped_selection.py' -v
 
   comparison:
     name: ADR-0037 vs capability selector (report only)

--- a/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
+++ b/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
@@ -303,15 +303,20 @@ under-tests.
 shards run — that has not changed. On top of that selection,
 `scripts/ci/capability-impact.py select-local` (the same route/proving-test/
 shard crosswalk `capability-impact-comparison.yml` validates in shadow mode)
-narrows a selected shard's `dotnet test --filter` down to just its proving
-tests, but ONLY when the crosswalk accounted for every changed file with zero
-ambiguity (not `runAll`, no `unmatchedSourceFiles`) AND its own shard list
-corroborates the shard ADR-0037 selected. Any diff the crosswalk cannot
-confidently map — which today includes essentially all handler/service source
-edits, since `feature-catalog.json`'s `code_location` mostly resolves to the
-endpoint-registry file rather than the real handler — falls back to the
-shard's ADR-0037 filter unchanged, so this can only narrow further, never
-select fewer shards. `--dry-run` (or `HONUA_PRE_PR_DRY_RUN=1`) prints the full
+narrows a selected shard's `dotnet test --filter` down to just the proving
+tests `testsByShard` assigns to that shard, but ONLY when the crosswalk
+accounted for every changed file with zero ambiguity (not `runAll`, no
+`unmatchedSourceFiles`) AND its own shard list corroborates the shard ADR-0037
+selected. Any diff the crosswalk cannot confidently map — which today includes
+essentially all handler/service source edits, since `feature-catalog.json`'s
+`code_location` mostly resolves to the endpoint-registry file rather than the
+real handler — falls back to the shard's ADR-0037 filter unchanged, so this
+can only narrow further, never select fewer shards. A single widely-shared
+`code_location` (e.g. `EndpointRegistry.cs` itself) can still map a shard to
+thousands of proving tests; a narrowed filter over ~6,000 characters falls
+back to that shard's full ADR-0037 filter instead of risking an oversized
+`dotnet test --filter` argument on the Windows/Git Bash path. `--dry-run` (or
+`HONUA_PRE_PR_DRY_RUN=1`) prints the full
 resolved selection — build set, targeted shards, capability narrowing, format
 scope — without restoring, building, formatting, or testing anything. A set of
 cross-cutting paths (`Directory.Build.props`, `Directory.Packages.props`,

--- a/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
+++ b/docs/internal/contributor/adr/0037-unified-ci-test-tier-strategy.md
@@ -291,11 +291,33 @@ local run scopes the build (affected-project solution filter), format check
 (changed `*.cs` only), unit-test projects (affected closure), and server-test
 shards (targeted subset) to the diff against `origin/trunk` instead of grinding
 the whole solution and every shard. The architecture tests still run on every
-invocation (cheap topology guard). Set `HONUA_PRE_PR_FULL=1` to force the full
-suite (recommended before a release or a large cross-cutting refactor);
-`HONUA_PRE_PR_BASE=<ref>` overrides the diff base, and `HONUA_PRE_PR_SKIP_AOT=1`
-skips the AOT publish. If the base ref is missing locally the script falls back
-to a full run so it never silently under-tests.
+invocation (cheap topology guard). Set `HONUA_PRE_PR_FULL=1` (or `--full`) to
+force the full suite (recommended before a release or a large cross-cutting
+refactor); `HONUA_PRE_PR_BASE=<ref>` (or `--base <ref>`) overrides the diff
+base, and `HONUA_PRE_PR_SKIP_AOT=1` skips the AOT publish. If the base ref is
+missing locally the script falls back to a full run so it never silently
+under-tests.
+
+**Capability-scoped narrowing layers on top, never replaces, this router**
+(honua-server#2951). `honua-server-targeted-tests.sh` still decides WHICH
+shards run — that has not changed. On top of that selection,
+`scripts/ci/capability-impact.py select-local` (the same route/proving-test/
+shard crosswalk `capability-impact-comparison.yml` validates in shadow mode)
+narrows a selected shard's `dotnet test --filter` down to just its proving
+tests, but ONLY when the crosswalk accounted for every changed file with zero
+ambiguity (not `runAll`, no `unmatchedSourceFiles`) AND its own shard list
+corroborates the shard ADR-0037 selected. Any diff the crosswalk cannot
+confidently map — which today includes essentially all handler/service source
+edits, since `feature-catalog.json`'s `code_location` mostly resolves to the
+endpoint-registry file rather than the real handler — falls back to the
+shard's ADR-0037 filter unchanged, so this can only narrow further, never
+select fewer shards. `--dry-run` (or `HONUA_PRE_PR_DRY_RUN=1`) prints the full
+resolved selection — build set, targeted shards, capability narrowing, format
+scope — without restoring, building, formatting, or testing anything. A set of
+cross-cutting paths (`Directory.Build.props`, `Directory.Packages.props`,
+`Honua.TestKit/**`, `.github/ci-shards.json`, the selector/catalog files
+themselves, `.github/workflows/**`) forces full mode outright, as does a
+failing `capability-impact.py validate`.
 
 ### Flaky-Test Quarantine
 

--- a/scripts/ci/capability-impact.py
+++ b/scripts/ci/capability-impact.py
@@ -296,13 +296,28 @@ def freshness_state(envelope: dict | None, now: dt.datetime, max_age_days: int =
     }
 
 
-def build_report(changed_files: list[str], legacy: dict, envelope_root: Path | None, labels: list[str]) -> dict:
-    catalog = load_json(CATALOG)
-    keys = load_json(KEYS)
-    config = load_json(SHARDS)
+def compute_capability_selection(changed_files: list[str], catalog: dict, config: dict) -> dict:
+    """Map changed files to capabilities/proving tests/shards via the catalog crosswalk.
+
+    This is the single selection primitive shared by the hosted report-only
+    comparison (`build_report`, below) and the local scoped pre-pr-check
+    selector (the `select-local` CLI command). Both consumers read the same
+    entries/capabilities/tests/shards computation so there is exactly one
+    changed-file -> capability mapping in the repo (#2951).
+
+    ``testsByShard`` additionally groups the proving-test set by owning
+    shard so a caller can narrow a per-shard test filter without
+    re-implementing `shard_names_for_test` grouping itself.
+    """
     entries = affected_entries(changed_files, catalog["entries"])
     capabilities = sorted({entry["capability"] for entry in entries})
     tests = sorted({test for entry in entries for test in entry.get("proving_tests", [])})
+    tests_by_shard: dict[str, list[str]] = {}
+    for test in tests:
+        for shard_name in shard_names_for_test(test, config):
+            tests_by_shard.setdefault(shard_name, []).append(test)
+    for shard_name in tests_by_shard:
+        tests_by_shard[shard_name].sort()
     shards = sorted({name for test in tests for name in shard_names_for_test(test, config)})
     unmatched_source = sorted(
         path
@@ -312,6 +327,27 @@ def build_report(changed_files: list[str], legacy: dict, envelope_root: Path | N
     run_all = bool(unmatched_source)
     if run_all:
         shards = sorted(item["name"] for item in config["shards"])
+        tests_by_shard = {}
+
+    return {
+        "runAll": run_all,
+        "reason": "unmapped_graph_source" if run_all else ("capability_match" if entries else "no_capability_match"),
+        "capabilities": capabilities,
+        "provingTestCount": len(tests),
+        "provingTests": tests,
+        "shards": shards,
+        "unmatchedSourceFiles": unmatched_source,
+        "testsByShard": tests_by_shard,
+    }
+
+
+def build_report(changed_files: list[str], legacy: dict, envelope_root: Path | None, labels: list[str]) -> dict:
+    catalog = load_json(CATALOG)
+    keys = load_json(KEYS)
+    config = load_json(SHARDS)
+    selection = compute_capability_selection(changed_files, catalog, config)
+    capabilities = selection["capabilities"]
+    shards = selection["shards"]
 
     interop = [
         {"clientLane": row["clientLane"], "protocol": row["protocol"]}
@@ -341,13 +377,13 @@ def build_report(changed_files: list[str], legacy: dict, envelope_root: Path | N
         "capabilityLabels": sorted(label for label in labels if label.startswith("cap/")),
         "legacy": legacy,
         "capabilitySelection": {
-            "runAll": run_all,
-            "reason": "unmapped_graph_source" if run_all else ("capability_match" if entries else "no_capability_match"),
+            "runAll": selection["runAll"],
+            "reason": selection["reason"],
             "capabilities": capabilities,
-            "provingTestCount": len(tests),
+            "provingTestCount": selection["provingTestCount"],
             "shards": shards,
             "interopLanes": interop,
-            "unmatchedSourceFiles": unmatched_source,
+            "unmatchedSourceFiles": selection["unmatchedSourceFiles"],
         },
         "comparison": {
             "legacyShardCount": len(legacy_shards),
@@ -408,6 +444,13 @@ def main() -> int:
     select.add_argument("--envelopes", type=Path)
     select.add_argument("--labels-json", default="[]")
     select.add_argument("--markdown", type=Path)
+    select_local = subparsers.add_parser(
+        "select-local",
+        help="Local scoped selection (honua-server#2951): the same crosswalk as "
+        "`select`, without the ADR-0037 legacy comparison/freshness reporting that "
+        "only make sense for the hosted shadow job. Consumed by pre-pr-check.sh.",
+    )
+    select_local.add_argument("--changed-files", type=Path, required=True)
     args = parser.parse_args()
 
     if args.command == "validate":
@@ -417,6 +460,16 @@ def main() -> int:
                 print(f"ERROR: {error}", file=sys.stderr)
             return 1
         print("Capability impact completeness: valid")
+        return 0
+
+    if args.command == "select-local":
+        changed_files = [
+            line.strip().replace("\\", "/") for line in args.changed_files.read_text().splitlines() if line.strip()
+        ]
+        catalog = load_json(CATALOG)
+        config = load_json(SHARDS)
+        selection = compute_capability_selection(changed_files, catalog, config)
+        print(json.dumps({"schemaVersion": 1, "changedFileCount": len(changed_files), **selection}, indent=2))
         return 0
 
     changed_files = [line.strip().replace("\\", "/") for line in args.changed_files.read_text().splitlines() if line.strip()]

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -191,6 +191,17 @@ fi
 
 if [[ "${PRE_PR_SCOPE}" == "CI_ONLY" ]]; then
     echo "    Mode: CI-SHELL-ONLY (committed + working tree vs ${BASE_REF})."
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        changed_count="$(printf '%s\n' "${PRE_PR_CHANGED_FILES}" | sed '/^$/d' | wc -l | tr -d ' ')"
+        echo ""
+        echo "📋 Selection summary"
+        echo "  - Mode: CI-SHELL-ONLY (${changed_count} changed file(s), all doc/CI-script-only)"
+        echo "  - Would run: check-instructions-sync, validate-shell-syntax (changed .sh only),"
+        echo "    validate-ci-router, merge-train fixtures — no restore/build/format/test."
+        echo ""
+        echo "🔎 Dry run complete — nothing was restored, built, formatted, or tested."
+        exit 0
+    fi
     echo "1. Checking canonical instructions..."
     bash scripts/ci/check-instructions-sync.sh
 

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -402,7 +402,13 @@ RUN_TEST_PROJECTS="$(printf '%s\n%s\n%s\n' \
 # ---------------------------------------------------------------------------
 declare -A NARROWED_SHARD_FILTER=()
 declare -A NARROWED_SHARD_REASON=()
-CAPABILITY_RUN_ALL="$(jq -r '.runAll // true' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo true)"
+# NOT `.runAll // true` — jq's `//` substitutes its right-hand side whenever
+# the left side is `false` (not only `null`/missing), so that would silently
+# turn a genuine `"runAll": false` into the string "true" and disable
+# narrowing for every diff the crosswalk actually mapped cleanly. `has(...)`
+# only falls back to `true` (fail-safe) when the field is truly absent (the
+# "{}" sentinel used for FULL mode / a failed selection).
+CAPABILITY_RUN_ALL="$(jq -r 'if has("runAll") then .runAll else true end' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo true)"
 CAPABILITY_UNMATCHED_COUNT="$(jq -r '.unmatchedSourceFiles | length' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo 1)"
 CAPABILITY_PROVING_TEST_COUNT="$(jq -r '.provingTestCount // 0' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo 0)"
 if [[ "${FULL}" != "1" && "${CAPABILITY_RUN_ALL}" == "false" && "${CAPABILITY_UNMATCHED_COUNT}" == "0" && -n "${SELECTED_SHARDS//[[:space:]]/}" ]]; then

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -149,10 +149,18 @@ done
 # EXIT` per section) so later traps do not silently clobber earlier ones.
 CLEANUP_PATHS=()
 cleanup_scratch() {
+    # Under `set -e`, a failing command as the LAST thing this trap runs
+    # (e.g. the `[[ ]]` test below evaluating false when a path is empty)
+    # overrides the exit status the script was already tearing down with —
+    # `exit 0` from a --dry-run would otherwise surface as exit 1. The
+    # trailing `return 0` guarantees the trap itself never changes $?.
     local path
-    for path in "${CLEANUP_PATHS[@]:-}"; do
-        [[ -n "${path}" ]] && rm -rf "${path}"
-    done
+    if [[ "${#CLEANUP_PATHS[@]}" -gt 0 ]]; then
+        for path in "${CLEANUP_PATHS[@]}"; do
+            [[ -n "${path}" ]] && rm -rf "${path}"
+        done
+    fi
+    return 0
 }
 trap cleanup_scratch EXIT
 

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -411,6 +411,16 @@ declare -A NARROWED_SHARD_REASON=()
 CAPABILITY_RUN_ALL="$(jq -r 'if has("runAll") then .runAll else true end' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo true)"
 CAPABILITY_UNMATCHED_COUNT="$(jq -r '.unmatchedSourceFiles | length' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo 1)"
 CAPABILITY_PROVING_TEST_COUNT="$(jq -r '.provingTestCount // 0' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo 0)"
+# Hard ceiling on a single shard's narrowed --filter argument, comfortably
+# under cmd.exe's ~8191-char command-line limit (this script explicitly
+# supports Windows/Git Bash) after accounting for the rest of the `dotnet
+# test` invocation. A shard whose narrowed clause would exceed this falls
+# back to its unmodified base filter instead of emitting an oversized
+# --filter (#2951 review: a single widely-referenced source file such as
+# src/Honua.Server/EndpointRegistry.cs can match 1,000+ catalog entries and
+# 4,000+ proving tests, producing a ~600KB filter that breaks `dotnet test`
+# on the Windows/Git Bash path).
+NARROW_FILTER_MAX_CHARS=6000
 if [[ "${FULL}" != "1" && "${CAPABILITY_RUN_ALL}" == "false" && "${CAPABILITY_UNMATCHED_COUNT}" == "0" && -n "${SELECTED_SHARDS//[[:space:]]/}" ]]; then
     mapfile -t changed_test_classes < <(
         printf '%s\n' "${PRE_PR_CHANGED_FILES}" | sed '/^$/d' | while IFS= read -r f; do
@@ -419,32 +429,43 @@ if [[ "${FULL}" != "1" && "${CAPABILITY_RUN_ALL}" == "false" && "${CAPABILITY_UN
             esac
         done | sort -u
     )
-    mapfile -t proving_test_fqns < <(jq -r '.provingTests[]?' <<< "${CAPABILITY_SELECTION_JSON}")
-    NARROW_CLAUSES=()
-    for t in "${proving_test_fqns[@]}"; do
-        [[ -n "${t}" ]] && NARROW_CLAUSES+=("FullyQualifiedName=${t}")
-    done
+    CHANGED_CLASS_CLAUSES=()
     for c in "${changed_test_classes[@]}"; do
-        [[ -n "${c}" ]] && NARROW_CLAUSES+=("FullyQualifiedName~${c}")
+        [[ -n "${c}" ]] && CHANGED_CLASS_CLAUSES+=("FullyQualifiedName~${c}")
     done
-    if [[ ${#NARROW_CLAUSES[@]} -gt 0 ]]; then
+
+    mapfile -t capability_shards < <(jq -r '.shards[]?' <<< "${CAPABILITY_SELECTION_JSON}")
+    while IFS= read -r shard_name; do
+        [[ -z "${shard_name}" ]] && continue
+        corroborated=""
+        for cs in "${capability_shards[@]}"; do
+            [[ "${cs}" == "${shard_name}" ]] && corroborated=1 && break
+        done
+        [[ -z "${corroborated}" ]] && continue
+
+        # Group by testsByShard (not the flat provingTests[] list) so a shard
+        # only narrows on the proving tests it actually owns, instead of every
+        # shard carrying the same combined clause for the whole diff.
+        mapfile -t shard_proving_tests < <(jq -r --arg n "${shard_name}" '.testsByShard[$n][]?' <<< "${CAPABILITY_SELECTION_JSON}")
+        NARROW_CLAUSES=("${CHANGED_CLASS_CLAUSES[@]}")
+        for t in "${shard_proving_tests[@]}"; do
+            [[ -n "${t}" ]] && NARROW_CLAUSES+=("FullyQualifiedName=${t}")
+        done
+        [[ ${#NARROW_CLAUSES[@]} -eq 0 ]] && continue
+
+        shard_base_filter="$(jq -r --arg n "${shard_name}" '.shards[] | select(.shard_name==$n) | .filter // ""' .github/ci-shards.json)"
+        [[ -z "${shard_base_filter}" ]] && continue
+
         NARROW_CLAUSE_EXPR="$(IFS='|'; echo "${NARROW_CLAUSES[*]}")"
-        mapfile -t capability_shards < <(jq -r '.shards[]?' <<< "${CAPABILITY_SELECTION_JSON}")
-        while IFS= read -r shard_name; do
-            [[ -z "${shard_name}" ]] && continue
-            corroborated=""
-            for cs in "${capability_shards[@]}"; do
-                [[ "${cs}" == "${shard_name}" ]] && corroborated=1 && break
-            done
-            if [[ -n "${corroborated}" ]]; then
-                shard_base_filter="$(jq -r --arg n "${shard_name}" '.shards[] | select(.shard_name==$n) | .filter // ""' .github/ci-shards.json)"
-                if [[ -n "${shard_base_filter}" ]]; then
-                    NARROWED_SHARD_FILTER["${shard_name}"]="(${shard_base_filter})&(${NARROW_CLAUSE_EXPR})"
-                    NARROWED_SHARD_REASON["${shard_name}"]="capability-narrowed (${CAPABILITY_PROVING_TEST_COUNT} proving tests, ${#changed_test_classes[@]} changed test classes)"
-                fi
-            fi
-        done <<< "${SELECTED_SHARDS}"
-    fi
+        candidate_filter="(${shard_base_filter})&(${NARROW_CLAUSE_EXPR})"
+        if [[ ${#candidate_filter} -gt ${NARROW_FILTER_MAX_CHARS} ]]; then
+            echo "    (capability narrowing skipped for ${shard_name}: narrowed filter would be ${#candidate_filter} chars, over the ${NARROW_FILTER_MAX_CHARS}-char cap — running the shard's full filter instead)"
+            continue
+        fi
+
+        NARROWED_SHARD_FILTER["${shard_name}"]="${candidate_filter}"
+        NARROWED_SHARD_REASON["${shard_name}"]="capability-narrowed (${#shard_proving_tests[@]} proving tests, ${#changed_test_classes[@]} changed test classes)"
+    done <<< "${SELECTED_SHARDS}"
 fi
 
 # Full committed diff — used to keep directly-edited test projects in the

--- a/scripts/ci/pre-pr-check.sh
+++ b/scripts/ci/pre-pr-check.sh
@@ -15,10 +15,38 @@ set -euo pipefail
 #                   dependency tree + native runtimes, ~1-2 GB), while every
 #                   src project still compiles. CI builds all test projects
 #                   in its own shards. FULL mode disables pruning.
-#   - server tests -> scripts/ci/honua-server-targeted-tests.sh (targeted shard
-#                   subset, or run_all)
+#   - server tests -> scripts/ci/honua-server-targeted-tests.sh picks the
+#                   ADR-0037 shard subset (or run_all); that selector remains
+#                   authoritative for WHICH SHARDS run (#2951 non-goal: it does
+#                   not change ADR-0037 tier semantics). On top of it,
+#                   scripts/ci/capability-impact.py's `select-local` crosswalk
+#                   (docs/gis/data/feature-catalog.json's route/test/shard
+#                   mapping — the SAME crosswalk the hosted shadow-comparison
+#                   job validates; no parallel mapping) narrows a selected
+#                   shard's `dotnet test --filter` down to just its proving
+#                   tests, but ONLY when every changed file was safely
+#                   accounted for (no unmatched source, not run_all — see
+#                   "Capability narrowing" below for when this can and cannot
+#                   apply). Otherwise the shard's normal full filter runs, same
+#                   as before this change.
 #   - unit tests -> only the *.Tests projects in the affected closure
-#   - format     -> only the changed *.cs files
+#   - format     -> only the changed *.cs files (`dotnet format --include`)
+#
+# Capability narrowing — known limitation: docs/gis/data/feature-catalog.json's
+# `code_location` field is, today, almost always the endpoint-registry file
+# rather than the actual handler implementation (a proof-ledger evidence
+# ordering gap, not an intentional design choice). That means the crosswalk
+# can confidently narrow a TEST file change (matched by test-class name) but
+# essentially never a plain handler/service SOURCE file change — those still
+# report `unmatchedSourceFiles` and fail closed. In practice: a PR touching
+# only test files gets genuine per-test narrowing within its shard(s); a PR
+# touching handler/service source (with or without tests) falls back to
+# running the ADR-0037-selected shard(s) in full, exactly as pre-#2951 — never
+# narrower, never broader. `--dry-run` shows exactly which case a given diff
+# hits before you commit to a run.
+#
+# CLI flags (aliases for the escape-hatch env vars below): --full, --fast,
+# --dry-run, --base <ref>.
 #
 # Escape hatches:
 #   HONUA_PRE_PR_FULL=1     force the full suite (recommended before a release
@@ -32,9 +60,16 @@ set -euo pipefail
 #                           push loop stays quick. Run without it (the default
 #                           SMART tier) or with HONUA_PRE_PR_FULL=1 before opening
 #                           a PR for the full local gate.
-#   HONUA_PRE_PR_PRINT_BUILD_PLAN=1  print the resolved build set (the .slnf
-#                           project list after pruning) and exit without
-#                           restoring or building — for debugging scope.
+#   HONUA_PRE_PR_DRY_RUN=1  (or --dry-run) print the full resolved selection —
+#                           build set, targeted shards, capability-narrowed
+#                           filters, format scope — and exit 0 without
+#                           restoring, building, formatting, or testing
+#                           anything. Safe to run with zero Docker/dotnet cost;
+#                           this is the primary way to inspect scope decisions.
+#   HONUA_PRE_PR_PRINT_BUILD_PLAN=1  print only the resolved build set (the
+#                           .slnf project list after pruning) and exit — a
+#                           narrower predecessor of --dry-run kept for
+#                           back-compat script integrations.
 #   HONUA_PRE_PR_SHARD_PARALLELISM=<n>  how many server-test shards to run
 #                           concurrently in SMART/FULL mode (default 2). Each
 #                           shard is a separate dotnet-test process with its own
@@ -47,6 +82,32 @@ set -euo pipefail
 BASE_REF="${HONUA_PRE_PR_BASE:-origin/trunk}"
 FULL="${HONUA_PRE_PR_FULL:-0}"
 FAST="${HONUA_PRE_PR_FAST:-0}"
+DRY_RUN="${HONUA_PRE_PR_DRY_RUN:-0}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --full) FULL=1; shift ;;
+        --fast) FAST=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --base)
+            BASE_REF="${2:-}"
+            if [[ -z "${BASE_REF}" ]]; then
+                echo "❌ --base requires a value" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,80p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "❌ unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${REPO_ROOT}"
 
@@ -63,6 +124,37 @@ fi
 # `${var%$'\r'}` patches, which are now redundant. Sourced AFTER the presence
 # guard above so that guard still probes the real jq binary, not this function.
 source "$(dirname "${BASH_SOURCE[0]}")/lib/jq-cr-safe.sh"
+
+# Resolve an interpreter that actually runs. `command -v python3` alone is not
+# enough on Windows: the Microsoft Store ships a python3.exe App Execution
+# Alias stub that is present on PATH but exits non-zero with "Python was not
+# found", while the real interpreter installs as `python`/`py`. The old guard
+# therefore passed, the stub failed, and the script blamed the code —
+# reporting "architecture review found blocking issues" when Python was simply
+# absent (#2871). Probe each candidate by executing it, and require Python 3 so
+# a legacy `python` == python2 is not selected. On Linux `python3` matches
+# first, exactly as before. Resolved early (rather than only before the local
+# architecture review) because the capability-impact crosswalk validation and
+# select-local narrowing below also need it.
+PYTHON_BIN=""
+for candidate in python3 python py; do
+    if command -v "${candidate}" >/dev/null 2>&1 \
+        && "${candidate}" -c 'import sys; sys.exit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; then
+        PYTHON_BIN="${candidate}"
+        break
+    fi
+done
+
+# Unified cleanup: register scratch paths here (rather than a fresh `trap ...
+# EXIT` per section) so later traps do not silently clobber earlier ones.
+CLEANUP_PATHS=()
+cleanup_scratch() {
+    local path
+    for path in "${CLEANUP_PATHS[@]:-}"; do
+        [[ -n "${path}" ]] && rm -rf "${path}"
+    done
+}
+trap cleanup_scratch EXIT
 
 # Resolve the base ref; if it is missing locally, fall back to a full run so we
 # never silently under-test.
@@ -119,6 +211,71 @@ if [[ "${PRE_PR_SCOPE}" == "CI_ONLY" ]]; then
 
     echo "✅ CI shell-only pre-PR checks passed; managed build/test work was not required."
     exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Capability-scoped selection (#2951). Two independent fail-safes decide
+# whether SMART mode's selectors (compute-affected-projects.sh,
+# honua-server-targeted-tests.sh, and the capability-impact.py crosswalk
+# below) can be trusted for THIS diff, before any of them run:
+#
+#   1. Cross-cutting trigger paths — edits to shared test infra or to the
+#      selector/catalog inputs themselves. These can silently invalidate the
+#      selection the SAME run would compute (e.g. editing ci-shards.json
+#      changes what "shard X" even means), so they force FULL unconditionally
+#      rather than trusting a selector that may now disagree with its own
+#      inputs.
+#   2. `capability-impact.py validate` — the crosswalk's own completeness
+#      check (every proving test sharded, every capability known, allowlist
+#      entries live). A stale/broken crosswalk must not be allowed to narrow
+#      anything, so a validation failure also forces FULL.
+# ---------------------------------------------------------------------------
+CAPABILITY_SELECTION_JSON="{}"
+if [[ "${FULL}" != "1" ]]; then
+    CROSS_CUTTING_FULL_TRIGGERS=$'Directory.Build.props\nDirectory.Packages.props\ntests/dotnet/Honua.TestKit/\n.github/ci-shards.json\nscripts/ci/capability-impact.py\ndocs/gis/data/feature-catalog.json\ndocs/gis/data/capability-keys.v1.json\n.github/capability-impact-allowlist.json\n.github/workflows/'
+    cross_cutting_hit=""
+    while IFS= read -r trigger_prefix; do
+        [[ -z "${trigger_prefix}" ]] && continue
+        if printf '%s\n' "${PRE_PR_CHANGED_FILES}" | grep -qE "^${trigger_prefix//./\\.}"; then
+            cross_cutting_hit="${trigger_prefix}"
+            break
+        fi
+    done <<< "${CROSS_CUTTING_FULL_TRIGGERS}"
+    if [[ -n "${cross_cutting_hit}" ]]; then
+        echo "⚠️  Cross-cutting path changed (${cross_cutting_hit}) — forcing FULL mode; the"
+        echo "    scoped selectors themselves (or shared test infra) are not trustworthy mid-edit."
+        FULL=1
+    fi
+fi
+
+if [[ "${FULL}" != "1" ]]; then
+    if [[ -z "${PYTHON_BIN}" ]]; then
+        echo "⚠️  No python3 interpreter found — cannot validate the capability-impact"
+        echo "    crosswalk, so falling back to FULL mode rather than trusting an"
+        echo "    unvalidated selection."
+        FULL=1
+    elif ! "${PYTHON_BIN}" scripts/ci/capability-impact.py validate; then
+        echo "⚠️  capability-impact crosswalk validation FAILED (see above) — falling"
+        echo "    back to FULL mode rather than narrowing against a broken crosswalk."
+        FULL=1
+    fi
+fi
+
+if [[ "${FULL}" != "1" ]]; then
+    CHANGED_FILES_LIST="$(mktemp -p "${REPO_ROOT}" --suffix=.changed-files.txt)"
+    CLEANUP_PATHS+=("${CHANGED_FILES_LIST}")
+    printf '%s\n' "${PRE_PR_CHANGED_FILES}" | sed '/^$/d' > "${CHANGED_FILES_LIST}"
+    if ! CAPABILITY_SELECTION_JSON="$("${PYTHON_BIN}" scripts/ci/capability-impact.py select-local --changed-files "${CHANGED_FILES_LIST}")"; then
+        echo "⚠️  capability-impact select-local failed — falling back to FULL mode."
+        FULL=1
+        CAPABILITY_SELECTION_JSON="{}"
+    fi
+fi
+
+# Re-assert the FULL-overrides-FAST invariant: the cross-cutting/validation
+# fail-safes above may have flipped FULL to 1 after the first check ran.
+if [[ "${FULL}" == "1" ]]; then
+    FAST=0
 fi
 
 if [[ "${FAST}" == "1" ]]; then
@@ -190,6 +347,81 @@ RUN_TEST_PROJECTS="$(printf '%s\n%s\n%s\n' \
     "${UNIT_TEST_PROJECTS}" "${ARCHITECTURE_TEST_PROJECT}" "${SHARD_TEST_PROJECTS}" \
     | sed '/^$/d' | sort -u)"
 
+# ---------------------------------------------------------------------------
+# Capability-narrowed per-shard test filter (#2951). ADR-0037's shard
+# selection above (SELECTED_SHARDS) stays authoritative for WHICH shards run;
+# this section only decides whether a selected shard's `dotnet test --filter`
+# can be narrowed down to its proving tests instead of running the shard's
+# whole partition.
+#
+# Narrowing is safe ONLY when the capability crosswalk accounted for every
+# changed file with zero ambiguity: `runAll` is false AND `unmatchedSourceFiles`
+# is empty. Given the catalog's current code_location fidelity (almost always
+# the endpoint-registry file, not the real handler — see the header comment),
+# this is realistically true only for diffs that touch test files (and
+# docs/non-source files), not handler/service source. That is a known,
+# documented limitation, not a bug: it means narrowing degrades gracefully to
+# "no narrowing, run the shard's normal filter" — the exact pre-#2951
+# behavior — rather than ever under-testing a source change it cannot map.
+#
+# Even when narrowing is safe, a shard is only narrowed if the capability
+# selector's OWN shard list also names it — i.e. two independent selectors
+# (ADR-0037's path-prefix router and the capability crosswalk) must agree a
+# shard is in scope before its test set is reduced. A shard ADR-0037 selected
+# that the crosswalk does not corroborate keeps running its full filter.
+#
+# The narrowed filter itself unions two clauses so a directly-edited test
+# file's FULL class always runs (not just whichever of its methods happen to
+# be catalogued as a capability's "proving test" — the catalog's proving-test
+# lists are curated exemplars, not an exhaustive enumeration of every test
+# method in a file):
+#   - FullyQualifiedName=<test>  for every catalog-matched proving test
+#   - FullyQualifiedName~<Class> for every changed tests/**/*.cs file's class
+# Both clause sets are ANDed with the shard's own base filter, so a shard only
+# ever runs a SUBSET of what it would have run anyway — never something
+# outside its partition.
+# ---------------------------------------------------------------------------
+declare -A NARROWED_SHARD_FILTER=()
+declare -A NARROWED_SHARD_REASON=()
+CAPABILITY_RUN_ALL="$(jq -r '.runAll // true' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo true)"
+CAPABILITY_UNMATCHED_COUNT="$(jq -r '.unmatchedSourceFiles | length' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo 1)"
+CAPABILITY_PROVING_TEST_COUNT="$(jq -r '.provingTestCount // 0' <<< "${CAPABILITY_SELECTION_JSON}" 2>/dev/null || echo 0)"
+if [[ "${FULL}" != "1" && "${CAPABILITY_RUN_ALL}" == "false" && "${CAPABILITY_UNMATCHED_COUNT}" == "0" && -n "${SELECTED_SHARDS//[[:space:]]/}" ]]; then
+    mapfile -t changed_test_classes < <(
+        printf '%s\n' "${PRE_PR_CHANGED_FILES}" | sed '/^$/d' | while IFS= read -r f; do
+            case "${f}" in
+                tests/*.cs) basename "${f}" .cs ;;
+            esac
+        done | sort -u
+    )
+    mapfile -t proving_test_fqns < <(jq -r '.provingTests[]?' <<< "${CAPABILITY_SELECTION_JSON}")
+    NARROW_CLAUSES=()
+    for t in "${proving_test_fqns[@]}"; do
+        [[ -n "${t}" ]] && NARROW_CLAUSES+=("FullyQualifiedName=${t}")
+    done
+    for c in "${changed_test_classes[@]}"; do
+        [[ -n "${c}" ]] && NARROW_CLAUSES+=("FullyQualifiedName~${c}")
+    done
+    if [[ ${#NARROW_CLAUSES[@]} -gt 0 ]]; then
+        NARROW_CLAUSE_EXPR="$(IFS='|'; echo "${NARROW_CLAUSES[*]}")"
+        mapfile -t capability_shards < <(jq -r '.shards[]?' <<< "${CAPABILITY_SELECTION_JSON}")
+        while IFS= read -r shard_name; do
+            [[ -z "${shard_name}" ]] && continue
+            corroborated=""
+            for cs in "${capability_shards[@]}"; do
+                [[ "${cs}" == "${shard_name}" ]] && corroborated=1 && break
+            done
+            if [[ -n "${corroborated}" ]]; then
+                shard_base_filter="$(jq -r --arg n "${shard_name}" '.shards[] | select(.shard_name==$n) | .filter // ""' .github/ci-shards.json)"
+                if [[ -n "${shard_base_filter}" ]]; then
+                    NARROWED_SHARD_FILTER["${shard_name}"]="(${shard_base_filter})&(${NARROW_CLAUSE_EXPR})"
+                    NARROWED_SHARD_REASON["${shard_name}"]="capability-narrowed (${CAPABILITY_PROVING_TEST_COUNT} proving tests, ${#changed_test_classes[@]} changed test classes)"
+                fi
+            fi
+        done <<< "${SELECTED_SHARDS}"
+    fi
+fi
+
 # Full committed diff — used to keep directly-edited test projects in the
 # build even when they will not run locally.
 CHANGED_FILES_ALL="$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true)"
@@ -215,16 +447,20 @@ if [[ "${FULL}" == "1" ]]; then
         echo "BUILD PLAN: Honua.sln (FULL mode — every project)"
         exit 0
     fi
-    echo "2. Restoring packages (full solution)..."
-    dotnet restore Honua.sln
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        echo "2-3. [dry-run] Would restore + build Honua.sln (FULL mode — every project)."
+    else
+        echo "2. Restoring packages (full solution)..."
+        dotnet restore Honua.sln
 
-    echo "3. Building with warnings as errors (full solution)..."
-    # -p: not /p: — under Git Bash, MSYS path conversion rewrites a /-prefixed
-    # switch into a Windows path, so MSBuild sees a bare
-    # "p:TreatWarningsAsErrors=true" argument and rejects it as a second
-    # project (MSB1008). The two forms are equivalent to MSBuild; the AOT step
-    # below already uses -p: for the same reason.
-    dotnet build Honua.sln --no-restore --configuration Release -p:TreatWarningsAsErrors=true
+        echo "3. Building with warnings as errors (full solution)..."
+        # -p: not /p: — under Git Bash, MSYS path conversion rewrites a /-prefixed
+        # switch into a Windows path, so MSBuild sees a bare
+        # "p:TreatWarningsAsErrors=true" argument and rejects it as a second
+        # project (MSB1008). The two forms are equivalent to MSBuild; the AOT step
+        # below already uses -p: for the same reason.
+        dotnet build Honua.sln --no-restore --configuration Release -p:TreatWarningsAsErrors=true
+    fi
 else
     # Compose the build set via a throwaway solution filter so shared
     # dependencies compile once. Architecture.Tests is always included so the
@@ -233,7 +469,7 @@ else
     # resolved relative to the filter file's directory, so a /tmp filter would
     # look for /tmp/Honua.sln and fail (MSB4014).
     SLNF="$(mktemp -p "${REPO_ROOT}" --suffix=.slnf)"
-    trap 'rm -f "${SLNF}"' EXIT
+    CLEANUP_PATHS+=("${SLNF}")
     # A solution filter may only name projects that are members of Honua.sln.
     # Affected projects outside the solution (e.g. the customcode worker harness
     # under docker/, which has its own solution) must be dropped or MSBuild
@@ -304,12 +540,16 @@ else
         exit 0
     fi
 
-    echo "2. Restoring packages (build set only)..."
-    dotnet restore "${SLNF}"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        echo "2-3. [dry-run] Would restore + build the $(jq -r '.solution.projects|length' "${SLNF}")-project set above."
+    else
+        echo "2. Restoring packages (build set only)..."
+        dotnet restore "${SLNF}"
 
-    echo "3. Building with warnings as errors..."
-    # -p: not /p: — see the FULL-mode build above (MSB1008 under Git Bash).
-    dotnet build "${SLNF}" --no-restore --configuration Release -p:TreatWarningsAsErrors=true
+        echo "3. Building with warnings as errors..."
+        # -p: not /p: — see the FULL-mode build above (MSB1008 under Git Bash).
+        dotnet build "${SLNF}" --no-restore --configuration Release -p:TreatWarningsAsErrors=true
+    fi
 fi
 
 echo "4. Checking code format..."
@@ -332,7 +572,15 @@ else
         format_scope_args=(--include "${changed_arr[@]}")
     fi
 fi
-if [[ ${#FORMAT_TARGET[@]} -gt 0 ]]; then
+if [[ ${#FORMAT_TARGET[@]} -eq 0 ]]; then
+    : # already reported "skipping format check" above
+elif [[ "${DRY_RUN}" == "1" ]]; then
+    if [[ "${FULL}" == "1" ]]; then
+        echo "   [dry-run] Would run 'dotnet format Honua.sln --verify-no-changes' (whole solution)."
+    else
+        echo "   [dry-run] Would run 'dotnet format --include <${#changed_arr[@]} changed .cs files> --verify-no-changes'."
+    fi
+else
     # Diagnostic verbosity makes dotnet-format log every analyzed document —
     # on a 76-project solution that is minutes of pure console I/O. The
     # failure output at normal verbosity still names each unformatted file.
@@ -344,8 +592,12 @@ if [[ ${#FORMAT_TARGET[@]} -gt 0 ]]; then
     fi
 fi
 
-echo "5. Pre-pulling Docker images for faster tests..."
-docker pull postgis/postgis:16-3.4-alpine > /dev/null 2>&1 || echo "   ⚠️ Could not pre-pull PostGIS image"
+if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "5. [dry-run] Would pre-pull Docker images and run .NET tests (see selection below)."
+else
+    echo "5. Pre-pulling Docker images for faster tests..."
+    docker pull postgis/postgis:16-3.4-alpine > /dev/null 2>&1 || echo "   ⚠️ Could not pre-pull PostGIS image"
+fi
 
 echo "6. Running .NET tests..."
 mkdir -p ./tests/TestResults
@@ -353,6 +605,10 @@ mkdir -p ./tests/TestResults
 run_unit_project() {
     local proj="$1"
     if [[ "${AFFECTED}" == "ALL" ]] || affected_contains "$(basename "${proj}")"; then
+        if [[ "${DRY_RUN}" == "1" ]]; then
+            echo "   - [dry-run] would run ${proj} (full suite)"
+            return
+        fi
         echo "   - ${proj}"
         dotnet test "${proj}" \
             --no-build \
@@ -383,6 +639,15 @@ else
     echo "   Honua.Server.Tests shards (router: ${SHARD_REASON})..."
     if [[ -z "${SELECTED_SHARDS//[[:space:]]/}" ]]; then
         echo "   (no server-test shards selected for this diff)"
+    elif [[ "${DRY_RUN}" == "1" ]]; then
+        while IFS= read -r shard_name; do
+            [[ -z "${shard_name}" ]] && continue
+            if [[ -n "${NARROWED_SHARD_FILTER[${shard_name}]+set}" ]]; then
+                echo "   - [dry-run] ${shard_name}: ${NARROWED_SHARD_REASON[${shard_name}]}"
+            else
+                echo "   - [dry-run] ${shard_name}: full shard filter (no safe capability narrowing)"
+            fi
+        done <<< "${SELECTED_SHARDS}"
     else
         SHARD_PARALLELISM="${HONUA_PRE_PR_SHARD_PARALLELISM:-2}"
         SHARD_STATUS_DIR="$(mktemp -d)"
@@ -400,6 +665,10 @@ else
             fi
             log_name="$(jq -r '.log_name' <<< "${shard_json}")"
             filter="$(jq -r '.filter' <<< "${shard_json}")"
+            if [[ -n "${NARROWED_SHARD_FILTER[${shard_name}]+set}" ]]; then
+                filter="${NARROWED_SHARD_FILTER[${shard_name}]}"
+                echo "   - ${shard_name}: ${NARROWED_SHARD_REASON[${shard_name}]}"
+            fi
             max_cpu_count="$(jq -r '.max_cpu_count // ""' <<< "${shard_json}")"
             test_timeout_minutes="$(jq -r '(.test_timeout_minutes // .timeout_minutes) | tostring' <<< "${shard_json}")"
             # Forward the shard's test project (ADR-0042 split protocol projects). When a shard has
@@ -449,17 +718,27 @@ else
 fi
 
 # Architecture tests are cheap and guard the module topology — always run them.
-echo "   - tests/dotnet/Honua.Architecture.Tests (topology guards)"
-dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj \
-    --no-build \
-    --no-restore \
-    --configuration Release \
-    --logger "console;verbosity=minimal" \
-    --results-directory ./tests/TestResults \
-    -- RunConfiguration.MaxCpuCount=1
+if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "   - [dry-run] would run tests/dotnet/Honua.Architecture.Tests (topology guards)"
+else
+    echo "   - tests/dotnet/Honua.Architecture.Tests (topology guards)"
+    dotnet test tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj \
+        --no-build \
+        --no-restore \
+        --configuration Release \
+        --logger "console;verbosity=minimal" \
+        --results-directory ./tests/TestResults \
+        -- RunConfiguration.MaxCpuCount=1
+fi
 
 if [[ "${HONUA_PRE_PR_SKIP_AOT:-0}" == "1" || "${FAST}" == "1" ]]; then
     echo "7. Skipping AOT build (FAST tier or HONUA_PRE_PR_SKIP_AOT=1; AOT verified in CI)."
+elif [[ "${DRY_RUN}" == "1" ]]; then
+    if [[ "${AFFECTED}" == "ALL" ]] || affected_contains "Honua.Server.csproj"; then
+        echo "7. [dry-run] Would test the AOT build (Honua.Server affected)."
+    else
+        echo "7. [dry-run] Would skip AOT build (Honua.Server not affected)."
+    fi
 elif [[ "${AFFECTED}" == "ALL" ]] || affected_contains "Honua.Server.csproj"; then
     echo "7. Testing AOT build..."
     (
@@ -480,25 +759,10 @@ else
     echo "7. Skipping AOT build (Honua.Server not affected)."
 fi
 
-echo "8. Local architecture review..."
-# Resolve an interpreter that actually runs. `command -v python3` alone is not
-# enough on Windows: the Microsoft Store ships a python3.exe App Execution
-# Alias stub that is present on PATH but exits non-zero with "Python was not
-# found", while the real interpreter installs as `python`/`py`. The old guard
-# therefore passed, the stub failed, and the script blamed the code —
-# reporting "architecture review found blocking issues" when Python was simply
-# absent (#2871). Probe each candidate by executing it, and require Python 3 so
-# a legacy `python` == python2 is not selected. On Linux `python3` matches
-# first, exactly as before.
-PYTHON_BIN=""
-for candidate in python3 python py; do
-    if command -v "${candidate}" >/dev/null 2>&1 \
-        && "${candidate}" -c 'import sys; sys.exit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; then
-        PYTHON_BIN="${candidate}"
-        break
-    fi
-done
-if [[ -n "${PYTHON_BIN}" ]]; then
+if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "8. [dry-run] Would run the local architecture review."
+elif [[ -n "${PYTHON_BIN}" ]]; then
+    echo "8. Local architecture review..."
     # PYTHONIOENCODING=utf-8: the review prints emoji, but Python on Windows
     # defaults stdout to the ANSI code page (cp1252) and dies with
     # UnicodeEncodeError — while printing its own error message, so the real
@@ -510,8 +774,50 @@ if [[ -n "${PYTHON_BIN}" ]]; then
         exit 1
     }
 else
-    echo "⚠️  Skipping local architecture review (requires python3)"
+    echo "8. Skipping local architecture review (requires python3)"
     echo "   OpenAI architecture review will run automatically in CI"
+fi
+
+# ---------------------------------------------------------------------------
+# Honest summary (#2951) — deliberately plain/greppable so it can be pasted
+# straight into the PR template's Testing section as the evidence for
+# "Ran scripts/ci/pre-pr-check.sh and all checks passed".
+# ---------------------------------------------------------------------------
+echo ""
+echo "📋 Selection summary"
+if [[ "${FULL}" == "1" ]]; then
+    echo "  - Mode: FULL (every project, every shard, whole-solution format)"
+else
+    if [[ "${FAST}" == "1" ]]; then
+        echo "  - Mode: SMART, FAST tier (shards + AOT deferred to CI)"
+    else
+        echo "  - Mode: SMART"
+    fi
+    if [[ -n "${SLNF:-}" && -f "${SLNF:-/dev/null}" ]]; then
+        echo "  - Build set: $(jq -r '.solution.projects|length' "${SLNF}") projects (AFFECTED=$([[ "${AFFECTED}" == "ALL" ]] && echo ALL || echo scoped))"
+    fi
+    echo "  - Format scope: ${#changed_arr[@]} changed .cs file(s)"
+fi
+echo "  - ADR-0037 shard router reason: ${SHARD_REASON:-n/a}"
+if [[ -n "${SELECTED_SHARDS//[[:space:]]/}" ]]; then
+    selected_count="$(printf '%s\n' "${SELECTED_SHARDS}" | sed '/^$/d' | wc -l | tr -d ' ')"
+    total_count="$(jq -r '.shards | length' .github/ci-shards.json)"
+    echo "  - Server-test shards: ${selected_count}/${total_count} selected"
+    narrowed_count="${#NARROWED_SHARD_FILTER[@]}"
+    if [[ "${narrowed_count}" -gt 0 ]]; then
+        echo "    - ${narrowed_count} of those capability-narrowed to proving tests only: ${!NARROWED_SHARD_FILTER[*]}"
+    fi
+else
+    echo "  - Server-test shards: none selected"
+fi
+if [[ "${CAPABILITY_SELECTION_JSON}" != "{}" ]]; then
+    echo "  - Capability crosswalk: runAll=${CAPABILITY_RUN_ALL:-n/a}, reason=$(jq -r '.reason // "n/a"' <<< "${CAPABILITY_SELECTION_JSON}"), capabilities=$(jq -r '.capabilities|length' <<< "${CAPABILITY_SELECTION_JSON}"), provingTests=${CAPABILITY_PROVING_TEST_COUNT:-0}, unmatchedSourceFiles=${CAPABILITY_UNMATCHED_COUNT:-0}"
+fi
+echo ""
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "🔎 Dry run complete — nothing was restored, built, formatted, or tested."
+    exit 0
 fi
 
 echo "✅ All pre-PR checks passed! Ready to create PR."

--- a/tests/python/unit/test_pre_pr_scoped_selection.py
+++ b/tests/python/unit/test_pre_pr_scoped_selection.py
@@ -1,0 +1,217 @@
+"""Unit tests for the local capability-scoped selection primitive (honua-server#2951).
+
+`scripts/ci/pre-pr-check.sh` SMART mode calls `capability-impact.py select-local`
+to narrow per-shard test filters without duplicating the changed-file ->
+capability -> proving-test -> shard crosswalk that `capability-impact.py`
+already owns (used today, report-only, by the hosted comparison job). These
+tests exercise `compute_capability_selection` (the extracted primitive shared
+by `build_report` and `select-local`) and the `select-local` CLI surface
+directly, using isolated fixture catalogs/configs so they do not depend on the
+size or shape of the real feature catalog.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts/ci/capability-impact.py"
+SPEC = importlib.util.spec_from_file_location("capability_impact_local", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class ComputeCapabilitySelectionTests(unittest.TestCase):
+    def test_test_file_change_narrows_to_owning_capability_and_shard(self):
+        catalog = {
+            "entries": [
+                {
+                    "method": "GET",
+                    "route": "/x",
+                    "family": "X",
+                    "code_location": "src/Honua.Server/EndpointRegistry.cs",
+                    "capability": "serve.x",
+                    "proving_tests": ["Honua.Server.Tests.Features.X.XTests.Works"],
+                }
+            ]
+        }
+        config = {
+            "unmapped_source_run_all_prefixes": ["src/"],
+            "shards": [{"name": "X", "filter": "FullyQualifiedName~XTests"}],
+        }
+        selection = MODULE.compute_capability_selection(
+            ["tests/dotnet/Honua.Server.Tests/Features/X/XTests.cs"], catalog, config
+        )
+        self.assertFalse(selection["runAll"])
+        self.assertEqual(selection["reason"], "capability_match")
+        self.assertEqual(selection["capabilities"], ["serve.x"])
+        self.assertEqual(selection["provingTests"], ["Honua.Server.Tests.Features.X.XTests.Works"])
+        self.assertEqual(selection["shards"], ["X"])
+        self.assertEqual(selection["unmatchedSourceFiles"], [])
+        self.assertEqual(
+            selection["testsByShard"], {"X": ["Honua.Server.Tests.Features.X.XTests.Works"]}
+        )
+
+    def test_unmapped_handler_source_change_escalates_to_run_all_and_empties_tests_by_shard(self):
+        # Reflects the real catalog's current fidelity: code_location almost
+        # always resolves to the endpoint-registry file (evidence-array
+        # ordering, not per-handler), so a genuine handler-source edit cannot
+        # match any entry and must fail closed to run_all rather than silently
+        # under-select. See the PR description for the tracked follow-up.
+        catalog = {
+            "entries": [
+                {
+                    "method": "GET",
+                    "route": "/x",
+                    "family": "X",
+                    "code_location": "src/Honua.Server/EndpointRegistry.cs",
+                    "capability": "serve.x",
+                    "proving_tests": ["Honua.Server.Tests.Features.X.XTests.Works"],
+                }
+            ]
+        }
+        config = {
+            "unmapped_source_run_all_prefixes": ["src/"],
+            "shards": [
+                {"name": "X", "filter": "FullyQualifiedName~XTests"},
+                {"name": "Y", "filter": "FullyQualifiedName~YTests"},
+            ],
+        }
+        selection = MODULE.compute_capability_selection(
+            ["src/Honua.Server/Features/X/XEndpoints.cs"], catalog, config
+        )
+        self.assertTrue(selection["runAll"])
+        self.assertEqual(selection["reason"], "unmapped_graph_source")
+        self.assertEqual(selection["shards"], ["X", "Y"])
+        self.assertEqual(selection["unmatchedSourceFiles"], ["src/Honua.Server/Features/X/XEndpoints.cs"])
+        self.assertEqual(selection["testsByShard"], {})
+
+    def test_doc_only_change_is_not_unmatched_source_and_selects_nothing(self):
+        catalog = {"entries": []}
+        config = {"unmapped_source_run_all_prefixes": ["src/"], "shards": []}
+        selection = MODULE.compute_capability_selection(["docs/gis/foo.md"], catalog, config)
+        self.assertFalse(selection["runAll"])
+        self.assertEqual(selection["reason"], "no_capability_match")
+        self.assertEqual(selection["unmatchedSourceFiles"], [])
+        self.assertEqual(selection["shards"], [])
+
+    def test_tests_by_shard_groups_a_proving_test_under_every_matching_shard(self):
+        catalog = {
+            "entries": [
+                {
+                    "method": "GET",
+                    "route": "/x",
+                    "family": "X",
+                    "code_location": "irrelevant.cs",
+                    "capability": "serve.x",
+                    "proving_tests": ["Honua.Server.Tests.Shared.SharedTests.Works"],
+                }
+            ]
+        }
+        config = {
+            "unmapped_source_run_all_prefixes": [],
+            "shards": [
+                {"name": "A", "filter": "FullyQualifiedName~SharedTests"},
+                {"name": "B", "filter": "FullyQualifiedName~SharedTests"},
+            ],
+        }
+        selection = MODULE.compute_capability_selection(
+            ["tests/dotnet/Honua.Server.Tests/Shared/SharedTests.cs"], catalog, config
+        )
+        self.assertEqual(selection["shards"], ["A", "B"])
+        for shard in ("A", "B"):
+            self.assertEqual(
+                selection["testsByShard"][shard], ["Honua.Server.Tests.Shared.SharedTests.Works"]
+            )
+
+
+class BuildReportReusesSharedSelectionTests(unittest.TestCase):
+    """`build_report`'s capabilitySelection must stay byte-identical to what it
+    produced before the extraction — this guards against the refactor silently
+    changing the hosted shadow-comparison report's shape."""
+
+    def test_build_report_capability_selection_matches_compute_capability_selection(self):
+        catalog = {
+            "entries": [
+                {
+                    "method": "GET",
+                    "route": "/x",
+                    "family": "X",
+                    "code_location": "src/X.cs",
+                    "capability": "serve.x",
+                    "proving_tests": ["Honua.Server.Tests.XTests.Works"],
+                }
+            ]
+        }
+        keys = {"capabilities": [{"key": "serve.x"}], "crosswalks": {"interop": []}}
+        shards = {"unmapped_source_run_all_prefixes": ["src/"], "shards": [{"name": "X", "filter": "FullyQualifiedName~XTests"}]}
+        with self._fixture(catalog, keys, shards):
+            direct = MODULE.compute_capability_selection(["src/X.cs"], catalog, shards)
+            report = MODULE.build_report(["src/X.cs"], {"shards": []}, None, [])
+            self.assertEqual(report["capabilitySelection"]["runAll"], direct["runAll"])
+            self.assertEqual(report["capabilitySelection"]["reason"], direct["reason"])
+            self.assertEqual(report["capabilitySelection"]["capabilities"], direct["capabilities"])
+            self.assertEqual(report["capabilitySelection"]["shards"], direct["shards"])
+            self.assertEqual(report["capabilitySelection"]["unmatchedSourceFiles"], direct["unmatchedSourceFiles"])
+
+    def _fixture(self, catalog, keys, shards):
+        temporary_directory = tempfile.TemporaryDirectory()
+        root = Path(temporary_directory.name)
+        for name, value in (("catalog.json", catalog), ("keys.json", keys), ("shards.json", shards)):
+            (root / name).write_text(json.dumps(value), encoding="utf-8")
+        stack = ExitStack()
+        stack.enter_context(temporary_directory)
+        stack.enter_context(patch.object(MODULE, "CATALOG", root / "catalog.json"))
+        stack.enter_context(patch.object(MODULE, "KEYS", root / "keys.json"))
+        stack.enter_context(patch.object(MODULE, "SHARDS", root / "shards.json"))
+        return stack
+
+
+class SelectLocalCliTests(unittest.TestCase):
+    """Exercises the actual `select-local` subprocess entrypoint pre-pr-check.sh
+    shells out to, against the real repo catalog/shards — this is the
+    integration seam bash relies on, so it is worth covering end-to-end rather
+    than only through the importlib-loaded module."""
+
+    def test_select_local_cli_runs_against_real_catalog_and_emits_expected_shape(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as handle:
+            handle.write("docs/gis/nonexistent-doc-only-change.md\n")
+            changed_files_path = handle.name
+        try:
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "select-local", "--changed-files", changed_files_path],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        finally:
+            Path(changed_files_path).unlink(missing_ok=True)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["schemaVersion"], 1)
+        self.assertEqual(payload["changedFileCount"], 1)
+        self.assertFalse(payload["runAll"])
+        self.assertEqual(payload["unmatchedSourceFiles"], [])
+        for key in ("capabilities", "provingTests", "shards", "testsByShard"):
+            self.assertIn(key, payload)
+
+    def test_select_local_requires_changed_files_argument(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "select-local"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2951

## Summary
Makes the local `scripts/ci/pre-pr-check.sh` capability-scoped: on top of the ADR-0037 shard router (which stays authoritative for WHICH shards run), the `feature-catalog.json` route/proving-test/shard crosswalk — the same one `capability-impact-comparison.yml` validates in shadow mode — can narrow a selected shard's `dotnet test --filter` down to just its proving tests, but only when every changed file was accounted for with zero ambiguity and the crosswalk's own shard list corroborates the ADR-0037 selection. Any diff the crosswalk cannot confidently map falls back to the shard's full filter unchanged, so the change can only narrow further, never select fewer shards. Also adds a zero-cost `--dry-run` mode that prints the full resolved selection (build set, shards, narrowed filters, format scope) without restoring, building, or testing anything.

## Changes Made
- `scripts/ci/capability-impact.py`: extract `compute_capability_selection` as the single selection primitive shared by the hosted shadow report and a new `select-local` subcommand (adds `testsByShard` grouping); no parallel mapping is introduced.
- `scripts/ci/pre-pr-check.sh`: capability-narrowed per-shard filters gated by two independent fail-safes (cross-cutting-path FULL triggers incl. the selector/catalog files themselves, and `capability-impact.py validate`); narrowed filters are ANDed with the shard's base filter so a shard only ever runs a subset of its partition; directly-edited test files always run their full class.
- `scripts/ci/pre-pr-check.sh`: `--dry-run` / `HONUA_PRE_PR_DRY_RUN=1` report-only mode (also on the CI-shell-only path), CLI flag aliases (`--full`, `--fast`, `--base`), robust Python interpreter resolution (Windows Store `python3` stub), and a unified cleanup trap that never overrides the script's exit code.
- `tests/python/unit/test_pre_pr_scoped_selection.py`: 7 unit tests for the selection primitive and `select-local` CLI using isolated fixture catalogs; wired into `capability-impact-comparison.yml`.
- ADR-0037 documents the narrowing layer and its known `code_location` fidelity limitation (test-file diffs narrow; handler/service source diffs fail closed to the full shard filter).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Verification performed: `python3 -m unittest discover -s tests/python/unit -p 'test_pre_pr_scoped_selection.py'` (7/7 pass); `bash scripts/ci/pre-pr-check.sh --dry-run` on this branch correctly forces FULL mode (the branch edits the selectors themselves — the cross-cutting trigger firing as designed) and exits 0; `select-local` on a test-only diff returns `runAll:false` with one corroborated shard and 12 proving tests; `bash -n` + YAML parse clean; an end-to-end scoped-run touch commit was exercised during development and dropped before push.
