### PR TITLE
feat: secondary-provider HTTP-stack GA proof (#2947)

### DIFF
--- a/.github/workflows/provider-http-smoke.yml
+++ b/.github/workflows/provider-http-smoke.yml
@@ -1,0 +1,167 @@
+name: Provider HTTP-Stack Smoke (DuckDB/MySql/SqlServer + Oracle real-DB lane)
+
+# honua-server#2947: secondary-provider HTTP-stack GA proof. Runs the interface-level
+# smoke suite (Honua.ProviderSmoke.Tests) that boots a real ASP.NET Core host per
+# provider (DuckDB in-process, MySql + SQL Server via Testcontainers) and exercises the
+# read/query GA surface each documents support for — GeoServices FeatureServer, OGC API
+# Features, OData, and tiles — asserting real seeded-row correctness, not just 200s. Also
+# runs the Oracle real-database lane (Honua.Oracle.Tests, HONUA_TEST_ORACLE=1), which
+# proves the provider-layer code (connection, query build+execute, WKB/geometry decode)
+# against a live gvenzl/oracle-free instance for the first time; Oracle stays
+# experimental and is NOT part of the smoke suite itself.
+#
+# Deliberately a separate workflow rather than PR-gate wiring: every one of these lanes
+# needs Docker containers (MySql, SQL Server, Oracle) that are too slow/heavy for the PR
+# path. This lane runs nightly and on demand; the release train path should run it before
+# cutting a release that advertises these providers as GA.
+on:
+  schedule:
+    - cron: '30 6 * * *' # Nightly 6:30 UTC
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Which lane to run (default: all)'
+        type: choice
+        required: false
+        default: all
+        options:
+          - all
+          - provider-smoke
+          - oracle-real-db
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+concurrency:
+  group: provider-http-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  provider-smoke:
+    name: Provider Smoke Suite (DuckDB/MySql/SqlServer)
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.suite == 'all' || github.event.inputs.suite == 'provider-smoke'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: scripts/ci/dotnet-restore-retry.sh tests/dotnet/Honua.ProviderSmoke.Tests/Honua.ProviderSmoke.Tests.csproj
+
+      - name: Build
+        run: dotnet build tests/dotnet/Honua.ProviderSmoke.Tests/Honua.ProviderSmoke.Tests.csproj --no-restore --configuration Release
+
+      - name: Create Test Results Directory
+        run: mkdir -p ./tests/TestResults
+
+      - name: Run provider-smoke suite (DuckDB in-process, MySql + SQL Server via Testcontainers)
+        run: |
+          dotnet test tests/dotnet/Honua.ProviderSmoke.Tests/Honua.ProviderSmoke.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --logger "trx;LogFileName=ProviderSmoke.trx" \
+            --logger "console;verbosity=normal" \
+            --results-directory ./tests/TestResults
+
+      - name: Surface pass/fail/skip counts in summary
+        if: always()
+        run: |
+          trx="./tests/TestResults/ProviderSmoke.trx"
+          if [[ -f "$trx" ]]; then
+            passed=$(grep -o 'outcome="Passed"' "$trx" | wc -l)
+            failed=$(grep -o 'outcome="Failed"' "$trx" | wc -l)
+            skipped=$(grep -o 'outcome="NotExecuted"' "$trx" | wc -l)
+            {
+              echo "### Provider Smoke Suite (DuckDB/MySql/SqlServer)"
+              echo "- Passed: ${passed}"
+              echo "- Failed: ${failed}"
+              echo "- Skipped: ${skipped}"
+              if [[ "${skipped}" -gt 0 ]]; then
+                echo "- Note: the 2 SQL Server OData/Tiles cases are expected skips — a real product routing gap tracked in honua-server#2962 (OData/Tiles bypass FeatureProviderQueryRouter for secondary providers), not a missing prerequisite."
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Provider Smoke Suite: no TRX produced" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload provider-smoke test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: provider-http-smoke-${{ github.run_id }}
+          path: tests/TestResults/
+          retention-days: 14
+
+  oracle-real-db:
+    name: Oracle Real-Database Lane (experimental, promotion groundwork)
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.suite == 'all' || github.event.inputs.suite == 'oracle-real-db'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HONUA_TEST_ORACLE: '1'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: ./.github/actions/setup-dotnet-ci
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: scripts/ci/dotnet-restore-retry.sh tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj
+
+      - name: Build
+        run: dotnet build tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj --no-restore --configuration Release
+
+      - name: Create Test Results Directory
+        run: mkdir -p ./tests/TestResults
+
+      - name: Run Oracle real-database lane (gvenzl/oracle-free via Testcontainers)
+        run: |
+          dotnet test tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj \
+            --no-build \
+            --no-restore \
+            --configuration Release \
+            --filter "Category=Oracle" \
+            --logger "trx;LogFileName=OracleRealDb.trx" \
+            --logger "console;verbosity=normal" \
+            --results-directory ./tests/TestResults
+
+      - name: Surface pass/fail/skip counts in summary
+        if: always()
+        run: |
+          trx="./tests/TestResults/OracleRealDb.trx"
+          if [[ -f "$trx" ]]; then
+            passed=$(grep -o 'outcome="Passed"' "$trx" | wc -l)
+            failed=$(grep -o 'outcome="Failed"' "$trx" | wc -l)
+            skipped=$(grep -o 'outcome="NotExecuted"' "$trx" | wc -l)
+            {
+              echo "### Oracle Real-Database Lane"
+              echo "- Passed: ${passed}"
+              echo "- Failed: ${failed}"
+              echo "- Skipped: ${skipped}"
+              echo "- Oracle remains experimental; this lane is provider-layer promotion groundwork, not GA HTTP-stack coverage."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Oracle Real-Database Lane: no TRX produced" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload Oracle real-db test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: oracle-real-db-${{ github.run_id }}
+          path: tests/TestResults/
+          retention-days: 14

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -136,7 +136,9 @@
          by any shipped project. -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MySql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.Oracle" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageVersion Include="WireMock.Net" Version="2.2.0" />

--- a/Honua.sln
+++ b/Honua.sln
@@ -167,6 +167,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.ControlPlane.Lambda.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Analyzers", "src\Honua.Analyzers\Honua.Analyzers.csproj", "{E2716F67-388F-4D07-B3BF-E1D78293F214}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.ProviderSmoke.Tests", "tests\dotnet\Honua.ProviderSmoke.Tests\Honua.ProviderSmoke.Tests.csproj", "{89393181-3265-4C93-B2C2-E13A75F32605}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1089,6 +1091,18 @@ Global
 		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|x64.Build.0 = Release|Any CPU
 		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|x86.ActiveCfg = Release|Any CPU
 		{E2716F67-388F-4D07-B3BF-E1D78293F214}.Release|x86.Build.0 = Release|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Debug|x64.Build.0 = Debug|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Debug|x86.Build.0 = Debug|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Release|x64.ActiveCfg = Release|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Release|x64.Build.0 = Release|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Release|x86.ActiveCfg = Release|Any CPU
+		{89393181-3265-4C93-B2C2-E13A75F32605}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1165,5 +1179,6 @@ Global
 		{C6BCF7FB-E329-4820-BC94-7D3939F747A7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{014DB146-0395-4086-BD8C-155FFF3AA9EB} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 		{E2716F67-388F-4D07-B3BF-E1D78293F214} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{89393181-3265-4C93-B2C2-E13A75F32605} = {35C501C9-8590-3B46-F622-E1ABED50CEA9}
 	EndGlobalSection
 EndGlobal

--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -1687,7 +1687,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 30,
-      "provingTestCount": 181,
+      "provingTestCount": 182,
       "maturity": {
         "implemented": 30
       },
@@ -1755,7 +1755,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 21,
-      "provingTestCount": 243,
+      "provingTestCount": 246,
       "maturity": {
         "implemented": 21
       },
@@ -1844,7 +1844,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 13,
-      "provingTestCount": 61,
+      "provingTestCount": 62,
       "maturity": {
         "implemented": 13
       },
@@ -1908,7 +1908,7 @@
       "category": "Serve",
       "edition": "Community",
       "entryCount": 7,
-      "provingTestCount": 36,
+      "provingTestCount": 37,
       "maturity": {
         "implemented": 7
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5846,6 +5846,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.ProviderSmoke.Tests.PrimaryProviderSmokeTestsBase.OData_Features_ReturnsAllSeededFeatures",
         "Honua.Server.Tests.Features.API.EndpointCoverageTests.OData_QueryFeatures_ShouldReturnODataFormat",
         "Honua.Server.Tests.Features.Protocols.OData.ODataClientIntegrationTests.FeaturesQuery_ReturnsAllFeatures_ViaODataClient",
         "Honua.Server.Tests.Features.Protocols.OData.ODataClientIntegrationTests.FeaturesResponse_HasAbsoluteContextUrl",
@@ -6297,6 +6298,9 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.ProviderSmoke.Tests.PrimaryProviderSmokeTestsBase.OgcFeatures_ItemsWithCql2Filter_ReturnsFilteredFeatures",
+        "Honua.ProviderSmoke.Tests.PrimaryProviderSmokeTestsBase.OgcFeatures_Items_ReturnsAllSeededFeatures",
+        "Honua.ProviderSmoke.Tests.SqlServerProviderSmokeTests.OgcFeatures_Items_ReturnsAllSeededFeatures",
         "Honua.Server.Tests.Admin.LayerPublishingIntegrationTests.PublishLayer_FeatureServerQuery_ReadsSourceBackedPostGisTable",
         "Honua.Server.Tests.Admin.LayerPublishingIntegrationTests.RefreshMaterializedFeatures_AfterSourceUpdate_RebuildsSnapshotMvtReads",
         "Honua.Server.Tests.Comprehensive.ApiSurfaceComplianceTests.ContentNegotiation_VariousFormats_ReturnCorrectContentType",
@@ -7125,6 +7129,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.ProviderSmoke.Tests.DuckDbProviderSmokeTests.Tiles_RasterTile_ReturnsNonEmptyPng",
         "Honua.Server.Tests.Admin.LayerPublishingIntegrationTests.RefreshMaterializedFeatures_AfterSourceUpdate_RebuildsSnapshotMvtReads",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Tiles.OgcTilesCrsTests.GetTile_WorldCRS84Quad_UsesGeographicTileEnvelopeForMvt",
         "Honua.Server.Tests.Features.Protocols.Ogc.Api.Tiles.OgcTilesCrsTests.GetTile_WorldCRS84Quad_WithCrs4326_ReturnsTile",
@@ -12283,6 +12288,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.ProviderSmoke.Tests.PrimaryProviderSmokeTestsBase.Tiles_TileJson_ReturnsMetadata",
         "Honua.Server.Tests.Features.Infrastructure.LayerEnablementIntegrationTests.DisabledLayer_ReturnsNotFoundAcrossProtocols",
         "Honua.Server.Tests.Features.Protocols.Tiles.TileJsonEndpointTests.GetTileJson_FeatureServerProtocolDisabled_ReturnsNotFound",
         "Honua.Server.Tests.Features.Protocols.Tiles.TileJsonEndpointTests.GetTileJson_NonExistentLayer_ReturnsRealNotFoundWithProblemJson",

--- a/docs/reference/configuration/data-sources/README.md
+++ b/docs/reference/configuration/data-sources/README.md
@@ -17,6 +17,20 @@ Honua serves data from one primary provider (PostgreSQL/PostGIS by default) plus
 
 Provider selection variables are listed in the [environment variable reference](../environment-variables.md#database-and-providers).
 
+### HTTP-Stack GA Proof
+
+DuckDB, MySQL/MariaDB, and SQL Server each have real HTTP-stack interface-level test
+coverage (`Honua.ProviderSmoke.Tests`, honua-server#2947): a provider-parameterized
+web-app fixture boots the actual ASP.NET Core host against the provider (DuckDB
+in-process, MySQL and SQL Server via Testcontainers) and asserts real seeded-row
+correctness — not just 200s — through the read/query GA surface each documents support
+for (GeoServices FeatureServer, OGC API Features, OData, and tiles where applicable; see
+each provider's page for exact coverage and known gaps). Runs nightly and on demand via
+[`provider-http-smoke.yml`](../../../../.github/workflows/provider-http-smoke.yml).
+Oracle, Redshift, Snowflake, and Databricks remain experimental and are not part of this
+suite; Oracle additionally gained a real-database provider-layer lane (see the
+[Oracle provider](oracle.md#integration) page) as promotion groundwork.
+
 ## Tested PostgreSQL configurations
 
 | Provider | Engine version | PostGIS version | CI status |

--- a/docs/reference/configuration/data-sources/duckdb.md
+++ b/docs/reference/configuration/data-sources/duckdb.md
@@ -214,6 +214,16 @@ FROM read_csv('/data/stations.csv');
 Ensure the `ObjectIdColumn` is a `BIGINT PRIMARY KEY` and the geometry column uses
 the `GEOMETRY` type.
 
+## Testing
+
+`Honua.ProviderSmoke.Tests` boots a full HTTP-stack host with `DataSource:Provider=duckdb`
+against a standalone, file-backed database and asserts real seeded-row correctness — not
+just 200s — through GeoServices FeatureServer, OGC API Features, OData, and tiles
+(TileJSON + a raster PNG tile; vector MVT is out of scope, see below). Runs nightly and on
+demand via
+[`provider-http-smoke.yml`](../../../../.github/workflows/provider-http-smoke.yml); not
+part of standard PR CI.
+
 ## Limitations
 
 | Capability | Status |

--- a/docs/reference/configuration/data-sources/mysql-mariadb.md
+++ b/docs/reference/configuration/data-sources/mysql-mariadb.md
@@ -348,6 +348,16 @@ If `HONUA_TEST_MYSQL` is unset (or not exactly `1`) each infrastructure-gated
 test is reported as skipped before `InitializeAsync` starts Docker. They are
 not part of the default PR test suite.
 
+### HTTP-stack smoke coverage (nightly)
+
+`Honua.ProviderSmoke.Tests` boots a full HTTP-stack host with
+`DataSource:Provider=mysql` against a Testcontainers `mysql:8` instance and asserts real
+seeded-row correctness — not just 200s — through GeoServices FeatureServer, OGC API
+Features, OData, and tiles (TileJSON + a raster PNG tile; vector MVT is out of scope, see
+Limitations Summary). Runs nightly and on demand via
+[`provider-http-smoke.yml`](../../../../.github/workflows/provider-http-smoke.yml); not
+part of standard PR CI.
+
 ### MariaDB compatibility
 
 The integration suite uses MySQL 8 as the canonical engine. MariaDB 10.6 is

--- a/docs/reference/configuration/data-sources/oracle.md
+++ b/docs/reference/configuration/data-sources/oracle.md
@@ -240,10 +240,28 @@ and versioning columns. No Oracle instance is required.
 
 ### Integration
 
-There is no live-Oracle integration suite in this slice — Oracle Free 23ai container
-images are large and Oracle licensing for CI is treated as a separate decision. Operators
-should run the read paths against a representative database before promoting the
-configuration.
+`OracleRealDatabaseIntegrationTests` (in `tests/dotnet/Honua.Oracle.Tests`) exercises
+connection open, query build+execute, and WKB/`SDO_GEOMETRY` decode against a real
+`gvenzl/oracle-free` instance via Testcontainers — promotion groundwork per
+honua-server#2947, not a change to Oracle's experimental status. It is **opt-in**: every
+test method is skipped unless `HONUA_TEST_ORACLE=1` is set, so the default
+`dotnet test tests/dotnet/Honua.Oracle.Tests` run (invoked unfiltered by the PR gate's
+fast-unit-only step) stays fast and never starts Docker.
+
+```bash
+# Requires Docker; pulls the gvenzl/oracle-free:23-faststart image (several GB —
+# NOT the "slim" variant, which excludes the Oracle Spatial component this lane
+# needs) and takes several
+# minutes to start.
+HONUA_TEST_ORACLE=1 dotnet test tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj \
+    --filter "Category=Oracle"
+```
+
+Runs nightly and on demand via
+[`provider-http-smoke.yml`](../../../../.github/workflows/provider-http-smoke.yml). Oracle
+is **not** wired into the `Honua.ProviderSmoke.Tests` HTTP-stack smoke suite and remains
+experimental — this lane proves the provider-layer code path only, not the full protocol
+stack.
 
 ## Limitations and Known Gaps
 

--- a/docs/reference/configuration/data-sources/sql-server.md
+++ b/docs/reference/configuration/data-sources/sql-server.md
@@ -203,6 +203,17 @@ The test fixture creates and drops a temporary table named
 have `CREATE TABLE` and `DROP TABLE` permission in the target database (a scratch
 database such as `tempdb` is recommended).
 
+### HTTP-Stack Smoke Coverage (nightly)
+
+`Honua.ProviderSmoke.Tests` boots a full HTTP stack (Postgres primary + this provider
+registered as a secondary connection) against a Testcontainers
+`mcr.microsoft.com/mssql/server:2022-latest` instance and asserts real seeded-row
+correctness — not just 200s — through GeoServices FeatureServer and OGC API Features.
+Runs nightly and on demand via
+[`provider-http-smoke.yml`](../../../../.github/workflows/provider-http-smoke.yml); not
+part of standard PR CI. See [Limitations and Known Gaps](#limitations-and-known-gaps)
+below for why OData and OGC API Tiles are excluded from this suite for this provider.
+
 ## Limitations and Known Gaps
 
 - **Read-only.** Edits, transactions, and applyEdits are not implemented.
@@ -214,6 +225,14 @@ database such as `tempdb` is recommended).
   `STEnvelope` indexing tricks beyond the explicit `EnvelopeIntersects` filter.
 - **WHERE grammar is intentionally narrow.** Use the canonical filter pipeline
   (`SqlFragment`/`Filter`) for complex predicates rather than free-form SQL.
+- **OData and OGC API Tiles do not reach SQL Server-backed layers.** Both resolve
+  `IFeatureReader`/`ITileProvider` directly via DI (always the primary provider) instead of
+  through `FeatureProviderQueryRouter`, so a layer whose storage binding routes to this
+  provider is only reachable via GeoServices FeatureServer and OGC API Features today.
+  Found during the honua-server#2947 HTTP-stack smoke-coverage work; tracked as a real
+  product gap in [honua-server#2962](https://github.com/honua-io/honua-server/issues/2962).
+  The same gap applies to every other secondary/additional provider (Oracle, Redshift,
+  Snowflake, Databricks).
 
 Follow-ups for write support, admin UI wiring, native output formats, statistics, and
 temporal/H3 aggregations are tracked under epic

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpCrsDetectionService.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/NoOpCrsDetectionService.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+
+namespace Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+
+/// <summary>
+/// CRS detection service that never recognizes anything. Registered by read-only feature
+/// providers (DuckDB, MySQL/MariaDB) so DI activation succeeds for
+/// <c>Honua.Infrastructure.Services.SpatialReferenceResolver</c> — a mandatory, scoped
+/// dependency of the FeatureServer, ImageServer, GeometryService, and gRPC protocol
+/// adapters regardless of the active data-source provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Found and fixed under honua-server#2947 (secondary-provider HTTP-stack GA proof): with
+/// no <see cref="ICrsDetectionService"/> registration at all, any request that resolved
+/// <c>SpatialReferenceResolver</c> under <c>DataSource:Provider=duckdb</c> or <c>mysql</c>
+/// failed DI activation outright (<c>InvalidOperationException: Unable to resolve service
+/// for type 'ICrsDetectionService'</c>) — breaking every FeatureServer query, not just ones
+/// that pass a named/WKT spatial reference. Only <c>Honua.Postgres</c> ever registered an
+/// implementation, because CRS detection from WKT/.prj/GeoJSON content genuinely depends on
+/// Postgres's <c>spatial_ref_sys</c> catalog.
+/// </para>
+/// <para>
+/// This stub is intentionally honest, not a workaround: the common paths (a plain numeric
+/// SRID or an <c>EPSG:nnnn</c> string) are already resolved by
+/// <c>SpatialReferenceHelpers.TryParseSrid</c> before
+/// <see cref="ICrsDetectionService"/> is ever consulted. Only named aliases (e.g.
+/// <c>"WGS84"</c>) and raw WKT/.prj/GeoJSON-CRS content fall through to this service, and
+/// DuckDB/MySQL genuinely have no CRS catalog to detect those against — reporting "not
+/// recognized" is the correct, capability-scoped answer, not a fabricated one.
+/// </para>
+/// </remarks>
+public sealed class NoOpCrsDetectionService : ICrsDetectionService
+{
+    /// <inheritdoc />
+    public Task<int?> DetectFromPrjAsync(string prjContent, CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    /// <inheritdoc />
+    public Task<int?> DetectFromWktAsync(string wktContent, CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    /// <inheritdoc />
+    public int? DetectFromEpsgCode(string epsgCode) => null;
+
+    /// <inheritdoc />
+    public Task<int?> DetectFromGeoJsonCrsAsync(string crsObject, CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    /// <inheritdoc />
+    public Task<int?> DetectFromShapefilePrjAsync(string shapefilePath, CancellationToken cancellationToken = default)
+        => Task.FromResult<int?>(null);
+
+    /// <inheritdoc />
+    public Task<bool> ValidateSridAsync(int srid, CancellationToken cancellationToken = default)
+        => Task.FromResult(false);
+}

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/ReadOnlyRelationshipStore.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/ReadOnlyRelationshipStore.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.FeatureStore.Abstractions;
+using Honua.Core.Features.FeatureStore.Domain;
+
+namespace Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+
+/// <summary>
+/// Relationship store that rejects all relationship queries with
+/// <see cref="NotSupportedException"/>. Registered by read-only feature providers (DuckDB,
+/// MySQL/MariaDB) — both documented as not supporting relationship queries — so DI
+/// consumers that require <see cref="IRelationshipStore"/> (for example
+/// <c>Honua.Protocols.OData.Services.ODataSearchService</c>, a mandatory dependency wired
+/// unconditionally regardless of provider) can activate.
+/// </summary>
+/// <remarks>
+/// Found under honua-server#2947 (secondary-provider HTTP-stack GA proof): with no
+/// <see cref="IRelationshipStore"/> registration at all, every OData request failed DI
+/// activation outright under <c>DataSource:Provider=duckdb</c> or <c>mysql</c> — not just
+/// requests that use OData's relationship/search surface. Only <c>Honua.Postgres</c> ever
+/// registered a real implementation.
+/// </remarks>
+public sealed class ReadOnlyRelationshipStore : IRelationshipStore
+{
+    private readonly string _providerName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReadOnlyRelationshipStore"/> class.
+    /// </summary>
+    /// <param name="providerName">
+    /// Display name of the read-only provider, used in the rejection message
+    /// (for example <c>"DuckDB"</c> or <c>"MySQL/MariaDB"</c>).
+    /// </param>
+    public ReadOnlyRelationshipStore(string providerName)
+    {
+        _providerName = providerName;
+    }
+
+    /// <inheritdoc />
+    public Task<QueryResult<Feature>> QueryRelatedAsync(int layerId, RelatedQuery query, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException($"{_providerName} provider does not support relationship queries.");
+}

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/WellKnownCoordinateTransformService.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/WellKnownCoordinateTransformService.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Infrastructure.Crs;
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+
+/// <summary>
+/// <see cref="ICoordinateTransformService"/> implementation covering only the transform
+/// paths <see cref="ICoordinateTransformService"/>'s own documentation calls out as
+/// in-memory / provider-independent: identity, Web Mercator aliasing, and WGS84 (4326)
+/// &#8596; Web Mercator (3857). Registered by read-only feature providers (DuckDB,
+/// MySQL/MariaDB) so DI activation succeeds for consumers that require
+/// <see cref="ICoordinateTransformService"/> (for example
+/// <c>Honua.Protocols.Ogc.Shared.OgcFeaturesGeometryServices</c>, a mandatory dependency of
+/// OGC API Features wired unconditionally regardless of provider).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Found under honua-server#2947 (secondary-provider HTTP-stack GA proof): with no
+/// <see cref="ICoordinateTransformService"/> registration at all, every OGC API Features
+/// request failed DI activation outright under <c>DataSource:Provider=duckdb</c> or
+/// <c>mysql</c> — not just requests that transform between CRSes. Only
+/// <c>Honua.Postgres.Features.Infrastructure.Transforms.PostGisCoordinateTransformService</c>
+/// ever registered an implementation, because arbitrary SRID-pair transforms genuinely
+/// depend on PostGIS's <c>ST_Transform</c>/<c>spatial_ref_sys</c>.
+/// </para>
+/// <para>
+/// This is not a fake/no-op: it reuses the exact same <see cref="WebMercatorMath"/> helper
+/// the PostGIS implementation itself uses for its own documented in-memory fast path (see
+/// <see cref="ICoordinateTransformService"/>'s remarks table), so results for the
+/// identity/Web-Mercator-alias/4326&#8596;3857 cases are byte-identical to what the PostGIS
+/// implementation would return without ever touching the database. Any other SRID pair
+/// returns <see langword="null"/> ("cannot be performed"), the same contract the interface
+/// already documents for an unknown SRID — a provider with no <c>spatial_ref_sys</c>
+/// catalog genuinely cannot resolve arbitrary datum transforms, so reporting "not
+/// supported" is the correct, capability-scoped answer.
+/// </para>
+/// </remarks>
+public sealed class WellKnownCoordinateTransformService : ICoordinateTransformService
+{
+    // Mirrors PostGisCoordinateTransformService.ExtentSampleSegmentsPerEdge so the sampled
+    // antimeridian-aware extent transform behaves identically.
+    private const int ExtentSampleSegmentsPerEdge = 4;
+
+    /// <inheritdoc />
+    public ValueTask<(double MinX, double MinY, double MaxX, double MaxY)?> TransformExtentAsync(
+        double minX, double minY, double maxX, double maxY,
+        int fromSrid, int toSrid,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsIdentityTransform(fromSrid, toSrid))
+        {
+            return ValueTask.FromResult<(double, double, double, double)?>((minX, minY, maxX, maxY));
+        }
+
+        if (TryTransformExtentInMemory(minX, minY, maxX, maxY, fromSrid, toSrid, out var result))
+        {
+            return ValueTask.FromResult<(double, double, double, double)?>(result);
+        }
+
+        return ValueTask.FromResult<(double, double, double, double)?>(null);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<(double X, double Y)?> TransformPointAsync(
+        double x, double y,
+        int fromSrid, int toSrid,
+        CancellationToken cancellationToken = default)
+    {
+        if (IsIdentityTransform(fromSrid, toSrid))
+        {
+            return ValueTask.FromResult<(double, double)?>((x, y));
+        }
+
+        if (TryTransformPointInMemory(x, y, fromSrid, toSrid, out var result))
+        {
+            return ValueTask.FromResult<(double, double)?>(result);
+        }
+
+        return ValueTask.FromResult<(double, double)?>(null);
+    }
+
+    private static bool IsIdentityTransform(int fromSrid, int toSrid)
+        => fromSrid == toSrid || (IsWebMercatorSrid(fromSrid) && IsWebMercatorSrid(toSrid));
+
+    private static bool TryTransformExtentInMemory(
+        double minX, double minY, double maxX, double maxY,
+        int fromSrid, int toSrid,
+        out (double MinX, double MinY, double MaxX, double MaxY) result)
+    {
+        if (IsWgs84Srid(fromSrid) && IsWebMercatorSrid(toSrid))
+        {
+            result = WebMercatorMath.TransformSampledExtent(
+                minX, minY, maxX, maxY, WebMercatorMath.LonLatToWebMercator, ExtentSampleSegmentsPerEdge);
+            return true;
+        }
+
+        if (IsWebMercatorSrid(fromSrid) && IsWgs84Srid(toSrid))
+        {
+            result = WebMercatorMath.TransformSampledExtent(
+                minX, minY, maxX, maxY, WebMercatorMath.WebMercatorToLonLat, ExtentSampleSegmentsPerEdge);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    private static bool TryTransformPointInMemory(
+        double x, double y,
+        int fromSrid, int toSrid,
+        out (double X, double Y) result)
+    {
+        if (IsWgs84Srid(fromSrid) && IsWebMercatorSrid(toSrid))
+        {
+            result = WebMercatorMath.LonLatToWebMercator(x, y);
+            return true;
+        }
+
+        if (IsWebMercatorSrid(fromSrid) && IsWgs84Srid(toSrid))
+        {
+            result = WebMercatorMath.WebMercatorToLonLat(x, y);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    private static bool IsWgs84Srid(int srid) => srid == 4326;
+
+    private static bool IsWebMercatorSrid(int srid) => SpatialReferenceExtensions.IsWebMercatorSrid(srid);
+}

--- a/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/WellKnownCrsRegistry.cs
+++ b/src/Honua.Core/Features/FeatureStore/ReadOnlyProviders/WellKnownCrsRegistry.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Shared.Models;
+
+namespace Honua.Core.Features.FeatureStore.ReadOnlyProviders;
+
+/// <summary>
+/// CRS registry that resolves only the three universally well-known CRSes (OGC:CRS84,
+/// EPSG:4326, EPSG:3857) with no backing catalog. Registered by read-only feature
+/// providers (DuckDB, MySQL/MariaDB) so DI activation succeeds for
+/// <c>Honua.Infrastructure.Services.SpatialReferenceResolver</c> — a mandatory, scoped
+/// dependency of the FeatureServer, ImageServer, GeometryService, and gRPC protocol
+/// adapters regardless of the active data-source provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Found and fixed alongside <see cref="NoOpCrsDetectionService"/> under honua-server#2947
+/// (secondary-provider HTTP-stack GA proof): with no <see cref="ICrsRegistry"/>
+/// registration at all, any request that resolved <c>SpatialReferenceResolver</c> under
+/// <c>DataSource:Provider=duckdb</c> or <c>mysql</c> failed DI activation outright, even
+/// for the overwhelmingly common case of a layer stored (and queried) in its own default
+/// SRID. Only <c>Honua.Postgres.Shared.PostgresCrsRegistry</c> ever registered an
+/// implementation, because arbitrary-SRID resolution beyond the three well-known
+/// definitions genuinely depends on Postgres's <c>spatial_ref_sys</c> catalog.
+/// </para>
+/// <para>
+/// This is intentionally the same three built-in definitions
+/// <c>PostgresCrsRegistry.TryGetBuiltInDefinition</c> falls back to before ever consulting
+/// <c>spatial_ref_sys</c> — DuckDB/MySQL layers are essentially always configured in
+/// WGS84 (4326) or Web Mercator (3857), so this covers the practical case honestly. Any
+/// other SRID reports "not supported" rather than fabricating a definition, which is the
+/// correct, capability-scoped answer for a provider with no CRS catalog to consult.
+/// </para>
+/// </remarks>
+public sealed class WellKnownCrsRegistry : ICrsRegistry
+{
+    private const string Crs84Uri = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
+    private const string EpsgUriPrefix = "http://www.opengis.net/def/crs/EPSG/0/";
+    private const string EpsgUrnPrefix = "urn:ogc:def:crs:EPSG::";
+    private const string EpsgPrefix = "EPSG:";
+
+    private static readonly CrsDefinition _crs84Definition = new(Crs84Uri, 4326, AxisOrder.EastNorth, true);
+    private static readonly CrsDefinition _epsg4326Definition = new($"{EpsgUriPrefix}4326", 4326, AxisOrder.NorthEast, true);
+    private static readonly CrsDefinition _epsg3857Definition = new($"{EpsgUriPrefix}3857", 3857, AxisOrder.EastNorth, false);
+
+    /// <inheritdoc />
+    public ValueTask<CrsDefinition?> ResolveAsync(string? crsIdentifier, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(crsIdentifier))
+        {
+            return ValueTask.FromResult<CrsDefinition?>(_crs84Definition);
+        }
+
+        var normalized = Normalize(crsIdentifier);
+        if (string.Equals(normalized, Crs84Uri, StringComparison.OrdinalIgnoreCase))
+        {
+            return ValueTask.FromResult<CrsDefinition?>(_crs84Definition);
+        }
+
+        return !TryParseSrid(normalized, out var srid)
+            ? ValueTask.FromResult<CrsDefinition?>(null)
+            : ResolveBySridAsync(srid, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<CrsDefinition?> ResolveBySridAsync(int srid, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(srid switch
+        {
+            4326 => (CrsDefinition?)_epsg4326Definition,
+            3857 => _epsg3857Definition,
+            _ => null,
+        });
+
+    /// <inheritdoc />
+    public async ValueTask<bool> IsSridSupportedAsync(int srid, CancellationToken cancellationToken = default)
+        => (await ResolveBySridAsync(srid, cancellationToken).ConfigureAwait(false)).HasValue;
+
+    private static string Normalize(string crsIdentifier)
+    {
+        var trimmed = crsIdentifier.Trim();
+        if (trimmed.Length > 1 && trimmed[0] == '<' && trimmed[^1] == '>')
+        {
+            trimmed = trimmed[1..^1];
+        }
+
+        if (string.Equals(trimmed, "CRS84", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(trimmed, "OGC:CRS84", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(trimmed, Crs84Uri, StringComparison.OrdinalIgnoreCase))
+        {
+            return Crs84Uri;
+        }
+
+        if (trimmed.StartsWith(EpsgUrnPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return EpsgUriPrefix + trimmed[EpsgUrnPrefix.Length..];
+        }
+
+        if (trimmed.StartsWith(EpsgPrefix, StringComparison.OrdinalIgnoreCase) &&
+            !trimmed.StartsWith(EpsgUriPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return EpsgUriPrefix + trimmed[EpsgPrefix.Length..];
+        }
+
+        return trimmed;
+    }
+
+    private static bool TryParseSrid(string normalizedIdentifier, out int srid)
+    {
+        srid = 0;
+
+        if (normalizedIdentifier.StartsWith(EpsgUriPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return int.TryParse(
+                normalizedIdentifier[EpsgUriPrefix.Length..],
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out srid);
+        }
+
+        return int.TryParse(normalizedIdentifier, NumberStyles.Integer, CultureInfo.InvariantCulture, out srid);
+    }
+}

--- a/src/Honua.Core/Features/Security/InMemorySecureConnectionRegistry.cs
+++ b/src/Honua.Core/Features/Security/InMemorySecureConnectionRegistry.cs
@@ -71,8 +71,29 @@ public sealed class InMemorySecureConnectionRegistry : ISecureConnectionRegistry
         => Task.FromResult(_byId.TryGetValue(connectionId, out var connection) ? connection : null);
 
     /// <inheritdoc />
-    public Task<DataConnection?> GetConnectionAsync(string connectionId, CancellationToken cancellationToken)
-        => GetConnectionAsync(connectionId);
+    /// <remarks>
+    /// Metadata V2 connection ids are not required to be GUIDs (test graphs and metadata
+    /// commonly use names like <c>conn-1</c>), so — matching
+    /// <c>PostgresSecureConnectionRegistry.GetConnectionAsync(string, CancellationToken)</c> —
+    /// a non-GUID id falls back to a name lookup instead of returning null. Without this,
+    /// <c>FeatureProviderQueryRouter</c> cannot resolve an in-memory-registered connection by
+    /// its metadata id/name, so secondary-provider publications either fail as missing or
+    /// route without their <see cref="DataConnection"/>.
+    /// </remarks>
+    public async Task<DataConnection?> GetConnectionAsync(string connectionId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(connectionId))
+        {
+            return null;
+        }
+
+        if (Guid.TryParse(connectionId, out var id))
+        {
+            return await GetConnectionAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await GetConnectionByNameAsync(connectionId, cancellationToken).ConfigureAwait(false);
+    }
 
     /// <inheritdoc />
     public Task<DataConnection?> GetConnectionByNameAsync(string connectionName, CancellationToken cancellationToken = default)

--- a/src/Honua.Core/Features/Security/InMemorySecureConnectionRegistry.cs
+++ b/src/Honua.Core/Features/Security/InMemorySecureConnectionRegistry.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+
+namespace Honua.Core.Features.Security;
+
+/// <summary>
+/// Process-local, non-durable <see cref="ISecureConnectionRegistry"/> backed by an
+/// in-memory dictionary. Registered by read-only primary feature providers (DuckDB,
+/// MySQL/MariaDB) that have no <c>honua.data_connections</c>-equivalent catalog of their
+/// own, so DI activation succeeds for <c>FeatureProviderQueryRouter</c> — a shared,
+/// provider-independent service every read request resolves regardless of the active
+/// data-source provider (see <c>InfrastructureCompositionRoot.RegisterInfrastructureServices</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Found and fixed under honua-server#2947 (secondary-provider HTTP-stack GA proof):
+/// with no <see cref="ISecureConnectionRegistry"/> registration at all, EVERY FeatureServer
+/// and OGC API Features request failed DI activation outright under
+/// <c>DataSource:Provider=duckdb</c> or <c>mysql</c>. Only <c>Honua.Postgres</c> ever
+/// registered a durable, database-backed implementation
+/// (<c>PostgresSecureConnectionRegistry</c>, storing rows in <c>honua.data_connections</c>).
+/// </para>
+/// <para>
+/// This is an honest, functional (not a no-op) implementation: connections registered
+/// through it are genuinely stored and retrievable for the lifetime of the process, which
+/// is sufficient for the router's lookup contract and for a standalone DuckDB/MySQL
+/// deployment that layers a secondary/additional provider (e.g. SQL Server) on top. What it
+/// does <b>not</b> provide is durability across restarts or multi-instance sharing — DuckDB
+/// and MySQL are documented as requiring no external catalog infrastructure of their own, so
+/// there is no natural place to persist connections durably without introducing one. A
+/// deployment that needs durable secure connections alongside DuckDB/MySQL as primary should
+/// register the Postgres security services explicitly, if available.
+/// </para>
+/// </remarks>
+public sealed class InMemorySecureConnectionRegistry : ISecureConnectionRegistry
+{
+    private readonly ConcurrentDictionary<Guid, DataConnection> _byId = new();
+
+    /// <inheritdoc />
+    public Task<DataConnection> CreateConnectionAsync(DataConnection connection, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        if (connection.ConnectionId == Guid.Empty)
+        {
+            connection.ConnectionId = Guid.NewGuid();
+        }
+
+        if (!_byId.TryAdd(connection.ConnectionId, connection))
+        {
+            throw new InvalidOperationException($"A connection with id '{connection.ConnectionId}' already exists.");
+        }
+
+        return Task.FromResult(connection);
+    }
+
+    /// <inheritdoc />
+    public Task RegisterConnectionAsync(DataConnection connection) => CreateConnectionAsync(connection);
+
+    /// <inheritdoc />
+    public Task<DataConnection?> GetConnectionAsync(string connectionId)
+        => Task.FromResult(Guid.TryParse(connectionId, out var id) && _byId.TryGetValue(id, out var connection)
+            ? connection
+            : null);
+
+    /// <inheritdoc />
+    public Task<DataConnection?> GetConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_byId.TryGetValue(connectionId, out var connection) ? connection : null);
+
+    /// <inheritdoc />
+    public Task<DataConnection?> GetConnectionAsync(string connectionId, CancellationToken cancellationToken)
+        => GetConnectionAsync(connectionId);
+
+    /// <inheritdoc />
+    public Task<DataConnection?> GetConnectionByNameAsync(string connectionName, CancellationToken cancellationToken = default)
+        => Task.FromResult(_byId.Values.FirstOrDefault(c => string.Equals(c.Name, connectionName, StringComparison.Ordinal)));
+
+    /// <inheritdoc />
+    public Task<IEnumerable<DataConnection>> GetAllConnectionsAsync()
+        => Task.FromResult<IEnumerable<DataConnection>>(_byId.Values.ToArray());
+
+    /// <inheritdoc />
+    public Task<IEnumerable<DataConnection>> GetActiveConnectionsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IEnumerable<DataConnection>>(_byId.Values.Where(c => c.IsActive).ToArray());
+
+    /// <inheritdoc />
+    public Task<bool> RemoveConnectionAsync(string connectionId)
+        => Task.FromResult(Guid.TryParse(connectionId, out var id) && _byId.TryRemove(id, out _));
+
+    /// <inheritdoc />
+    public Task<bool> DeleteConnectionAsync(Guid connectionId, CancellationToken cancellationToken = default)
+        => Task.FromResult(_byId.TryRemove(connectionId, out _));
+
+    /// <inheritdoc />
+    public Task<DataConnection> UpdateConnectionAsync(DataConnection connection, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        _byId[connection.ConnectionId] = connection;
+        return Task.FromResult(connection);
+    }
+
+    /// <inheritdoc />
+    public Task UpdateHealthStatusAsync(string connectionId, bool isHealthy, CancellationToken cancellationToken = default)
+    {
+        if (Guid.TryParse(connectionId, out var id) && _byId.TryGetValue(id, out var connection))
+        {
+            connection.HealthStatus = isHealthy ? ConnectionHealthStatus.Healthy : ConnectionHealthStatus.Unhealthy;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<Dictionary<string, ConnectionHealthStatus>> TestAllConnectionsAsync()
+        => Task.FromResult(_byId.Values.ToDictionary(c => c.ConnectionId.ToString(), c => c.HealthStatus));
+}

--- a/src/Honua.DuckDB/ServiceCollectionExtensions.cs
+++ b/src/Honua.DuckDB/ServiceCollectionExtensions.cs
@@ -8,6 +8,8 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.FeatureStore.ReadOnlyProviders;
 using Honua.Core.Features.HealthCheck.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Security;
+using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.DuckDB.Features.FeatureStore;
@@ -60,10 +62,15 @@ internal static class ServiceCollectionExtensions
 
         // Build connection string
         var connectionString = options.ReadOnly
-            ? $"Data Source={options.DatabasePath};Access Mode=ReadOnly"
+            ? $"Data Source={options.DatabasePath};access_mode=READ_ONLY"
             : $"Data Source={options.DatabasePath}";
 
         services.AddSingleton<ISqlDialect>(DuckDbSqlDialect.Instance);
+        // Honua.Hosting's shared FilterExpressionTranslator (wired unconditionally in
+        // AddValidationServices) requires ISqlFilterTranslator regardless of provider;
+        // without this every FeatureServer/OGC API Features request failed DI activation
+        // outright, not just ones using a CQL2 filter (honua-server#2947; translator
+        // implemented with CQL2 spatial support in #2963).
         services.AddScoped<ISqlFilterTranslator, DuckDbSqlFilterTranslator>();
 
         // Register infrastructure singletons
@@ -134,6 +141,33 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
         services.AddScoped<IChangeTracker>(_ => new NoOpChangeTracker());
         services.AddScoped<IVersionManager>(_ => new NoOpVersionManager());
+        // Honua.Infrastructure.Services.SpatialReferenceResolver (a mandatory scoped
+        // dependency of FeatureServer/ImageServer/GeometryService/gRPC) requires
+        // ICrsDetectionService regardless of provider. Only Postgres ever registered one
+        // (CRS detection from WKT/.prj/GeoJSON needs its spatial_ref_sys catalog), so every
+        // FeatureServer query under DataSource:Provider=duckdb failed DI activation outright
+        // before this fix (honua-server#2947).
+        services.AddScoped<ICrsDetectionService>(_ => new NoOpCrsDetectionService());
+        // Same gap, same fix shape: SpatialReferenceResolver also requires ICrsRegistry.
+        // WellKnownCrsRegistry covers CRS84/EPSG:4326/EPSG:3857 (the practical case for a
+        // provider with no spatial_ref_sys-equivalent catalog) and honestly reports
+        // "unsupported" for anything else.
+        services.AddScoped<ICrsRegistry>(_ => new WellKnownCrsRegistry());
+        // FeatureProviderQueryRouter (wired unconditionally in
+        // InfrastructureCompositionRoot, regardless of primary provider) requires
+        // ISecureConnectionRegistry to resolve any publication's storage-binding
+        // connection. DuckDB has no honua.data_connections-equivalent catalog of its
+        // own; a process-local in-memory registry keeps DI activation working and
+        // supports a secondary/additional provider (e.g. SQL Server) layered on top
+        // (honua-server#2947).
+        services.AddSingleton<ISecureConnectionRegistry, InMemorySecureConnectionRegistry>();
+        // Honua.Protocols.OData's ODataSearchService (wired unconditionally regardless of
+        // provider) requires IRelationshipStore; DuckDB documents relationship queries as
+        // unsupported (honua-server#2947).
+        services.AddScoped<IRelationshipStore>(_ => new ReadOnlyRelationshipStore("DuckDB"));
+        // OGC API Features' shared geometry services (mandatory, wired unconditionally
+        // regardless of provider) require ICoordinateTransformService (honua-server#2947).
+        services.AddSingleton<ICoordinateTransformService>(_ => new WellKnownCoordinateTransformService());
         services.AddScoped<IGeoJsonFeatureStore>(sp => sp.GetRequiredService<DuckDBFeatureStore>());
         services.AddScoped<IStreamingFeatureStore>(sp => sp.GetRequiredService<DuckDBFeatureStore>());
         services.AddScoped<ITileProvider>(_ => new ReadOnlyTileProvider("DuckDB"));

--- a/src/Honua.MySql/ServiceCollectionExtensions.cs
+++ b/src/Honua.MySql/ServiceCollectionExtensions.cs
@@ -8,6 +8,8 @@ using Honua.Core.Features.FeatureStore.Domain;
 using Honua.Core.Features.FeatureStore.ReadOnlyProviders;
 using Honua.Core.Features.HealthCheck.Abstractions;
 using Honua.Core.Features.Infrastructure.Abstractions;
+using Honua.Core.Features.Security;
+using Honua.Core.Features.Security.Abstractions;
 using Honua.Core.Features.Shared.Models;
 using Honua.Core.Queries.Filters;
 using Honua.MySql.Features.FeatureStore;
@@ -119,6 +121,33 @@ internal static class ServiceCollectionExtensions
         services.AddScoped<IReplicaConflictRepository>(_ => new NoOpReplicaConflictRepository());
         services.AddScoped<IChangeTracker>(_ => new NoOpChangeTracker());
         services.AddScoped<IVersionManager>(_ => new NoOpVersionManager());
+        // Honua.Infrastructure.Services.SpatialReferenceResolver (a mandatory scoped
+        // dependency of FeatureServer/ImageServer/GeometryService/gRPC) requires
+        // ICrsDetectionService regardless of provider. Only Postgres ever registered one
+        // (CRS detection from WKT/.prj/GeoJSON needs its spatial_ref_sys catalog), so every
+        // FeatureServer query under DataSource:Provider=mysql failed DI activation outright
+        // before this fix (honua-server#2947).
+        services.AddScoped<ICrsDetectionService>(_ => new NoOpCrsDetectionService());
+        // Same gap, same fix shape: SpatialReferenceResolver also requires ICrsRegistry.
+        // WellKnownCrsRegistry covers CRS84/EPSG:4326/EPSG:3857 (the practical case for a
+        // provider with no spatial_ref_sys-equivalent catalog) and honestly reports
+        // "unsupported" for anything else.
+        services.AddScoped<ICrsRegistry>(_ => new WellKnownCrsRegistry());
+        // FeatureProviderQueryRouter (wired unconditionally in
+        // InfrastructureCompositionRoot, regardless of primary provider) requires
+        // ISecureConnectionRegistry to resolve any publication's storage-binding
+        // connection. MySql has no honua.data_connections-equivalent catalog of its
+        // own; a process-local in-memory registry keeps DI activation working and
+        // supports a secondary/additional provider (e.g. SQL Server) layered on top
+        // (honua-server#2947).
+        services.AddSingleton<ISecureConnectionRegistry, InMemorySecureConnectionRegistry>();
+        // Honua.Protocols.OData's ODataSearchService (wired unconditionally regardless of
+        // provider) requires IRelationshipStore; MySql/MariaDB documents relationship
+        // queries as unsupported (honua-server#2947).
+        services.AddScoped<IRelationshipStore>(_ => new ReadOnlyRelationshipStore("MySQL/MariaDB"));
+        // OGC API Features' shared geometry services (mandatory, wired unconditionally
+        // regardless of provider) require ICoordinateTransformService (honua-server#2947).
+        services.AddSingleton<ICoordinateTransformService>(_ => new WellKnownCoordinateTransformService());
         services.AddScoped<ITileProvider>(_ => new ReadOnlyTileProvider("MySQL/MariaDB"));
         services.AddScoped<IGmlFeatureStore>(_ => new ReadOnlyGmlFeatureStore("MySQL/MariaDB"));
 

--- a/tests/dotnet/Honua.Architecture.Tests/ArchitectureTestHelpers.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/ArchitectureTestHelpers.cs
@@ -65,7 +65,11 @@ internal static class ArchitectureTestHelpers
             "Honua.Server.Tests.dll",
             "Honua.Protocols.*.Tests.dll",
             "Honua.Ai.Tests.dll",
-            "Honua.Worker.Gdal.Tests.dll"
+            "Honua.Worker.Gdal.Tests.dll",
+            // honua-server#2947: provider-http-smoke suite. Named Honua.ProviderSmoke.Tests
+            // (not Honua.Protocols.*.Tests) since it spans multiple protocol families
+            // against multiple provider fixtures, so it needs its own explicit glob entry.
+            "Honua.ProviderSmoke.Tests.dll"
         };
 
         var assemblies = new List<Assembly>();

--- a/tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj
+++ b/tests/dotnet/Honua.Architecture.Tests/Honua.Architecture.Tests.csproj
@@ -35,6 +35,13 @@
     <ProjectReference Include="..\Honua.Protocols.Stac.Tests\Honua.Protocols.Stac.Tests.csproj" />
     <ProjectReference Include="..\Honua.Protocols.SensorThings.Tests\Honua.Protocols.SensorThings.Tests.csproj" />
     <ProjectReference Include="..\Honua.Worker.Gdal.Tests\Honua.Worker.Gdal.Tests.csproj" />
+    <!-- honua-server#2947: provider-http-smoke suite (FeatureServer/OGC API Features/
+         OData/Tiles smoke coverage against DuckDB/MySql/SQL Server). Named
+         Honua.ProviderSmoke.Tests rather than Honua.Protocols.*.Tests since it spans
+         multiple protocol families against multiple provider fixtures rather than one
+         protocol; see the matching explicit glob entry in
+         ArchitectureTestHelpers.IntegrationTestAssemblies. -->
+    <ProjectReference Include="..\Honua.ProviderSmoke.Tests\Honua.ProviderSmoke.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnet/Honua.Core.Tests/Features/Security/InMemorySecureConnectionRegistryTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Security/InMemorySecureConnectionRegistryTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Core.Features.Security;
+using Honua.Core.Features.Security.Domain;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Security;
+
+/// <summary>
+/// Unit tests for <see cref="InMemorySecureConnectionRegistry"/> (honua-server#2947 review
+/// finding): <c>FeatureProviderQueryRouter</c> resolves a storage binding's connection by
+/// passing the Metadata V2 connection id string into <c>GetConnectionAsync(string,
+/// CancellationToken)</c>. Those ids are not required to be GUIDs (test graphs and metadata
+/// commonly use names like <c>conn-1</c>), so this registry must fall back to a name lookup
+/// the same way <c>PostgresSecureConnectionRegistry.GetConnectionAsync(string,
+/// CancellationToken)</c> does, instead of returning null for any non-GUID id.
+/// </summary>
+public sealed class InMemorySecureConnectionRegistryTests
+{
+    [UnitTest]
+    public async Task GetConnectionAsync_StringOverloadWithCancellationToken_NonGuidId_FallsBackToNameLookup()
+    {
+        var registry = new InMemorySecureConnectionRegistry();
+        var connection = new DataConnection { Name = "conn-1", Provider = "mysql" };
+        await registry.CreateConnectionAsync(connection);
+
+        var resolved = await registry.GetConnectionAsync("conn-1", CancellationToken.None);
+
+        resolved.Should().NotBeNull();
+        resolved!.ConnectionId.Should().Be(connection.ConnectionId);
+    }
+
+    [UnitTest]
+    public async Task GetConnectionAsync_StringOverloadWithCancellationToken_GuidId_ResolvesById()
+    {
+        var registry = new InMemorySecureConnectionRegistry();
+        var connection = new DataConnection { Name = "sqlserver-primary", Provider = "sqlserver" };
+        await registry.CreateConnectionAsync(connection);
+
+        var resolved = await registry.GetConnectionAsync(
+            connection.ConnectionId.ToString(),
+            CancellationToken.None);
+
+        resolved.Should().NotBeNull();
+        resolved!.Name.Should().Be("sqlserver-primary");
+    }
+
+    [UnitTest]
+    public async Task GetConnectionAsync_StringOverloadWithCancellationToken_UnknownId_ReturnsNull()
+    {
+        var registry = new InMemorySecureConnectionRegistry();
+
+        var resolved = await registry.GetConnectionAsync("does-not-exist", CancellationToken.None);
+
+        resolved.Should().BeNull();
+    }
+}

--- a/tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj
+++ b/tests/dotnet/Honua.Oracle.Tests/Honua.Oracle.Tests.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NetTopologySuite" />
+    <PackageReference Include="Testcontainers.Oracle" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/dotnet/Honua.Oracle.Tests/OracleRealDatabaseIntegrationTests.cs
+++ b/tests/dotnet/Honua.Oracle.Tests/OracleRealDatabaseIntegrationTests.cs
@@ -151,7 +151,6 @@ public sealed class OracleRealDatabaseIntegrationTests : IAsyncLifetime
         var mapping = BuildMapping();
         var dataAccess = CreateDataAccess();
 
-        var query = OracleFeatureQueryBuilder.BuildSelectQuery(mapping, new FeatureQuery(), []);
         var countQuery = OracleFeatureQueryBuilder.BuildCountQuery(mapping, new FeatureQuery());
         var count = await dataAccess.ExecuteCountAsync(mapping, countQuery, dataConnection: null, CancellationToken.None);
 

--- a/tests/dotnet/Honua.Oracle.Tests/OracleRealDatabaseIntegrationTests.cs
+++ b/tests/dotnet/Honua.Oracle.Tests/OracleRealDatabaseIntegrationTests.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Catalog.Domain;
+using Honua.Core.Features.FeatureStore.Domain;
+using Honua.Core.Features.Security.Domain;
+using Honua.Oracle.Features.FeatureStore.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using Oracle.ManagedDataAccess.Client;
+using Testcontainers.Oracle;
+using Xunit;
+
+namespace Honua.Oracle.Tests;
+
+/// <summary>
+/// Real-database lane for the Oracle provider (honua-server#2947). Every other test in this
+/// project (<see cref="OracleFeatureQueryBuilderTests"/>, <see cref="OracleFeatureDataAccessWkbTests"/>,
+/// <see cref="OracleProviderResolutionTests"/>, <see cref="OracleSpatialGuardTests"/>,
+/// <see cref="OracleSpatialMetadataProbeSqlTests"/>) exercises the provider against
+/// <c>ThrowingConnectionFactory</c>/<c>RecordingConnectionFactory</c> fakes — none of it has
+/// ever executed against a real Oracle instance. This class does, via Testcontainers
+/// <c>gvenzl/oracle-free</c>, proving connection open, query build+execute, and WKB/geometry
+/// decode against a live <c>SDO_GEOMETRY</c> table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Gated by <c>HONUA_TEST_ORACLE=1</c> so the default <c>dotnet test</c> run (this project is
+/// unconditionally invoked, unfiltered, by the PR gate's "Additional fast unit-only projects"
+/// step in <c>ci.yml</c>) stays fast and does not spin up a Docker container: the fixture only
+/// starts the container when the env var is set, and every test method additionally carries a
+/// <see cref="RequiredOracleEnvironmentFactAttribute"/> so an absent prerequisite is an explicit
+/// skip in the run summary rather than a silent no-op or a hard failure. The dedicated
+/// <c>provider-http-smoke.yml</c> nightly/dispatch workflow sets the env var to actually run
+/// this lane.
+/// </para>
+/// <para>
+/// Oracle remains experimental (see docs/reference/configuration/data-sources/oracle.md) — this
+/// lane is promotion groundwork only, per #2947's acceptance criteria. It is NOT wired into the
+/// provider-http-smoke suite (<c>Honua.ProviderSmoke.Tests</c>), which only covers DuckDB/MySql/
+/// SQL Server.
+/// </para>
+/// </remarks>
+[Trait("Category", "Oracle")]
+public sealed class OracleRealDatabaseIntegrationTests : IAsyncLifetime
+{
+    private const string TestOracleEnvVar = "HONUA_TEST_ORACLE";
+    private const int LayerId = 1;
+    private const string TableName = "HONUA_SMOKE_PARCELS";
+
+    private OracleContainer? _container;
+    private string? _connectionString;
+
+    public async Task InitializeAsync()
+    {
+        if (!ShouldRun)
+        {
+            return;
+        }
+
+        _container = new OracleBuilder()
+            // NOT the "slim" variant: gvenzl/oracle-free's slim images strip out the
+            // Oracle Spatial component entirely (SDO_GEOMETRY is not a recognized datatype
+            // there — confirmed empirically while building this lane, "ORA-00902: invalid
+            // datatype" on CREATE TABLE), and this lane's whole point is proving the
+            // provider's SDO_GEOMETRY/WKB decode path against a real instance.
+            .WithImage("gvenzl/oracle-free:23-faststart")
+            .Build();
+        await _container.StartAsync().ConfigureAwait(false);
+        _connectionString = _container.GetConnectionString();
+
+        await using var connection = new OracleConnection(_connectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        await ExecuteAsync(connection, $"""
+            CREATE TABLE {TableName} (
+                objectid NUMBER(19) NOT NULL PRIMARY KEY,
+                shape SDO_GEOMETRY,
+                name VARCHAR2(64),
+                area NUMBER
+            )
+            """).ConfigureAwait(false);
+
+        for (var i = 1; i <= 5; i++)
+        {
+            var lon = -122.0 + (i * 0.01);
+            var lat = 37.0 + (i * 0.01);
+            await ExecuteAsync(connection, FormattableString.Invariant($"""
+                INSERT INTO {TableName} (objectid, shape, name, area)
+                VALUES ({i}, SDO_GEOMETRY(2001, 4326, SDO_POINT_TYPE({lon}, {lat}, NULL), NULL, NULL), 'Parcel {i}', {i * 100.5})
+                """)).ConfigureAwait(false);
+        }
+
+        await ExecuteAsync(connection, "COMMIT").ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static bool ShouldRun
+        => string.Equals(Environment.GetEnvironmentVariable(TestOracleEnvVar), "1", StringComparison.Ordinal);
+
+    [RequiredOracleEnvironmentFact]
+    public async Task Connection_OpensAgainstRealOracleFree()
+    {
+        await using var connection = new OracleConnection(_connectionString);
+        await connection.OpenAsync();
+
+        Assert.Equal(System.Data.ConnectionState.Open, connection.State);
+    }
+
+    [RequiredOracleEnvironmentFact]
+    public async Task QueryBuildAndExecute_AgainstRealTable_ReturnsSeededRows()
+    {
+        var mapping = BuildMapping();
+        var dataAccess = CreateDataAccess();
+
+        var query = OracleFeatureQueryBuilder.BuildSelectQuery(mapping, new FeatureQuery(), ["NAME", "AREA"]);
+        var features = await dataAccess.ExecuteSelectAsync(mapping, query, ["NAME", "AREA"], dataConnection: null, CancellationToken.None);
+
+        Assert.Equal(5, features.Length);
+        Assert.All(features, f => Assert.NotNull(f.Geometry));
+    }
+
+    [RequiredOracleEnvironmentFact]
+    public async Task QueryBuildAndExecute_WithWhereClause_ReturnsFilteredRow()
+    {
+        var mapping = BuildMapping();
+        var dataAccess = CreateDataAccess();
+
+        var query = OracleFeatureQueryBuilder.BuildSelectQuery(
+            mapping,
+            new FeatureQuery { Where = "name = 'Parcel 3'" },
+            ["NAME", "AREA"]);
+        var features = await dataAccess.ExecuteSelectAsync(mapping, query, ["NAME", "AREA"], dataConnection: null, CancellationToken.None);
+
+        var feature = Assert.Single(features);
+        Assert.Equal(3, feature.Id);
+    }
+
+    [RequiredOracleEnvironmentFact]
+    public async Task CountAsync_AgainstRealTable_ReturnsRowCount()
+    {
+        var mapping = BuildMapping();
+        var dataAccess = CreateDataAccess();
+
+        var query = OracleFeatureQueryBuilder.BuildSelectQuery(mapping, new FeatureQuery(), []);
+        var countQuery = OracleFeatureQueryBuilder.BuildCountQuery(mapping, new FeatureQuery());
+        var count = await dataAccess.ExecuteCountAsync(mapping, countQuery, dataConnection: null, CancellationToken.None);
+
+        Assert.Equal(5, count);
+    }
+
+    [RequiredOracleEnvironmentFact]
+    public async Task WkbDecode_AgainstRealSdoGeometry_RoundTripsCoordinates()
+    {
+        var mapping = BuildMapping();
+        var dataAccess = CreateDataAccess();
+
+        var query = OracleFeatureQueryBuilder.BuildSelectQuery(
+            mapping,
+            new FeatureQuery { Where = "name = 'Parcel 1'" },
+            ["NAME"]);
+        var features = await dataAccess.ExecuteSelectAsync(mapping, query, ["NAME"], dataConnection: null, CancellationToken.None);
+
+        var feature = Assert.Single(features);
+        Assert.NotNull(feature.Geometry);
+
+        var reader = new WKBReader();
+        var geometry = reader.Read(feature.Geometry);
+
+        Assert.IsType<Point>(geometry);
+        var point = (Point)geometry;
+        Assert.Equal(-121.99, point.X, precision: 2);
+        Assert.Equal(37.01, point.Y, precision: 2);
+    }
+
+    private static OracleLayerMapping BuildMapping()
+    {
+        var storage = new LayerStorageMapping(
+            TableName: TableName,
+            SchemaName: null,
+            CatalogName: null,
+            DatabaseName: null,
+            PrimaryKeyColumn: "OBJECTID",
+            GeometryColumn: "SHAPE",
+            StorageSrid: 4326);
+
+        return OracleLayerMapping.FromStorage(LayerId, storage);
+    }
+
+    private OracleFeatureDataAccess CreateDataAccess()
+    {
+        var connectionFactory = new RealOracleConnectionFactory(_connectionString!);
+        return new OracleFeatureDataAccess(
+            connectionFactory,
+            Options.Create(new OracleOptions()),
+            NullLogger<OracleFeatureDataAccess>.Instance);
+    }
+
+    private static async Task ExecuteAsync(OracleConnection connection, string sql)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Minimal real <see cref="IOracleConnectionFactory"/> that always opens the
+    /// Testcontainers connection string directly, bypassing secure-connection resolution
+    /// (out of scope for this provider-layer smoke lane).
+    /// </summary>
+    private sealed class RealOracleConnectionFactory(string connectionString) : IOracleConnectionFactory
+    {
+        public async Task<OracleConnection> OpenAsync(DataConnection? dataConnection, CancellationToken cancellationToken)
+        {
+            var connection = new OracleConnection(connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            return connection;
+        }
+    }
+}
+
+/// <summary>
+/// Skips the decorated fact unless <c>HONUA_TEST_ORACLE=1</c> is set. Local to this project
+/// (rather than reusing <c>Honua.TestKit.Attributes.RequiredEnvironmentFactAttribute</c>) so
+/// <c>Honua.Oracle.Tests</c> does not take on a new project reference for one attribute; the
+/// behavior mirrors it exactly — see honua-server#2947.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class RequiredOracleEnvironmentFactAttribute : FactAttribute
+{
+    public RequiredOracleEnvironmentFactAttribute()
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("HONUA_TEST_ORACLE"), "1", StringComparison.Ordinal))
+        {
+            Skip = "Set HONUA_TEST_ORACLE=1 (Docker required) to run the real-Oracle integration lane.";
+        }
+    }
+}

--- a/tests/dotnet/Honua.ProviderSmoke.Tests/DuckDbProviderSmokeTests.cs
+++ b/tests/dotnet/Honua.ProviderSmoke.Tests/DuckDbProviderSmokeTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.ProviderSmoke.Tests;
+
+/// <summary>
+/// Interface-level HTTP-stack smoke coverage for the DuckDB provider (honua-server#2947).
+/// Boots a real ASP.NET Core host with <c>DataSource:Provider=duckdb</c> against a
+/// standalone, file-backed DuckDB database. See <see cref="PrimaryProviderSmokeTestsBase"/>
+/// for the shared assertions.
+/// </summary>
+[Trait("Provider", "DuckDb")]
+public sealed class DuckDbProviderSmokeTests : PrimaryProviderSmokeTestsBase, IClassFixture<DuckDbProviderWebAppFixture>
+{
+    private readonly DuckDbProviderWebAppFixture _fixture;
+
+    public DuckDbProviderSmokeTests(DuckDbProviderWebAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    protected override HttpClient Client => _fixture.Client;
+
+    // Not in the shared base (see PrimaryProviderSmokeTestsBase's comment): MySQL fails
+    // this due to a real product bug (honua-server#2965), so each concrete subclass
+    // declares its own copy rather than the base sharing a same-named [Fact] xunit's
+    // analyzer would forbid hiding.
+    [IntegrationTest]
+    [Protocol(ProtocolNames.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServer_QueryWithBbox_ReturnsWindowedFeatures()
+    {
+        var (west, south, east, north) = ProviderSmokeData.NarrowBbox;
+        var response = await Client.GetAsync(
+            $"/rest/services/{ProviderSmokeGraph.ServiceName}/FeatureServer/{ProviderSmokeGraph.LayerId}/query" +
+            $"?where=1%3D1&geometry={west},{south},{east},{north}&geometryType=esriGeometryEnvelope" +
+            "&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=*&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var features = document.RootElement.GetProperty("features").EnumerateArray().ToArray();
+
+        features.Should().HaveCount(ProviderSmokeData.NarrowBboxCount);
+    }
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.OgcApiTiles)]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")]
+    public async Task Tiles_RasterTile_ReturnsNonEmptyPng()
+    {
+        // WorldCRS84Quad (native EPSG:4326, matching the seeded layer's storage SRID), not
+        // WebMercatorQuad (EPSG:3857): a WebMercatorQuad tile request would require the
+        // provider to reproject 4326 storage geometry into 3857 tile space. WorldCRS84Quad
+        // needs no reprojection. Zoom 0 / row 0 / col 0 covers the western hemisphere
+        // (-180..0 longitude), so the seeded parcels (~-122 longitude) always fall inside it.
+        var response = await Client.GetAsync(
+            $"/ogc/tiles/collections/{ProviderSmokeGraph.LayerId}/tiles/WorldCRS84Quad/0/0/0?f=png");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Length.Should().BeGreaterThan(0);
+    }
+}

--- a/tests/dotnet/Honua.ProviderSmoke.Tests/GlobalUsings.cs
+++ b/tests/dotnet/Honua.ProviderSmoke.Tests/GlobalUsings.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+global using System.Net;
+global using System.Net.Http.Json;
+global using FluentAssertions;
+global using Honua.TestKit.Attributes;
+global using Honua.TestKit.Providers;
+global using Xunit;
+global using Operations = Honua.TestKit.Constants.Operations;
+global using ProtocolNames = Honua.TestKit.Constants.ProtocolNames;

--- a/tests/dotnet/Honua.ProviderSmoke.Tests/Honua.ProviderSmoke.Tests.csproj
+++ b/tests/dotnet/Honua.ProviderSmoke.Tests/Honua.ProviderSmoke.Tests.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!--
+      honua-server#2947: secondary-provider HTTP-stack GA proof. Deliberately its own
+      project (not folded into Honua.Server.Tests or a per-protocol *.Tests project):
+      it spans multiple protocol families (GeoServices FeatureServer, OGC API Features,
+      OData, Tiles) against multiple provider-parameterized web-app fixtures (DuckDB in-
+      process, MySql + SQL Server via Testcontainers), and is intentionally NOT part of
+      the default PR gate — it is wired into .github/workflows/provider-http-smoke.yml
+      (nightly + workflow_dispatch) instead, per that ticket's cadence requirement.
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="DuckDB.NET.Data.Full" />
+    <PackageReference Include="MySqlConnector" />
+    <PackageReference Include="Testcontainers.MsSql" />
+    <PackageReference Include="Testcontainers.MySql" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Honua.Core\Honua.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\Honua.Server\Honua.Server.csproj" />
+    <ProjectReference Include="..\..\..\src\Honua.Postgres\Honua.Postgres.csproj" />
+    <ProjectReference Include="..\Honua.TestKit\Honua.TestKit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/dotnet/Honua.ProviderSmoke.Tests/MySqlProviderSmokeTests.cs
+++ b/tests/dotnet/Honua.ProviderSmoke.Tests/MySqlProviderSmokeTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+namespace Honua.ProviderSmoke.Tests;
+
+/// <summary>
+/// Interface-level HTTP-stack smoke coverage for the MySql/MariaDB provider
+/// (honua-server#2947). Boots a real ASP.NET Core host with
+/// <c>DataSource:Provider=mysql</c> against a Testcontainers <c>mysql:8</c> instance. See
+/// <see cref="PrimaryProviderSmokeTestsBase"/> for the shared assertions.
+/// </summary>
+/// <remarks>
+/// Declares its own (skipped) bbox test rather than inheriting one from the shared base:
+/// real MySQL execution found a real product bug —
+/// <c>GeoServicesGeometryConverter</c> emits EWKB (SRID-embedded WKB) for any positive
+/// SRID, but MySQL's <c>ST_GeomFromWKB</c> expects plain WKB with the SRID passed as a
+/// separate argument, so every bbox/envelope spatial-filter query 500s against MySQL.
+/// Filed as honua-server#2965; this test stays present (skipped, not deleted) so it is
+/// visible in every run summary and starts failing loudly the moment that issue is fixed.
+/// </remarks>
+[Trait("Provider", "MySql")]
+public sealed class MySqlProviderSmokeTests : PrimaryProviderSmokeTestsBase, IClassFixture<MySqlProviderWebAppFixture>
+{
+    private const string BboxEwkbGapReason =
+        "Real product bug found via this suite: GeoServicesGeometryConverter emits EWKB " +
+        "(SRID-embedded WKB) for any positive SRID, but MySQL's ST_GeomFromWKB expects " +
+        "plain WKB with the SRID as a separate argument, so bbox/envelope spatial-filter " +
+        "queries 500 against MySQL. Tracked in honua-server#2965.";
+
+    private const string TileEwkbGapReason =
+        "Same real bug family as the bbox skip (honua-server#2965): the identical " +
+        "WorldCRS84Quad z=0/x=0/y=0 tile request that renders real content for DuckDB " +
+        "returns an empty (204) tile for MySQL, consistent with the tile renderer's " +
+        "envelope-intersects spatial query silently matching zero rows rather than the " +
+        "500 the explicit FeatureServer bbox path raises.";
+
+    private readonly MySqlProviderWebAppFixture _fixture;
+
+    public MySqlProviderSmokeTests(MySqlProviderWebAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    protected override HttpClient Client => _fixture.Client;
+
+    [Fact(Skip = BboxEwkbGapReason)]
+    [Trait("Category", "Integration")]
+    [Protocol(ProtocolNames.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public Task FeatureServer_QueryWithBbox_NotSupportedForMySql_SeeIssue2965() => Task.CompletedTask;
+
+    [Fact(Skip = TileEwkbGapReason)]
+    [Trait("Category", "Integration")]
+    [Protocol(ProtocolNames.OgcApiTiles)]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")]
+    public Task Tiles_RasterTile_NotSupportedForMySql_SeeIssue2965() => Task.CompletedTask;
+}

--- a/tests/dotnet/Honua.ProviderSmoke.Tests/PrimaryProviderSmokeTestsBase.cs
+++ b/tests/dotnet/Honua.ProviderSmoke.Tests/PrimaryProviderSmokeTestsBase.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.ProviderSmoke.Tests;
+
+/// <summary>
+/// Shared interface-level smoke assertions run against every primary-provider
+/// (DuckDB/MySql) web-app fixture (honua-server#2947). Both providers are primary
+/// <c>DataSource:Provider</c> replacements, so the seeded "parcels" layer
+/// (<see cref="ProviderSmokeGraph.LayerId"/>, see <see cref="ProviderSmokeData"/>) is
+/// reachable through every read/query GA
+/// surface it documents support for: GeoServices FeatureServer, OGC API Features,
+/// OData, and tiles (TileJSON + a raster PNG tile; vector MVT is out of scope —
+/// both providers' <c>FeatureProviderCapabilities.SupportsNativeMvt</c> is
+/// <see langword="false"/> by design, see docs/reference/configuration/data-sources).
+/// </summary>
+/// <remarks>
+/// xunit runs <c>[Fact]</c>-attributed methods declared on a base class once per
+/// concrete subclass, so this base class's test bodies execute independently
+/// against the DuckDB fixture (<see cref="DuckDbProviderSmokeTests"/>) and the
+/// MySql fixture (<see cref="MySqlProviderSmokeTests"/>) — real, separate test
+/// results per provider, not a single shared run.
+/// </remarks>
+public abstract class PrimaryProviderSmokeTestsBase
+{
+    /// <summary>HTTP client bound to the concrete subclass's provider-backed host.</summary>
+    protected abstract HttpClient Client { get; }
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServer_QueryWithWhereClause_ReturnsFilteredFeatures()
+    {
+        var response = await Client.GetAsync(
+            $"/rest/services/{ProviderSmokeGraph.ServiceName}/FeatureServer/{ProviderSmokeGraph.LayerId}/query" +
+            $"?where={Uri.EscapeDataString("type='commercial'")}&outFields=*&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var features = document.RootElement.GetProperty("features").EnumerateArray().ToArray();
+
+        features.Should().HaveCount(ProviderSmokeData.CommercialCount);
+        foreach (var feature in features)
+        {
+            feature.GetProperty("attributes").GetProperty("type").GetString().Should().Be("commercial");
+        }
+    }
+
+    // FeatureServer_QueryWithBbox_ReturnsWindowedFeatures is NOT shared here: MySQL fails it
+    // due to a real product bug (honua-server#2965 — GeoServicesGeometryConverter emits
+    // EWKB, MySQL's ST_GeomFromWKB expects plain WKB), so each concrete subclass declares
+    // its own copy (DuckDbProviderSmokeTests runs it for real; MySqlProviderSmokeTests
+    // documents the skip). xunit's analyzer (xUnit1024) forbids a derived class from
+    // hiding a same-named base class [Fact], so this cannot live here as a single
+    // overridable method.
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.OgcApiFeatures)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeatures_Items_ReturnsAllSeededFeatures()
+    {
+        var response = await Client.GetAsync($"/ogc/features/collections/{ProviderSmokeGraph.LayerId}/items");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        document.RootElement.GetProperty("features").GetArrayLength().Should().Be(ProviderSmokeData.Parcels.Count);
+    }
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.OgcApiFeatures)]
+    [Operation(Operations.CqlFilter)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeatures_ItemsWithCql2Filter_ReturnsFilteredFeatures()
+    {
+        var filter = "type = 'commercial'";
+        var response = await Client.GetAsync(
+            $"/ogc/features/collections/{ProviderSmokeGraph.LayerId}/items?filter={Uri.EscapeDataString(filter)}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var features = document.RootElement.GetProperty("features").EnumerateArray().ToArray();
+
+        features.Should().HaveCount(ProviderSmokeData.CommercialCount);
+        foreach (var feature in features)
+        {
+            feature.GetProperty("properties").GetProperty("type").GetString().Should().Be("commercial");
+        }
+    }
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.ODataV4)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /odata/Features({layerId})")]
+    public async Task OData_Features_ReturnsAllSeededFeatures()
+    {
+        var response = await Client.GetAsync($"/odata/Features({ProviderSmokeGraph.LayerId})");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("value").GetArrayLength().Should().Be(ProviderSmokeData.Parcels.Count);
+    }
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.ODataV4)]
+    [Operation(Operations.ODataFilter)]
+    [Endpoint("GET /odata/Features({layerId})?$filter=name eq 'value'")]
+    public async Task OData_FeaturesWithFilter_ReturnsFilteredFeatures()
+    {
+        var filter = "type eq 'commercial'";
+        var response = await Client.GetAsync(
+            $"/odata/Features({ProviderSmokeGraph.LayerId})?$filter={Uri.EscapeDataString(filter)}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var features = document.RootElement.GetProperty("value").EnumerateArray().ToArray();
+
+        features.Should().HaveCount(ProviderSmokeData.CommercialCount);
+        foreach (var feature in features)
+        {
+            var attrs = Honua.TestKit.Helpers.ODataTestHelpers.ParseAttributes(feature);
+            attrs.GetProperty("type").GetString().Should().Be("commercial");
+        }
+    }
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.OgcApiTiles)]
+    [Operation(Operations.GetTileMetadata)]
+    [Endpoint("GET /tiles/{layerId}/tile.json")]
+    public async Task Tiles_TileJson_ReturnsMetadata()
+    {
+        var response = await Client.GetAsync($"/tiles/{ProviderSmokeGraph.LayerId}/tile.json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+    }
+
+    // Tiles_RasterTile_ReturnsNonEmptyPng is NOT shared here for the same reason as the
+    // bbox test above: MySQL returns an empty (204) tile for the same request that renders
+    // real content for DuckDB, tracked under the same real-bug umbrella (honua-server#2965).
+    // Each concrete subclass declares its own copy.
+}

--- a/tests/dotnet/Honua.ProviderSmoke.Tests/SqlServerProviderSmokeTests.cs
+++ b/tests/dotnet/Honua.ProviderSmoke.Tests/SqlServerProviderSmokeTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.ProviderSmoke.Tests;
+
+/// <summary>
+/// Interface-level HTTP-stack smoke coverage for the SQL Server secondary/additional
+/// provider (honua-server#2947). Boots a Postgres-primary <see cref="Honua.TestKit.WebAppFixture"/>
+/// with a Testcontainers <c>mcr.microsoft.com/mssql/server:2022-latest</c> instance
+/// registered as a secure connection routed through <c>FeatureProviderQueryRouter</c>,
+/// replacing the creds-gated <c>HONUA_SQLSERVER_TEST_CONNECTION</c> approach for this suite
+/// (the existing creds-gated tests in <c>Honua.SqlServer.Tests</c> are untouched).
+/// </summary>
+/// <remarks>
+/// Only <see cref="FeatureServer_QueryWithWhereClause_ReturnsFilteredFeatures"/> and
+/// <see cref="OgcFeatures_Items_ReturnsAllSeededFeatures"/> exercise real, working
+/// end-to-end coverage. Every other case is present but skipped, each with a reason
+/// pointing at a specific finding rather than silently omitting the coverage:
+/// <list type="bullet">
+///   <item>bbox/envelope (FeatureServer <c>geometry=</c>) — real product bug,
+///   honua-server#2965 (shared EWKB/plain-WKB mismatch, also reproduces on MySQL).</item>
+///   <item>CQL2 <c>filter=</c> (OGC API Features) — pre-existing, already-documented
+///   limitation (sql-server.md), not a new finding.</item>
+///   <item>OData / OGC API Tiles — real product gap, honua-server#2962 (both resolve
+///   <c>IFeatureReader</c>/<c>ITileProvider</c> directly via DI instead of through
+///   <c>FeatureProviderQueryRouter</c>, so a SQL-Server-backed layer is unreachable).</item>
+/// </list>
+/// </remarks>
+[Trait("Provider", "SqlServer")]
+public sealed class SqlServerProviderSmokeTests : IClassFixture<SqlServerProviderWebAppFixture>
+{
+    private const string SecondaryProviderRoutingGapReason =
+        "SQL Server is a secondary/additional provider; OData and OGC API Tiles resolve " +
+        "IFeatureReader/ITileProvider directly via DI (always the primary provider) instead " +
+        "of through FeatureProviderQueryRouter, so a SQL-Server-backed layer is unreachable " +
+        "through these two protocols. Real product gap, tracked in honua-server#2962.";
+
+    private const string Cql2FilterUnsupportedReason =
+        "Pre-existing, already-documented limitation (sql-server.md's WHERE Clause section): " +
+        "the shared ISqlFilterTranslator pipeline only registers a PostgreSQL translator, so " +
+        "CQL2/OGC API Features filter=... throws NotSupportedException for SQL Server. " +
+        "FeatureServer's where= (canonical Where text) path works and is covered by " +
+        "FeatureServer_QueryWithWhereClause_ReturnsFilteredFeatures.";
+
+    private const string BboxEwkbGapReason =
+        "Real product bug found via this suite: GeoServicesGeometryConverter emits EWKB " +
+        "(SRID-embedded WKB); SQL Server's geometry::STGeomFromWKB(wkb, srid) expects plain " +
+        "WKB with the SRID as a separate argument, so the embedded SRID header corrupts ring/" +
+        "point-count parsing (\"Polygon input... exterior ring does not have enough points\"). " +
+        "Same root cause as the MySQL bbox skip; tracked in honua-server#2965.";
+
+    private readonly SqlServerProviderWebAppFixture _fixture;
+
+    public SqlServerProviderSmokeTests(SqlServerProviderWebAppFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private HttpClient Client => _fixture.Client;
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public async Task FeatureServer_QueryWithWhereClause_ReturnsFilteredFeatures()
+    {
+        var response = await Client.GetAsync(
+            $"/rest/services/{ProviderSmokeGraph.ServiceName}/FeatureServer/{ProviderSmokeGraph.LayerId}/query" +
+            $"?where={Uri.EscapeDataString("type='commercial'")}&outFields=*&f=json");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var features = document.RootElement.GetProperty("features").EnumerateArray().ToArray();
+
+        features.Should().HaveCount(ProviderSmokeData.CommercialCount);
+        foreach (var feature in features)
+        {
+            feature.GetProperty("attributes").GetProperty("type").GetString().Should().Be("commercial");
+        }
+    }
+
+    [Fact(Skip = BboxEwkbGapReason)]
+    [Trait("Category", "Integration")]
+    [Protocol(ProtocolNames.FeatureServer)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /rest/services/{id}/FeatureServer/{layerId}/query")]
+    public Task FeatureServer_QueryWithBbox_NotSupportedForSqlServer_SeeIssue2965() => Task.CompletedTask;
+
+    [IntegrationTest]
+    [Protocol(ProtocolNames.OgcApiFeatures)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public async Task OgcFeatures_Items_ReturnsAllSeededFeatures()
+    {
+        var response = await Client.GetAsync($"/ogc/features/collections/{ProviderSmokeGraph.LayerId}/items");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        document.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        document.RootElement.GetProperty("features").GetArrayLength().Should().Be(ProviderSmokeData.Parcels.Count);
+    }
+
+    [Fact(Skip = Cql2FilterUnsupportedReason)]
+    [Trait("Category", "Integration")]
+    [Protocol(ProtocolNames.OgcApiFeatures)]
+    [Operation(Operations.CqlFilter)]
+    [Endpoint("GET /ogc/features/collections/{collectionId}/items")]
+    public Task OgcFeatures_ItemsWithCql2Filter_NotSupportedForSqlServer() => Task.CompletedTask;
+
+    [Fact(Skip = SecondaryProviderRoutingGapReason)]
+    [Trait("Category", "Integration")]
+    [Protocol(ProtocolNames.ODataV4)]
+    [Operation(Operations.Query)]
+    [Endpoint("GET /odata/Features({layerId})")]
+    public Task OData_Features_NotReachableForSecondaryProvider_SeeIssue2962()
+        => Task.CompletedTask;
+
+    [Fact(Skip = SecondaryProviderRoutingGapReason)]
+    [Trait("Category", "Integration")]
+    [Protocol(ProtocolNames.OgcApiTiles)]
+    [Operation(Operations.GetTile)]
+    [Endpoint("GET /ogc/tiles/collections/{collectionId}/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}")]
+    public Task Tiles_NotReachableForSecondaryProvider_SeeIssue2962()
+        => Task.CompletedTask;
+}

--- a/tests/dotnet/Honua.ProviderSmoke.Tests/xunit.runner.json
+++ b/tests/dotnet/Honua.ProviderSmoke.Tests/xunit.runner.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": true,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": -1,
+  "methodDisplay": "method",
+  "methodDisplayOptions": "all",
+  "diagnosticMessages": false,
+  "internalDiagnosticMessages": false,
+  "preEnumerateTheories": true,
+  "shadowCopy": false,
+  "stopOnFail": false,
+  "longRunningTestSeconds": 120
+}

--- a/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
+++ b/tests/dotnet/Honua.TestKit/Honua.TestKit.csproj
@@ -15,6 +15,12 @@
     <!-- DbUp: TestKit serializes the embedded migration set under the shared seed advisory lock
          (RunEmbeddedMigrationsUnderLockAsync) so global-honua DDL stays off the 40P01 path (#1568). -->
     <PackageReference Include="dbup-postgresql" />
+    <!-- #2947: raw ADO.NET drivers used only to seed the standalone DuckDB/MySql/SqlServer
+         provider-smoke web-app fixtures below (Providers/). No Honua.DuckDB/Honua.MySql/
+         Honua.SqlServer ProjectReference is needed — the fixtures configure the provider
+         purely through DataSource:Provider + the provider's own config section, which
+         Honua.Server's own composition root (already referenced) reads at host-build time. -->
+    <PackageReference Include="DuckDB.NET.Data.Full" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="FluentAssertions.Json" />
     <PackageReference Include="FsCheck.Xunit" />
@@ -22,8 +28,10 @@
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Net.Client.Web" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
     <!-- Direct pin of NBomber's transitive MessagePack to a patched version (GHSA-hv8m-jj95-wg3x). -->
     <PackageReference Include="MessagePack" />
+    <PackageReference Include="MySqlConnector" />
     <PackageReference Include="NBomber" />
     <PackageReference Include="Parquet.Net" />
     <PackageReference Include="Snappier" />
@@ -32,6 +40,8 @@
     <PackageReference Include="NBomber.Http" />
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Testcontainers.MsSql" />
+    <PackageReference Include="Testcontainers.MySql" />
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="Testcontainers.Redis" />
 

--- a/tests/dotnet/Honua.TestKit/Providers/DuckDbProviderWebAppFixture.cs
+++ b/tests/dotnet/Honua.TestKit/Providers/DuckDbProviderWebAppFixture.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using DuckDB.NET.Data;
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace Honua.TestKit.Providers;
+
+/// <summary>
+/// Web-app fixture that boots a real <see cref="WebApplicationFactory{TEntryPoint}"/> host
+/// with <c>DataSource:Provider=duckdb</c> against a standalone, file-backed DuckDB database
+/// seeded with <see cref="ProviderSmokeData"/> (honua-server#2947). DuckDB is embedded — no
+/// Testcontainer is needed; the fixture creates a temp <c>.duckdb</c> file, installs/loads
+/// the <c>spatial</c> extension, and seeds it directly via <see cref="DuckDBConnection"/>
+/// before the host opens the same file read-only (matching the documented production
+/// default, <c>DuckDB:ReadOnly=true</c>).
+/// </summary>
+/// <remarks>
+/// DuckDB is a primary-provider replacement (mutually exclusive with Postgres at
+/// <c>InfrastructureCompositionRoot</c>'s <c>DataSource:Provider</c> switch), so this
+/// fixture builds its own <see cref="WebApplicationFactory{TEntryPoint}"/> from scratch
+/// rather than reusing <see cref="WebAppFixture"/>, which is hard-wired to Postgres. Layer
+/// mapping (table/column names) is static, config-time (<c>DuckDB:Layers:0:*</c>), so the
+/// Metadata v2 graph built by <see cref="ProviderSmokeGraph"/> is used only for protocol
+/// discovery/schema surfaces (OGC API Features collection, OData $metadata, FeatureServer
+/// layer metadata) — both must agree on the layer id (ProviderSmokeGraph.LayerId) / table "parcels".
+/// </remarks>
+public sealed class DuckDbProviderWebAppFixture : IAsyncLifetime
+{
+    private string _dbPath = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    /// <summary>HTTP client bound to the fixture's DuckDB-backed host.</summary>
+    public HttpClient Client { get; private set; } = null!;
+
+    /// <summary>The in-memory Metadata v2 graph provider installed into the test host.</summary>
+    public TestMetadataV2GraphProvider GraphProvider { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"honua_provider_smoke_{Guid.NewGuid():N}.duckdb");
+        await SeedAsync(_dbPath).ConfigureAwait(false);
+
+        var graph = ProviderSmokeGraph.Build(locator: "parcels");
+
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.UseSetting("HONUA_DEV_AUTH", "true");
+            builder.UseSetting("HONUA_DEV_AUTH_ALLOW_BYPASS", "true");
+            builder.UseSetting("HONUA_SKIP_MIGRATIONS", "true");
+
+            ProviderSmokeHostConfiguration.ApplySettings(builder, new Dictionary<string, string?>
+            {
+                ["DataSource:Provider"] = "duckdb",
+                ["DuckDB:DatabasePath"] = _dbPath,
+                ["DuckDB:ReadOnly"] = "true",
+                ["DuckDB:Layers:0:Id"] = "1",
+                ["DuckDB:Layers:0:Table"] = "parcels",
+                ["DuckDB:Layers:0:GeometryColumn"] = "geom",
+                ["DuckDB:Layers:0:ObjectIdColumn"] = "objectid",
+                ["DuckDB:Layers:0:Srid"] = "4326",
+                ["DuckDB:Layers:0:GeometryType"] = "Point",
+                ["DuckDB:Layers:0:Attributes:0"] = "name",
+                ["DuckDB:Layers:0:Attributes:1"] = "area",
+                ["DuckDB:Layers:0:Attributes:2"] = "type",
+                ["DuckDB:Services:0:Name"] = ProviderSmokeGraph.ServiceName,
+                ["DuckDB:Services:0:LayerIds:0"] = "1",
+            });
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IMetadataV2GraphProvider>();
+                services.RemoveAll<IMetadataV2GraphStore>();
+                GraphProvider = new TestMetadataV2GraphProvider(graph);
+                services.AddSingleton(GraphProvider);
+                services.AddSingleton<IMetadataV2GraphProvider>(sp => sp.GetRequiredService<TestMetadataV2GraphProvider>());
+                services.AddSingleton<IMetadataV2GraphStore>(sp => sp.GetRequiredService<TestMetadataV2GraphProvider>());
+            });
+        });
+
+        Client = _factory.CreateClient();
+        Client.Timeout = TimeSpan.FromMinutes(2);
+    }
+
+    public async Task DisposeAsync()
+    {
+        Client?.Dispose();
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (!string.IsNullOrEmpty(_dbPath) && File.Exists(_dbPath))
+        {
+            try
+            {
+                File.Delete(_dbPath);
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup; a lingering file handle on Windows/CI runners
+                // should not fail the test run.
+            }
+        }
+    }
+
+    private static async Task SeedAsync(string dbPath)
+    {
+        var connectionString = $"Data Source={dbPath}";
+        await using var connection = new DuckDBConnection(connectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        await ExecuteAsync(connection, "INSTALL spatial; LOAD spatial;").ConfigureAwait(false);
+        await ExecuteAsync(connection, """
+            CREATE TABLE parcels (
+                objectid BIGINT PRIMARY KEY,
+                geom GEOMETRY,
+                name VARCHAR,
+                area DOUBLE,
+                type VARCHAR
+            )
+            """).ConfigureAwait(false);
+
+        foreach (var parcel in ProviderSmokeData.Parcels)
+        {
+            await ExecuteAsync(connection, FormattableString.Invariant(
+                $"INSERT INTO parcels VALUES ({parcel.Id}, ST_Point({parcel.Longitude}, {parcel.Latitude}), '{parcel.Name}', {parcel.Area}, '{parcel.Type}')"))
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ExecuteAsync(DuckDBConnection connection, string sql)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Providers/MySqlProviderWebAppFixture.cs
+++ b/tests/dotnet/Honua.TestKit/Providers/MySqlProviderWebAppFixture.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.TestKit.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MySqlConnector;
+using Testcontainers.MySql;
+using Xunit;
+
+namespace Honua.TestKit.Providers;
+
+/// <summary>
+/// Web-app fixture that boots a real <see cref="WebApplicationFactory{TEntryPoint}"/> host
+/// with <c>DataSource:Provider=mysql</c> against a Testcontainers <c>mysql:8</c> instance
+/// seeded with <see cref="ProviderSmokeData"/> (honua-server#2947).
+/// </summary>
+/// <remarks>
+/// MySql is a primary-provider replacement (mutually exclusive with Postgres at
+/// <c>InfrastructureCompositionRoot</c>'s <c>DataSource:Provider</c> switch), so this
+/// fixture builds its own <see cref="WebApplicationFactory{TEntryPoint}"/> from scratch
+/// rather than reusing <see cref="WebAppFixture"/>, which is hard-wired to Postgres. Layer
+/// mapping (table/column names) is static, config-time (<c>MySql:Layers:0:*</c>), so the
+/// Metadata v2 graph built by <see cref="ProviderSmokeGraph"/> is used only for protocol
+/// discovery/schema surfaces (OGC API Features collection, OData $metadata, FeatureServer
+/// layer metadata) — both must agree on the layer id (ProviderSmokeGraph.LayerId) / table "parcels".
+/// </remarks>
+public sealed class MySqlProviderWebAppFixture : IAsyncLifetime
+{
+    private MySqlContainer _container = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    /// <summary>HTTP client bound to the fixture's MySql-backed host.</summary>
+    public HttpClient Client { get; private set; } = null!;
+
+    /// <summary>The in-memory Metadata v2 graph provider installed into the test host.</summary>
+    public TestMetadataV2GraphProvider GraphProvider { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        _container = new MySqlBuilder()
+            .WithImage("mysql:8.0.36")
+            .WithDatabase("honua_smoke")
+            .WithUsername("honua")
+            .WithPassword("honua-smoke-test")
+            .Build();
+        await _container.StartAsync().ConfigureAwait(false);
+
+        await SeedAsync(_container.GetConnectionString()).ConfigureAwait(false);
+
+        var graph = ProviderSmokeGraph.Build(locator: "parcels");
+
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.UseSetting("HONUA_DEV_AUTH", "true");
+            builder.UseSetting("HONUA_DEV_AUTH_ALLOW_BYPASS", "true");
+            builder.UseSetting("HONUA_SKIP_MIGRATIONS", "true");
+
+            ProviderSmokeHostConfiguration.ApplySettings(builder, new Dictionary<string, string?>
+            {
+                ["DataSource:Provider"] = "mysql",
+                ["MySql:ConnectionString"] = _container.GetConnectionString(),
+                ["MySql:EngineFlavor"] = "Mysql",
+                ["MySql:Layers:0:Id"] = "1",
+                ["MySql:Layers:0:Name"] = "parcels",
+                ["MySql:Layers:0:Table"] = "parcels",
+                ["MySql:Layers:0:GeometryColumn"] = "geom",
+                ["MySql:Layers:0:PrimaryKeyColumn"] = "objectid",
+                ["MySql:Layers:0:Srid"] = "4326",
+                ["MySql:Layers:0:GeometryType"] = "Point",
+                ["MySql:Layers:0:Attributes:0"] = "name",
+                ["MySql:Layers:0:Attributes:1"] = "area",
+                ["MySql:Layers:0:Attributes:2"] = "type",
+                ["MySql:Services:0:Name"] = ProviderSmokeGraph.ServiceName,
+                ["MySql:Services:0:LayerIds:0"] = "1",
+            });
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IMetadataV2GraphProvider>();
+                services.RemoveAll<IMetadataV2GraphStore>();
+                GraphProvider = new TestMetadataV2GraphProvider(graph);
+                services.AddSingleton(GraphProvider);
+                services.AddSingleton<IMetadataV2GraphProvider>(sp => sp.GetRequiredService<TestMetadataV2GraphProvider>());
+                services.AddSingleton<IMetadataV2GraphStore>(sp => sp.GetRequiredService<TestMetadataV2GraphProvider>());
+            });
+        });
+
+        Client = _factory.CreateClient();
+        Client.Timeout = TimeSpan.FromMinutes(2);
+    }
+
+    public async Task DisposeAsync()
+    {
+        Client?.Dispose();
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async Task SeedAsync(string connectionString)
+    {
+        await using var dataSource = new MySqlDataSourceBuilder(connectionString).Build();
+
+        await using (var connection = await dataSource.OpenConnectionAsync().ConfigureAwait(false))
+        await using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                CREATE TABLE parcels (
+                    objectid BIGINT PRIMARY KEY,
+                    geom POINT NOT NULL SRID 4326,
+                    name VARCHAR(64),
+                    area DOUBLE,
+                    type VARCHAR(32),
+                    SPATIAL INDEX(geom)
+                ) ENGINE=InnoDB
+                """;
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        foreach (var parcel in ProviderSmokeData.Parcels)
+        {
+            await using var connection = await dataSource.OpenConnectionAsync().ConfigureAwait(false);
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO parcels (objectid, geom, name, area, type)
+                VALUES (@id, ST_SRID(POINT(@lon, @lat), 4326), @name, @area, @type)
+                """;
+            command.Parameters.AddWithValue("@id", parcel.Id);
+            command.Parameters.AddWithValue("@lon", parcel.Longitude);
+            command.Parameters.AddWithValue("@lat", parcel.Latitude);
+            command.Parameters.AddWithValue("@name", parcel.Name);
+            command.Parameters.AddWithValue("@area", parcel.Area);
+            command.Parameters.AddWithValue("@type", parcel.Type);
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Providers/ProviderSmokeData.cs
+++ b/tests/dotnet/Honua.TestKit/Providers/ProviderSmokeData.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.TestKit.Providers;
+
+/// <summary>
+/// The single "parcels" dataset seeded identically (same ids, coordinates, attributes)
+/// by every provider-http-smoke fixture (DuckDB/MySql/SqlServer). Keeping the seed data
+/// in one place lets the shared smoke test assertions (row counts, filter results,
+/// bbox windows, extents) be byte-identical across providers.
+/// </summary>
+public static class ProviderSmokeData
+{
+    /// <summary>One seeded parcel row.</summary>
+    public sealed record Parcel(long Id, double Longitude, double Latitude, string Name, double Area, string Type);
+
+    /// <summary>The 5 seeded rows, ids 1..5.</summary>
+    public static IReadOnlyList<Parcel> Parcels { get; } = BuildParcels();
+
+    /// <summary>Count of parcels whose <see cref="Parcel.Type"/> is <c>"commercial"</c> (odd ids).</summary>
+    public const int CommercialCount = 3;
+
+    /// <summary>Count of parcels whose <see cref="Parcel.Type"/> is <c>"residential"</c> (even ids).</summary>
+    public const int ResidentialCount = 2;
+
+    public const double MinLongitude = -122.40;
+    public const double MinLatitude = 37.77;
+    public const double MaxLongitude = -122.30;
+    public const double MaxLatitude = 37.87;
+
+    /// <summary>
+    /// A bounding box (WGS84) that covers only parcels 1 (-122.39, 37.78) and 2
+    /// (-122.38, 37.79), used to prove bbox windowing narrows the result set instead of
+    /// returning every row. Parcel 3 (-122.37, 37.80) sits just outside the east/north
+    /// edge.
+    /// </summary>
+    public static (double West, double South, double East, double North) NarrowBbox
+        => (-122.395, 37.775, -122.375, 37.795);
+
+    /// <summary>Number of parcels expected inside <see cref="NarrowBbox"/>.</summary>
+    public const int NarrowBboxCount = 2;
+
+    private static List<Parcel> BuildParcels()
+    {
+        var parcels = new List<Parcel>(5);
+        for (var i = 1; i <= 5; i++)
+        {
+            var lon = -122.40 + (i * 0.01);
+            var lat = 37.77 + (i * 0.01);
+            var area = i * 100.5;
+            var type = i % 2 == 0 ? "residential" : "commercial";
+            parcels.Add(new Parcel(i, lon, lat, string.Format(CultureInfo.InvariantCulture, "Parcel {0}", i), area, type));
+        }
+
+        return parcels;
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Providers/ProviderSmokeGraph.cs
+++ b/tests/dotnet/Honua.TestKit/Providers/ProviderSmokeGraph.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using Honua.Core.Features.Metadata.Domain.V2;
+using Honua.Core.Features.Security.Domain;
+using MetadataV2ServiceProtocols = Honua.Core.Features.Metadata.Domain.V2.ServiceProtocols;
+
+namespace Honua.TestKit.Providers;
+
+/// <summary>
+/// Builds the shared Metadata v2 graph used by the provider-http-smoke fixtures
+/// (<see cref="DuckDbProviderWebAppFixture"/>, <see cref="MySqlProviderWebAppFixture"/>,
+/// <see cref="SqlServerProviderWebAppFixture"/>). Every fixture seeds the exact same
+/// 5-row "parcels" dataset (see <see cref="ProviderSmokeData"/>) so the smoke test
+/// assertions (row counts, filter results, extents) are identical across providers —
+/// only the physical storage and Metadata v2 storage-binding connection differ.
+/// </summary>
+/// <remarks>
+/// One resource is published three times, once per protocol family, mirroring the
+/// convention <c>WebAppFixtureMetadataV2Mixin.BuildDefaultTestGraph</c> uses for the
+/// Postgres-backed default test graph: a dedicated <see cref="MetadataV2Service"/> per
+/// protocol (GeoServices FeatureServer, OGC API Features, OData) each with a single
+/// publication of the protocol-appropriate <see cref="MetadataV2PublicationType"/>. OGC
+/// API Tiles is layered onto the OGC API Features service since it addresses the same
+/// collection resource (<c>/ogc/tiles/collections/{collectionId}/tiles/...</c>).
+/// </remarks>
+public static class ProviderSmokeGraph
+{
+    /// <summary>
+    /// Layer id / OGC API Features collection id used by every smoke fixture. 1, not 0:
+    /// <c>MySqlOptionsValidator</c> requires a positive layer <c>Id</c> (DuckDB's validator
+    /// has no such floor), so a shared id across all three provider fixtures must satisfy
+    /// the stricter constraint.
+    /// </summary>
+    public const int LayerId = 1;
+
+    /// <summary>Service name used for the GeoServices FeatureServer smoke publication.</summary>
+    public const string ServiceName = "smoke";
+
+    /// <summary>Resource id of the published "parcels" dataset.</summary>
+    public const string ResourceId = "res-smoke";
+
+    private const string BindingId = "binding-smoke";
+
+    /// <summary>
+    /// Builds the Metadata v2 graph for a provider-smoke fixture.
+    /// </summary>
+    /// <param name="locator">
+    /// Storage binding locator (e.g. <c>"parcels"</c> for DuckDB/MySql static-config layers,
+    /// or <c>"dbo.parcels_xxx"</c> for a SQL Server table resolved dynamically through the
+    /// storage mapping).
+    /// </param>
+    /// <param name="connectionId">
+    /// Metadata v2 connection id routing this binding to a secondary provider (SQL Server).
+    /// Left <see langword="null"/> for primary-provider fixtures (DuckDB/MySql), where the
+    /// binding falls back to the router's default provider (the primary <c>DataSource:Provider</c>).
+    /// </param>
+    /// <param name="connectionProvider">
+    /// Canonical provider name for the connection node (e.g. <c>"sqlserver"</c>). Only used
+    /// when <paramref name="connectionId"/> is set.
+    /// </param>
+    public static MetadataV2Graph Build(string locator, string? connectionId = null, string? connectionProvider = null)
+    {
+        var fields = new[]
+        {
+            new MetadataV2Field
+            {
+                // Named "objectid" (not just PK-mapped as "id") to sidestep a real,
+                // pre-existing bug found while building this suite:
+                // Honua.Core.Features.Query.QueryProcessor.OptimizeQuery hardcodes
+                // FieldNames.ObjectId ("objectid") as the default deterministic-pagination
+                // sort field instead of resolving the resource's actual primary-id field
+                // (resource.FindPrimaryIdField()?.Name), so any resource whose PK field is
+                // named anything else fails every paged query with a SQL binder error.
+                // Tracked as honua-server#2964; every existing seed/schema in this repo
+                // happens to already name its PK field "objectid", which is why this has
+                // never surfaced before.
+                Name = "objectid",
+                Type = MetadataV2FieldType.BigInteger,
+                Nullable = false,
+                SemanticRoles = ["id.primary"],
+                Description = "Object id",
+            },
+            new MetadataV2Field
+            {
+                Name = "geom",
+                Type = MetadataV2FieldType.Geometry,
+                Nullable = false,
+                SemanticRoles = ["geometry.primary", "geometry"],
+                Description = "Geometry",
+            },
+            new MetadataV2Field { Name = "name", Type = MetadataV2FieldType.String, Nullable = true, Description = "Parcel name" },
+            new MetadataV2Field { Name = "area", Type = MetadataV2FieldType.Double, Nullable = true, Description = "Parcel area" },
+            new MetadataV2Field { Name = "type", Type = MetadataV2FieldType.String, Nullable = true, Description = "Parcel type" },
+        };
+
+        var spatial = new MetadataV2ResourceSpatial
+        {
+            SpatialReference = MetadataV2SpatialReference.Wgs84,
+            GeometryType = MetadataV2GeometryType.Point,
+            PrimaryGeometryField = "geom",
+            Bbox = new MetadataV2Bbox
+            {
+                West = ProviderSmokeData.MinLongitude,
+                South = ProviderSmokeData.MinLatitude,
+                East = ProviderSmokeData.MaxLongitude,
+                North = ProviderSmokeData.MaxLatitude,
+            },
+            SupportedCrs = [MetadataV2SpatialReference.Wgs84],
+        };
+
+        var bindingOptions = new Dictionary<string, JsonElement>
+        {
+            ["primaryKeyColumn"] = JsonSerializer.SerializeToElement("objectid"),
+            ["geometryColumn"] = JsonSerializer.SerializeToElement("geom"),
+        };
+
+        var builder = new Honua.TestKit.Infrastructure.TestMetadataV2GraphBuilder();
+
+        if (!string.IsNullOrWhiteSpace(connectionId))
+        {
+            builder.AddConnection(connectionId, "smoke-connection", MetadataV2ConnectionType.Database, connectionProvider);
+        }
+
+        var layerIdText = LayerId.ToString(CultureInfo.InvariantCulture);
+        var anonymous = new AccessPolicy { AllowAnonymous = true };
+
+        // A single service, not one-per-protocol: ResourceValidator.ValidateServiceV2Async
+        // resolves a service by name via snapshot.Index.ServicesByName, a dictionary keyed
+        // by MetadataV2Service.Name — only ONE MetadataV2Service record can ever be reachable
+        // per name (the default test graph's "svc-test" carries protocols: All for exactly
+        // this reason; its same-named svc-test-feature/svc-test-map/svc-test-stac siblings
+        // are never resolved by name-based lookup). Splitting the smoke service across
+        // several same-named MetadataV2Service records here would make every protocol but
+        // the one on the first-indexed record 404 with "<protocol> is not enabled for this
+        // service" — found the hard way while building this fixture (honua-server#2947).
+        builder
+            .AddResource(
+                ResourceId,
+                "parcels",
+                MetadataV2ResourceType.FeatureDataset,
+                fields: fields,
+                accessPolicy: anonymous,
+                spatial: spatial)
+            .AddStorageBinding(
+                BindingId,
+                ResourceId,
+                locator,
+                connectionId: connectionId,
+                storageLayerId: LayerId,
+                options: bindingOptions)
+            .AddService(
+                "svc-smoke",
+                ServiceName,
+                route: "/ogc/features",
+                protocols: MetadataV2ServiceProtocols.All,
+                accessPolicy: anonymous)
+            // OGC API Features + OGC API Tiles (Tiles addresses
+            // /ogc/tiles/collections/{collectionId}/tiles/... for the same collection id).
+            .AddPublication(
+                "pub-smoke-ogc",
+                serviceId: "svc-smoke",
+                resourceId: ResourceId,
+                layerIndex: LayerId,
+                storageBindingId: BindingId,
+                serviceLocalId: layerIdText,
+                publicationType: MetadataV2PublicationType.OgcCollection)
+            // GeoServices REST FeatureServer.
+            .AddPublication(
+                "pub-smoke-feature",
+                serviceId: "svc-smoke",
+                resourceId: ResourceId,
+                layerIndex: LayerId,
+                storageBindingId: BindingId,
+                serviceLocalId: layerIdText,
+                publicationType: MetadataV2PublicationType.EsriFeatureLayer)
+            // OData. Query dispatch for /odata/Layers({layerId})/Features addresses the
+            // primary provider's IFeatureReader directly by numeric layer id — this
+            // publication only feeds $metadata/schema generation.
+            .AddPublication(
+                "pub-smoke-odata",
+                serviceId: "svc-smoke",
+                resourceId: ResourceId,
+                layerIndex: LayerId,
+                storageBindingId: BindingId,
+                serviceLocalId: layerIdText,
+                publicationType: MetadataV2PublicationType.ODataEntitySet);
+
+        return builder.Build();
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Providers/ProviderSmokeHostConfiguration.cs
+++ b/tests/dotnet/Honua.TestKit/Providers/ProviderSmokeHostConfiguration.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.TestKit.Providers;
+
+/// <summary>
+/// Common in-memory app-configuration entries shared by the standalone provider-smoke
+/// fixtures (<see cref="DuckDbProviderWebAppFixture"/>, <see cref="MySqlProviderWebAppFixture"/>).
+/// Mirrors the provider-neutral subset of
+/// <c>Honua.TestKit.Mixins.WebAppFixturePostgresWiringMixin.BuildAppConfigurationDictionary</c> —
+/// duplicated rather than shared because that mixin's dictionary hard-codes
+/// <c>ConnectionStrings:*</c> to a Postgres connection string these fixtures never have.
+/// </summary>
+internal static class ProviderSmokeHostConfiguration
+{
+    private const string StableTestGeocodingBaseUrl = "https://8.8.8.8/nominatim";
+    private const string TestEncryptionMasterKey =
+        "test-master-key-that-is-at-least-32-characters-long-for-security";
+    private const string TestEncryptionSalt =
+        "dGVzdC1zYWx0LWZvci1lbmNyeXB0aW9uLXRlc3RpbmctcHVycG9zZXM=";
+
+    /// <summary>
+    /// Applies the merged provider-smoke settings to <paramref name="builder"/> via
+    /// <see cref="IWebHostBuilder.UseSetting(string, string?)"/> rather than
+    /// <c>ConfigureAppConfiguration</c>.
+    /// </summary>
+    /// <remarks>
+    /// This distinction matters: <c>Program.cs</c> reads several of these keys (notably
+    /// <c>DataSource:Provider</c>, <c>HONUA_REGISTER_TEST_INFRASTRUCTURE</c>, and
+    /// <c>HONUA_SKIP_MIGRATIONS</c>) directly off <c>builder.Configuration</c> as top-level
+    /// statements executed while the <c>WebApplicationBuilder</c> is still being assembled —
+    /// before <c>WebApplicationFactory</c>'s <c>ConfigureAppConfiguration</c> callback has run.
+    /// <c>UseSetting</c> values, by contrast, are folded into the host's configuration at
+    /// construction time (the same mechanism <c>UseEnvironment</c>/<c>HONUA_DEV_AUTH</c> rely
+    /// on in <c>WebAppFixturePostgresWiringMixin.ApplyCommonHostSettings</c>), so Program.cs's
+    /// early reads see them. A standalone (non-<c>WebAppFixture</c>) provider host that needs
+    /// the composition root to read a non-default <c>DataSource:Provider</c> must use this path,
+    /// not <c>ConfigureAppConfiguration</c>.
+    /// </remarks>
+    internal static void ApplySettings(IWebHostBuilder builder, IDictionary<string, string?> providerSettings)
+    {
+        foreach (var (key, value) in Build(providerSettings))
+        {
+            builder.UseSetting(key, value);
+        }
+    }
+
+    /// <summary>
+    /// Builds the merged settings dictionary for a standalone (non-Postgres-primary)
+    /// provider-smoke host, merging in the caller's provider-specific settings.
+    /// </summary>
+    private static Dictionary<string, string?> Build(IDictionary<string, string?> providerSettings)
+    {
+        var attachmentsPath = Path.Combine(Directory.GetCurrentDirectory(), "tmp", "attachments");
+        var settings = new Dictionary<string, string?>
+        {
+            ["Geocoding:Nominatim:BaseUrl"] = StableTestGeocodingBaseUrl,
+            ["Geocoding:Providers:Nominatim:BaseUrl"] = StableTestGeocodingBaseUrl,
+            ["HONUA_SKIP_MIGRATIONS"] = "true",
+            // Program.cs's TestInfrastructureRegistrationPolicy skips
+            // InfrastructureCompositionRoot.RegisterInfrastructureServices in the Test
+            // environment by default, on the assumption that a WebAppFixture-style host
+            // wires its own providers directly via ConfigureTestServices. These standalone
+            // DuckDB/MySql fixtures have no such fixture — they rely on the ordinary
+            // DataSource:Provider composition root switch reading the DuckDB/MySql config
+            // supplied below — so they must opt back in explicitly.
+            ["HONUA_REGISTER_TEST_INFRASTRUCTURE"] = "true",
+            ["HONUA_TEST_SCHEMA_HEADERS"] = "true",
+            ["Limits:Connections:RequestTimeout"] = "00:05:00",
+            ["Limits:Query:QueryTimeout"] = "00:02:00",
+            ["FileStorage:Provider"] = "Local",
+            ["FileStorage:LocalStorage:BasePath"] = attachmentsPath,
+            ["Security:ConnectionEncryption:MasterKey"] = TestEncryptionMasterKey,
+            ["Security:ConnectionEncryption:Salt"] = TestEncryptionSalt,
+            ["Observability:OpsHealthRollup:Enabled"] = "false",
+            // No secondary-provider connections are configured for these standalone
+            // fixtures; keep the always-registered secondary providers (SqlServer/
+            // ArcGisRest/Oracle) dormant rather than erroring on missing config
+            // (honua-server "secondary-provider-dormant-startup" contract).
+            ["SqlServer:Enabled"] = "false",
+            ["ArcGisRest:Enabled"] = "false",
+            ["Oracle:Enabled"] = "false",
+        };
+
+        foreach (var (key, value) in providerSettings)
+        {
+            settings[key] = value;
+        }
+
+        return settings;
+    }
+}

--- a/tests/dotnet/Honua.TestKit/Providers/SqlServerProviderWebAppFixture.cs
+++ b/tests/dotnet/Honua.TestKit/Providers/SqlServerProviderWebAppFixture.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Metadata.Abstractions;
+using Honua.Core.Features.Security.Abstractions;
+using Honua.Core.Features.Security.Domain;
+using Honua.TestKit.Infrastructure;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Testcontainers.MsSql;
+using Xunit;
+
+namespace Honua.TestKit.Providers;
+
+/// <summary>
+/// Fixture that pairs a Postgres-backed <see cref="Honua.TestKit.WebAppFixture"/> (the
+/// primary provider) with a Testcontainers <c>mcr.microsoft.com/mssql/server:2022-latest</c>
+/// instance registered as a secondary/additional provider (honua-server#2947), replacing
+/// the creds-gated <c>HONUA_SQLSERVER_TEST_CONNECTION</c> approach for this smoke suite.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SQL Server is architecturally an "additional" provider (see
+/// <c>InfrastructureCompositionRoot.RegisterInfrastructureServices</c>): it is always
+/// layered on top of whatever the primary <c>DataSource:Provider</c> is (Postgres here)
+/// and routed per-publication through a Metadata v2 <see cref="Honua.Core.Features.Metadata.Domain.V2.MetadataV2Connection"/>
+/// whose provider resolves to <c>sqlserver</c>. Unlike the DuckDB/MySql fixtures, layer
+/// mapping is fully dynamic — <c>SqlServerFeatureStore</c> implements
+/// <c>IBindableFeatureDataProvider</c> and builds its column mapping from the Metadata v2
+/// resource's schema fields and storage-binding locator at request time, so no
+/// <c>SqlServer:Layers</c> config is needed.
+/// </para>
+/// <para>
+/// <b>Known protocol-coverage gap (honua-server#2947 finding, tracked separately):</b> only
+/// GeoServices FeatureServer and OGC API Features route reads through
+/// <c>FeatureProviderQueryRouter</c> for secondary/additional providers. OData and OGC API
+/// Tiles resolve <c>IFeatureReader</c>/<c>ITileProvider</c> directly via DI (always the
+/// primary provider), so a SQL Server-backed publication is invisible to those two
+/// protocols today. The smoke suite only exercises FeatureServer + OGC API Features for
+/// this fixture and skips OData/Tiles with a reason pointing at the filed follow-up issue.
+/// </para>
+/// </remarks>
+public sealed class SqlServerProviderWebAppFixture : IAsyncLifetime
+{
+    private MsSqlContainer _container = null!;
+    private WebAppFixture _webApp = null!;
+    private string _tableName = null!;
+
+    /// <summary>HTTP client bound to the underlying Postgres-primary host.</summary>
+    public HttpClient Client => _webApp.Client;
+
+    /// <summary>The underlying Postgres-backed web-app fixture (primary provider).</summary>
+    public WebAppFixture WebApp => _webApp;
+
+    /// <summary>The in-memory Metadata v2 graph provider installed into the test host.</summary>
+    public TestMetadataV2GraphProvider GraphProvider { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        _container = new MsSqlBuilder().Build();
+        await _container.StartAsync().ConfigureAwait(false);
+
+        _tableName = $"parcels_{Guid.NewGuid():N}";
+        await SeedAsync().ConfigureAwait(false);
+
+        var connectionId = Guid.NewGuid();
+        var graph = ProviderSmokeGraph.Build(
+            locator: $"dbo.{_tableName}",
+            connectionId: connectionId.ToString(),
+            connectionProvider: "sqlserver");
+
+        _webApp = new WebAppFixture();
+        _webApp.ConfigureServices(services =>
+        {
+            services.RemoveAll<IMetadataV2GraphProvider>();
+            services.RemoveAll<IMetadataV2GraphStore>();
+            GraphProvider = new TestMetadataV2GraphProvider(graph);
+            services.AddSingleton(GraphProvider);
+            services.AddSingleton<IMetadataV2GraphProvider>(sp => sp.GetRequiredService<TestMetadataV2GraphProvider>());
+            services.AddSingleton<IMetadataV2GraphStore>(sp => sp.GetRequiredService<TestMetadataV2GraphProvider>());
+
+            // WebAppFixture's isolated test host bypasses InfrastructureCompositionRoot
+            // entirely (Program.cs's TestInfrastructureRegistrationPolicy skips it in the
+            // Test environment so WebAppFixture can wire its own providers), which is
+            // exactly where AddSqlServerFeatureProvider normally gets called in production.
+            // WebAppFixturePostgresWiringMixin only re-registers the Postgres primary, so
+            // SQL Server must be registered explicitly here (honua-server#2947).
+            Honua.SqlServer.ServiceCollectionExtensions.AddSqlServerFeatureProvider(
+                services, new ConfigurationBuilder().Build());
+        });
+
+        await _webApp.InitializeAsync().ConfigureAwait(false);
+
+        await RegisterSecureConnectionAsync(connectionId).ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_webApp is not null)
+        {
+            await _webApp.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_container is not null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task SeedAsync()
+    {
+        await using var connection = new SqlConnection(_container.GetConnectionString());
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        await ExecuteAsync(connection, $"""
+            CREATE TABLE [dbo].[{_tableName}] (
+                [objectid] bigint NOT NULL PRIMARY KEY,
+                [geom] geometry NULL,
+                [name] nvarchar(64) NULL,
+                [area] float NULL,
+                [type] nvarchar(32) NULL
+            )
+            """).ConfigureAwait(false);
+
+        foreach (var parcel in ProviderSmokeData.Parcels)
+        {
+            await ExecuteAsync(connection, FormattableString.Invariant($"""
+                INSERT INTO [dbo].[{_tableName}] ([objectid], [geom], [name], [area], [type])
+                VALUES ({parcel.Id}, geometry::STGeomFromText('POINT({parcel.Longitude} {parcel.Latitude})', 4326), '{parcel.Name}', {parcel.Area}, '{parcel.Type}')
+                """)).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ExecuteAsync(SqlConnection connection, string sql)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    private async Task RegisterSecureConnectionAsync(Guid connectionId)
+    {
+        var registry = _webApp.GetService<ISecureConnectionRegistry>();
+        var encryption = _webApp.GetService<IConnectionEncryptionService>();
+
+        // SqlServerConnectionFactory (Honua.SqlServer) forces Encrypt=true on every
+        // resolved connection string but does not set TrustServerCertificate; the
+        // Testcontainers mssql image serves a self-signed certificate, so the encrypted
+        // connection string stored here must carry TrustServerCertificate=true itself.
+        var builder = new SqlConnectionStringBuilder(_container.GetConnectionString())
+        {
+            TrustServerCertificate = true,
+        };
+        var rawConnectionString = builder.ConnectionString;
+
+        var encrypted = await encryption.EncryptConnectionStringAsync(rawConnectionString).ConfigureAwait(false);
+        var keyVersion = await encryption.GetCurrentKeyVersionAsync().ConfigureAwait(false);
+
+        var hostPort = builder.DataSource.Split(',', 2);
+        var host = hostPort[0];
+        var port = hostPort.Length > 1 && int.TryParse(hostPort[1], out var parsedPort) ? parsedPort : 1433;
+
+        var connection = DataConnection.CreateWithEncryptedCredentials(
+            name: $"sqlserver-smoke-{connectionId:N}",
+            host: host,
+            port: port,
+            databaseName: string.IsNullOrWhiteSpace(builder.InitialCatalog) ? "master" : builder.InitialCatalog,
+            username: builder.UserID,
+            encryptedConnectionString: encrypted,
+            encryptionKeyVersion: keyVersion,
+            createdBy: "provider-smoke-fixture",
+            sslRequired: false,
+            sslMode: SslMode.Disable);
+        connection.ConnectionId = connectionId;
+        connection.Provider = "sqlserver";
+
+        await registry.CreateConnectionAsync(connection).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2947

> **⚠️ Stacked on #2971 (`fix/2963-duckdb-cql2-spatial`) — dispatch/merge this PR only after #2971 lands.** Both branches need a DuckDB `ISqlFilterTranslator`; #2971's implementation (with CQL2 spatial support) supersedes the attribute-only one this work originally carried, so this branch was rebased onto #2971 to share a single translator instead of colliding on the same file. The diff below shows #2971's commits until it merges; this PR's own change is the top commit.

## Summary
Interface-level HTTP-stack smoke proof for the secondary providers advertised in the docs (release-safety pillar P2, provider GA gap): a new `Honua.ProviderSmoke.Tests` suite boots a real ASP.NET Core host per provider — DuckDB in-process, MySql via Testcontainers as primaries, SQL Server via Testcontainers as a secondary/additional provider routed through `FeatureProviderQueryRouter` — and exercises the read/query GA surface each documents (GeoServices FeatureServer, OGC API Features incl. CQL2, OData, tiles), asserting seeded-row correctness rather than bare 200s. Also adds an Oracle real-database lane (`gvenzl/oracle-free` Testcontainer) to `Honua.Oracle.Tests` as promotion groundwork — Oracle stays experimental. Building the suite surfaced and fixed real DI-activation bugs: FeatureServer/OGC requests under a DuckDB or MySql primary failed DI activation outright (missing `ISqlFilterTranslator`, `ICrsDetectionService`, `ICrsRegistry`, `ISecureConnectionRegistry`, `IRelationshipStore`, `ICoordinateTransformService` registrations), and it produced the findings now tracked as #2962 (secondary-provider routing gaps in OData/Tiles) and #2965 (EWKB vs plain-WKB mismatch) — every skipped case in the suite names its tracked bug instead of silently omitting coverage.

## Changes Made
- `tests/dotnet/Honua.ProviderSmoke.Tests/`: shared `PrimaryProviderSmokeTestsBase` run per provider fixture (real per-provider test results), plus SqlServer secondary-provider suite with honestly-skipped-and-tracked gaps (#2962, #2965, documented CQL2 limitation).
- `tests/dotnet/Honua.TestKit/Providers/`: provider-parameterized WebAppFixtures (DuckDB file-backed in-process, MySql `mysql:8` Testcontainer, SQL Server `mcr.microsoft.com/mssql/server:2022` Testcontainer registered as a secure connection), shared seed graph/data.
- DI-activation fixes in `Honua.DuckDB`/`Honua.MySql` `ServiceCollectionExtensions` with new shared `ReadOnlyProviders` implementations in `Honua.Core` (no-op CRS detection, well-known CRS registry + transform service covering CRS84/EPSG:4326/EPSG:3857, in-memory secure-connection registry, read-only relationship store); DuckDB read-only connection-string fix (`access_mode=READ_ONLY`).
- `tests/dotnet/Honua.Oracle.Tests/OracleRealDatabaseIntegrationTests.cs`: first live-database proof of the Oracle provider layer (connection, query build+execute, WKB/geometry decode), gated by `HONUA_TEST_ORACLE=1`.
- `.github/workflows/provider-http-smoke.yml`: nightly + on-demand workflow running the smoke suite and the Oracle lane (too container-heavy for the PR path; intended as a release-train input).
- Provider docs updated (per-provider protocol-support notes); capability matrix + feature catalog regenerated.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [x] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Verification performed: full `Honua.ProviderSmoke.Tests` run (DuckDB in-process + MySql and SQL Server Testcontainers) locally under the shared build lock; feature-catalog regeneration verified drift-free.
