### PR TITLE
feat: demote native mTLS client-certificate auth to experimental (#2958)

### DIFF
--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -937,9 +937,9 @@
       "category": "Identity",
       "edition": "Enterprise",
       "entryCount": 13,
-      "provingTestCount": 23,
+      "provingTestCount": 24,
       "maturity": {
-        "implemented": 13
+        "experimental": 13
       },
       "noSurface": null,
       "cite": [],

--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -21,7 +21,7 @@
       "category": "ControlPlane",
       "edition": "Community",
       "entryCount": 364,
-      "provingTestCount": 945,
+      "provingTestCount": 947,
       "maturity": {
         "implemented": 364
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -516,7 +516,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.DisableProfile_ExistingProfile_ReturnsDisabledProfile"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -530,7 +530,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.DisableMapping_ExistingMapping_ReturnsDisabledMapping"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -544,7 +544,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.RemoveRevocation_ExistingRevocation_ReturnsOk"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -3642,10 +3642,11 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ListProfiles_WithAdminAuth_ReturnsConfiguredProfiles",
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ListProfiles_WithProEdition_ReturnsPaymentRequired",
-        "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.ClientCertificatesEndpoint_AfterGaPromotion_IsNotExperimentalGated"
+        "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.ClientCertificatesEndpoint_WhenExperimentalDisabled_Returns404ExperimentalDisabled",
+        "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.ClientCertificatesEndpoint_WhenExperimentalEnabled_IsNotExperimentalGated"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -3659,7 +3660,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.GetProfile_ExistingProfile_ReturnsProfile"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -3673,7 +3674,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ListMappings_ExistingProfile_ReturnsMappings"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -3687,7 +3688,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ListRevocations_ExistingProfile_ReturnsRevocations"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -4092,6 +4093,7 @@
       "proving_tests": [
         "Honua.Server.Tests.Features.Admin.AdminAuthorizationTests.GetVersion_WithoutAuth_Returns401",
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.RequiredForAdmin_WithApiKeyButMissingCertificate_ReturnsMachineReadableProblem",
+        "Honua.Server.Tests.Infrastructure.Authentication.OidcAuthenticationTests.AdminEndpoint_MtlsCapabilityDisabled_ValidBearerToken_ReturnsCleanOk",
         "Honua.Server.Tests.Infrastructure.Authentication.OidcAuthenticationTests.AdminEndpoint_OidcEnabled_DistributedCacheWithoutRedis_FallsBackToMemoryReplayProtection",
         "Honua.Server.Tests.Infrastructure.Authentication.OidcAuthenticationTests.AdminEndpoint_OidcEnabled_ReusedBearerToken_IsRejectedWhenReplayProtectionEnabled"
       ],
@@ -15170,7 +15172,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.CreateProfile_WithMalformedCustomTrustAnchor_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -15187,7 +15189,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.CreateMapping_WithInvertedValidityWindow_ReturnsBadRequest"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -15201,7 +15203,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.AddRevocation_ValidRequest_ReturnsCreated"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -15216,7 +15218,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.ValidateCertificate_WithMappedCertificate_ReturnsValidResult"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -20519,7 +20521,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.UpdateProfile_ExistingProfile_ReturnsUpdatedRevision"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {
@@ -20533,7 +20535,7 @@
         "Honua.Server.Tests.Features.Admin.ClientCertificateAdminEndpointsTests.UpdateMapping_ExistingMapping_ReturnsUpdatedMapping"
       ],
       "proof_ledger_surface": "control-plane-admin",
-      "maturity": "implemented",
+      "maturity": "experimental",
       "capability": "identity.mtls-client-certificate"
     },
     {

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -1131,7 +1131,8 @@
         "Honua.Server.Tests.Features.Admin.AdminAuthEndpointsTests.GetAuthConfig_IsAnonymous_Returns200",
         "Honua.Server.Tests.Features.Admin.AdminAuthEndpointsTests.GetAuthConfig_NoOidcConfigured_ReturnsEmptyProviders",
         "Honua.Server.Tests.Features.Admin.AdminAuthEndpointsTests.GetAuthConfig_WithAzureAdConfigured_ReturnsSelectionMetadataOnly",
-        "Honua.Server.Tests.Features.Admin.AdminAuthEndpointsTests.GetAuthConfig_WithMultipleProviders_ReturnsProviderKeysAndNames"
+        "Honua.Server.Tests.Features.Admin.AdminAuthEndpointsTests.GetAuthConfig_WithMultipleProviders_ReturnsProviderKeysAndNames",
+        "Honua.Server.Tests.Features.Capabilities.ExperimentalCapabilityGatingIntegrationTests.AdminAuthConfigEndpoint_WhenExperimentalDisabled_Returns200"
       ],
       "proof_ledger_surface": "control-plane-admin",
       "maturity": "implemented",

--- a/docs/guides/secure/tls-and-mtls.md
+++ b/docs/guides/secure/tls-and-mtls.md
@@ -2,6 +2,11 @@
 
 Encrypt every hop — browser to edge, edge to Honua, Honua to PostgreSQL — and optionally require mTLS client certificates on admin and native surfaces.
 
+> **Experimental.** Native mTLS / client-certificate authentication (`security.mtls`) is off
+> by default. `Authentication__ClientCertificates__Mode` alone has no effect — also set
+> `Capabilities__Experimental__security.mtls__Enabled=true` (or the global
+> `Capabilities__Experimental__Enabled=true` switch) to enable it.
+
 **Prerequisites:** A reverse proxy or load balancer you control (nginx, ALB, Application Gateway, ingress), and an admin API key for the trust-management endpoints.
 
 ## Steps

--- a/docs/internal/contributor/adr/0058-unified-capability-registry-single-source-of-truth.md
+++ b/docs/internal/contributor/adr/0058-unified-capability-registry-single-source-of-truth.md
@@ -191,6 +191,13 @@ ADR gives the registry, and the manifest lever the Console release gate
 > client-certificate enforcement still self-gates on
 > `Authentication:ClientCertificates:Mode` (default `Disabled`).
 
+> **Update (#2958).** **mTLS client-certificate validation** (`security.mtls`) was DEMOTED
+> back from `Implemented` to `experimental` (release-safety follow-up): the always-on
+> client-certificate scheme/RBAC layer could 403 a fully valid bearer-token admin request
+> (#2945). It is back in the registry-flag experimental roster (a); the scheme
+> registration, `Admin`/`OpsRead` policy scheme lists, and enforcement middleware are now
+> also conditioned on `Capabilities:Experimental:security.mtls:Enabled`.
+
 > **Update (#2428).** **Realtime feature streams** (`realtime.feature-streams`,
 > `/api/v1/streaming/features` + `/api/v1/admin/(operations/)streaming/*`) — the
 > WebSocket/SSE feature-change streams with subscription filters and durable

--- a/docs/internal/contributor/adr/0059-first-release-scope-and-fix-forward-operate-model.md
+++ b/docs/internal/contributor/adr/0059-first-release-scope-and-fix-forward-operate-model.md
@@ -155,6 +155,12 @@ deployment. It lights up when the customer opts in.
 > `Disabled`) — but that is a runtime enablement switch, not experimental gating.
 > The mTLS entry in the two-mechanism roster below is superseded by this note.
 
+> **Update (#2958).** The #2431 GA promotion above is superseded: **mTLS
+> client-certificate validation** (`security.mtls`) is DEMOTED back to **experimental**
+> (release-safety follow-up) — the always-on client-certificate scheme/RBAC layer could
+> 403 a fully valid bearer-token admin request (#2945). It is `maturity: experimental`
+> again, gated behind `Capabilities:Experimental:security.mtls:Enabled`.
+
 **Two mechanisms hold this set OFF — not one uniform registry flag.** The
 route-bearing experimental capabilities — **temporal** analytics/versioning
 (`/api/v1/temporal/*`), **disconnected-sync / replicas**, **realtime

--- a/docs/reference/configuration/environment-variables.md
+++ b/docs/reference/configuration/environment-variables.md
@@ -35,7 +35,7 @@ Provider capabilities and versions: [data sources](data-sources/README.md).
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `HONUA_ADMIN_PASSWORD` | — (**required in production**) | Password for the admin API (`/api/v1/admin/*`). |
-| `Authentication__ClientCertificates__Mode` | `Disabled` | Client-certificate auth mode: `Disabled`, `Optional`, `RequiredForNative`, `RequiredForAdmin`, `RequiredForEnvironment`. |
+| `Authentication__ClientCertificates__Mode` | `Disabled` | Client-certificate auth mode: `Disabled`, `Optional`, `RequiredForNative`, `RequiredForAdmin`, `RequiredForEnvironment`. **Experimental** — has no effect unless `Capabilities__Experimental__security.mtls__Enabled=true` (or the global experimental switch); see [TLS and mTLS](../../guides/secure/tls-and-mtls.md). |
 | `Authentication__ClientCertificates__EnvironmentId` | — | Environment id matched by `RequiredForEnvironment` and trust profiles. |
 | `Authentication__ClientCertificates__ProtectedAdminPathPrefixes__N` | — | Admin path prefixes protected by client-certificate auth. |
 | `Authentication__ClientCertificates__ProtectedGrpcServices__N` | — | gRPC service names protected by client-certificate auth. |

--- a/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
+++ b/src/Honua.Core/Features/Capabilities/CapabilityRegistry.cs
@@ -266,11 +266,17 @@ public sealed class CapabilityRegistry : ICapabilityRegistry
             ("transport.qgis", "transports", null, CapabilityKind.ProtocolOperation, null, CapabilityMaturity.Implemented),
 
             // Native mTLS (client-certificate) authentication — promoted to GA (Implemented) in
-            // #2431. Second Experimental->Implemented promotion (after alerts.geofence, #2427):
-            // hardened chain/CRL-OCSP revocation validation, then flipped off the experimental
-            // gate. Enterprise entitlement (FeatureCatalog.MtlsClientCertificateKey) so the
-            // manifest/registry advertise it as Enterprise-gated.
-            ("security.mtls", "security", FeatureCatalog.MtlsClientCertificateKey, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
+            // #2431, then DEMOTED back to experimental in #2958 (release-safety follow-up to
+            // #2946/#2431): the always-on client-certificate scheme/RBAC layer interposed on
+            // every admin request regardless of bearer-token validity (a fully valid JWT could
+            // get a 403 from the cert layer in a host that never configured mTLS). It is now a
+            // built-experimental capability again, gated OFF by default; the auth-layer wiring
+            // (scheme registration, admin/ops-read policy scheme lists, and the enforcement
+            // middleware) reads this same flag directly — see
+            // ClientCertificateAuthenticationExtensions.IsMtlsCapabilityEnabled. Enterprise
+            // entitlement (FeatureCatalog.MtlsClientCertificateKey) still applies on top once
+            // the flag is on.
+            ("security.mtls", "security", FeatureCatalog.MtlsClientCertificateKey, CapabilityKind.Feature, null, CapabilityMaturity.Experimental),
             ("preview.file-import", "preview", "import.file", CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
             ("query.features", "query", null, CapabilityKind.Feature, null, CapabilityMaturity.Implemented),
             // analysis.spatial is gated by a composite of four analytics keys; the

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -232,7 +232,9 @@ public static class FeatureCatalog
     /// Entitlement key for native mTLS client-certificate authentication (#2431). Enterprise-only:
     /// gates the client-certificate trust-profile admin surface
     /// (<c>/api/v1/admin/security/client-certificates/*</c>) and the enforcement pipeline that maps
-    /// a presented client certificate to a Honua principal.
+    /// a presented client certificate to a Honua principal. The capability itself is also
+    /// experimental again (#2958; registry id <c>security.mtls</c>) — it is off by default
+    /// regardless of edition until <c>Capabilities:Experimental:security.mtls:Enabled=true</c>.
     /// </summary>
     public const string MtlsClientCertificateKey = "identity.mtls-client-certificate";
 

--- a/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/AuthenticationExtensions.cs
@@ -61,7 +61,9 @@ public static class AuthenticationExtensions
     /// <summary>
     /// Adds API key authentication and authorization services
     /// </summary>
-    public static IServiceCollection AddApiKeyAuthentication(this IServiceCollection services)
+    public static IServiceCollection AddApiKeyAuthentication(
+        this IServiceCollection services,
+        IConfiguration configuration)
     {
         services.AddScoped<ApiKeyAuthenticationDependencies>();
 
@@ -84,15 +86,20 @@ public static class AuthenticationExtensions
                 ApiKeyScheme,
                 options => { });
 
+        // #2958: the client-certificate scheme is only ever a valid policy scheme
+        // reference when the security.mtls experimental capability is enabled — resolved
+        // once here (composition time) rather than per-policy-evaluation.
+        var mtlsCapabilityEnabled = ClientCertificateAuthenticationExtensions.IsMtlsCapabilityEnabled(configuration);
+
         // Add authorization policies
         _ = services.AddAuthorization(options =>
         {
-            options.AddPolicy(AdminPolicy, ConfigureAdminPolicy);
-            options.AddPolicy(AdminPolicyAlias, ConfigureAdminPolicy);
-            options.AddPolicy(OpsReadPolicy, ConfigureOpsReadPolicy);
-            options.AddPolicy(TemporalHistoryReadPolicy, ConfigureAdminPolicy);
-            options.AddPolicy(TemporalDiffReadPolicy, ConfigureAdminPolicy);
-            options.AddPolicy(TemporalRollbackExecutePolicy, ConfigureAdminPolicy);
+            options.AddPolicy(AdminPolicy, policy => ConfigureAdminPolicy(policy, mtlsCapabilityEnabled));
+            options.AddPolicy(AdminPolicyAlias, policy => ConfigureAdminPolicy(policy, mtlsCapabilityEnabled));
+            options.AddPolicy(OpsReadPolicy, policy => ConfigureOpsReadPolicy(policy, mtlsCapabilityEnabled));
+            options.AddPolicy(TemporalHistoryReadPolicy, policy => ConfigureAdminPolicy(policy, mtlsCapabilityEnabled));
+            options.AddPolicy(TemporalDiffReadPolicy, policy => ConfigureAdminPolicy(policy, mtlsCapabilityEnabled));
+            options.AddPolicy(TemporalRollbackExecutePolicy, policy => ConfigureAdminPolicy(policy, mtlsCapabilityEnabled));
         });
 
         return services;
@@ -104,13 +111,23 @@ public static class AuthenticationExtensions
     /// (#1985). The role check preserves the legacy gate; the permission requirement
     /// adds scoped-key enforcement so a read-only admin key cannot mutate.
     /// </summary>
-    private static void ConfigureAdminPolicy(AuthorizationPolicyBuilder policy)
+    /// <param name="policy">The policy builder to configure.</param>
+    /// <param name="mtlsCapabilityEnabled">
+    /// Whether the <c>security.mtls</c> experimental capability is enabled (#2958). Only
+    /// then is the client-certificate scheme added to the policy's accepted schemes — while
+    /// disabled (the default), a valid bearer token authenticates admin requests with no
+    /// interposed cert-RBAC check.
+    /// </param>
+    private static void ConfigureAdminPolicy(AuthorizationPolicyBuilder policy, bool mtlsCapabilityEnabled)
     {
         _ = policy.RequireAuthenticatedUser();
         _ = policy.RequireRole("admin");
         _ = policy.AddRequirements(new AdminPermissionRequirement());
         policy.AuthenticationSchemes.Add(ApiKeyScheme);
-        policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
+        if (mtlsCapabilityEnabled)
+        {
+            policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
+        }
     }
 
     /// <summary>
@@ -120,12 +137,20 @@ public static class AuthenticationExtensions
     /// <see cref="OpsReadRequirement"/> (via <see cref="AdminApiKeyPermission.IsOpsReadAuthorized"/>):
     /// admin (any level) or ops:read for safe methods; full admin write for mutating methods.
     /// </summary>
-    private static void ConfigureOpsReadPolicy(AuthorizationPolicyBuilder policy)
+    /// <param name="policy">The policy builder to configure.</param>
+    /// <param name="mtlsCapabilityEnabled">
+    /// Whether the <c>security.mtls</c> experimental capability is enabled (#2958); see
+    /// <see cref="ConfigureAdminPolicy"/>.
+    /// </param>
+    private static void ConfigureOpsReadPolicy(AuthorizationPolicyBuilder policy, bool mtlsCapabilityEnabled)
     {
         _ = policy.RequireAuthenticatedUser();
         _ = policy.AddRequirements(new OpsReadRequirement());
         policy.AuthenticationSchemes.Add(ApiKeyScheme);
-        policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
+        if (mtlsCapabilityEnabled)
+        {
+            policy.AuthenticationSchemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
+        }
     }
 
     /// <summary>

--- a/src/Honua.Hosting/Features/Authentication/ClientCertificates/ClientCertificateAuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/ClientCertificates/ClientCertificateAuthenticationExtensions.cs
@@ -13,15 +13,16 @@ internal static class ClientCertificateAuthenticationExtensions
     /// <summary>
     /// Registers native mTLS/client-certificate authentication ONLY when the
     /// <c>security.mtls</c> experimental capability is enabled (#2958). The options section
-    /// is always bound (unvalidated) so read-only consumers such as
-    /// <c>CapabilityManifestService</c> can still report the configured
-    /// <see cref="ClientCertificateAuthenticationOptions.Mode"/> without eagerly validating
-    /// or standing up the auth surface. While the capability is off the feature stays fully
-    /// dormant: no eager options validation, no authentication scheme, no DI-registered
-    /// validator/trust-store — an operator who has configured (or half-configured)
-    /// <c>Authentication:ClientCertificates:*</c> without opting into the experimental flag
-    /// never hits a startup validation failure or an interposed cert-RBAC check on an
-    /// otherwise-valid bearer-token admin request.
+    /// is always bound (unvalidated) and the read-only <see cref="IClientCertificateTrustStore"/>
+    /// is always registered so read-only consumers — <c>CapabilityManifestService</c> and the
+    /// anonymous admin auth bootstrap endpoint (<c>HandleGetAuthConfig</c>) — can still report
+    /// the configured <see cref="ClientCertificateAuthenticationOptions.Mode"/> and trust-profile
+    /// hints without eagerly validating or standing up the auth surface. While the capability is
+    /// off the enforcement surface stays fully dormant: no eager options validation, no
+    /// authentication scheme, no DI-registered validator/extractor — an operator who has
+    /// configured (or half-configured) <c>Authentication:ClientCertificates:*</c> without opting
+    /// into the experimental flag never hits a startup validation failure or an interposed
+    /// cert-RBAC check on an otherwise-valid bearer-token admin request.
     /// </summary>
     public static IServiceCollection AddHonuaClientCertificateAuthentication(
         this IServiceCollection services,
@@ -29,6 +30,14 @@ internal static class ClientCertificateAuthenticationExtensions
     {
         var optionsBuilder = services.AddOptions<ClientCertificateAuthenticationOptions>()
             .Bind(configuration.GetSection(ClientCertificateAuthenticationOptions.SectionName));
+
+        // Registered unconditionally (unlike the scheme/validator/enforcement below): the
+        // anonymous admin auth bootstrap endpoint (HandleGetAuthConfig) resolves this via
+        // [FromServices] to report trust-profile hints regardless of whether the experimental
+        // capability is opted in, so it must stay resolvable even while mTLS is gated off.
+        // The in-memory store only seeds itself from the (unvalidated) bound options and has
+        // no other side effects, so registering it does not stand up any auth surface.
+        services.TryAddSingleton<IClientCertificateTrustStore, InMemoryClientCertificateTrustStore>();
 
         if (!IsMtlsCapabilityEnabled(configuration))
         {
@@ -40,7 +49,6 @@ internal static class ClientCertificateAuthenticationExtensions
             IValidateOptions<ClientCertificateAuthenticationOptions>,
             ClientCertificateAuthenticationOptionsValidator>());
         services.TryAddSingleton<ClientCertificateExtractor>();
-        services.TryAddSingleton<IClientCertificateTrustStore, InMemoryClientCertificateTrustStore>();
         services.TryAddSingleton<IClientCertificateValidator, ClientCertificateValidator>();
         services.TryAddSingleton<ClientCertificateAuthenticationDependencies>();
 

--- a/src/Honua.Hosting/Features/Authentication/ClientCertificates/ClientCertificateAuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/ClientCertificates/ClientCertificateAuthenticationExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE in the project root.
 
+using Honua.Core.Features.Capabilities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -9,13 +10,32 @@ namespace Honua.Infrastructure.Authentication.ClientCertificates;
 
 internal static class ClientCertificateAuthenticationExtensions
 {
+    /// <summary>
+    /// Registers native mTLS/client-certificate authentication ONLY when the
+    /// <c>security.mtls</c> experimental capability is enabled (#2958). The options section
+    /// is always bound (unvalidated) so read-only consumers such as
+    /// <c>CapabilityManifestService</c> can still report the configured
+    /// <see cref="ClientCertificateAuthenticationOptions.Mode"/> without eagerly validating
+    /// or standing up the auth surface. While the capability is off the feature stays fully
+    /// dormant: no eager options validation, no authentication scheme, no DI-registered
+    /// validator/trust-store — an operator who has configured (or half-configured)
+    /// <c>Authentication:ClientCertificates:*</c> without opting into the experimental flag
+    /// never hits a startup validation failure or an interposed cert-RBAC check on an
+    /// otherwise-valid bearer-token admin request.
+    /// </summary>
     public static IServiceCollection AddHonuaClientCertificateAuthentication(
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        services.AddOptions<ClientCertificateAuthenticationOptions>()
-            .Bind(configuration.GetSection(ClientCertificateAuthenticationOptions.SectionName))
-            .ValidateOnStart();
+        var optionsBuilder = services.AddOptions<ClientCertificateAuthenticationOptions>()
+            .Bind(configuration.GetSection(ClientCertificateAuthenticationOptions.SectionName));
+
+        if (!IsMtlsCapabilityEnabled(configuration))
+        {
+            return services;
+        }
+
+        optionsBuilder.ValidateOnStart();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IValidateOptions<ClientCertificateAuthenticationOptions>,
             ClientCertificateAuthenticationOptionsValidator>());
@@ -32,9 +52,37 @@ internal static class ClientCertificateAuthenticationExtensions
         return services;
     }
 
+    /// <summary>
+    /// Runs the client-certificate enforcement middleware ONLY when the <c>security.mtls</c>
+    /// experimental capability is enabled (#2958); otherwise it is a no-op so the pipeline
+    /// never attempts to resolve the (unregistered, when the flag is off) enforcement
+    /// dependencies.
+    /// </summary>
     public static IApplicationBuilder UseHonuaClientCertificateAuthentication(this IApplicationBuilder app)
     {
         ArgumentNullException.ThrowIfNull(app);
-        return app.UseMiddleware<ClientCertificateEnforcementMiddleware>();
+
+        var configuration = app.ApplicationServices.GetRequiredService<IConfiguration>();
+        return IsMtlsCapabilityEnabled(configuration)
+            ? app.UseMiddleware<ClientCertificateEnforcementMiddleware>()
+            : app;
+    }
+
+    /// <summary>
+    /// Whether the <c>security.mtls</c> built-experimental capability is enabled, per the
+    /// same <c>Capabilities:Experimental</c> config precedence as every other experimental
+    /// capability (global switch or per-capability override; see
+    /// <see cref="CapabilityFlagOptions"/>). This is a one-time, startup-time (or per-request,
+    /// for the composite-scheme selector) config read rather than an injected
+    /// <c>IOptions&lt;CapabilityFlagOptions&gt;</c> because several call sites run at
+    /// composition time, before the DI container is built.
+    /// </summary>
+    public static bool IsMtlsCapabilityEnabled(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var flags = new CapabilityFlagOptions();
+        CapabilityFlagOptions.Bind(flags, configuration.GetSection(CapabilityFlagOptions.SectionName));
+        return flags.IsExperimentalEnabled(ClientCertificateAuthenticationDefaults.CapabilityId);
     }
 }

--- a/src/Honua.Hosting/Features/Authentication/ClientCertificates/ClientCertificateAuthenticationHandler.cs
+++ b/src/Honua.Hosting/Features/Authentication/ClientCertificates/ClientCertificateAuthenticationHandler.cs
@@ -10,6 +10,14 @@ namespace Honua.Infrastructure.Authentication.ClientCertificates;
 internal static class ClientCertificateAuthenticationDefaults
 {
     public const string AuthenticationScheme = "HonuaClientCertificate";
+
+    /// <summary>
+    /// The unified capability-registry id gating native mTLS / client-certificate
+    /// authentication (#2958: demoted back to <c>Experimental</c>). See
+    /// <c>Honua.Core.Features.Capabilities.CapabilityRegistry</c> and
+    /// <see cref="ClientCertificateAuthenticationExtensions.IsMtlsCapabilityEnabled"/>.
+    /// </summary>
+    public const string CapabilityId = "security.mtls";
 }
 
 internal sealed class ClientCertificateAuthenticationHandler(

--- a/src/Honua.Hosting/Features/Authentication/OidcAuthenticationExtensions.cs
+++ b/src/Honua.Hosting/Features/Authentication/OidcAuthenticationExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Security.Claims;
 using System.Text;
 using Honua.Core.Features.Authorization.Domain;
+using Honua.Core.Features.Capabilities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -195,9 +196,21 @@ public static class OidcAuthenticationExtensions
                     return AdminSessionScheme;
                 }
 
-                var clientCertificateOptions = context.RequestServices
-                    .GetService<IOptions<ClientCertificateAuthenticationOptions>>()?
-                    .Value;
+                // #2958: the client-certificate scheme is only registered (and only a valid
+                // forward target) when the security.mtls experimental capability is enabled.
+                // Routing to it while the flag is off would throw (no handler registered for
+                // the scheme), so the capability flag is checked before Mode/certificate
+                // presence even though it changes the branch's meaning: a caller presenting a
+                // certificate while the capability is off falls through to API-key auth below.
+                var mtlsCapabilityEnabled = (context.RequestServices
+                    .GetService<IOptions<CapabilityFlagOptions>>()?
+                    .Value ?? new CapabilityFlagOptions())
+                    .IsExperimentalEnabled(ClientCertificateAuthenticationDefaults.CapabilityId);
+                var clientCertificateOptions = mtlsCapabilityEnabled
+                    ? context.RequestServices
+                        .GetService<IOptions<ClientCertificateAuthenticationOptions>>()?
+                        .Value
+                    : null;
                 if (clientCertificateOptions is not null &&
                     clientCertificateOptions.Mode != ClientCertificateAuthenticationMode.Disabled &&
                     (context.Connection.ClientCertificate is not null ||
@@ -240,7 +253,8 @@ public static class OidcAuthenticationExtensions
         // client-certificate principals with admin roles.
         services.PostConfigure<Microsoft.AspNetCore.Authorization.AuthorizationOptions>(authzOptions =>
         {
-            var schemes = BuildSchemes();
+            var schemes = BuildSchemes(
+                ClientCertificateAuthenticationExtensions.IsMtlsCapabilityEnabled(configuration));
             var adminRoles = BuildRoleSet(oidcOptions.AdminRoles, "admin", "administrator", "Administrator");
 
             UpdateRolePolicy(
@@ -277,7 +291,7 @@ public static class OidcAuthenticationExtensions
         return services;
     }
 
-    private static List<string> BuildSchemes()
+    private static List<string> BuildSchemes(bool mtlsCapabilityEnabled)
     {
         // Admin APIs authenticate through the composite scheme. Interactive provider
         // schemes are used by backend-assisted login endpoints; adding them to API
@@ -286,12 +300,19 @@ public static class OidcAuthenticationExtensions
         var schemes = new List<string>
         {
             CompositeScheme,
-            ClientCertificateAuthenticationDefaults.AuthenticationScheme,
             // Console-consumable operator bearer (#2258): admin policies must accept
             // a principal projected from a forwardable operator bearer so it resolves
             // to the same RBAC as the cookie session it was issued from.
             OperatorBearerScheme
         };
+
+        // #2958: the client-certificate scheme is only registered when the security.mtls
+        // experimental capability is enabled; adding an unregistered scheme name to a
+        // policy throws at authorization time, so it must be conditional here too.
+        if (mtlsCapabilityEnabled)
+        {
+            schemes.Add(ClientCertificateAuthenticationDefaults.AuthenticationScheme);
+        }
 
         return schemes;
     }

--- a/src/Honua.Server/Features/Admin/ClientCertificateAdminEndpoints.cs
+++ b/src/Honua.Server/Features/Admin/ClientCertificateAdminEndpoints.cs
@@ -27,10 +27,13 @@ internal static class ClientCertificateAdminEndpoints
     public static void MapClientCertificateAdminEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("/api/v{version:apiVersion}/admin/security/client-certificates")
-            // #2431: native mTLS / client-certificate authentication was promoted from
-            // experimental to GA (security.mtls Experimental -> Implemented). The gate is
-            // retained but now resolves enabled for the GA capability, so these routes ship on
-            // the default first-release surface (Enterprise entitlement enforced separately).
+            // #2431 promoted native mTLS / client-certificate authentication from experimental
+            // to GA; #2958 DEMOTED it back to experimental (release-safety follow-up): the
+            // always-on client-certificate scheme/RBAC layer interposed on admin requests
+            // regardless of bearer-token validity. These routes are gated OFF the default
+            // surface again until a customer opts in via
+            // Capabilities:Experimental:security.mtls:Enabled=true (Enterprise entitlement is
+            // enforced separately, on top, once the capability is enabled).
             .WithCapabilityGate("security.mtls")
             .WithApiVersionSet()
             .HasApiVersion(1, 0)

--- a/src/Honua.Server/Startup/AuthenticationOptionsRegistration.cs
+++ b/src/Honua.Server/Startup/AuthenticationOptionsRegistration.cs
@@ -110,7 +110,7 @@ internal static class AuthenticationOptionsRegistration
         services.AddScoped<OperatorApprovalGate>();
 
         // Authentication and authorization handlers
-        services.AddApiKeyAuthentication();
+        services.AddApiKeyAuthentication(configuration);
         services.AddHonuaClientCertificateAuthentication(configuration);
         services.AddOidcAuthentication(configuration);
         services.AddOidcAuthorization(configuration);

--- a/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
+++ b/tests/dotnet/Honua.Architecture.Tests/FeatureCatalog/FeatureCatalogGenerator.cs
@@ -250,9 +250,15 @@ internal static class FeatureCatalogGenerator
         // through to the in-release surface (implemented) like any other GA capability.
 
         // Native mTLS (client certificates) — /api/v1/admin/security/client-certificates/* was
-        // promoted to GA (Implemented) in #2431, so it is no longer a flipped experimental group:
-        // its routes fall through to the in-release surface (implemented) like any other GA
-        // capability.
+        // promoted to GA (Implemented) in #2431, then DEMOTED back to experimental in #2958
+        // (release-safety follow-up to #2946/#2431): the always-on client-certificate scheme/RBAC
+        // layer interposed on admin requests regardless of bearer-token validity. It is a flipped
+        // experimental group again.
+        if (route.StartsWith(
+            "/api/v1/admin/security/client-certificates/", StringComparison.OrdinalIgnoreCase))
+        {
+            return "security.mtls";
+        }
 
         // Disconnected-sync replica / conflict review — /api/v1/admin/services/{serviceId}/replicas/*
         if (route.StartsWith("/api/v1/admin/services/", StringComparison.OrdinalIgnoreCase) &&

--- a/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Capabilities/CapabilityManifestRegistryProjectionTests.cs
@@ -84,9 +84,13 @@ public sealed class CapabilityManifestRegistryProjectionTests
         // temporal.* promoted to Implemented (GA) in #2429 — no longer omitted.
         "sync.offline",
         // realtime.feature-streams promoted to Implemented (GA) in #2428 — no longer omitted.
-        // alerts.geofence promoted in #2427 and security.mtls in #2431 — neither is omitted.
+        // alerts.geofence promoted in #2427 — not omitted.
         // versioning.branch (VMS REST surface) gated Preview in the BH6-001/BH6-002 fix batch.
         "versioning.branch",
+        // security.mtls was promoted to Implemented (GA) in #2431, then DEMOTED back to
+        // experimental in #2958 (release-safety follow-up): the always-on client-certificate
+        // scheme/RBAC layer interposed on admin requests regardless of bearer-token validity.
+        "security.mtls",
     ];
 
     [Fact]

--- a/tests/dotnet/Honua.Server.Tests/Features/Admin/ClientCertificateAdminEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Admin/ClientCertificateAdminEndpointsTests.cs
@@ -502,7 +502,11 @@ public sealed class ClientCertificateAdminEndpointsTests : IDisposable
                     ["HONUA_DEV_AUTH"] = "false",
                     ["HONUA_ADMIN_PASSWORD"] = AdminPassword,
                     ["Authentication:ClientCertificates:Mode"] = "Optional",
-                    ["Authentication:ClientCertificates:EnvironmentId"] = "prod"
+                    ["Authentication:ClientCertificates:EnvironmentId"] = "prod",
+                    // #2958: mTLS client-certificate auth is demoted to experimental and gated
+                    // behind Capabilities:Experimental:security.mtls:Enabled (default off). This
+                    // suite proves the flag-ON behavior, so every fixture opts in explicitly.
+                    ["Capabilities:Experimental:security.mtls:Enabled"] = "true"
                 };
 
                 if (extra is not null)

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/ExperimentalCapabilityGatingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/ExperimentalCapabilityGatingIntegrationTests.cs
@@ -269,6 +269,33 @@ public sealed class ExperimentalCapabilityGatingIntegrationTests
     }
 
     [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/auth/config")]
+    public async Task AdminAuthConfigEndpoint_WhenExperimentalDisabled_Returns200()
+    {
+        // #2958 regression guard: HandleGetAuthConfig resolves IClientCertificateTrustStore
+        // via [FromServices] to report trust-profile bootstrap hints. That store must stay
+        // registered even while security.mtls is gated off, or this anonymous admin auth
+        // bootstrap endpoint fails DI activation (500) instead of serving a clean 200 for
+        // every OIDC/bearer-only deployment that has never opted into the experimental
+        // capability (the production default) — the exact class of regression this PR
+        // exists to prevent, just against a different endpoint than #2945's.
+        var fixture = CreateFixture(experimentalGlobalEnabled: false);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var response = await client.GetAsync("/api/v1/admin/auth/config");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
     [Endpoint("GET /api/v1/admin/operations/streaming/subscribers")]
     public async Task StreamingEndpoint_AfterGaPromotion_IsNotExperimentalGated()
     {

--- a/tests/dotnet/Honua.Server.Tests/Features/Capabilities/ExperimentalCapabilityGatingIntegrationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Capabilities/ExperimentalCapabilityGatingIntegrationTests.cs
@@ -18,11 +18,11 @@ namespace Honua.Server.Tests.Features.Capabilities;
 /// <summary>
 /// Track-B integration coverage for honua-server#2347 (T11): the built-experimental
 /// capabilities the T10 flip (#2346) gated OFF the first-release surface
-/// (<c>sync.offline</c> and <c>versioning.branch</c>; <c>alerts.geofence</c>,
-/// <c>realtime.feature-streams</c>, <c>security.mtls</c>, and <c>temporal.*</c> were
-/// promoted to GA, so they are no longer experimental) must be genuinely <b>absent</b>
-/// from every served surface end-to-end when experimental is disabled (the production
-/// default), and become present/served the moment a customer opts one in via
+/// (<c>sync.offline</c>, <c>versioning.branch</c>, and — since #2958 — <c>security.mtls</c>
+/// again; <c>alerts.geofence</c>, <c>realtime.feature-streams</c>, and <c>temporal.*</c>
+/// were promoted to GA, so they are no longer experimental) must be genuinely
+/// <b>absent</b> from every served surface end-to-end when experimental is disabled (the
+/// production default), and become present/served the moment a customer opts one in via
 /// <c>Capabilities:Experimental</c>. This closes the loop B2 (#2334) and B3 (#2335)
 /// opened at the registry/composition layer by asserting the posture at the wire:
 /// <list type="bullet">
@@ -32,10 +32,12 @@ namespace Honua.Server.Tests.Features.Capabilities;
 ///     opted-in one;
 ///   </description></item>
 ///   <item><description>
-///     the gated VMS route group (<c>/rest/services/{id}/VersionManagementServer</c>)
-///     short-circuits with <c>404 honua:capability-experimental-disabled</c> while
-///     disabled. The now-GA client-certificate, streaming, and temporal groups are
-///     asserted to NOT short-circuit even with experimental off.
+///     the gated VMS and client-certificate route groups
+///     (<c>/rest/services/{id}/VersionManagementServer</c>,
+///     <c>/api/v1/admin/security/client-certificates/*</c>) short-circuit with
+///     <c>404 honua:capability-experimental-disabled</c> while disabled. The now-GA
+///     streaming and temporal groups are asserted to NOT short-circuit even with
+///     experimental off.
 ///   </description></item>
 /// </list>
 /// The Test environment turns experimental ON globally (appsettings.Test.json), which is
@@ -56,9 +58,13 @@ public sealed class ExperimentalCapabilityGatingIntegrationTests
         // temporal.* promoted to GA (Implemented) in #2429 — no longer experimental-gated.
         "sync.offline",
         // realtime.feature-streams promoted to GA (Implemented) in #2428 — no longer experimental-gated.
-        // alerts.geofence promoted in #2427 and security.mtls in #2431 — neither is gated.
+        // alerts.geofence promoted in #2427 — not gated.
         // versioning.branch (VMS REST surface) gated Preview in the BH6-001/BH6-002 fix batch.
         "versioning.branch",
+        // security.mtls was promoted to GA in #2431, then DEMOTED back to experimental in
+        // #2958 (release-safety follow-up to #2946/#2431): the always-on client-certificate
+        // scheme/RBAC layer interposed on admin requests regardless of bearer-token validity.
+        "security.mtls",
     ];
 
     [IntegrationTest]
@@ -215,13 +221,37 @@ public sealed class ExperimentalCapabilityGatingIntegrationTests
 
     [IntegrationTest]
     [Endpoint("GET /api/v1/admin/security/client-certificates/profiles")]
-    public async Task ClientCertificatesEndpoint_AfterGaPromotion_IsNotExperimentalGated()
+    public async Task ClientCertificatesEndpoint_WhenExperimentalDisabled_Returns404ExperimentalDisabled()
     {
-        // #2431 promoted security.mtls Experimental -> Implemented (GA). The client-certificate
-        // trust-profile admin group must no longer short-circuit as experimental-disabled even
-        // with the global experimental switch OFF — the request reaches the handler (subject to
-        // admin auth / edition) instead of the 404 the T10 flip previously produced.
+        // #2958: security.mtls was promoted to GA in #2431, then DEMOTED back to experimental
+        // (release-safety follow-up to #2946/#2431). The client-certificate trust-profile admin
+        // group is gated Preview again: with experimental OFF the capability-gate filter must
+        // short-circuit with 404 honua:capability-experimental-disabled before any handler runs.
         var fixture = CreateFixture(experimentalGlobalEnabled: false);
+        await fixture.InitializeAsync();
+
+        try
+        {
+            using var client = fixture.CreateAdminClient();
+            using var response = await client.GetAsync(
+                "/api/v1/admin/security/client-certificates/profiles");
+
+            await AssertExperimentalDisabledAsync(response);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/security/client-certificates/profiles")]
+    public async Task ClientCertificatesEndpoint_WhenExperimentalEnabled_IsNotExperimentalGated()
+    {
+        // Opting the security.mtls capability in (per-capability override, global switch still
+        // OFF) must open the gate — the request reaches the handler (subject to admin auth /
+        // edition) instead of the 404 the capability-gate filter produces while disabled.
+        var fixture = CreateFixture(experimentalGlobalEnabled: false, perCapabilityEnabled: "security.mtls");
         await fixture.InitializeAsync();
 
         try

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ClientCertificateGrpcWebPipelineTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/ClientCertificateGrpcWebPipelineTests.cs
@@ -96,6 +96,9 @@ public sealed class ClientCertificateGrpcWebPipelineTests
                 builder.UseSetting("Authentication:ClientCertificates:Mode", "RequiredForNative");
                 builder.UseSetting("Authentication:ClientCertificates:EnvironmentId", "test");
                 builder.UseSetting("Authentication:ClientCertificates:ProtectedGrpcServices:0", "geospatial.v1.SpecService");
+                // #2958: mTLS is experimental and gated behind Capabilities:Experimental:security.mtls;
+                // this suite exercises the enforcement middleware directly, so it opts in explicitly.
+                builder.UseSetting("Capabilities:Experimental:security.mtls:Enabled", "true");
             });
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcAuthenticationTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Infrastructure/Authentication/OidcAuthenticationTests.cs
@@ -658,6 +658,45 @@ public class OidcAuthenticationTests
 
     [IntegrationTest]
     [Endpoint("GET /api/v1/admin/version")]
+    public async Task AdminEndpoint_MtlsCapabilityDisabled_ValidBearerToken_ReturnsCleanOk()
+    {
+        // honua-server#2958: native mTLS/client-certificate authentication is demoted to
+        // experimental and gated behind Capabilities:Experimental:security.mtls:Enabled
+        // (default off). Even when an operator has configured
+        // Authentication:ClientCertificates:Mode (here RequiredForAdmin, which — before
+        // #2958 — made the always-on cert-RBAC layer interpose on every admin request
+        // regardless of bearer-token validity) but has NOT opted into the experimental
+        // capability, the client-certificate scheme/policy-scheme entry/enforcement
+        // middleware must not be registered at all, so a valid bearer-token admin request
+        // is authenticated by the bearer scheme alone with a clean 200 — no interposed
+        // cert-RBAC 403 (the concrete failure #2945's OIDC hardening work surfaced).
+        var settings = CreateEnabledOidcSettings(new Dictionary<string, string?>
+        {
+            // The ambient "Test" environment (appsettings.Test.json) turns every
+            // experimental capability on by default; override the global switch back off
+            // so this test exercises the production default posture.
+            ["Capabilities:Experimental:Enabled"] = "false",
+            ["Authentication:ClientCertificates:Mode"] = "RequiredForAdmin",
+            ["Authentication:ClientCertificates:EnvironmentId"] = "prod",
+        });
+        using var factory = CreateOidcTestFactory(oidcSettings: settings);
+        using var client = factory.CreateClient();
+        var token = GenerateTestJwtToken(roles: ["admin"]);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/admin/version");
+        request.Headers.Add("Authorization", $"Bearer {token}");
+        var response = await client.SendAsync(request);
+
+        if (response.StatusCode != System.Net.HttpStatusCode.OK)
+        {
+            _output.WriteLine($"Unexpected status {response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+        }
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/admin/version")]
     public async Task AdminEndpoint_OidcEnabled_ReusedBearerToken_IsRejectedWhenReplayProtectionEnabled()
     {
         var settings = CreateEnabledOidcSettings(new Dictionary<string, string?>


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2958

## Summary
Demotes native mTLS / client-certificate authentication (`security.mtls`) from GA back to **experimental**, gated behind `Capabilities:Experimental:security.mtls:Enabled` (default off). The trigger (found during #2945's OIDC hardening): the always-on client-certificate scheme/RBAC layer interposed on every admin request regardless of bearer-token validity, so a host that never configured mTLS could 403 a fully valid JWT. While the capability is off the feature is fully dormant — no eager options validation, no authentication scheme, no policy-scheme entry, no enforcement middleware — so a half-configured `Authentication:ClientCertificates:*` section can no longer break startup or interpose on valid bearer auth. Scope is deliberately minimal per the release owner's direction ("mTLS should go experimental; we should not work on it too much more").

## Changes Made
- `CapabilityRegistry`: `security.mtls` maturity `Implemented` → `Experimental`; admin trust-profile routes (`/api/v1/admin/security/client-certificates/*`) are capability-gated OFF the default surface again (404 `honua:capability-experimental-disabled`).
- `ClientCertificateAuthenticationExtensions`: scheme/validator/trust-store registration and the enforcement middleware only activate when the flag is on; options are still bound (unvalidated) so read-only manifest consumers can report the configured mode.
- `AuthenticationExtensions` / `OidcAuthenticationExtensions`: the client-certificate scheme is added to Admin/OpsRead policy scheme lists and the composite-scheme selector only when the capability is enabled (an unregistered scheme name in a policy throws at authorization time).
- Integration tests: valid-bearer-with-mTLS-configured-but-capability-off returns a clean 200 (the exact #2945 regression); experimental-gating tests assert both gate directions (404 while off, handler reached with per-capability opt-in); `FeatureCatalogGenerator` maps the route group back to the flipped-experimental set.
- Docs: TLS/mTLS guide experimental callout, environment-variables reference, ADR-0058/ADR-0059 update notes; capability matrix + feature catalog regenerated.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] None — standard merge-and-release flow

Existing deployments relying on client-certificate auth must opt in via `Capabilities__Experimental__security.mtls__Enabled=true` after upgrading (no released version ships yet — this lands before the first release, which is the point).

## Breaking Changes
`security.mtls` is no longer on the default (GA) surface: client-certificate authentication and the `/api/v1/admin/security/client-certificates/*` admin group require the experimental opt-in. Pre-first-release, so no released-version compatibility impact.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Verification performed: targeted integration runs of `OidcAuthenticationTests`, `ClientCertificateAdminEndpointsTests`, `ExperimentalCapabilityGatingIntegrationTests`, `ClientCertificateGrpcWebPipelineTests` (Testcontainers + PostGIS) and `CapabilityManifestRegistryProjectionTests`; feature-catalog regeneration verified drift-free.
