### PR TITLE
fix: gate SAML and SCIM behind Enterprise entitlements (#2978)

### DIFF
--- a/docs/gis/data/capability-keys.v1.json
+++ b/docs/gis/data/capability-keys.v1.json
@@ -379,14 +379,14 @@
       "key": "identity.saml",
       "displayName": "SAML 2.0 Authentication",
       "category": "Identity",
-      "edition": "Community",
-      "description": "SAML 2.0 service-provider metadata and assertion consumer endpoints."
+      "edition": "Enterprise",
+      "description": "SAML 2.0 service-provider metadata, assertion consumer, and single-logout endpoints."
     },
     {
       "key": "identity.scim",
       "displayName": "SCIM 2.0 Provisioning",
       "category": "Identity",
-      "edition": "Community",
+      "edition": "Enterprise",
       "description": "User/group provisioning through the SCIM 2.0 protocol surface."
     },
     {

--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -1032,9 +1032,9 @@
       "key": "identity.saml",
       "displayName": "SAML 2.0 Authentication",
       "category": "Identity",
-      "edition": "Community",
+      "edition": "Enterprise",
       "entryCount": 3,
-      "provingTestCount": 10,
+      "provingTestCount": 13,
       "maturity": {
         "implemented": 3
       },
@@ -1049,9 +1049,9 @@
       "key": "identity.scim",
       "displayName": "SCIM 2.0 Provisioning",
       "category": "Identity",
-      "edition": "Community",
+      "edition": "Enterprise",
       "entryCount": 17,
-      "provingTestCount": 22,
+      "provingTestCount": 25,
       "maturity": {
         "implemented": 17
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -11223,6 +11223,9 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.IdentityEntitlementGateTests.SamlMetadata_WithEnterpriseEntitlement_ReachesEndpoint",
+        "Honua.Server.Tests.Features.Identity.IdentityEntitlementGateTests.SamlMetadata_WithProEntitlement_StillReturns402",
+        "Honua.Server.Tests.Features.Identity.IdentityEntitlementGateTests.SamlMetadata_WithoutEntitlement_Returns402WithEntitlementDetail",
         "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Metadata_WhenConfigured_ReturnsSpMetadata",
         "Honua.Server.Tests.Features.Identity.SamlBridgeEndpointsTests.Metadata_WhenSloConfigured_AdvertisesSingleLogoutService"
       ],
@@ -11521,6 +11524,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.IdentityEntitlementGateTests.ScimDiscovery_WithEnterpriseEntitlement_ReachesEndpoint",
         "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.ServiceProviderConfig_ReturnsSupportedFeatures",
         "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.ServiceProviderConfig_WithoutToken_ReturnsUnauthorized"
       ],
@@ -11536,6 +11540,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Identity.IdentityEntitlementGateTests.ScimUsers_WithProEntitlement_StillReturns402",
+        "Honua.Server.Tests.Features.Identity.IdentityEntitlementGateTests.ScimUsers_WithoutEntitlement_Returns402EvenWithValidBearer",
         "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.ListUsers_WithUserNameFilter_ReturnsMatch",
         "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.Request_WithWrongBearerToken_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Identity.ScimProvisioningEndpointsTests.Request_WithoutBearerToken_ReturnsUnauthorized"

--- a/docs/internal/contributor/adr/0024-open-core-edition-model.md
+++ b/docs/internal/contributor/adr/0024-open-core-edition-model.md
@@ -51,7 +51,7 @@ A complete, production-capable feature server for a single-process deployment.
 | **Protocols** | All — GeoServices REST (FeatureServer, MapServer, ImageServer, GeometryService), OGC API (Features, Tiles, Maps), WMS 1.3, WMTS 1.0, OData v4, MVT, gRPC (unary) |
 | **Data** | PostGIS backend; GeoJSON, Shapefile, GeoPackage, GPX, KML, WKT, FlatGeobuf, File Geodatabase, GeoParquet import; public ArcGIS GeoServices REST layer import; GeoServer/ArcGIS migration inventory |
 | **Query** | Full Filter AST (CQL2, OData `$filter`, WHERE), spatial queries, statistics, pagination |
-| **Edits** | Full CRUD across GeoServices, OGC, and OData; attachments; related records |
+| **Edits** | Full CRUD via the open protocols — OGC API Features, WFS-T, OData, gRPC — plus attachments and related records. The Esri GeoServices FeatureServer *write dialect* (`applyEdits`/`addFeatures`/`updateFeatures`/`deleteFeatures`/`calculate`) is Pro (`editing.featureserver-edits`, #1591): a compatibility surface for deployed Esri clients, not the only edit path |
 | **SDKs** | JS SDK, Python SDK, .NET SDK — full query + edit capabilities |
 | **MCP Server** | AI-assisted discovery, query, statistics (REST transport) |
 | **Admin UI** | Connections, layer publishing, JSON-based style editing with Maputnik visual editing tracked as backlog, map preview, import wizard, spatial SQL playground (query editor with autocomplete, inline map preview, EXPLAIN visualization) |

--- a/src/Honua.Core/Features/Licensing/Domain/CapabilityKeyCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/CapabilityKeyCatalog.cs
@@ -165,11 +165,11 @@ public static class CapabilityKeyCatalog
         new("fieldops.forms", "Field Collection Forms", FeatureCatalog.Categories.FieldOps,
             HonuaEdition.Community, "Read and submit online form packages. Disconnected/offline sync is Pro-gated separately by fieldops.offline-sync."),
 
-        // Identity
-        new("identity.saml", "SAML 2.0 Authentication", FeatureCatalog.Categories.Identity,
-            HonuaEdition.Community, "SAML 2.0 service-provider metadata and assertion consumer endpoints."),
-        new("identity.scim", "SCIM 2.0 Provisioning", FeatureCatalog.Categories.Identity,
-            HonuaEdition.Community, "User/group provisioning through the SCIM 2.0 protocol surface."),
+        // Identity: identity.saml and identity.scim moved to FeatureCatalog entitlements
+        // (both Enterprise, per ADR-0024's Identity Governance tier) in #2978 — they
+        // previously shipped here ungated, catalog drift from the ADR that let any
+        // SAML-speaking IdP bypass SSO tiering. They flow back into All via the
+        // FeatureCatalog union below.
 
         // Styling
         new("styling.ogc-api-styles", "OGC API Styles", FeatureCatalog.Categories.Styling,

--- a/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
+++ b/src/Honua.Core/Features/Licensing/Domain/FeatureCatalog.cs
@@ -198,6 +198,24 @@ public static class FeatureCatalog
     public const string OidcAuthenticationKey = "identity.oidc";
 
     /// <summary>
+    /// Entitlement key for SAML 2.0 service-provider authentication (#2978). Enterprise-only
+    /// per ADR-0024's Identity Governance tier ("Multi-provider OIDC configuration,
+    /// claim-to-role mapping, SAML bridge, SCIM user/group provisioning"); the Pro "no SSO
+    /// tax" position covers single-provider <see cref="OidcAuthenticationKey"/> only.
+    /// Previously shipped ungated (Community) in <c>CapabilityKeyCatalog.CommunityKeys</c> —
+    /// catalog drift from the ADR that let any SAML-speaking IdP bypass SSO tiering entirely.
+    /// </summary>
+    public const string SamlAuthenticationKey = "identity.saml";
+
+    /// <summary>
+    /// Entitlement key for SCIM 2.0 user/group provisioning (#2978). Enterprise-only per
+    /// ADR-0024's Identity Governance tier, alongside <see cref="OidcMultiProviderKey"/> and
+    /// <see cref="OidcClaimsMappingKey"/>. Previously shipped ungated (Community) — the same
+    /// catalog drift as <see cref="SamlAuthenticationKey"/>.
+    /// </summary>
+    public const string ScimProvisioningKey = "identity.scim";
+
+    /// <summary>
     /// Entitlement key for configuring multiple OIDC identity providers in one deployment.
     /// Enterprise-only identity governance; basic single-provider OIDC is separately gated
     /// by <see cref="OidcAuthenticationKey"/>.
@@ -305,6 +323,10 @@ public static class FeatureCatalog
             HonuaEdition.Enterprise, "Custom claim-to-role mapping and identity governance for OIDC providers."),
         new(MtlsClientCertificateKey, "mTLS Client-Certificate Authentication", Categories.Identity,
             HonuaEdition.Enterprise, "Native client-certificate (mTLS) authentication: trust profiles, issuer/chain validation with CRL/OCSP revocation, and certificate-to-principal mapping."),
+        new(SamlAuthenticationKey, "SAML 2.0 Authentication", Categories.Identity,
+            HonuaEdition.Enterprise, "SAML 2.0 service-provider metadata, assertion consumer, and single-logout endpoints."),
+        new(ScimProvisioningKey, "SCIM 2.0 Provisioning", Categories.Identity,
+            HonuaEdition.Enterprise, "User/group provisioning through the SCIM 2.0 protocol surface."),
 
         // Caching — Pro
         new("caching.output-cache", "Output Caching", Categories.Caching,

--- a/src/Honua.Server/Features/Identity/Saml/SamlEndpoints.cs
+++ b/src/Honua.Server/Features/Identity/Saml/SamlEndpoints.cs
@@ -9,8 +9,10 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using Honua.Core.Features.Licensing.Domain;
 using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Helpers;
+using Honua.Infrastructure.Licensing;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -40,7 +42,22 @@ internal static partial class SamlEndpoints
 
         var group = endpoints.MapGroup("/saml")
             .WithTags("Identity", "SAML")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            // #2978: SAML SP authentication is an Enterprise entitlement (FeatureCatalog
+            // .SamlAuthenticationKey; ADR-0024 Identity Governance tier). Gated at the group
+            // so /metadata is covered too — an unlicensed deployment must not advertise an
+            // SSO surface it cannot serve.
+            .AddEndpointFilter((invocationContext, next) =>
+            {
+                var gate = LicenseGate.RequireEntitlement(
+                    invocationContext.HttpContext,
+                    FeatureCatalog.SamlAuthenticationKey,
+                    "SAML 2.0 authentication");
+
+                return gate is null
+                    ? next(invocationContext)
+                    : ValueTask.FromResult<object?>(gate);
+            });
 
         group.MapGet("/metadata", HandleMetadata).WithDisplayName("SAML SP Metadata");
         group.MapPost("/acs", HandleAssertionConsumerService).WithDisplayName("SAML Assertion Consumer Service");

--- a/src/Honua.Server/Features/Identity/Scim/ScimEndpoints.cs
+++ b/src/Honua.Server/Features/Identity/Scim/ScimEndpoints.cs
@@ -6,6 +6,8 @@ using System.Text;
 using System.Text.Json;
 using Honua.Core.Features.Identity.Abstractions;
 using Honua.Core.Features.Identity.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Infrastructure.Licensing;
 using Honua.Server.Features.Identity.Scim.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -36,9 +38,29 @@ internal static partial class ScimEndpoints
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
+        // #2978: SCIM provisioning is an Enterprise entitlement (FeatureCatalog
+        // .ScimProvisioningKey; ADR-0024 Identity Governance tier, with OIDC
+        // multi-provider/claims-mapping). Applied to every /scim/v2 group
+        // (Users, Groups, and the RFC 7643 discovery documents) so an unlicensed deployment
+        // does not advertise a provisioning surface it cannot serve.
+        static ValueTask<object?> RequireScimEntitlement(
+            EndpointFilterInvocationContext invocationContext,
+            EndpointFilterDelegate next)
+        {
+            var gate = LicenseGate.RequireEntitlement(
+                invocationContext.HttpContext,
+                FeatureCatalog.ScimProvisioningKey,
+                "SCIM 2.0 provisioning");
+
+            return gate is null
+                ? next(invocationContext)
+                : ValueTask.FromResult<object?>(gate);
+        }
+
         var users = endpoints.MapGroup("/scim/v2/Users")
             .WithTags("Identity", "SCIM")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            .AddEndpointFilter(RequireScimEntitlement);
 
         users.MapGet("/", HandleListUsers).WithDisplayName("SCIM List Users");
         users.MapPost("/", HandleCreateUser).WithDisplayName("SCIM Create User");
@@ -49,7 +71,8 @@ internal static partial class ScimEndpoints
 
         var groups = endpoints.MapGroup("/scim/v2/Groups")
             .WithTags("Identity", "SCIM")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            .AddEndpointFilter(RequireScimEntitlement);
 
         groups.MapGet("/", HandleListGroups).WithDisplayName("SCIM List Groups");
         groups.MapPost("/", HandleCreateGroup).WithDisplayName("SCIM Create Group");
@@ -62,7 +85,8 @@ internal static partial class ScimEndpoints
         // optional features, resource types, and attribute schemas Honua supports.
         var discovery = endpoints.MapGroup("/scim/v2")
             .WithTags("Identity", "SCIM")
-            .AllowAnonymous();
+            .AllowAnonymous()
+            .AddEndpointFilter(RequireScimEntitlement);
 
         discovery.MapGet("/ServiceProviderConfig", HandleServiceProviderConfig).WithDisplayName("SCIM ServiceProviderConfig");
         discovery.MapGet("/ResourceTypes", HandleResourceTypes).WithDisplayName("SCIM ResourceTypes");

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/IdentityEntitlementGateTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/IdentityEntitlementGateTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Constants;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Honua.Server.Tests.Features.Identity;
+
+/// <summary>
+/// Entitlement-gate tests for the SAML and SCIM identity surfaces (#2978). Both previously
+/// shipped ungated in every edition — catalog drift from ADR-0024, whose Identity
+/// Governance tier places SAML and SCIM at Enterprise (<c>identity.saml</c> /
+/// <c>identity.scim</c>), while Pro covers single-provider OIDC only. These tests prove
+/// the gate in both directions — 402 with the standard
+/// entitlement problem detail when unlicensed, and normal endpoint behavior once the
+/// required edition is granted. The SAML/SCIM machinery itself is covered by
+/// <see cref="SamlBridgeEndpointsTests"/> / <see cref="ScimProvisioningEndpointsTests"/>,
+/// which run with the entitlement granted.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Admin)]
+[Operation(Operations.IdentityManagement)]
+public sealed class IdentityEntitlementGateTests
+{
+    private const string ScimToken = "scim-gate-bearer-token";
+
+    private static WebAppFixture CreateFixture(string? devGrantEdition)
+        => new WebAppFixture()
+            .UseSeed("tests/seed/server.yaml")
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseEnvironment("Test");
+                builder.UseSetting("HONUA_DEV_AUTH", "false");
+                builder.UseSetting("Saml:Enabled", "true");
+                builder.UseSetting("Scim:BearerToken", ScimToken);
+                if (devGrantEdition is not null)
+                {
+                    builder.UseSetting("Licensing:DevGrantEdition", devGrantEdition);
+                }
+            });
+
+    [IntegrationTest]
+    [Endpoint("GET /saml/metadata")]
+    public async Task SamlMetadata_WithoutEntitlement_Returns402WithEntitlementDetail()
+    {
+        var fixture = CreateFixture(devGrantEdition: null);
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var response = await client.GetAsync("/saml/metadata");
+
+            Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Contains("identity.saml", body);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /saml/metadata")]
+    public async Task SamlMetadata_WithProEntitlement_StillReturns402()
+    {
+        // SAML is Enterprise (ADR-0024 Identity Governance), not Pro: the Pro "no SSO tax"
+        // position covers single-provider OIDC only.
+        var fixture = CreateFixture(devGrantEdition: "Pro");
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var response = await client.GetAsync("/saml/metadata");
+
+            Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /saml/metadata")]
+    public async Task SamlMetadata_WithEnterpriseEntitlement_ReachesEndpoint()
+    {
+        var fixture = CreateFixture(devGrantEdition: "Enterprise");
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var response = await client.GetAsync("/saml/metadata");
+
+            // The gate must not fire; the endpoint's own enabled/configured handling takes
+            // over from here.
+            Assert.NotEqual(HttpStatusCode.PaymentRequired, response.StatusCode);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Users")]
+    public async Task ScimUsers_WithoutEntitlement_Returns402EvenWithValidBearer()
+    {
+        var fixture = CreateFixture(devGrantEdition: null);
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/scim/v2/Users");
+            request.Headers.Add("Authorization", $"Bearer {ScimToken}");
+            using var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Contains("identity.scim", body);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/Users")]
+    public async Task ScimUsers_WithProEntitlement_StillReturns402()
+    {
+        // SCIM is Enterprise, not Pro: a Pro license (which covers SAML/OIDC sign-in) must
+        // not unlock directory provisioning.
+        var fixture = CreateFixture(devGrantEdition: "Pro");
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/scim/v2/Users");
+            request.Headers.Add("Authorization", $"Bearer {ScimToken}");
+            using var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /scim/v2/ServiceProviderConfig")]
+    public async Task ScimDiscovery_WithEnterpriseEntitlement_ReachesEndpoint()
+    {
+        var fixture = CreateFixture(devGrantEdition: "Enterprise");
+        await fixture.InitializeAsync();
+        try
+        {
+            using var client = fixture.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, "/scim/v2/ServiceProviderConfig");
+            request.Headers.Add("Authorization", $"Bearer {ScimToken}");
+            using var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/SamlBridgeEndpointsTests.cs
@@ -37,6 +37,10 @@ public class SamlBridgeEndpointsTests : IAsyncLifetime
             {
                 builder.UseEnvironment("Test");
                 builder.UseSetting("HONUA_DEV_AUTH", "false");
+                // #2978: SAML SP auth is an Enterprise entitlement (ADR-0024 Identity
+                // Governance tier); grant it so these tests keep exercising the SAML
+                // machinery itself (the gate has its own tests in IdentityEntitlementGateTests).
+                builder.UseSetting("Licensing:DevGrantEdition", "Enterprise");
                 builder.UseSetting("Saml:Enabled", "true");
                 builder.UseSetting("Saml:EntityId", SamlTestAssertions.Audience);
                 builder.UseSetting("Saml:IdpEntityId", SamlTestAssertions.Issuer);

--- a/tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Identity/ScimProvisioningEndpointsTests.cs
@@ -41,6 +41,10 @@ public class ScimProvisioningEndpointsTests : IAsyncLifetime
             {
                 builder.UseEnvironment("Test");
                 builder.UseSetting("HONUA_DEV_AUTH", "false");
+                // #2978: SCIM provisioning is an Enterprise entitlement; grant it so these
+                // tests keep exercising the SCIM machinery itself (the gate has its own tests
+                // in IdentityEntitlementGateTests).
+                builder.UseSetting("Licensing:DevGrantEdition", "Enterprise");
                 builder.UseSetting("Scim:BearerToken", ScimToken);
             });
     }


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #2978

## Summary
Gates SAML 2.0 authentication and SCIM 2.0 provisioning behind **Enterprise** license entitlements, per ADR-0024's Identity Governance tier ("Multi-provider OIDC configuration, claim-to-role mapping, SAML bridge, SCIM user/group provisioning"). Both previously shipped completely ungated in every edition — catalog drift from the ADR that let any SAML-speaking IdP bypass SSO tiering entirely and gave away directory provisioning for free. Also corrects ADR-0024's Community Edits row to record the deliberate editing split (open-protocol CRUD is Community; only the Esri FeatureServer write dialect is Pro, #1591) so the tiering docs match the shipped, intended design in both directions.

## Changes Made
- `FeatureCatalog`: new `SamlAuthenticationKey` (`identity.saml`) and `ScimProvisioningKey` (`identity.scim`) Enterprise entitlements with ADR-0024 rationale; removed both from `CapabilityKeyCatalog.CommunityKeys` (they flow back into `All` via the FeatureCatalog union).
- `SamlEndpoints`: `/saml/{metadata,acs,slo}` group gated with the standard `LicenseGate.RequireEntitlement` endpoint filter (402 + upgrade message; metadata included so an unlicensed deployment doesn't advertise an SSO surface it cannot serve).
- `ScimEndpoints`: `/scim/v2/Users`, `/scim/v2/Groups`, and the RFC 7643 discovery groups gated with the same filter.
- New `IdentityEntitlementGateTests` (5 integration tests): 402 with `entitlement:` detail on unlicensed hosts (including with a valid SCIM bearer), **Pro-is-not-enough** for both SAML and SCIM, and endpoint-reached at Enterprise.
- Existing `SamlBridgeEndpointsTests` / `ScimProvisioningEndpointsTests` fixtures grant `Licensing:DevGrantEdition=Enterprise` so they keep proving the SAML/SCIM machinery itself.
- `capability-keys.v1.json` editions → Enterprise (drift-guard enforced); `feature-catalog.json` + `capability-matrix.v1.json` regenerated.
- ADR-0024: Community Edits row corrected to the deliberate open-protocol-free / Esri-dialect-Pro split.

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [x] Requires environment variable or secret changes
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] None — no docs or contract impact

Deployments using SAML or SCIM need an Enterprise license (or, for non-production, `Licensing:DevGrantEdition=Enterprise`). Pre-first-release, so no released-version compatibility impact.

## Breaking Changes
SAML (`/saml/*`) and SCIM (`/scim/v2/*`) now return 402 without an Enterprise entitlement. Nothing has shipped publicly, so no released-version compatibility impact — landing this before release 1 is the point.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

Verification performed: 34/34 targeted integration tests (SamlBridge + ScimProvisioning + new gate tests, Testcontainers + PostGIS); 12/12 capability/feature-catalog drift-guard architecture tests; catalogs regenerated via `scripts/generate-feature-catalog.sh` + `generate-capability-matrix.py`.

Related: honua-io/honua-release#64 (per-edition entitlement conformance lane) will make the next tiering drift fail the release train instead of shipping.
