### PR TITLE
fix(ci): address AI quality findings

### DIFF
--- a/scripts/ci/merge-train/autofix.sh
+++ b/scripts/ci/merge-train/autofix.sh
@@ -184,3 +184,18 @@ train_autofix_attempt() {
   train_warn "autofix attempt $((attempt + 1)) produced no commit; treating as unfixable"
   return 1
 }
+
+# train_autofix_verification_action <run-id> <fqn-list-newline>:
+# map surgical verification to the caller's control-flow decision. Returns 0
+# to land, 1 to retry, and 2 to escalate without retrying. A missing test list
+# cannot become green through retries, so it escalates immediately.
+train_autofix_verification_action() {
+  local run_id="$1" fqns="$2" rc=0
+
+  train_surgical_rerun "${run_id}" "${fqns}" || rc=$?
+  case "${rc}" in
+    0) return 0 ;;
+    2) return 2 ;;
+    *) return 1 ;;
+  esac
+}

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -773,6 +773,14 @@ train_surgical_rerun some-run "${fqns}" && bad "surgical: failing rerun should b
 # No FQNs => rc2 (caller must fall back, never a full rerun).
 set +e; train_surgical_rerun some-run ""; rc_sr=$?; set -e
 assert_eq "surgical: no FQNs => rc2 (fall back, no full shard rerun)" "${rc_sr}" "2"
+set +e
+train_autofix_verification_action some-run "${fqns}"
+rc_verify_failed=$?
+train_autofix_verification_action some-run ""
+rc_verify_empty=$?
+set -e
+assert_eq "surgical: failed verification => retry autofix" "${rc_verify_failed}" "1"
+assert_eq "surgical: committed fix with no FQNs => escalate without retry" "${rc_verify_empty}" "2"
 unset TRAIN_SURGICAL_RUNNER TRAIN_TEST_PROJECT_FOR
 
 echo

--- a/scripts/ci/merge-train/train.sh
+++ b/scripts/ci/merge-train/train.sh
@@ -152,6 +152,19 @@ train_run_batch_ci() {
   train_smart_ci_run "${batch}"
 }
 
+# Restore the branch and scratch paths after an attribution probe.
+_train_restore_attribute_probe_state() {
+  local probe_inc="$1" probe_skp="$2" probe_run="$3" anchor_batch="$4"
+  local prev_batch="$5" prev_included="$6" prev_skipped="$7" prev_run_id="$8"
+
+  rm -f "${probe_inc}" "${probe_skp}" "${probe_run}"
+  git -C "${TRAIN_REPO_ROOT}" checkout -q "${anchor_batch}" || true
+  TRAIN_BATCH_BRANCH="${prev_batch}"
+  TRAIN_INCLUDED_FILE="${prev_included}"
+  TRAIN_SKIPPED_FILE="${prev_skipped}"
+  TRAIN_RUN_ID_FILE="${prev_run_id}"
+}
+
 # train_attribute_probe_gate <comma-separated-prs> <trunk-sha7> <anchor-batch>:
 # Build just those PRs into a disposable batch branch and run batch CI. Prints the
 # resulting gate (FAILURE / SUCCESS / etc.) and preserves the caller's working
@@ -190,25 +203,25 @@ train_attribute_probe_gate() {
 
   local probe_batch
   if ! probe_batch="$(train_assemble "${trunk_sha7}" "${probe_prs[@]}" )"; then
-    rm -f "${probe_inc}" "${probe_skp}" "${probe_run}"
-    git -C "${TRAIN_REPO_ROOT}" checkout -q "${anchor_batch}" || true
-    TRAIN_BATCH_BRANCH="${prev_batch}" TRAIN_INCLUDED_FILE="${prev_included}" TRAIN_SKIPPED_FILE="${prev_skipped}" TRAIN_RUN_ID_FILE="${prev_run_id}"
+    _train_restore_attribute_probe_state \
+      "${probe_inc}" "${probe_skp}" "${probe_run}" "${anchor_batch}" \
+      "${prev_batch}" "${prev_included}" "${prev_skipped}" "${prev_run_id}"
     echo "NO_RUN"
     return 0
   fi
   include_count="$(cut -f1 "${probe_inc}" | sed '/^$/d' | wc -l | tr -d ' ')"
   if [[ "${include_count}" -eq 0 ]]; then
-    rm -f "${probe_inc}" "${probe_skp}" "${probe_run}"
-    git -C "${TRAIN_REPO_ROOT}" checkout -q "${anchor_batch}" || true
-    TRAIN_BATCH_BRANCH="${prev_batch}" TRAIN_INCLUDED_FILE="${prev_included}" TRAIN_SKIPPED_FILE="${prev_skipped}" TRAIN_RUN_ID_FILE="${prev_run_id}"
+    _train_restore_attribute_probe_state \
+      "${probe_inc}" "${probe_skp}" "${probe_run}" "${anchor_batch}" \
+      "${prev_batch}" "${prev_included}" "${prev_skipped}" "${prev_run_id}"
     echo "NO_RUN"
     return 0
   fi
 
   gate="$(train_run_batch_ci "${probe_batch}")"
-  rm -f "${probe_inc}" "${probe_skp}" "${probe_run}"
-  git -C "${TRAIN_REPO_ROOT}" checkout -q "${anchor_batch}" || true
-  TRAIN_BATCH_BRANCH="${prev_batch}" TRAIN_INCLUDED_FILE="${prev_included}" TRAIN_SKIPPED_FILE="${prev_skipped}" TRAIN_RUN_ID_FILE="${prev_run_id}"
+  _train_restore_attribute_probe_state \
+    "${probe_inc}" "${probe_skp}" "${probe_run}" "${anchor_batch}" \
+    "${prev_batch}" "${prev_included}" "${prev_skipped}" "${prev_run_id}"
   echo "${gate:-FAILURE}"
 }
 
@@ -517,18 +530,29 @@ main() {
         # full smart-CI is exactly the waste we're avoiding. If the fix
         # incidentally broke a previously-passing test, the optimistic model
         # catches it on trunk's next batch (accept-some-failure for throughput).
-        if [[ -n "$(printf '%s' "${fqns}" | sed '/^$/d')" ]] && train_surgical_rerun "${run_id}" "${fqns}"; then
-          train_metric_set autofix_fixes "$(( $(train_metric_get autofix_fixes 0) + 1 ))"
-          train_notice "autofix verified by surgical rerun of the failed tests; landing the batch (no full re-run)"
-          gate="SUCCESS"
-          continue
-        else
-          # Fix didn't hold: loop back to retry autofix against the SAME failed
-          # tests (gate is still non-SUCCESS) up to the cap, then escalate — still
-          # NO wasteful full re-run. The surgical rerun is the only re-check.
-          train_warn "autofix commit did not pass surgical re-verify; retrying autofix (no full re-run) up to the cap"
-          continue
-        fi
+        local verification_rc=0
+        train_autofix_verification_action "${run_id}" "${fqns}" || verification_rc=$?
+        case "${verification_rc}" in
+          0)
+            train_metric_set autofix_fixes "$(( $(train_metric_get autofix_fixes 0) + 1 ))"
+            train_notice "autofix verified by surgical rerun of the failed tests; landing the batch (no full re-run)"
+            gate="SUCCESS"
+            continue
+            ;;
+          1)
+            # Fix didn't hold: loop back to retry autofix against the SAME failed
+            # tests (gate is still non-SUCCESS) up to the cap, then escalate — still
+            # NO wasteful full re-run. The surgical rerun is the only re-check.
+            train_warn "autofix commit did not pass surgical re-verify; retrying autofix (no full re-run) up to the cap"
+            continue
+            ;;
+          2)
+            train_warn "autofix produced a commit but no failed test names were available for surgical re-verify; escalating"
+            ;;
+          *)
+            train_warn "autofix surgical verification returned an unexpected status; escalating"
+            ;;
+        esac
       fi
       # autofix declined / produced no commit / cap reached => escalate below.
       train_warn "autofix did not produce a landable fix; escalating as genuinely-hard"

--- a/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
+++ b/src/Honua.Postgres/Features/Migration/PostgresMigrationCatalogWriter.cs
@@ -528,7 +528,7 @@ internal sealed partial class PostgresMigrationCatalogWriter : IMigrationCatalog
             """;
 
         // honua.relationships has CHECK constraints on relationship_id > 0 and
-        // relationship_type âˆˆ {esriRelRoleOrigin, esriRelRoleDestination,
+        // relationship_type ∈ {esriRelRoleOrigin, esriRelRoleDestination,
         // esriRelRoleAny}. Stable-hash the source identifier when the source did
         // not advertise an integer id so the row still satisfies the schema.
         var relationshipId = request.EsriRelationshipId ?? DeriveStableRelationshipId(request.SourceRelationshipId);


### PR DESCRIPTION
# Pull Request

## Issue Link

Related to #2865

Code Quality AI findings: https://github.com/honua-io/honua-server/security/quality/ai-findings

## Summary

Addresses all four current AI Code Quality findings. The merge train now restores probe state through one helper and stops retrying autofix commits that cannot be surgically verified because no failed test names were reported. The remaining migration-source comment encoding is corrected.

## Changes Made

- Centralize attribution-probe cleanup and state restoration.
- Map surgical autofix results to explicit land, retry, or escalate actions.
- Escalate no-FQN autofix commits immediately instead of exhausting the fix-agent cap.
- Add regression coverage for retryable verification failures and no-FQN escalation.
- Correct the garbled element-of symbol in the migration catalog writer comment.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:

- `bash -n` passed for the three changed shell scripts.
- The full offline merge-train fixture completed with 151 passing checks and 7 pre-existing MSYS/Windows-only failures.
- All 14 surgical/autofix checks passed, including the two new control-flow regressions.
- `git diff --check` passed.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
