### PR TITLE
fix(ci): parse merge-train state fence exactly

### DIFF
--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -460,6 +460,13 @@ assert_eq "state: included persisted" "$(jq -rc '.active_batch.included' <<<"${s
 assert_eq "state: max_batch in config" "$(jq -r '.config.max_batch' <<<"${sj}")" "${MAX_BATCH:-3}"
 assert_eq "state: last_landed_trunk" "$(jq -r '.last_landed_trunk' <<<"${sj}")" "cafef00d"
 
+aggregate='{"totals":{"batches":1,"prs_landed":1}}'
+state_dashboard="$(printf '%s\n\n```json aggregate\n%s\n```\n' "${body}" "${aggregate}")"
+parsed_state="$(TRAIN_STATE_ISSUE_OVERRIDE=2044 TRAIN_STATE_BODY_OVERRIDE="${state_dashboard}" train_state_read)"
+assert_eq "state: reader ignores aggregate JSON fence" "$(jq -r '.active_batch.phase' <<<"${parsed_state}")" "smart-ci"
+assert_eq "state: aggregate reader selects aggregate fence" \
+  "$(TRAIN_STATE_ISSUE_OVERRIDE=2044 TRAIN_AGG_BODY_OVERRIDE="${state_dashboard}" train_aggregate_block | jq -r '.totals.prs_landed')" "1"
+
 echo
 echo "== select: CI-Gate classification + ordering + hold/draft filters =="
 export TRAIN_PR_LIST_JSON='[

--- a/scripts/ci/merge-train/state.sh
+++ b/scripts/ci/merge-train/state.sh
@@ -127,7 +127,7 @@ train_state_read() {
   fi
   # Extract the fenced ```json ... ``` block.
   json="$(printf '%s\n' "${body}" | awk '
-    /^```json/ { inblk=1; next }
+    /^```json[[:space:]]*$/ { inblk=1; next }
     /^```/     { if (inblk) { inblk=0 } ; next }
     inblk      { print }
   ')"
@@ -156,7 +156,7 @@ train_aggregate_block() {
     body="$(gh issue view "${num}" --json body --jq '.body' 2>/dev/null)" || return 1
   fi
   printf '%s\n' "${body}" | awk '
-    /^```json aggregate/ { inblk=1; next }
+    /^```json aggregate[[:space:]]*$/ { inblk=1; next }
     /^```/               { if (inblk) { inblk=0 }; next }
     inblk                { print }
   '


### PR DESCRIPTION
# Pull Request

## Issue Link

Related to #2865

Failed train run: https://github.com/honua-io/honua-server/actions/runs/29966905153

## Summary

Fixes the post-land merge-train log jam. The state issue contains both a machine-state `json` fence and a `json aggregate` fence. The state reader's prefix match consumed both blocks, produced malformed concatenated JSON, and caused every self-chained controller to fail closed before selection.

## Changes Made

- Match the machine-state and aggregate fence openers exactly.
- Add a regression that renders both blocks and verifies each reader selects only its own JSON.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:

- `bash -n scripts/ci/merge-train/state.sh scripts/ci/merge-train/fixtures/validate-merge-train.sh`
- `bash scripts/ci/merge-train/fixtures/validate-merge-train.sh` — 158 passed, 0 failed
- `git diff --check`

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
