### PR TITLE
fix(ci): stop merge-train chaining on held PRs

### DIFF
--- a/.github/workflows/merge-train.yml
+++ b/.github/workflows/merge-train.yml
@@ -263,7 +263,7 @@ jobs:
             --json number,isDraft,mergeable,labels \
             --jq '[.[] | select(.isDraft == false)
                        | select((.mergeable // "MERGEABLE") != "CONFLICTING")
-                       | select([.labels[].name] | (index("train:hold") or index("train:escalated")) | not)]
+                       | select([.labels[].name] | (index("hold") or index("train:hold") or index("train:escalated")) | not)]
                   | length')"
           echo "Selectable PRs remaining after this run: ${ready:-0}"
           if [[ "${ready:-0}" -gt 0 ]]; then


### PR DESCRIPTION
# Pull Request

## Issue Link

Related to #2865

## Summary

Stops the merge train from self-dispatching no-op runs when every remaining non-draft PR is intentionally held. The self-chain readiness query recognized `train:hold` but omitted the repository's legacy `hold` opt-out label.

## Changes Made

- Exclude `hold`, `train:hold`, and `train:escalated` consistently in the self-chain readiness query.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Manual testing performed

Validation performed:

- Evaluated the corrected eligibility rules against the live open-PR set: 0 selectable PRs.
- Confirmed the prior rules treated the four legacy-`hold` PRs as selectable.
- `git diff --check` passed.

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes

None

---

## Pre-PR Checklist

- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
