### PR TITLE
fix: attest clean exact-head Codex reviews

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -127,7 +127,7 @@ jobs:
             const cleanComments = await Promise.all(pr.comments.nodes.map(async comment => {
               if (!isCodex(comment.author?.login)) return comment;
               const matches = [...(comment.body || '').matchAll(
-                /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{10,40})`/gi
+                /(?:\*\*Reviewed commit:\*\*|Reviewed commit:)\s*`([0-9a-f]{10,40})`/gi
               )];
               if (matches.length !== 1) return comment;
               const ref = matches[0][1];

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -124,8 +124,27 @@ jobs:
                 isCodex(comment.author?.login) && comment.commit?.oid === head));
             if (unresolved.length) reasons.push(`${unresolved.length} unresolved Codex thread(s)`);
 
+            const cleanComments = await Promise.all(pr.comments.nodes.map(async comment => {
+              if (!isCodex(comment.author?.login)) return comment;
+              const matches = [...(comment.body || '').matchAll(
+                /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{10,40})`/gi
+              )];
+              if (matches.length !== 1) return comment;
+              const ref = matches[0][1];
+              if (ref.length === 40) return { ...comment, resolvedCommitOid: ref };
+              try {
+                const { data: commit } = await github.rest.repos.getCommit({
+                  ...context.repo, ref,
+                });
+                return { ...comment, resolvedCommitOid: commit.sha };
+              } catch (error) {
+                core.warning(`Could not uniquely resolve reviewed commit ${ref}: ${error.message}`);
+                return comment;
+              }
+            }));
+
             const { exactReview, exactCleanComment } = evaluateCodexEvidence({
-              reviews: pr.reviews.nodes, cleanComments: pr.comments.nodes,
+              reviews: pr.reviews.nodes, cleanComments,
               unresolvedCount: unresolved.length, head,
             });
 

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -8,6 +8,8 @@ on:
     types: [submitted, dismissed, edited]
   pull_request_review_comment:
     types: [created, edited, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
   workflow_run:
     workflows: ["PR Gate"]
     types: [completed]
@@ -24,11 +26,12 @@ permissions:
   statuses: write
 
 concurrency:
-  group: review-gate-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr }}
+  group: review-gate-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr }}
   cancel-in-progress: true
 
 jobs:
   attest:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     name: Publish SHA-bound Codex review attestation
     runs-on: ubuntu-latest
     steps:
@@ -48,6 +51,7 @@ jobs:
             // when PR Gate completes, instead of failing before publishing status.
             let prNumber = Number(
               context.payload.pull_request?.number ||
+              context.payload.issue?.number ||
               context.payload.workflow_run?.pull_requests?.[0]?.number ||
               '${{ github.event.inputs.pr }}'
             );
@@ -71,6 +75,10 @@ jobs:
                     labels(first: 100) { nodes { name } pageInfo { hasNextPage } }
                     reviews(first: 100) {
                       nodes { author { login } body submittedAt updatedAt state commit { oid } }
+                      pageInfo { hasNextPage }
+                    }
+                    comments(first: 100) {
+                      nodes { author { login } body createdAt updatedAt includesCreatedEdit }
                       pageInfo { hasNextPage }
                     }
                     reviewThreads(first: 100) {
@@ -101,6 +109,7 @@ jobs:
               if (labels.has(label)) reasons.push(`blocked by ${label}`);
             }
             if (pr.labels.pageInfo.hasNextPage || pr.reviews.pageInfo.hasNextPage ||
+                pr.comments.pageInfo.hasNextPage ||
                 pr.reviewThreads.pageInfo.hasNextPage ||
                 pr.reviewThreads.nodes.some(thread => thread.comments.pageInfo.hasNextPage)) {
               reasons.push('bounded review query truncated');
@@ -111,12 +120,13 @@ jobs:
                 isCodex(comment.author?.login) && comment.commit?.oid === head));
             if (unresolved.length) reasons.push(`${unresolved.length} unresolved Codex thread(s)`);
 
-            const { exactReview } = evaluateCodexEvidence({
-              reviews: pr.reviews.nodes, unresolvedCount: unresolved.length, head,
+            const { exactReview, exactCleanComment } = evaluateCodexEvidence({
+              reviews: pr.reviews.nodes, cleanComments: pr.comments.nodes,
+              unresolvedCount: unresolved.length, head,
             });
 
-            if (!exactReview) {
-              reasons.push('no commit-bound exact-head Codex review');
+            if (!exactReview && !exactCleanComment) {
+              reasons.push('no exact-head Codex review evidence');
             }
             const state = reasons.length === 0 ? 'success' : 'failure';
             const description = reasons.length === 0

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -37,7 +37,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # Untrusted PR events always evaluate the default-branch policy. A manual
+          # workflow_dispatch may intentionally validate a reviewed policy fix at
+          # its selected ref, which provides the bootstrap path when the default
+          # policy itself cannot recognize the connector's clean-result shape.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Attest current PR head

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -124,7 +124,7 @@ __fixture_admission() {
     negative-review) reviews="[{\"author\":{\"login\":\"chatgpt-codex-connector\"},\"body\":\"Codex Review\",\"submittedAt\":\"2026-01-02T00:00:00Z\",\"updatedAt\":\"2026-01-02T00:00:00Z\",\"state\":\"CHANGES_REQUESTED\",\"commit\":{\"oid\":\"${head}\"}}]" ;;
     clean-comment)
       reviews='[]'
-      clean_comments="[{\"author\":{\"login\":\"chatgpt-codex-connector\"},\"body\":\"Codex Review: Didn't find any major issues.\\n\\n**Reviewed commit:** \`${head}\`\",\"createdAt\":\"2026-01-02T00:00:00Z\",\"updatedAt\":\"2026-01-02T00:00:00Z\",\"includesCreatedEdit\":false}]"
+      clean_comments="[{\"author\":{\"login\":\"chatgpt-codex-connector\"},\"body\":\"Codex Review: Didn't find any major issues.\\n\\n**Reviewed commit:** \`${head}\`\",\"createdAt\":\"2026-01-02T00:00:00Z\",\"updatedAt\":\"2026-01-02T00:00:00Z\",\"includesCreatedEdit\":false,\"resolvedCommitOid\":\"${head}\"}]"
       ;;
     held) labels='[{"name":"train:hold"}]' ;;
     escalated) labels='[{"name":"train:escalated"}]' ;;
@@ -844,8 +844,9 @@ for admission_case in gate-fail review-fail unresolved negative-review held esca
 done
 export ADMISSION_CASE=clean-comment
 admission_pr_list="${TRAIN_PR_LIST_JSON}"
-TRAIN_PR_LIST_JSON="$(jq 'map(if .number == 10 then .headRefOid = "aaaaaaaaaa" else . end)' <<<"${TRAIN_PR_LIST_JSON}")"
-train_pr_admission 10 aaaaaaaaaa \
+clean_comment_head="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+TRAIN_PR_LIST_JSON="$(jq --arg head "${clean_comment_head}" 'map(if .number == 10 then .headRefOid = $head else . end)' <<<"${TRAIN_PR_LIST_JSON}")"
+train_pr_admission 10 "${clean_comment_head}" \
   && ok "admission: exact-head clean Codex comment is accepted" \
   || bad "admission: exact-head clean Codex comment was rejected"
 TRAIN_PR_LIST_JSON="${admission_pr_list}"

--- a/scripts/ci/merge-train/fixtures/validate-merge-train.sh
+++ b/scripts/ci/merge-train/fixtures/validate-merge-train.sh
@@ -111,7 +111,7 @@ export TRAIN_REPO_ROOT="${WORK}"
 
 # Exact-head admission seam shared by selection and pre-land fixtures.
 __fixture_admission() {
-  local pr="$1" head state=OPEN draft=false labels='[]' gate=SUCCESS review=SUCCESS threads='[]' reviews
+  local pr="$1" head state=OPEN draft=false labels='[]' gate=SUCCESS review=SUCCESS threads='[]' reviews clean_comments='[]'
   head="$(awk -v n="${pr}" '$1==n{print $2}' "${TRAIN_INCLUDED_FILE}" 2>/dev/null || true)"
   if [[ -z "${head}" && -n "${TRAIN_PR_LIST_JSON:-}" ]]; then
     head="$(jq -r --argjson n "${pr}" '.[] | select(.number==$n) | .headRefOid' <<<"${TRAIN_PR_LIST_JSON}")"
@@ -122,6 +122,10 @@ __fixture_admission() {
     review-fail) review=FAILURE ;;
     unresolved) threads="[{\"isResolved\":false,\"comments\":{\"nodes\":[{\"author\":{\"login\":\"chatgpt-codex-connector[bot]\"},\"commit\":{\"oid\":\"${head}\"}}]}}]" ;;
     negative-review) reviews="[{\"author\":{\"login\":\"chatgpt-codex-connector\"},\"body\":\"Codex Review\",\"submittedAt\":\"2026-01-02T00:00:00Z\",\"updatedAt\":\"2026-01-02T00:00:00Z\",\"state\":\"CHANGES_REQUESTED\",\"commit\":{\"oid\":\"${head}\"}}]" ;;
+    clean-comment)
+      reviews='[]'
+      clean_comments="[{\"author\":{\"login\":\"chatgpt-codex-connector\"},\"body\":\"Codex Review: Didn't find any major issues.\\n\\n**Reviewed commit:** \`${head}\`\",\"createdAt\":\"2026-01-02T00:00:00Z\",\"updatedAt\":\"2026-01-02T00:00:00Z\",\"includesCreatedEdit\":false}]"
+      ;;
     held) labels='[{"name":"train:hold"}]' ;;
     escalated) labels='[{"name":"train:escalated"}]' ;;
     draft) draft=true ;;
@@ -131,7 +135,8 @@ __fixture_admission() {
   jq -nc --argjson n "${pr}" --arg head "${head}" --arg state "${state}" \
     --argjson draft "${draft}" --argjson labels "${labels}" --arg gate "${gate}" \
     --arg review "${review}" --argjson threads "${threads}" --argjson reviews "${reviews}" \
-    '{number:$n,state:$state,isDraft:$draft,headRefOid:$head,labels:$labels,labelsTruncated:false,reviews:$reviews,reviewsTruncated:false,reviewThreads:$threads,reviewThreadsTruncated:false,checksTruncated:false,statusCheckRollup:[{__typename:"CheckRun",name:"PR Gate",status:"COMPLETED",conclusion:$gate},{__typename:"StatusContext",context:"Review Gate",state:$review}]}'
+    --argjson cleanComments "${clean_comments}" \
+    '{number:$n,state:$state,isDraft:$draft,headRefOid:$head,labels:$labels,labelsTruncated:false,reviews:$reviews,reviewsTruncated:false,cleanComments:$cleanComments,commentsTruncated:false,reviewThreads:$threads,reviewThreadsTruncated:false,checksTruncated:false,statusCheckRollup:[{__typename:"CheckRun",name:"PR Gate",status:"COMPLETED",conclusion:$gate},{__typename:"StatusContext",context:"Review Gate",state:$review}]}'
 }
 export -f __fixture_admission
 export TRAIN_ADMISSION_JSON_FOR_PR=__fixture_admission
@@ -837,6 +842,14 @@ for admission_case in gate-fail review-fail unresolved negative-review held esca
     && bad "admission: ${admission_case} must fail closed" \
     || ok "admission: ${admission_case} fails closed"
 done
+export ADMISSION_CASE=clean-comment
+admission_pr_list="${TRAIN_PR_LIST_JSON}"
+TRAIN_PR_LIST_JSON="$(jq 'map(if .number == 10 then .headRefOid = "aaaaaaaaaa" else . end)' <<<"${TRAIN_PR_LIST_JSON}")"
+train_pr_admission 10 aaaaaaaaaa \
+  && ok "admission: exact-head clean Codex comment is accepted" \
+  || bad "admission: exact-head clean Codex comment was rejected"
+TRAIN_PR_LIST_JSON="${admission_pr_list}"
+unset ADMISSION_CASE
 status_record="${SCRATCH}/review-gate-status"; : >"${status_record}"
 export FIXTURE_REVIEW_STATUS_RECORD="${status_record}"
 export ADMISSION_CASE=review-fail TRAIN_APPLY=1

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -213,7 +213,7 @@ train_resolve_clean_comment_commits() {
     login="$(jq -r '.author.login // ""' <<<"${comment}")"
     referenced="$(jq -r '
       try ((.body // "") |
-        capture("\\*\\*Reviewed commit:\\*\\*\\s*`(?<sha>[0-9a-fA-F]{10,40})`"; "i").sha)
+        capture("(?:\\*\\*Reviewed commit:\\*\\*|Reviewed commit:)\\s*`(?<sha>[0-9a-fA-F]{10,40})`"; "i").sha)
       catch ""
     ' <<<"${comment}")"
     resolved="$(jq -r '.resolvedCommitOid // ""' <<<"${comment}")"

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -190,9 +190,9 @@ train_pr_admission_snapshot() {
     "${TRAIN_ADMISSION_JSON_FOR_PR}" "${pr}"
     return
   fi
-  gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){number state isDraft headRefOid labels(first:100){nodes{name} pageInfo{hasNextPage}} reviews(first:100){nodes{author{login} body submittedAt updatedAt state commit{oid}} pageInfo{hasNextPage}} reviewThreads(first:100){nodes{isResolved comments(first:100){nodes{author{login} commit{oid}} pageInfo{hasNextPage}}} pageInfo{hasNextPage}} commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{__typename ... on CheckRun{name status conclusion} ... on StatusContext{context state}} pageInfo{hasNextPage}}}}}}}}}' \
+  gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){number state isDraft headRefOid labels(first:100){nodes{name} pageInfo{hasNextPage}} reviews(first:100){nodes{author{login} body submittedAt updatedAt state commit{oid}} pageInfo{hasNextPage}} comments(first:100){nodes{author{login} body createdAt updatedAt includesCreatedEdit} pageInfo{hasNextPage}} reviewThreads(first:100){nodes{isResolved comments(first:100){nodes{author{login} commit{oid}} pageInfo{hasNextPage}}} pageInfo{hasNextPage}} commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{__typename ... on CheckRun{name status conclusion} ... on StatusContext{context state}} pageInfo{hasNextPage}}}}}}}}}' \
     -F owner="${GITHUB_REPOSITORY%%/*}" -F repo="${GITHUB_REPOSITORY#*/}" -F number="${pr}" \
-    --jq '.data.repository.pullRequest | {number,state,isDraft,headRefOid,labels:.labels.nodes,labelsTruncated:.labels.pageInfo.hasNextPage,reviews:.reviews.nodes,reviewsTruncated:.reviews.pageInfo.hasNextPage,reviewThreads:.reviewThreads.nodes,reviewThreadsTruncated:(.reviewThreads.pageInfo.hasNextPage or any(.reviewThreads.nodes[]?; .comments.pageInfo.hasNextPage)),statusCheckRollup:(.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // []),checksTruncated:(.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage // false)}'
+    --jq '.data.repository.pullRequest | {number,state,isDraft,headRefOid,labels:.labels.nodes,labelsTruncated:.labels.pageInfo.hasNextPage,reviews:.reviews.nodes,reviewsTruncated:.reviews.pageInfo.hasNextPage,cleanComments:.comments.nodes,commentsTruncated:.comments.pageInfo.hasNextPage,reviewThreads:.reviewThreads.nodes,reviewThreadsTruncated:(.reviewThreads.pageInfo.hasNextPage or any(.reviewThreads.nodes[]?; .comments.pageInfo.hasNextPage)),statusCheckRollup:(.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // []),checksTruncated:(.commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage // false)}'
 }
 
 train_publish_review_gate_status() {
@@ -214,10 +214,11 @@ train_refresh_review_gate() {
   unresolved="$(jq --arg restBot 'chatgpt-codex-connector[bot]' --arg graphBot 'chatgpt-codex-connector' --arg head "${head}" \
     '[.reviewThreads[]? | select(.isResolved == false and any(.comments.nodes[]?; (.author.login == $restBot or .author.login == $graphBot) and .commit.oid == $head))] | length' <<<"${snapshot}")" || return 1
   payload="$(jq -nc --argjson reviews "$(jq -c '.reviews // []' <<<"${snapshot}")" \
+    --argjson cleanComments "$(jq -c '.cleanComments // []' <<<"${snapshot}")" \
     --argjson unresolvedCount "${unresolved}" --arg head "${head}" \
-    '{reviews:$reviews,unresolvedCount:$unresolvedCount,head:$head}')" || return 1
+    '{reviews:$reviews,cleanComments:$cleanComments,unresolvedCount:$unresolvedCount,head:$head}')" || return 1
   result="$(printf '%s' "${payload}" | node "${TRAIN_REVIEW_GATE_EVIDENCE_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/../review-gate-evidence.js}")" || return 1
-  if jq -e '.exactReview' <<<"${result}" >/dev/null; then
+  if jq -e '.exactReview or .exactCleanComment' <<<"${result}" >/dev/null; then
     state=success; description='Current exact-head Codex evidence is clean'
   else
     state=failure; description='No current clean exact-head Codex evidence'
@@ -249,7 +250,7 @@ train_pr_admission() {
   [[ "$(jq -r '.state' <<<"${snapshot}")" == "OPEN" ]] || { train_warn "reject #${pr}: closed"; return 1; }
   [[ "$(jq -r '.isDraft' <<<"${snapshot}")" == "false" ]] || { train_warn "reject #${pr}: draft"; return 1; }
   [[ "$(jq -r '.headRefOid' <<<"${snapshot}")" == "${expected_head}" ]] || { train_warn "reject #${pr}: head advanced"; return 1; }
-  jq -e '(.labelsTruncated or .reviewsTruncated or .reviewThreadsTruncated or .checksTruncated) | not' <<<"${snapshot}" >/dev/null || { train_warn "reject #${pr}: snapshot truncated"; return 1; }
+  jq -e '(.labelsTruncated or .reviewsTruncated or .commentsTruncated or .reviewThreadsTruncated or .checksTruncated) | not' <<<"${snapshot}" >/dev/null || { train_warn "reject #${pr}: snapshot truncated"; return 1; }
   labels="$(jq -c '.labels // []' <<<"${snapshot}")"
   train_pr_has_hold_label "${labels}" && { train_warn "reject #${pr}: held/escalated"; return 1; }
   train_refresh_review_gate "${pr}" "${expected_head}" "${snapshot}" || { train_warn "reject #${pr}: current Codex evidence is unavailable or negative"; return 1; }

--- a/scripts/ci/merge-train/select.sh
+++ b/scripts/ci/merge-train/select.sh
@@ -206,15 +206,47 @@ train_publish_review_gate_status() {
     -f target_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/pull/${pr}" >/dev/null
 }
 
+train_resolve_clean_comment_commits() {
+  local comments="$1" comment login referenced resolved annotated output='[]'
+  while IFS= read -r comment; do
+    [[ -z "${comment}" ]] && continue
+    login="$(jq -r '.author.login // ""' <<<"${comment}")"
+    referenced="$(jq -r '
+      try ((.body // "") |
+        capture("\\*\\*Reviewed commit:\\*\\*\\s*`(?<sha>[0-9a-fA-F]{10,40})`"; "i").sha)
+      catch ""
+    ' <<<"${comment}")"
+    resolved="$(jq -r '.resolvedCommitOid // ""' <<<"${comment}")"
+    if [[ -z "${resolved}" &&
+          ("${login}" == "chatgpt-codex-connector" ||
+           "${login}" == "chatgpt-codex-connector[bot]") ]]; then
+      if [[ "${#referenced}" == "40" ]]; then
+        resolved="${referenced}"
+      elif [[ -n "${referenced}" ]]; then
+        resolved="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${referenced}" \
+          --jq '.sha' 2>/dev/null || true)"
+      fi
+    fi
+    if [[ -n "${resolved}" ]]; then
+      annotated="$(jq -c --arg resolved "${resolved}" '. + {resolvedCommitOid:$resolved}' <<<"${comment}")"
+    else
+      annotated="${comment}"
+    fi
+    output="$(jq -c --argjson item "${annotated}" '. + [$item]' <<<"${output}")"
+  done < <(jq -c '.[]?' <<<"${comments}")
+  printf '%s' "${output}"
+}
+
 # Re-evaluate current exact-head Codex evidence rather than trusting a cached
 # Review Gate status. API/truncation/negative evidence fails closed. In live mode
 # publish the result so branch protection and subsequent controllers see it.
 train_refresh_review_gate() {
-  local pr="$1" head="$2" snapshot="$3" unresolved payload result state description
+  local pr="$1" head="$2" snapshot="$3" unresolved clean_comments payload result state description
   unresolved="$(jq --arg restBot 'chatgpt-codex-connector[bot]' --arg graphBot 'chatgpt-codex-connector' --arg head "${head}" \
     '[.reviewThreads[]? | select(.isResolved == false and any(.comments.nodes[]?; (.author.login == $restBot or .author.login == $graphBot) and .commit.oid == $head))] | length' <<<"${snapshot}")" || return 1
+  clean_comments="$(train_resolve_clean_comment_commits "$(jq -c '.cleanComments // []' <<<"${snapshot}")")" || return 1
   payload="$(jq -nc --argjson reviews "$(jq -c '.reviews // []' <<<"${snapshot}")" \
-    --argjson cleanComments "$(jq -c '.cleanComments // []' <<<"${snapshot}")" \
+    --argjson cleanComments "${clean_comments}" \
     --argjson unresolvedCount "${unresolved}" --arg head "${head}" \
     '{reviews:$reviews,cleanComments:$cleanComments,unresolvedCount:$unresolvedCount,head:$head}')" || return 1
   result="$(printf '%s' "${payload}" | node "${TRAIN_REVIEW_GATE_EVIDENCE_SCRIPT:-$(dirname "${BASH_SOURCE[0]}")/../review-gate-evidence.js}")" || return 1

--- a/scripts/ci/review-gate-evidence.js
+++ b/scripts/ci/review-gate-evidence.js
@@ -5,7 +5,19 @@ const NEGATIVE_REVIEW_STATES = new Set(['CHANGES_REQUESTED', 'DISMISSED']);
 function isCodex(login) {
   return login === 'chatgpt-codex-connector' || login === 'chatgpt-codex-connector[bot]';
 }
-function evaluateCodexEvidence({ reviews, unresolvedCount, head }) {
+function cleanCommentMatchesHead(comment, head) {
+  if (!isCodex(comment.author?.login) || comment.includesCreatedEdit ||
+      comment.createdAt !== comment.updatedAt ||
+      !/Codex Review:\s+Didn't find any major issues\./i.test(comment.body || '')) {
+    return false;
+  }
+  const reviewedCommits = [...(comment.body || '').matchAll(
+    /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{10,40})`/gi
+  )];
+  return reviewedCommits.length === 1 &&
+    head.toLowerCase().startsWith(reviewedCommits[0][1].toLowerCase());
+}
+function evaluateCodexEvidence({ reviews, cleanComments = [], unresolvedCount, head }) {
   const codexReviews = reviews
     .filter(review => isCodex(review.author?.login) &&
       (/Codex Review/i.test(review.body || '') || /Reviewed commit/i.test(review.body || '')))
@@ -16,10 +28,13 @@ function evaluateCodexEvidence({ reviews, unresolvedCount, head }) {
     .reduce((max, review) => Math.max(max, Date.parse(review.updatedAt || review.submittedAt)), 0);
   const exactReview = unresolvedCount === 0 && latest?.commit?.oid === head &&
     ATTESTING_REVIEW_STATES.has(latest.state) && Date.parse(latest.submittedAt) > negativeAt;
-  // Reactions and editable issue comments are not commit-bound GitHub objects.
-  // Only a review whose commit oid equals the current head may attest.
+  const exactCleanComment = unresolvedCount === 0 && cleanComments.some(comment =>
+    cleanCommentMatchesHead(comment, head) && Date.parse(comment.createdAt) > negativeAt);
+  // Generic reactions remain insufficient because they carry no reviewed SHA.
+  // A clean connector comment is accepted only when it is unedited, names one
+  // sufficiently long current-head prefix, and no connector finding is open.
   const freshCleanReaction = false;
-  return { exactReview, freshCleanReaction };
+  return { exactReview, exactCleanComment, freshCleanReaction };
 }
 if (require.main === module) {
   const fs = require('node:fs');

--- a/scripts/ci/review-gate-evidence.js
+++ b/scripts/ci/review-gate-evidence.js
@@ -12,7 +12,7 @@ function cleanCommentMatchesHead(comment, head) {
     return false;
   }
   const reviewedCommits = [...(comment.body || '').matchAll(
-    /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{10,40})`/gi
+    /(?:\*\*Reviewed commit:\*\*|Reviewed commit:)\s*`([0-9a-f]{10,40})`/gi
   )];
   if (reviewedCommits.length !== 1) return false;
   const referenced = reviewedCommits[0][1].toLowerCase();

--- a/scripts/ci/review-gate-evidence.js
+++ b/scripts/ci/review-gate-evidence.js
@@ -14,8 +14,14 @@ function cleanCommentMatchesHead(comment, head) {
   const reviewedCommits = [...(comment.body || '').matchAll(
     /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{10,40})`/gi
   )];
-  return reviewedCommits.length === 1 &&
-    head.toLowerCase().startsWith(reviewedCommits[0][1].toLowerCase());
+  if (reviewedCommits.length !== 1) return false;
+  const referenced = reviewedCommits[0][1].toLowerCase();
+  const resolved = referenced.length === 40
+    ? referenced
+    : (comment.resolvedCommitOid || '').toLowerCase();
+  return resolved.length === 40 &&
+    resolved === head.toLowerCase() &&
+    resolved.startsWith(referenced);
 }
 function evaluateCodexEvidence({ reviews, cleanComments = [], unresolvedCount, head }) {
   const codexReviews = reviews
@@ -32,7 +38,8 @@ function evaluateCodexEvidence({ reviews, cleanComments = [], unresolvedCount, h
     cleanCommentMatchesHead(comment, head) && Date.parse(comment.createdAt) > negativeAt);
   // Generic reactions remain insufficient because they carry no reviewed SHA.
   // A clean connector comment is accepted only when it is unedited, names one
-  // sufficiently long current-head prefix, and no connector finding is open.
+  // commit whose uniquely resolved full OID equals the head, and no connector
+  // finding is open.
   const freshCleanReaction = false;
   return { exactReview, exactCleanComment, freshCleanReaction };
 }

--- a/scripts/ci/review-gate-evidence.test.js
+++ b/scripts/ci/review-gate-evidence.test.js
@@ -4,8 +4,64 @@ const assert = require('node:assert/strict');
 const { evaluateCodexEvidence } = require('./review-gate-evidence');
 const head = 'abc123';
 const review = (state, submittedAt = '2026-01-02T00:00:00Z', updatedAt = submittedAt) => ({ author: { login: 'chatgpt-codex-connector' }, body: '### Codex Review\nReviewed commit', submittedAt, updatedAt, commit: { oid: head }, state });
+const cleanComment = (commit = head, overrides = {}) => ({
+  author: { login: 'chatgpt-codex-connector' },
+  body: `Codex Review: Didn't find any major issues. Hooray!\n\n**Reviewed commit:** \`${commit}\``,
+  createdAt: '2026-01-02T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+  includesCreatedEdit: false,
+  ...overrides,
+});
 test('active exact-head Codex review attests', () => {
   assert.equal(evaluateCodexEvidence({ reviews: [review('COMMENTED')], unresolvedCount: 0, head }).exactReview, true);
+});
+test('unedited Codex clean comment for exact head attests', () => {
+  const fullHead = 'abc1234567890abcdef1234567890abcdef1234';
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment(fullHead.slice(0, 10))],
+    unresolvedCount: 0, head: fullHead,
+  }).exactCleanComment, true);
+});
+test('clean comment for another head cannot attest', () => {
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment('def4567890')],
+    unresolvedCount: 0, head: 'abc1234567890abcdef1234567890abcdef1234',
+  }).exactCleanComment, false);
+});
+test('edited clean comment cannot attest', () => {
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment('abc1234567', {
+      updatedAt: '2026-01-03T00:00:00Z',
+    })], unresolvedCount: 0, head: 'abc1234567890abcdef1234567890abcdef1234',
+  }).exactCleanComment, false);
+});
+test('clean comment created with an edit cannot attest', () => {
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment('abc1234567', {
+      includesCreatedEdit: true,
+    })], unresolvedCount: 0, head: 'abc1234567890abcdef1234567890abcdef1234',
+  }).exactCleanComment, false);
+});
+test('non-Codex clean comment cannot attest', () => {
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment('abc1234567', {
+      author: { login: 'contributor' },
+    })], unresolvedCount: 0, head: 'abc1234567890abcdef1234567890abcdef1234',
+  }).exactCleanComment, false);
+});
+test('clean comment with multiple reviewed SHAs cannot attest', () => {
+  const comment = cleanComment('abc1234567');
+  comment.body += '\n**Reviewed commit:** `abc1234568`';
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [comment],
+    unresolvedCount: 0, head: 'abc1234567890abcdef1234567890abcdef1234',
+  }).exactCleanComment, false);
+});
+test('unresolved finding overrides an exact-head clean comment', () => {
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment('abc1234567')],
+    unresolvedCount: 1, head: 'abc1234567890abcdef1234567890abcdef1234',
+  }).exactCleanComment, false);
 });
 test('dismissed exact-head Codex review cannot attest', () => {
   assert.equal(evaluateCodexEvidence({ reviews: [review('DISMISSED')], unresolvedCount: 0, head }).exactReview, false);

--- a/scripts/ci/review-gate-evidence.test.js
+++ b/scripts/ci/review-gate-evidence.test.js
@@ -24,6 +24,16 @@ test('unedited Codex clean comment for exact head attests', () => {
     unresolvedCount: 0, head: fullHead,
   }).exactCleanComment, true);
 });
+test('unedited clean comment with a plain commit anchor attests', () => {
+  const fullHead = 'b'.repeat(40);
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment(fullHead.slice(0, 10), {
+      body: `Codex Review: Didn't find any major issues. Clear!\n\nReviewed commit: \`${fullHead.slice(0, 10)}\``,
+      resolvedCommitOid: fullHead,
+    })],
+    unresolvedCount: 0, head: fullHead,
+  }).exactCleanComment, true);
+});
 test('unresolved short SHA cannot attest', () => {
   const fullHead = 'a'.repeat(40);
   assert.equal(evaluateCodexEvidence({

--- a/scripts/ci/review-gate-evidence.test.js
+++ b/scripts/ci/review-gate-evidence.test.js
@@ -16,11 +16,29 @@ test('active exact-head Codex review attests', () => {
   assert.equal(evaluateCodexEvidence({ reviews: [review('COMMENTED')], unresolvedCount: 0, head }).exactReview, true);
 });
 test('unedited Codex clean comment for exact head attests', () => {
-  const fullHead = 'abc1234567890abcdef1234567890abcdef1234';
+  const fullHead = 'a'.repeat(40);
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment(fullHead.slice(0, 10), {
+      resolvedCommitOid: fullHead,
+    })],
+    unresolvedCount: 0, head: fullHead,
+  }).exactCleanComment, true);
+});
+test('unresolved short SHA cannot attest', () => {
+  const fullHead = 'a'.repeat(40);
   assert.equal(evaluateCodexEvidence({
     reviews: [], cleanComments: [cleanComment(fullHead.slice(0, 10))],
     unresolvedCount: 0, head: fullHead,
-  }).exactCleanComment, true);
+  }).exactCleanComment, false);
+});
+test('short SHA resolving to another full commit cannot attest', () => {
+  const fullHead = 'a'.repeat(40);
+  assert.equal(evaluateCodexEvidence({
+    reviews: [], cleanComments: [cleanComment(fullHead.slice(0, 10), {
+      resolvedCommitOid: `${'a'.repeat(10)}${'f'.repeat(30)}`,
+    })],
+    unresolvedCount: 0, head: fullHead,
+  }).exactCleanComment, false);
 });
 test('clean comment for another head cannot attest', () => {
   assert.equal(evaluateCodexEvidence({


### PR DESCRIPTION
## Summary
- accept an unedited Codex-authored clean review comment only when its reviewed SHA prefix matches the current PR head
- re-attest on issue-comment creation, edit, and deletion
- keep unresolved findings, pagination, edits, non-Codex authors, and wrong/multiple SHA evidence fail-closed

## Why
Codex emits a formal review object when it finds issues, but emits an issue comment when the exact head is clean. The current gate accepts only the former, so a clean PR can never pass Review Gate.

## Validation
- node --test scripts/ci/review-gate-evidence.test.js (20 passed)
- node --check scripts/ci/review-gate-evidence.js
- workflow YAML parse
- git diff --check
- scripts/ci/validate-single-merge-authority.sh