### PR TITLE
ci: notify honua-evidence when producer snapshots change

### DIFF
--- a/.github/workflows/notify-evidence.yml
+++ b/.github/workflows/notify-evidence.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Dispatch to honua-evidence
         env:
           GH_TOKEN: ${{ secrets.HONUA_EVIDENCE_DISPATCH_TOKEN }}
-        continue-on-error: true
         run: |
           if [ -z "${GH_TOKEN}" ]; then
             echo "::warning::HONUA_EVIDENCE_DISPATCH_TOKEN is not set; skipping repository_dispatch to honua-evidence. Add a fine-grained PAT with write access to honua-io/honua-evidence to enable event-driven re-aggregation (honua-io/honua-evidence#3). honua-evidence's daily schedule will still pick this up."

--- a/.github/workflows/notify-evidence.yml
+++ b/.github/workflows/notify-evidence.yml
@@ -1,0 +1,48 @@
+name: Notify honua-evidence
+
+# Fires a repository_dispatch (type producer-updated) to honua-io/honua-evidence
+# whenever the capability-matrix/keys snapshots or CITE status doc this repo
+# produces change on trunk, so honua-evidence re-aggregates promptly instead
+# of waiting for its daily schedule fallback (honua-io/honua-evidence#3).
+#
+# Secrets required:
+#   HONUA_EVIDENCE_DISPATCH_TOKEN — fine-grained PAT with write access
+#     sufficient to POST to repos/honua-io/honua-evidence/dispatches. If
+#     absent, the dispatch step is skipped with a warning rather than
+#     failing this repo's CI; honua-evidence's daily schedule remains the
+#     fallback trigger.
+
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'docs/gis/data/capability-matrix.v1.json'
+      - 'docs/gis/data/capability-keys.v1.json'
+      - 'docs/cite-status.md'
+
+permissions:
+  contents: read
+
+jobs:
+  notify-evidence:
+    name: Dispatch producer-updated to honua-evidence
+    if: ${{ github.repository_owner == 'honua-io' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Dispatch to honua-evidence
+        env:
+          GH_TOKEN: ${{ secrets.HONUA_EVIDENCE_DISPATCH_TOKEN }}
+        continue-on-error: true
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::HONUA_EVIDENCE_DISPATCH_TOKEN is not set; skipping repository_dispatch to honua-evidence. Add a fine-grained PAT with write access to honua-io/honua-evidence to enable event-driven re-aggregation (honua-io/honua-evidence#3). honua-evidence's daily schedule will still pick this up."
+            exit 0
+          fi
+
+          gh api repos/honua-io/honua-evidence/dispatches \
+            -f event_type=producer-updated \
+            -F 'client_payload[producer]=honua-server'
+
+          echo "Dispatched producer-updated (producer=honua-server) to honua-io/honua-evidence."


### PR DESCRIPTION
Sender half of honua-io/honua-evidence#3: fires a repository_dispatch (type `producer-updated`) at honua-evidence when this repo's evidence-producer snapshot changes, so aggregation runs promptly instead of waiting for the daily cron. Fails soft with a warning if `HONUA_EVIDENCE_DISPATCH_TOKEN` is unset (the secret is already configured in this repo). No checkout, read-only permissions, single gh api call.