### PR TITLE
docs: make Amazon Location + PrivateLink the primary geocoding fix (#2948)

### DIFF
--- a/docs/internal/demo/demo-honua-io-capability-runbook.md
+++ b/docs/internal/demo/demo-honua-io-capability-runbook.md
@@ -35,7 +35,7 @@ wins.
 | Track 2 — Pro license | **Live.** `/api/v1/capabilities/manifest` → `policies.currentEdition = "Pro"`, `licenseValidationState = "Valid"`. `geocoding.forward`/`geocoding.reverse`/`geocoding.failover`/`streaming.feature-subscriptions`/`editing.featureserver-edits` all `active: true`. The 14/29 `available:false` capability entries seen on an **anonymous** manifest call are RBAC (`insufficient-policy`, expected with no caller identity) or correctly `minimumEdition: Enterprise` gates (we're Pro) — not a licensing gap. | Direct probe, 2026-07-23 |
 | Elevation / terrain | **Live and fully functional**, contradicting the 2026-07-20 probe. `maui-terrain` (layerId 8) is a registered raster dataset; `/elevation/maui-terrain/{value,profile,viewshed,line-of-sight,sun-shadow}` all return real computed results over real Maui terrain (elevations in a sane 4–590 m range), and `/terrain/maui-terrain/tile.json` + `.png` tiles serve `terrain-rgb` encoded tiles. No remediation needed. | Direct probe, 2026-07-23 |
 | Catalog cleanup — layer 68823 | **Done.** Not present in `/rest/services` (25 services, none named `test_service`/68823) or `/ogc/features/collections` (11 collections). Direct probe of `/rest/services/test_service/FeatureServer` returns `499 Unauthorized` (`allowAnonymous: false`), consistent with the recorded remediation (`PUT /api/v1/admin/services/test_service/access-policy {"allowAnonymous": false}`). | Direct probe, 2026-07-23 |
-| Geocoding | **Not working — categorical failure, not a cold-start.** The locator is published as `World` (not `maui`, which the original probe and this runbook's Step 4 assumed — `GET /rest/services/World/GeocodeServer?f=json` returns valid metadata with `Provider: nominatim`). But every `findAddressCandidates` call — first and repeated — fails after ~15.8s with `500 "Geocoding service error"`. Two consecutive calls both took ~15.8s (15.790s, 15.854s): this rules out a cold-start/keep-warm fix. Root cause (per the 2026-07-20/21 coordinator note, reconfirmed): the demo Lambda's VPC subnets have no NAT/IGW egress route, so the external Nominatim endpoint is unreachable from inside the VPC on every call. | Direct probe, 2026-07-23 |
+| Geocoding | **Not working — categorical failure, not a cold-start.** The locator is published as `World` (not `maui`, which the original probe and this runbook's Step 4 assumed — `GET /rest/services/World/GeocodeServer?f=json` returns valid metadata with `Provider: nominatim`). But every `findAddressCandidates` call — first and repeated — fails after ~15.8s with `500 "Geocoding service error"`. Two consecutive calls both took ~15.8s (15.790s, 15.854s): this rules out a cold-start/keep-warm fix. Root cause (per the 2026-07-20/21 coordinator note, reconfirmed): the demo Lambda's VPC subnets have no NAT/IGW egress route, so the external Nominatim endpoint is unreachable from inside the VPC on every call. **Operator-decided fix (2026-07-23): switch to Amazon Location Service via a VPC interface endpoint (PrivateLink) — no NAT gateway.** IaC in `honua-io/honua-iac#127` (not applied); see *Remediation plan* item 1. | Direct probe, 2026-07-23 |
 | SensorThings | **Confirmed intentional.** `/sta/v1.1/*` → 404. `Experimental:Features:SensorThings` defaults `false` in `src/Honua.Server/appsettings.json` with no environment override, and there is no SensorThings entry in the capabilities manifest at all (not even a gated one). This matches honua-io/honua-server#2434 ("Promote SensorThings to GA" — `roadmap:later`, still experimental). No action needed for this issue; GA promotion is tracked separately in #2434. | Direct probe + code read, 2026-07-23 |
 | `/api/scenes` (adjacent, server#2991) | **Fixed live.** Returns `200` with the scene listing — confirms the out-of-band migration run (073→082) documented in #2991 has landed on the shared demo DB. | Direct probe, 2026-07-23 |
 | ImageServer `maui-imagery` metadata (adjacent, server#2991/#2993) | **Still hangs** (>70s, no response) — expected: the code fix is in PR #2993, which has not been deployed to the demo image yet. Will be resolved by the next demo image redeploy (see remediation plan). | Direct probe, 2026-07-23 |
@@ -256,19 +256,25 @@ Lambda filesystem with no bootstrap file write.
 > route**, so the external Nominatim endpoint is categorically unreachable from inside
 > the VPC — not slow, unreachable, timing out at whatever the outbound HTTP client
 > timeout is configured to (~15–16s). A scheduled keep-warm probe cannot fix this: it
-> would just be another call that times out the same way. See the remediation plan at
-> the end of this document — the actual fix is a network-egress change, which is
-> **honua-terraform's IaC surface**, out of this issue's scope per its own Non-goals,
-> and needs a separate infra-track decision/ticket.
+> would just be another call that times out the same way.
+>
+> **Operator decision (2026-07-23): fixed via Amazon Location Service over a VPC
+> interface endpoint (PrivateLink), not a NAT gateway.** No new compute, no general
+> egress opened up. IaC: `honua-io/honua-iac#127` (place index + IAM grant + `geo`
+> interface endpoint — not applied). See *Remediation plan* item 1 below for the exact
+> env keys, sequencing, and rollback; a NAT-gateway + Nominatim fallback is kept at item
+> 1a if Amazon Location is ever rejected later.
 
 Geocoding is published when `Geocoding:Enabled=true` with a configured provider and locator
-name. On the demo Lambda, this is already configured:
+name. On the demo Lambda, this is already configured (Nominatim/`World`, currently
+broken per the callout above):
 
 ```
 Geocoding__Enabled=true
 Geocoding__LocatorName=World              # confirmed live; do not change without also
                                            # updating every demo probe/smoke script
-Geocoding__DefaultProvider=nominatim       # confirmed live
+Geocoding__DefaultProvider=nominatim       # confirmed live; PLANNED to become
+                                           # amazon-location — see Remediation plan item 1
 # provider config (endpoint/key) per Geocoding__Providers__* — not independently
 # re-verified here; the failure is at the network layer (see callout above), before
 # provider request construction would matter.
@@ -276,7 +282,8 @@ Geocoding__DefaultProvider=nominatim       # confirmed live
 
 The forward/reverse geocoding **operations** are Pro-gated (`geocoding.forward` /
 `geocoding.reverse`), so the Pro license from Steps 1–3 must be active (it is — see
-*As-verified live state* above).
+*As-verified live state* above). This holds for either provider — `amazon-location` and
+`nominatim` are both entitled the same way once Pro is active.
 
 ### Step 5 — Streaming + editing need no extra config
 
@@ -333,7 +340,8 @@ node scripts/site-demo-smoke.mjs    # the four affected pages leave their fixtur
 | License mint CLI commands                      | N/A — Pro license **already applied and live** (2026-07-23 confirmed) |
 | Elevation/terrain dataset (`maui-terrain`)    | **Already registered and fully working** (2026-07-23 confirmed) — no action needed |
 | Layer 68823 catalog cleanup                   | **Already applied and live** (2026-07-23 confirmed) |
-| Geocoding network egress fix                  | **[OPERATOR + honua-terraform]** — VPC NAT/IGW route or alternate reachable provider; live env + IaC |
+| Geocoding — Amazon Location + PrivateLink (PRIMARY) | IaC ready, **not applied**: `honua-io/honua-iac#127` — **[OPERATOR]** review/apply, then fold `Geocoding__*` env into the image redeploy below |
+| Geocoding — NAT gateway + Nominatim (fallback, not chosen) | **[OPERATOR + honua-terraform]** only if Amazon Location is rejected later |
 | SensorThings GA promotion                     | Out of scope for this issue — tracked in #2434 |
 | Demo image redeploy (picks up #2993 + migrations 083-088) | **[OPERATOR]** — live env, standard versioned-alias deploy |
 
@@ -383,8 +391,11 @@ else
 fi
 curl -s -o /dev/null -w '%{http_code}\n' "$BASE/rest/services/test_service/FeatureServer?f=json"   # expect 499 (or 403), not 200
 
-# Geocoding — known-broken; documents the failure, does not assert success
-curl -s -o /dev/null -w 'geocode locator meta: %{http_code}\n' "$BASE/rest/services/World/GeocodeServer?f=json"
+# Geocoding — known-broken today (Nominatim, no NAT egress); documents the failure,
+# does not assert success. After the Amazon Location switch (Remediation plan item 1)
+# ships, re-run these two and expect: Provider "amazon-location", and the second call
+# in well under 1s with candidates.length > 0 (no more ~15.8s egress timeout).
+curl -s "$BASE/rest/services/World/GeocodeServer?f=json" | jq -r '.locatorProperties.Provider'
 time curl -s -o /dev/null -w 'geocode candidates: %{http_code} in %{time_total}s\n' \
   "$BASE/rest/services/World/GeocodeServer/findAddressCandidates?f=json&singleLine=Kahului"
 
@@ -402,46 +413,129 @@ curl -s -o /dev/null -w 'imageserver (expect timeout until #2993 deploys): %{htt
 Everything in *As-verified live state* above marked "Live"/"Already applied" needs **no
 further action**. The items below are the only ones still open as of 2026-07-23.
 
-### 1. Geocoding — VPC egress (or provider) fix
+### 1. Geocoding — Amazon Location Service via PrivateLink (PRIMARY, operator-decided 2026-07-23)
 
-**Not runnable from this repo** — it is a network/IaC change owned by `honua-terraform`,
-which is explicitly out of this issue's scope (see *Non-goals*). Recorded here so the
-decision and rollback are visible in one place when an operator picks it up in the
-owning repo.
+**Decision:** the operator chose Amazon Location Service reached over a VPC interface
+endpoint (PrivateLink) as the fix — **not** a NAT gateway. No new compute, no general
+egress opened up; the server's built-in `amazon-location` geocoding provider
+(`Honua.Geocoding.Features.Geocoding.Providers.AmazonLocationGeocodeProvider`) talks to
+Amazon Location's classic Places API (`SearchPlaceIndexForText` /
+`SearchPlaceIndexForPosition` / `SearchPlaceIndexForSuggestions`) against a named place
+index, authenticating via the Lambda execution role (`UseIamRole=true`, the default —
+no access keys). IaC PR (not applied): **honua-io/honua-iac#127** — adds an
+`enable_amazon_location_geocoding` toggle to the `aws-serverless` module (place index +
+least-privilege IAM grant) and wires a `com.amazonaws.us-west-2.geo` interface endpoint
+into the demo's `vpc-endpoints.tf` (single-AZ, same pattern as the existing Secrets
+Manager/Bedrock endpoints — see that PR for the exact resources and a read-only AWS
+audit of the account's current VPC/endpoint state, including one piece of *unrelated*
+pre-existing drift it flagged: the live `bedrock-runtime` endpoint spans all 3 private
+subnets despite being documented as single-AZ).
 
-- **Option A — NAT Gateway egress.** Add a public NAT Gateway with an Elastic IP in a
-  public subnet whose route table sends `0.0.0.0/0` to the VPC Internet Gateway. Then
-  update each private Lambda subnet's route table to send `0.0.0.0/0` to that NAT
-  Gateway (or use a correctly routed NAT instance, cost-dependent). Lambda ENIs remain
-  in the private subnets; placing the NAT Gateway there, or merely adding an Internet
-  Gateway route to those private subnets, does not provide internet egress. This is a
-  standard `honua-terraform` change; review there for cost/blast radius before applying.
-- **Option B — in-VPC-reachable provider.** Point `Geocoding__Providers__*` at a
-  provider reachable via a VPC endpoint / PrivateLink (or a self-hosted Photon/Pelias
-  instance inside the VPC) instead of the public internet. Avoids a NAT Gateway but is a
-  larger change (new provider integration + data).
-- **Rollback:** either option is additive (new NAT route / new provider config) and can
-  be torn down without touching the license, STAC, or catalog state; no coupling to the
-  other tracks.
-- **After either fix**, re-run the geocoding lines of the verification script above —
-  expect `findAddressCandidates` to return `200` with `candidates.length > 0` in well
-  under a second once the network path exists (Nominatim itself is fast; the current
-  ~15.8s is the egress timeout, not provider latency). *Only then* does a scheduled
-  keep-warm probe (e.g. an EventBridge-scheduled Lambda invocation of
-  `GET /rest/services/World/GeocodeServer/findAddressCandidates?f=json&singleLine=Kahului`
-  every few minutes) become a meaningful mitigation for genuine cold-start latency —
-  before the egress fix, a keep-warm probe would just be another guaranteed-timeout
-  call.
+**Why this is the primary fix, not the NAT+Nominatim fallback below:** no NAT gateway
+to provision or pay for (~$33/mo saved), no general internet egress opened on a public
+demo Lambda, and it reuses a provider the server already ships — this is config +
+one new AWS resource, not new infrastructure surface area.
 
-### 2. Demo image redeploy (picks up PR #2993 + migrations 083–088)
+**This requires the versioned-alias deploy below, not a standalone env change.** All of
+the following are plain (non-secret) Lambda environment variables — per the
+*Deployment model correction* above, environment variables only take effect on a
+**newly published Lambda version with the `live` alias repointed to it**; there is no
+way to apply them to what's actually serving `demo.honua.io` short of a real deploy.
+Fold them into the same deploy that picks up PR #2993 (item 2 below) rather than
+attempting a separate env-only change:
 
-Routine versioned-alias deploy, no schema/env changes of its own beyond what the new
-image already contains. See the *Deployment model correction* note above for why this
-must be a real publish-and-repoint, not an env edit on `$LATEST`.
+```
+Geocoding__Enabled                                   = true
+Geocoding__DefaultProvider                           = amazon-location
+Geocoding__Providers__Nominatim__Enabled             = false
+Geocoding__Providers__AmazonLocation__Enabled        = true
+Geocoding__Providers__AmazonLocation__Region         = us-west-2
+Geocoding__Providers__AmazonLocation__PlaceIndexName = <honua-iac output: amazon_location_place_index_name>
+Geocoding__Providers__AmazonLocation__UseIamRole     = true
+Geocoding__Providers__AmazonLocation__MaxResults     = 10
+```
 
-- **[OPERATOR]** Once PR #2993 merges to `trunk`: build and push a new demo image from
-  `trunk` HEAD, publish a new Lambda version, and repoint the `live` alias from v33 to
-  the new version (`aws lambda update-alias --function-name honua-demo-demo-honua
+`Geocoding__Providers__Nominatim__Enabled=false` is not optional cleanup —
+`NominatimProviderConfiguration` defaults `Enabled=true` in its own constructor, so
+without this override Nominatim stays registered as a failover candidate
+(`GeocodeCoordinatorService` tries the default provider first, then every other
+registered provider when `EnableFailover` is on, the server default). Leaving it on
+would mean any Amazon Location error (e.g. a place-index typo) triggers a failover
+attempt to Nominatim, which hangs its own ~15.8s before failing — compounding, not
+fixing, latency on an already-broken path.
+
+**Sequencing:**
+1. **[OPERATOR]** Review and apply `honua-io/honua-iac#127` (`terraform plan` then
+   `apply`, scoped to `enable_amazon_location_geocoding = true` plus the other toggles
+   this environment already runs) — creates the place index, the IAM grant, and the
+   `geo` VPC interface endpoint. This alone does **not** change what's serving
+   `demo.honua.io` (no Lambda env change yet, and the place index/endpoint are inert
+   until referenced).
+2. **[OPERATOR]** Fold the `Geocoding__*` env block above into the image-redeploy
+   step (item 2 below) — same publish-new-version-and-repoint-alias operation, so the
+   code fix (#2993), the migrations (083–088), and the geocoding provider switch all
+   land in the one deploy that actually changes live behavior.
+3. **Expected verification** (after the deploy in item 2 completes):
+   ```bash
+   curl -s 'https://demo.honua.io/rest/services/World/GeocodeServer?f=json' \
+     | jq '.locatorProperties.Provider'                # expect "amazon-location"
+   time curl -s -o /dev/null -w '%{http_code} in %{time_total}s\n' \
+     'https://demo.honua.io/rest/services/World/GeocodeServer/findAddressCandidates?f=json&singleLine=Kahului'
+     # expect 200 in well under 1s (no more ~15.8s egress timeout)
+   ```
+4. **Rollback:** the `Geocoding__*` env change rolls back the same way any other part
+   of this deploy does — repoint the `live` alias back to the prior version (see item
+   2's rollback). The place index and VPC endpoint from `honua-iac#127` are additive
+   AWS resources with no coupling to STAC/license/catalog state; `terraform destroy
+   -target` (or setting `enable_amazon_location_geocoding = false` and applying) removes
+   them cleanly once nothing references them, but there is no urgency to tear them down
+   just because the Lambda alias was rolled back — they cost nothing extra idle beyond
+   the endpoint's fixed per-hour charge.
+
+**Data-source note:** results come from **Esri** (the iac PR's default; `Here` is the
+other option), not OpenStreetMap — this is a full provider swap, not a drop-in
+replacement with identical results. Coverage, address formatting, and attribution
+differ from Nominatim.
+
+**Cost:** `geo` VPC interface endpoint ~$7–8/month (single-AZ, same pricing as the
+existing Secrets Manager endpoint) + Amazon Location's per-request Esri pricing tier
+(low single dollars/month at demo traffic volumes). No NAT gateway (~$33/mo avoided),
+no new compute.
+
+### 1a. Fallback — NAT gateway + Nominatim (not the chosen path; kept for reference)
+
+If Amazon Location is ever rejected (e.g. Esri/HERE data-licensing concerns, or the
+place index proves unreliable), the fallback is what this runbook originally proposed:
+
+- **NAT Gateway egress.** Add a public NAT Gateway with an Elastic IP in a public
+  subnet whose route table sends `0.0.0.0/0` to the VPC Internet Gateway, then update
+  each private Lambda subnet's route table to send `0.0.0.0/0` to that NAT Gateway (or
+  use a correctly routed NAT instance, cost-dependent). Lambda ENIs remain in the
+  private subnets; placing the NAT Gateway there, or merely adding an Internet Gateway
+  route to those private subnets, does not provide internet egress —
+  `enable_nat_gateway = true` in the `aws-serverless` module call handles this routing
+  correctly, but a hand-rolled NAT setup should double-check both route-table hops.
+  Costs ~$33/mo + data, the exact cost the Amazon Location path avoids.
+- **Rollback:** additive (new NAT route); can be torn down without touching license,
+  STAC, or catalog state.
+- Once reachable, Nominatim itself is fast — the current ~15.8s is purely the egress
+  timeout, not provider latency — so *only in this fallback path* would a scheduled
+  keep-warm probe be a meaningful mitigation for genuine cold-start latency (it is not
+  a fix for the current failure mode either way, which is unreachability, not
+  slowness).
+
+### 2. Demo image redeploy (picks up PR #2993 + migrations 083–088 + the Amazon Location env switch)
+
+Routine versioned-alias deploy. See the *Deployment model correction* note above for
+why this must be a real publish-and-repoint, not an env edit on `$LATEST` — and why
+item 1's `Geocoding__*` env variables are folded into this same step rather than
+attempted separately.
+
+- **[OPERATOR]** Once PR #2993 merges to `trunk` and `honua-io/honua-iac#127` is
+  applied (place index + `geo` endpoint exist): build and push a new demo image from
+  `trunk` HEAD, set the `Geocoding__*` env block from item 1 above on the new version,
+  publish it, and repoint the `live` alias from v33 to the new version
+  (`aws lambda update-alias --function-name honua-demo-demo-honua
   --name live --function-version <new-version>` or the equivalent `terraform apply`).
 - **Expected verification:**
   - `GET /rest/services/maui-imagery/ImageServer?f=json` returns within the 20s
@@ -450,12 +544,16 @@ must be a real publish-and-repoint, not an env edit on `$LATEST`.
     with the byte-limit message, not an opaque 500.
   - `GET /api/v1/admin/observability/migrations` (authenticated) shows migrations
     through `088_CreateNetworkTopologyPromotions`.
-  - Everything in the *As-verified live state* table above still holds (STAC, Pro
-    license, elevation, catalog cleanup, geocoding-fails-the-same-way, SensorThings
-    404) — this is a regression check, not expected to change any of those.
+  - Geocoding: see item 1's verification block (`locatorProperties.Provider ==
+    "amazon-location"`, `findAddressCandidates` in well under 1s).
+  - Everything else in the *As-verified live state* table above still holds (STAC, Pro
+    license, elevation, catalog cleanup, SensorThings 404) — this is a regression
+    check, not expected to change any of those.
 - **Rollback:** repoint the `live` alias back to v33
   (`aws lambda update-alias --function-name honua-demo-demo-honua --name live
-  --function-version 33`). No DB rollback needed — migrations 083–088 are additive
+  --function-version 33`) — this reverts the geocoding provider switch along with
+  everything else in the deploy, back to Nominatim/`World` (broken, as today) until a
+  fixed version is published. No DB rollback needed — migrations 083–088 are additive
   (`CreateNetworkDataset*`/`CreateOpsHealth*`/network-topology tables) and unrelated to
   any table the demo currently reads from.
 

--- a/docs/internal/demo/demo-honua-io-capability-runbook.md
+++ b/docs/internal/demo/demo-honua-io-capability-runbook.md
@@ -447,6 +447,7 @@ attempting a separate env-only change:
 ```
 Geocoding__Enabled                                   = true
 Geocoding__DefaultProvider                           = amazon-location
+Geocoding__EnableFailover                            = false
 Geocoding__Providers__Nominatim__Enabled             = false
 Geocoding__Providers__AmazonLocation__Enabled        = true
 Geocoding__Providers__AmazonLocation__Region         = us-west-2
@@ -455,14 +456,16 @@ Geocoding__Providers__AmazonLocation__UseIamRole     = true
 Geocoding__Providers__AmazonLocation__MaxResults     = 10
 ```
 
-`Geocoding__Providers__Nominatim__Enabled=false` is not optional cleanup —
-`NominatimProviderConfiguration` defaults `Enabled=true` in its own constructor, so
-without this override Nominatim stays registered as a failover candidate
-(`GeocodeCoordinatorService` tries the default provider first, then every other
-registered provider when `EnableFailover` is on, the server default). Leaving it on
-would mean any Amazon Location error (e.g. a place-index typo) triggers a failover
-attempt to Nominatim, which hangs its own ~15.8s before failing — compounding, not
-fixing, latency on an already-broken path.
+`Geocoding__EnableFailover=false` is the effective safeguard against the existing
+Nominatim timeout. The current server registration path always registers Nominatim for
+backward compatibility, even when
+`Geocoding__Providers__Nominatim__Enabled=false`; with failover enabled, the coordinator
+would therefore still try it after any Amazon Location error (for example, a place-index
+typo) and hang for another ~15.8 seconds. Keep the provider-specific flag false to record
+the intended provider set, but do not rely on it until runtime registration honors that
+flag. This demo deployment deliberately runs Amazon Location as its only attempted
+provider; re-enable failover only after every registered fallback has a working network
+path.
 
 **Sequencing:**
 1. **[OPERATOR]** Review and apply `honua-io/honua-iac#127` (`terraform plan` then

--- a/docs/internal/demo/demo-honua-io-capability-runbook.md
+++ b/docs/internal/demo/demo-honua-io-capability-runbook.md
@@ -394,11 +394,11 @@ curl -s -o /dev/null -w '%{http_code}\n' "$BASE/rest/services/test_service/Featu
 
 # Geocoding — known-broken today (Nominatim, no NAT egress); documents the failure,
 # does not assert success. After the Amazon Location switch (Remediation plan item 1)
-# ships, re-run these two and expect: Provider "amazon-location", and the second call
-# in well under 1s with candidates.length > 0 (no more ~15.8s egress timeout).
+# ships, re-run these two and expect: Provider "amazon-location", and the CLI call
+# in well under 1s with at least one candidate (no more ~15.8s egress timeout).
 curl -s "$BASE/rest/services/World/GeocodeServer?f=json" | jq -r '.locatorProperties.Provider'
-time curl -s -o /dev/null -w 'geocode candidates: %{http_code} in %{time_total}s\n' \
-  "$BASE/rest/services/World/GeocodeServer/findAddressCandidates?f=json&singleLine=Kahului"
+time honua geocode "Kahului" --locator World --limit 1 --json \
+  | jq -e 'type == "array" and length > 0'
 
 # SensorThings — expected 404 (intentional, #2434)
 curl -s -o /dev/null -w 'sta: %{http_code}\n' "$BASE/sta/v1.1/"
@@ -465,8 +465,11 @@ backward compatibility, even when
 would therefore still try it after any Amazon Location error (for example, a place-index
 typo) and hang for another ~15.8 seconds. Keep the provider-specific flag false to record
 the intended provider set, but do not rely on it until runtime registration honors that
-flag. This demo deployment deliberately runs Amazon Location as its only attempted
-provider; re-enable failover only after every registered fallback has a working network
+flag. For normal requests that omit the optional `provider` query parameter, this demo
+deployment deliberately attempts only Amazon Location. An explicit
+`provider=nominatim` request can still select the registered Nominatim provider and
+incur the unreachable-path timeout; demo smoke tests and clients must not send that
+override. Re-enable failover only after every registered fallback has a working network
 path.
 
 **Sequencing:**
@@ -485,9 +488,10 @@ path.
    ```bash
    curl -s 'https://demo.honua.io/rest/services/World/GeocodeServer?f=json' \
      | jq '.locatorProperties.Provider'                # expect "amazon-location"
-   time curl -s -o /dev/null -w '%{http_code} in %{time_total}s\n' \
-     'https://demo.honua.io/rest/services/World/GeocodeServer/findAddressCandidates?f=json&singleLine=Kahului'
-     # expect 200 in well under 1s (no more ~15.8s egress timeout)
+   export HONUA_BASE_URL=https://demo.honua.io
+   time honua geocode "Kahului" --locator World --limit 1 --json \
+     | jq -e 'type == "array" and length > 0'
+     # expect a non-empty candidate array in well under 1s
    ```
 4. **Rollback:** the `Geocoding__*` env change rolls back the same way any other part
    of this deploy does — repoint the `live` alias back to the prior version (see item

--- a/docs/internal/demo/demo-honua-io-capability-runbook.md
+++ b/docs/internal/demo/demo-honua-io-capability-runbook.md
@@ -260,7 +260,8 @@ Lambda filesystem with no bootstrap file write.
 >
 > **Operator decision (2026-07-23): fixed via Amazon Location Service over a VPC
 > interface endpoint (PrivateLink), not a NAT gateway.** No new compute, no general
-> egress opened up. IaC: `honua-io/honua-iac#127` (place index + IAM grant + `geo`
+> egress opened up. IaC: `honua-io/honua-iac#127` (place index + IAM grant +
+> `com.amazonaws.us-west-2.geo.places`
 > interface endpoint — not applied). See *Remediation plan* item 1 below for the exact
 > env keys, sequencing, and rollback; a NAT-gateway + Nominatim fallback is kept at item
 > 1a if Amazon Location is ever rejected later.
@@ -424,7 +425,8 @@ Amazon Location's classic Places API (`SearchPlaceIndexForText` /
 index, authenticating via the Lambda execution role (`UseIamRole=true`, the default —
 no access keys). IaC PR (not applied): **honua-io/honua-iac#127** — adds an
 `enable_amazon_location_geocoding` toggle to the `aws-serverless` module (place index +
-least-privilege IAM grant) and wires a `com.amazonaws.us-west-2.geo` interface endpoint
+least-privilege IAM grant) and wires a
+`com.amazonaws.us-west-2.geo.places` interface endpoint
 into the demo's `vpc-endpoints.tf` (single-AZ, same pattern as the existing Secrets
 Manager/Bedrock endpoints — see that PR for the exact resources and a read-only AWS
 audit of the account's current VPC/endpoint state, including one piece of *unrelated*
@@ -471,7 +473,8 @@ path.
 1. **[OPERATOR]** Review and apply `honua-io/honua-iac#127` (`terraform plan` then
    `apply`, scoped to `enable_amazon_location_geocoding = true` plus the other toggles
    this environment already runs) — creates the place index, the IAM grant, and the
-   `geo` VPC interface endpoint. This alone does **not** change what's serving
+   `com.amazonaws.us-west-2.geo.places` VPC interface endpoint. This alone does **not**
+   change what's serving
    `demo.honua.io` (no Lambda env change yet, and the place index/endpoint are inert
    until referenced).
 2. **[OPERATOR]** Fold the `Geocoding__*` env block above into the image-redeploy
@@ -500,7 +503,8 @@ other option), not OpenStreetMap — this is a full provider swap, not a drop-in
 replacement with identical results. Coverage, address formatting, and attribution
 differ from Nominatim.
 
-**Cost:** `geo` VPC interface endpoint ~$7–8/month (single-AZ, same pricing as the
+**Cost:** `com.amazonaws.us-west-2.geo.places` VPC interface endpoint ~$7–8/month
+(single-AZ, same pricing as the
 existing Secrets Manager endpoint) + Amazon Location's per-request Esri pricing tier
 (low single dollars/month at demo traffic volumes). No NAT gateway (~$33/mo avoided),
 no new compute.
@@ -535,7 +539,8 @@ item 1's `Geocoding__*` env variables are folded into this same step rather than
 attempted separately.
 
 - **[OPERATOR]** Once PR #2993 merges to `trunk` and `honua-io/honua-iac#127` is
-  applied (place index + `geo` endpoint exist): build and push a new demo image from
+  applied (place index + `com.amazonaws.us-west-2.geo.places` endpoint exists): build
+  and push a new demo image from
   `trunk` HEAD, set the `Geocoding__*` env block from item 1 above on the new version,
   publish it, and repoint the `live` alias from v33 to the new version
   (`aws lambda update-alias --function-name honua-demo-demo-honua

--- a/docs/internal/demo/demo-honua-io-capability-runbook.md
+++ b/docs/internal/demo/demo-honua-io-capability-runbook.md
@@ -397,8 +397,12 @@ curl -s -o /dev/null -w '%{http_code}\n' "$BASE/rest/services/test_service/Featu
 # ships, re-run these two and expect: Provider "amazon-location", and the CLI call
 # in well under 1s with at least one candidate (no more ~15.8s egress timeout).
 curl -s "$BASE/rest/services/World/GeocodeServer?f=json" | jq -r '.locatorProperties.Provider'
-time honua geocode "Kahului" --locator World --limit 1 --json \
-  | jq -e 'type == "array" and length > 0'
+if time honua geocode "Kahului" --locator World --limit 1 --json \
+  | jq -e 'type == "array" and length > 0'; then
+  echo "OK: geocoding returned a candidate"
+else
+  echo "KNOWN: geocoding remains unavailable until remediation item 1 is deployed"
+fi
 
 # SensorThings — expected 404 (intentional, #2434)
 curl -s -o /dev/null -w 'sta: %{http_code}\n' "$BASE/sta/v1.1/"


### PR DESCRIPTION
# Pull Request

## Issue Link
Related to #2948

## Summary
Follow-up to #2996 (merged) — the operator has since decided the geocoding
remediation for #2948: switch `demo.honua.io` to Amazon Location Service
reached over a VPC interface endpoint (PrivateLink), instead of reopening a
NAT gateway for Nominatim. This PR updates the runbook to make that the
**primary** documented fix, demoting NAT+Nominatim to an explicit fallback,
and folds the required `Geocoding__*` env switch into the same
image-redeploy step as PR #2993 (also since merged) + migrations 083–088,
since demo config is frozen into published Lambda versions and there is no
separate env-only path to apply it. Docs-only; no live mutations.

Rebased/cherry-picked onto current `trunk`, which already carries three other
docs-only runbook updates from other work on this same file since #2996
merged (host-vs-metadata-environment distinction, hardened NAT-gateway
routing detail, fail-closed probe script changes) — those are preserved
here, not reverted.

## Changes Made
- Runbook's "As-verified live state" table, Track 2 Step 4 callout, and
  "Runnable now" table: geocoding is now framed as "Amazon Location +
  PrivateLink (PRIMARY, operator-decided 2026-07-23)" with the NAT-gateway
  path demoted to an explicit "1a. Fallback" section, kept only in case
  Amazon Location is rejected later.
- New "Remediation plan" item 1: exact `Geocoding__*` env keys
  (`DefaultProvider=amazon-location`, `Providers__Nominatim__Enabled=false`,
  `Providers__AmazonLocation__*`), why Nominatim must be explicitly disabled
  (its own default is `Enabled=true`, and geocode failover would otherwise
  retry it and hang another ~15.8s on any Amazon Location error), sequencing
  against `honua-io/honua-iac#127` (place index + IAM grant + VPC endpoint,
  not applied), expected verification, cost, and rollback.
- Folded the env switch into item 2 (demo image redeploy) so the code fix
  (#2993), migrations (083–088), and the geocoding provider switch land in
  one deploy, rather than describing a separate env-only change that the
  frozen-published-version deployment model doesn't actually support.
- Updated the consolidated verification probe script's geocoding lines to
  check `locatorProperties.Provider` and expect sub-second responses once
  the switch ships.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [ ] Manual testing performed

Docs-only change (one `.md` file) — no code/build/test surface to exercise.
All factual claims here were verified in the parent task against
`https://demo.honua.io` (read-only HTTP probes) and by reading the relevant
`Honua.Geocoding` provider/coordinator source, not re-verified again for this
follow-up beyond the merge-conflict reconciliation.

## Gate Impact
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated

## Release/Deploy Impact
- [ ] None — standard merge-and-release flow

This PR itself has no release/deploy impact (docs only). The runbook
documents deploy/infra/DB actions for #2948 that still need operator
approval and are not part of this PR's diff.

## Breaking Changes
None.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

`pre-pr-check.sh` not run: documentation-only change, no `src/`/`tests/dotnet`
diff.

## Related
- Companion IaC PR (not applied): honua-io/honua-iac#127
- Supersedes-in-spirit (already merged): #2996
- #2993 has also merged since #2996 landed; the demo image redeploy step
  this PR documents picks up both that code fix and migrations 083–088
  together with the geocoding provider switch.

Do not merge without operator review of the Amazon Location decision.
