### PR TITLE
fix: resolve aws:secretsmanager: Redis connection-string references before Redis multiplexer startup

### DIFF
--- a/src/Honua.Hosting/Features/Helpers/ConnectionStringResolutionHelper.cs
+++ b/src/Honua.Hosting/Features/Helpers/ConnectionStringResolutionHelper.cs
@@ -7,20 +7,46 @@ namespace Honua.Infrastructure.Helpers;
 
 internal static class ConnectionStringResolutionHelper
 {
-    public static async Task<string?> ResolveDefaultConnectionStringAsync(
+    public static Task<string?> ResolveDefaultConnectionStringAsync(
         IConfiguration configuration,
         IConnectionSecretResolver? secretResolver,
         CancellationToken cancellationToken = default)
+        => ResolveConnectionStringValueAsync(
+            configuration.GetConnectionString("DefaultConnection"),
+            "ConnectionStrings:DefaultConnection",
+            secretResolver,
+            cancellationToken);
+
+    /// <summary>
+    /// Resolves a raw connection-string value through the same env:-reference-then-secret-resolver-chain
+    /// mechanism <see cref="ResolveDefaultConnectionStringAsync"/> uses for
+    /// <c>ConnectionStrings:DefaultConnection</c>, generalized so other connection strings that must go
+    /// through the identical resolution order (currently Redis — honua-server#3011) can reuse it instead
+    /// of duplicating it: an <c>env:VARIABLE_NAME</c> reference is substituted first, then the remaining
+    /// value is handed to <paramref name="secretResolver"/> (e.g. the AWS Secrets Manager / Azure Key
+    /// Vault-backed <c>IConnectionSecretResolver</c> chain) only if it reports it can resolve the value;
+    /// a plain value, or a resolver-less caller, passes the value through unchanged.
+    /// </summary>
+    /// <param name="connectionString">The raw configured value (may be null/empty, an <c>env:</c>
+    /// reference, a resolver-backed reference such as <c>aws:secretsmanager:&lt;arn&gt;</c>, or a plain
+    /// connection string).</param>
+    /// <param name="settingName">The configuration key, used only in the error message if an <c>env:</c>
+    /// reference names a variable that is not set.</param>
+    /// <param name="secretResolver">The resolver chain to try for non-<c>env:</c> references, or
+    /// <see langword="null"/> to skip resolver-backed resolution entirely.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task<string?> ResolveConnectionStringValueAsync(
+        string? connectionString,
+        string settingName,
+        IConnectionSecretResolver? secretResolver,
+        CancellationToken cancellationToken = default)
     {
-        var connectionString = configuration.GetConnectionString("DefaultConnection");
         if (string.IsNullOrWhiteSpace(connectionString))
         {
             return connectionString;
         }
 
-        connectionString = SecretReferenceResolver.ResolveEnvironmentReference(
-            connectionString,
-            "ConnectionStrings:DefaultConnection");
+        connectionString = SecretReferenceResolver.ResolveEnvironmentReference(connectionString, settingName);
 
         if (string.IsNullOrWhiteSpace(connectionString) || secretResolver is null)
         {

--- a/src/Honua.Postgres/Features/Security/ConnectionSecretResolvers/AwsSecretsManagerResolver.cs
+++ b/src/Honua.Postgres/Features/Security/ConnectionSecretResolvers/AwsSecretsManagerResolver.cs
@@ -47,9 +47,24 @@ internal sealed class AwsSecretsManagerResolver : IConnectionSecretResolver, IDi
     public string ProviderName => ProviderType;
 
     public AwsSecretsManagerResolver(IHttpClientFactory httpClientFactory, ILogger<AwsSecretsManagerResolver> logger)
+        : this(
+            (httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory))).CreateClient(SecretsClientName),
+            httpClientFactory.CreateClient(MetadataClientName),
+            logger)
     {
-        _secretsClient = httpClientFactory.CreateClient(SecretsClientName);
-        _metadataClient = httpClientFactory.CreateClient(MetadataClientName);
+    }
+
+    /// <summary>
+    /// Bootstrap constructor for callers that must resolve a secret-backed connection string before the
+    /// DI container exists — e.g. Program.cs's Redis <c>ConnectionMultiplexer</c> wiring, which runs
+    /// ahead of <c>WebApplicationBuilder.Build()</c> and therefore has no <see cref="IHttpClientFactory"/>
+    /// to pull the named resilient clients from (honua-server#3011). Callers own the supplied
+    /// <see cref="HttpClient"/> instances and are responsible for disposing them.
+    /// </summary>
+    internal AwsSecretsManagerResolver(HttpClient secretsClient, HttpClient metadataClient, ILogger<AwsSecretsManagerResolver> logger)
+    {
+        _secretsClient = secretsClient ?? throw new ArgumentNullException(nameof(secretsClient));
+        _metadataClient = metadataClient ?? throw new ArgumentNullException(nameof(metadataClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 

--- a/src/Honua.Server/Program.cs
+++ b/src/Honua.Server/Program.cs
@@ -103,6 +103,11 @@ var builder = WebApplication.CreateBuilder(args);
 var useTestSchemaHeaders = builder.Configuration.GetValue<bool>("HONUA_TEST_SCHEMA_HEADERS");
 var forwardedHeadersEnabled = StartupConfigurationHelpers.ConfigureForwardedHeaders(builder.Services, builder.Configuration);
 StartupConfigurationHelpers.ResolveEnvironmentSecretReferences(builder.Configuration);
+// Resolve aws:secretsmanager: Redis connection-string references before anything below reads
+// ConnectionStrings:redis — the multiplexer wiring a few lines down runs ahead of
+// WebApplicationBuilder.Build(), so it cannot use the DI-registered IConnectionSecretResolver
+// composite the way the Postgres DefaultConnection path does (honua-server#3011).
+await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(builder.Configuration);
 var isTestEnvironment = builder.Environment.IsEnvironment("Test");
 var registerInfrastructureInTestEnvironment =
     builder.Configuration.GetValue<bool>("HONUA_REGISTER_TEST_INFRASTRUCTURE") ||

--- a/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
+++ b/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
@@ -11,6 +11,7 @@ using Honua.Infrastructure.Authentication;
 using Honua.Infrastructure.Helpers;
 using Honua.Infrastructure.Licensing;
 using Honua.Infrastructure.Security;
+using Honua.Postgres.Features.Security.ConnectionSecretResolvers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -75,6 +76,81 @@ internal static class StartupConfigurationHelpers
     {
         var value = configuration[key];
         var resolved = SecretReferenceResolver.ResolveEnvironmentReference(value, key);
+        if (!string.Equals(value, resolved, StringComparison.Ordinal))
+        {
+            configuration[key] = resolved;
+        }
+    }
+
+    /// <summary>
+    /// Resolves AWS Secrets Manager-backed secret references (<c>aws:secretsmanager:&lt;arn-or-name&gt;</c>)
+    /// for the Redis connection-string settings Program.cs reads before <c>WebApplicationBuilder.Build()</c>
+    /// runs, so the raw reference is never handed to <c>StackExchange.Redis.ConfigurationOptions.Parse</c>
+    /// (honua-server#3011). The honua-iac AWS serverless module wires <c>ConnectionStrings__redis</c> as an
+    /// <c>aws:secretsmanager:&lt;arn&gt;</c> reference — the same style already resolved for the Postgres
+    /// <c>DefaultConnection</c> string post-Build, through the DI-registered <c>IConnectionSecretResolver</c>
+    /// composite (<see cref="Honua.Infrastructure.Helpers.ConnectionStringResolutionHelper.ResolveDefaultConnectionStringAsync"/>)
+    /// — but the Redis <c>ConnectionMultiplexer</c> is built directly against <c>builder.Configuration</c>
+    /// ahead of service registration, before that composite exists. This resolves the identical reference
+    /// style through the exact same mechanism
+    /// (<see cref="Honua.Infrastructure.Helpers.ConnectionStringResolutionHelper.ResolveConnectionStringValueAsync"/>),
+    /// using a bootstrap-only instance of the SAME AOT-safe <c>AwsSecretsManagerResolver</c> (raw HTTP +
+    /// SigV4, no AWSSDK dependency) the Postgres path uses — mirroring the bootstrap-resolver pattern
+    /// <see cref="CreateBootstrapLicenseSecretResolvers"/> already establishes for the license snapshot.
+    /// <c>env:</c> references are handled first, unconditionally, by that same helper (mirroring
+    /// <see cref="ResolveEnvironmentSecretReferences"/> above). Resolved values are written back into
+    /// <paramref name="configuration"/> in place so every other in-process reader of these keys
+    /// (output-cache wiring, the admin SignalR backplane, deployment-mode config validation) observes the
+    /// resolved value without resolving it again itself.
+    /// </summary>
+    public static async Task ResolveRedisConnectionSecretReferencesAsync(
+        ConfigurationManager configuration,
+        CancellationToken cancellationToken = default)
+    {
+        await ResolveRedisConnectionSecretReferenceAsync(configuration, "ConnectionStrings:redis", cancellationToken)
+            .ConfigureAwait(false);
+        await ResolveRedisConnectionSecretReferenceAsync(
+                configuration, "Aspire:StackExchange:Redis:ConnectionString", cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task ResolveRedisConnectionSecretReferenceAsync(
+        ConfigurationManager configuration,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        var value = configuration[key];
+        if (string.IsNullOrWhiteSpace(value) ||
+            !value.StartsWith("aws:secretsmanager:", StringComparison.OrdinalIgnoreCase))
+        {
+            // Not configured, or not a reference style this bootstrap resolver understands: env:
+            // references are already normalized above by ResolveEnvironmentSecretReferences, and a
+            // plain connection string needs no resolution.
+            return;
+        }
+
+        using var loggerFactory = LoggerFactory.Create(static builder => builder.AddConsole());
+        using var secretsClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        using var metadataClient = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        using var resolver = new AwsSecretsManagerResolver(
+            secretsClient,
+            metadataClient,
+            loggerFactory.CreateLogger<AwsSecretsManagerResolver>());
+
+        string? resolved;
+        try
+        {
+            resolved = await ConnectionStringResolutionHelper
+                .ResolveConnectionStringValueAsync(value, key, resolver, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new InvalidOperationException(
+                $"Failed to resolve the secret-backed connection string for '{key}' from AWS Secrets Manager.",
+                ex);
+        }
+
         if (!string.Equals(value, resolved, StringComparison.Ordinal))
         {
             configuration[key] = resolved;

--- a/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
+++ b/src/Honua.Server/Startup/StartupConfigurationHelpers.cs
@@ -107,10 +107,14 @@ internal static class StartupConfigurationHelpers
         ConfigurationManager configuration,
         CancellationToken cancellationToken = default)
     {
-        await ResolveRedisConnectionSecretReferenceAsync(configuration, "ConnectionStrings:redis", cancellationToken)
-            .ConfigureAwait(false);
-        await ResolveRedisConnectionSecretReferenceAsync(
-                configuration, "Aspire:StackExchange:Redis:ConnectionString", cancellationToken)
+        const string primaryKey = "ConnectionStrings:redis";
+        const string fallbackKey = "Aspire:StackExchange:Redis:ConnectionString";
+
+        // Match every Redis consumer's null-coalescing precedence: a configured primary value
+        // shadows the Aspire fallback, even when the primary is empty. Resolving the shadowed
+        // fallback could otherwise fail startup for a value the application never reads.
+        var effectiveKey = configuration[primaryKey] is null ? fallbackKey : primaryKey;
+        await ResolveRedisConnectionSecretReferenceAsync(configuration, effectiveKey, cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/tests/dotnet/Honua.Postgres.Tests/Features/Security/AwsSecretsManagerResolverEndpointValidationTests.cs
+++ b/tests/dotnet/Honua.Postgres.Tests/Features/Security/AwsSecretsManagerResolverEndpointValidationTests.cs
@@ -3,12 +3,50 @@
 
 using Honua.Postgres.Features.Security.ConnectionSecretResolvers;
 using Honua.TestKit.Attributes;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.Postgres.Tests.Features.Security;
 
 [Collection("Security")]
 public class AwsSecretsManagerResolverEndpointValidationTests
 {
+    // Bootstrap (HttpClient-based) constructor added for honua-server#3011: Program.cs's Redis
+    // ConnectionMultiplexer wiring must resolve aws:secretsmanager: connection-string references
+    // before WebApplicationBuilder.Build() runs, so it cannot pull the named resilient clients from
+    // an IHttpClientFactory the way the DI-registered instance (used for the Postgres
+    // DefaultConnection string) does. These tests only prove the bootstrap constructor produces a
+    // working resolver for reference-recognition purposes — no network call is made.
+    [Fact]
+    public void BootstrapConstructor_ArnStyleSecretReference_CanResolveReturnsTrue()
+    {
+        using var secretsClient = new HttpClient();
+        using var metadataClient = new HttpClient();
+        var resolver = new AwsSecretsManagerResolver(
+            secretsClient,
+            metadataClient,
+            NullLogger<AwsSecretsManagerResolver>.Instance);
+
+        var canResolve = resolver.CanResolve("aws:secretsmanager:arn:aws:secretsmanager:us-east-1:123456789012:secret:demo-redis-abc123");
+
+        Assert.True(canResolve);
+        Assert.Equal("aws", resolver.ProviderName);
+    }
+
+    [Fact]
+    public void BootstrapConstructor_NonAwsSecretReference_CanResolveReturnsFalse()
+    {
+        using var secretsClient = new HttpClient();
+        using var metadataClient = new HttpClient();
+        var resolver = new AwsSecretsManagerResolver(
+            secretsClient,
+            metadataClient,
+            NullLogger<AwsSecretsManagerResolver>.Instance);
+
+        var canResolve = resolver.CanResolve("localhost:6379");
+
+        Assert.False(canResolve);
+    }
+
     [SecurityTest]
     [Theory]
     [InlineData("http://169.254.170.2/v2/credentials")]

--- a/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Helpers/ConnectionStringResolutionHelperTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Infrastructure/Helpers/ConnectionStringResolutionHelperTests.cs
@@ -42,6 +42,61 @@ public sealed class ConnectionStringResolutionHelperTests
         connectionString.Should().Be("Host=localhost;Database=test;Username=test;Password=test");
     }
 
+    // ResolveConnectionStringValueAsync is the generalized mechanism ResolveDefaultConnectionStringAsync
+    // now delegates to; Program.cs's bootstrap Redis wiring (honua-server#3011) reuses it directly for
+    // ConnectionStrings:redis since it runs before WebApplicationBuilder.Build(), when no DI-registered
+    // IConnectionSecretResolver exists yet. These tests exercise the exact same resolution order the
+    // Postgres DefaultConnection path uses, with a fake resolver — no real AWS calls.
+    [Fact]
+    public async Task ResolveConnectionStringValueAsync_AwsSecretsManagerReference_ResolvesThroughResolverChain()
+    {
+        var resolver = new StubConnectionSecretResolver(
+            "aws:secretsmanager:prod/redis",
+            "redis-host.internal:6379,password=resolved-secret");
+
+        var resolved = await ConnectionStringResolutionHelper.ResolveConnectionStringValueAsync(
+            "aws:secretsmanager:prod/redis",
+            "ConnectionStrings:redis",
+            resolver);
+
+        resolved.Should().Be("redis-host.internal:6379,password=resolved-secret");
+    }
+
+    [Fact]
+    public async Task ResolveConnectionStringValueAsync_EnvironmentReference_ResolvesFromEnvironmentVariable()
+    {
+        const string variableName = "HONUA_TEST_REDIS_CONNECTION_STRING_3011";
+        Environment.SetEnvironmentVariable(variableName, "localhost:6380,password=env-secret");
+        try
+        {
+            var resolved = await ConnectionStringResolutionHelper.ResolveConnectionStringValueAsync(
+                $"env:{variableName}",
+                "ConnectionStrings:redis",
+                secretResolver: null);
+
+            resolved.Should().Be("localhost:6380,password=env-secret");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, null);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveConnectionStringValueAsync_PlainConnectionString_PassesThroughUnchanged()
+    {
+        // A resolver is present but must never be consulted for a value it can't recognize as a
+        // reference — proves a plain connection string is left untouched.
+        var resolver = new StubConnectionSecretResolver("aws:secretsmanager:prod/redis", "should-not-be-used");
+
+        var resolved = await ConnectionStringResolutionHelper.ResolveConnectionStringValueAsync(
+            "localhost:6379",
+            "ConnectionStrings:redis",
+            resolver);
+
+        resolved.Should().Be("localhost:6379");
+    }
+
     private sealed class StubConnectionSecretResolver(string secretRef, string resolvedConnectionString) : IConnectionSecretResolver
     {
         public string ProviderName => "aws";

--- a/tests/dotnet/Honua.Server.Tests/Startup/StartupConfigurationHelpersTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Startup/StartupConfigurationHelpersTests.cs
@@ -24,7 +24,7 @@ public sealed class StartupConfigurationHelpersTests
     [Fact]
     public async Task ResolveRedisConnectionSecretReferencesAsync_PlainConnectionString_LeavesValueUnchanged()
     {
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["ConnectionStrings:redis"] = "localhost:6379",
@@ -38,7 +38,7 @@ public sealed class StartupConfigurationHelpersTests
     [Fact]
     public async Task ResolveRedisConnectionSecretReferencesAsync_NotConfigured_NoOp()
     {
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
 
         await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(configuration);
 
@@ -53,7 +53,7 @@ public sealed class StartupConfigurationHelpersTests
         // method ever runs (Program.cs calls it first), so by the time this method sees the value it
         // is already a plain connection string — prove it is left untouched here too, and that no
         // network call is attempted for it.
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["ConnectionStrings:redis"] = "already-resolved-host:6379",
@@ -67,7 +67,7 @@ public sealed class StartupConfigurationHelpersTests
     [Fact]
     public async Task ResolveRedisConnectionSecretReferencesAsync_AspireConnectionStringConfigured_PlainValueLeftUnchanged()
     {
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["Aspire:StackExchange:Redis:ConnectionString"] = "localhost:6379",
@@ -76,5 +76,22 @@ public sealed class StartupConfigurationHelpersTests
         await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(configuration);
 
         configuration["Aspire:StackExchange:Redis:ConnectionString"].Should().Be("localhost:6379");
+    }
+
+    [Fact]
+    public async Task ResolveRedisConnectionSecretReferencesAsync_PrimaryConfigured_SkipsShadowedAspireReference()
+    {
+        const string shadowedReference = "aws:secretsmanager:stale/redis";
+        using var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:redis"] = "primary-host:6379",
+            ["Aspire:StackExchange:Redis:ConnectionString"] = shadowedReference,
+        });
+
+        await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(configuration);
+
+        configuration["ConnectionStrings:redis"].Should().Be("primary-host:6379");
+        configuration["Aspire:StackExchange:Redis:ConnectionString"].Should().Be(shadowedReference);
     }
 }

--- a/tests/dotnet/Honua.Server.Tests/Startup/StartupConfigurationHelpersTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Startup/StartupConfigurationHelpersTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using FluentAssertions;
+using Honua.Server.Startup;
+using Microsoft.Extensions.Configuration;
+
+namespace Honua.Server.Tests.Startup;
+
+/// <summary>
+/// Coverage for the pre-Build Redis connection-string secret-reference resolution
+/// (<see cref="StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync"/>,
+/// honua-server#3011). The <c>aws:secretsmanager:</c> resolution mechanism itself — the part that
+/// matters for the bug (a secret reference must come out the other side as a real connection
+/// string before <c>ConfigurationOptions.Parse</c> sees it) — is covered without any network access
+/// in <c>ConnectionStringResolutionHelperTests</c>, since this method delegates to
+/// <c>ConnectionStringResolutionHelper.ResolveConnectionStringValueAsync</c> with a bootstrap-only
+/// <c>AwsSecretsManagerResolver</c> instance. These tests instead prove the production entry
+/// point's guard behavior: it must recognize non-reference values and return immediately without
+/// constructing an HTTP client or touching the network.
+/// </summary>
+public sealed class StartupConfigurationHelpersTests
+{
+    [Fact]
+    public async Task ResolveRedisConnectionSecretReferencesAsync_PlainConnectionString_LeavesValueUnchanged()
+    {
+        var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:redis"] = "localhost:6379",
+        });
+
+        await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(configuration);
+
+        configuration["ConnectionStrings:redis"].Should().Be("localhost:6379");
+    }
+
+    [Fact]
+    public async Task ResolveRedisConnectionSecretReferencesAsync_NotConfigured_NoOp()
+    {
+        var configuration = new ConfigurationManager();
+
+        await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(configuration);
+
+        configuration["ConnectionStrings:redis"].Should().BeNull();
+        configuration["Aspire:StackExchange:Redis:ConnectionString"].Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveRedisConnectionSecretReferencesAsync_AlreadyResolvedEnvironmentValue_LeavesValueUnchanged()
+    {
+        // env: references are normalized in place by ResolveEnvironmentSecretReferences before this
+        // method ever runs (Program.cs calls it first), so by the time this method sees the value it
+        // is already a plain connection string — prove it is left untouched here too, and that no
+        // network call is attempted for it.
+        var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:redis"] = "already-resolved-host:6379",
+        });
+
+        await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(configuration);
+
+        configuration["ConnectionStrings:redis"].Should().Be("already-resolved-host:6379");
+    }
+
+    [Fact]
+    public async Task ResolveRedisConnectionSecretReferencesAsync_AspireConnectionStringConfigured_PlainValueLeftUnchanged()
+    {
+        var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Aspire:StackExchange:Redis:ConnectionString"] = "localhost:6379",
+        });
+
+        await StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync(configuration);
+
+        configuration["Aspire:StackExchange:Redis:ConnectionString"].Should().Be("localhost:6379");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Fixes #3011

## Summary
The honua-iac AWS serverless module wires `ConnectionStrings__redis` as an `aws:secretsmanager:<arn>` reference — the same style already resolved for the Postgres `DefaultConnection` string. But `Program.cs`'s Redis `ConnectionMultiplexer` wiring runs before `WebApplicationBuilder.Build()`, so the DI-registered `IConnectionSecretResolver` composite the Postgres path uses isn't available yet, and the raw reference string was handed straight to `StackExchange.Redis.ConfigurationOptions.Parse`. That parsed as a bogus hostname, the multiplexer timed out, and startup threw `Redis durable coordination is required in this environment, but startup could not establish the Redis multiplexer.` — crash-looping demo.honua.io as Lambda v34 (rolled back).

This resolves `aws:secretsmanager:` (and, as before, `env:`) references for the Redis connection string through the same mechanism the Postgres path uses, before the multiplexer is built.

## Changes Made
- `Honua.Infrastructure.Helpers.ConnectionStringResolutionHelper`: extracted the Postgres `DefaultConnection` resolution logic (env: reference substitution, then hand off to the `IConnectionSecretResolver` chain) into a reusable `ResolveConnectionStringValueAsync(connectionString, settingName, secretResolver, cancellationToken)`. `ResolveDefaultConnectionStringAsync` now delegates to it — behavior and signature unchanged for its 5 existing call sites.
- `AwsSecretsManagerResolver` (Honua.Postgres): added a bootstrap constructor that takes plain `HttpClient` instances instead of `IHttpClientFactory`, so it can be constructed before the DI container exists. It is the exact same AOT-safe resolver (raw HTTP + SigV4, no AWSSDK dependency) the DI-registered instance uses for Postgres — no parallel resolver.
- `StartupConfigurationHelpers.ResolveRedisConnectionSecretReferencesAsync` (new): resolves `aws:secretsmanager:` references for `ConnectionStrings:redis` and `Aspire:StackExchange:Redis:ConnectionString` in place, using a bootstrap `AwsSecretsManagerResolver` through `ConnectionStringResolutionHelper.ResolveConnectionStringValueAsync` — mirroring the existing bootstrap-resolver pattern `CreateBootstrapLicenseSecretResolvers` already establishes in the same file for the license snapshot. A resolution failure now throws a clear, actionable exception instead of surfacing as an opaque multiplexer timeout.
- `Program.cs`: calls the new method immediately after the existing `ResolveEnvironmentSecretReferences` (env: resolution), before anything reads `ConnectionStrings:redis`. Because the value is mutated on `builder.Configuration` in place (the same `ConfigurationManager` instance the built app's `IConfiguration` service resolves to), every other in-process reader of that key — the output-cache wiring (`ObservabilityServiceCollectionExtensions`), the admin SignalR backplane (`AdminRealtimeHubExtensions`), and deployment-mode config validation (`ConfigurationValidationService`) — observes the resolved value too, without each call site resolving it independently.

## Other Redis connection-string reads (noted, not touched)
- `Honua.Worker.Gdal/GdalWorkerServiceCollectionExtensions.cs:45` builds its own `ConnectionMultiplexer` directly from raw configuration and has the same latent gap. It's a separate deployable/host (its own `Program.cs`) that deliberately does not reference `Honua.Server` or `Honua.Postgres` (ADR-0038 boundary), so reusing the same bootstrap resolver there is a larger, separate change — flagging for a follow-up rather than expanding this PR's scope.
- Azure Key Vault (`azure:keyvault:`) references are not resolved for Redis by this change (only `aws:secretsmanager:`, matching the reported bug and the honua-iac AWS module). The Postgres path's Azure resolver could be wired the same way if/when an Azure-hosted Redis reference shows up.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Architecture tests pass (implied by full `Honua.Server` build; not run standalone)
- [ ] Manual testing performed

New tests:
- `ConnectionStringResolutionHelperTests`: `ResolveConnectionStringValueAsync` resolves an `aws:secretsmanager:` reference through a stub `IConnectionSecretResolver` (no real AWS calls), resolves an `env:` reference from an environment variable, and passes a plain connection string through unchanged.
- `StartupConfigurationHelpersTests` (new file): `ResolveRedisConnectionSecretReferencesAsync` leaves a plain connection string and an already-resolved value unchanged, and is a no-op when Redis isn't configured — proving the production entry point's network-call guard without touching the network.
- `AwsSecretsManagerResolverEndpointValidationTests`: the new bootstrap (`HttpClient`-based) constructor produces a working resolver (`CanResolve` true for an ARN-style reference, false for a plain host:port string).

### Verification (foreground, exit-code gated)
- `dotnet build src/Honua.Server/Honua.Server.csproj -c Release /p:TreatWarningsAsErrors=true` — exit 0, 0 warnings, 0 errors (full transitive build including `Honua.Hosting` and `Honua.Postgres`).
- `dotnet test tests/dotnet/Honua.Postgres.Tests -c Release --filter FullyQualifiedName~AwsSecretsManagerResolverEndpointValidationTests` — exit 0, **13/13 passed**.
- `dotnet test tests/dotnet/Honua.Server.Tests -c Release --filter "FullyQualifiedName~ConnectionStringResolutionHelperTests|FullyQualifiedName~StartupConfigurationHelpersTests"` — exit 0, **9/9 passed**.

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow (fixes existing behavior for a connection-string style honua-iac already produces)

## Breaking Changes
None.

---

## Pre-PR Checklist
- [ ] Ran `scripts/ci/pre-pr-check.sh` and all checks passed (ran targeted `dotnet build` + `dotnet test --filter` directly instead; see Verification above)
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
