### PR TITLE
feat(studio): grant-gated end-user access to AI generation endpoints

### DIFF
--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -21,7 +21,7 @@
       "category": "ControlPlane",
       "edition": "Community",
       "entryCount": 368,
-      "provingTestCount": 981,
+      "provingTestCount": 982,
       "maturity": {
         "implemented": 368
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -16241,6 +16241,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.GenerateMapPackage_FlagOn_NonAdminRequiresExecuteGrant",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.GenerateMapPackage_MissingPrompt_ReachesHandlerAndReturnsBadRequest",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.GeneratePackages_FlagOn_NonAdminScopedKeyDeniedBeforeHandler"
       ],

--- a/docs/internal/admin-api/studio-package-lifecycle.md
+++ b/docs/internal/admin-api/studio-package-lifecycle.md
@@ -74,10 +74,6 @@ With the flag on:
   regardless of ownership. Cross-user access to a non-owned, non-published
   resource is denied by default. No operator grant is required for the baseline
   tier — the flag itself is the widening switch (REQ-002).
-- **AI generation remains admin-only.** `POST /map-packages/generate` and
-  `POST /app-packages/generate` can invoke configured model providers before a
-  resource with an enforceable owner exists. The end-user lifecycle flag does
-  not widen these potentially costly operations; both retain the admin policy.
 - **Save-as-version authorizes both mutation boundaries.** Saving a draft creates
   an immutable version *and* advances the parent item's `currentVersionId`.
   Consequently, a non-admin caller must own both the draft and the immutable
@@ -123,6 +119,19 @@ With the flag on:
   which (as above) can be recorded under a different owner. A caller who owns
   only the target version, even with a matching `StudioDraft` operator grant,
   cannot move another principal's item's pointer.
+- **AI generation is elevated, never implicitly widened.** `POST
+  /map-packages/generate` and `POST /app-packages/generate` are not opened to
+  every authenticated principal by the end-user flag: generation consumes model
+  resources and creates content with no pre-existing resource whose ownership
+  could gate it, so a non-admin caller requires a `StudioDraft` `Execute`
+  operator grant (the self-service `own`-sentinel form suffices; admins are
+  unaffected, and with the flag off both routes stay admin-only exactly as
+  before). Without the grant the request is denied
+  `studio_authorization/elevated_grant_required` before the request body is
+  even parsed. To enable generation for a pilot end user, an operator
+  provisions the grant `Service=StudioDraft`, `Layer=own`, `Operation=Execute`
+  on a role held by that user (honua-server#3023); revoking the grant closes
+  access again without touching the flag.
 - **Version comparison authorizes both requested versions individually** —
   `leftVersionId` and `rightVersionId` are each checked against their own
   recorded owner (never publicly readable, since a diff can expose unpublished

--- a/src/Honua.Core/Features/Studio/Abstractions/IStudioAuthorizationService.cs
+++ b/src/Honua.Core/Features/Studio/Abstractions/IStudioAuthorizationService.cs
@@ -56,6 +56,15 @@ public enum StudioAuthorizationOperation
     /// ownership.
     /// </summary>
     Rollback,
+
+    /// <summary>
+    /// Generate or refine a map/app package from a natural-language prompt. Elevated: AI
+    /// generation consumes model resources and is not implicitly widened by the end-user flag;
+    /// non-admin callers require a <c>StudioDraft</c> <c>Execute</c> operator grant (the
+    /// <c>own</c> sentinel form suffices — generation creates content the caller will own, so
+    /// no concrete resource id exists at authorization time).
+    /// </summary>
+    Generate,
 }
 
 /// <summary>

--- a/src/Honua.Core/Features/Studio/Services/StudioAuthorizationService.cs
+++ b/src/Honua.Core/Features/Studio/Services/StudioAuthorizationService.cs
@@ -163,7 +163,9 @@ public sealed class StudioAuthorizationService : IStudioAuthorizationService
                 "Authentication is required for Studio package lifecycle operations.");
         }
 
-        var isElevated = operation is StudioAuthorizationOperation.PublishRequest or StudioAuthorizationOperation.Rollback;
+        var isElevated = operation is StudioAuthorizationOperation.PublishRequest
+            or StudioAuthorizationOperation.Rollback
+            or StudioAuthorizationOperation.Generate;
         var isRead = operation is StudioAuthorizationOperation.ReadDraft
             or StudioAuthorizationOperation.ReadContentItem
             or StudioAuthorizationOperation.ListOwn;
@@ -201,9 +203,12 @@ public sealed class StudioAuthorizationService : IStudioAuthorizationService
         // id regardless of who owns it. A grant scoped to the "own" sentinel authorizes every
         // resource the caller owns; a grant scoped to the concrete resourceId (or the "*"
         // wildcard) authorizes an operator-provisioned delegate, independent of ownership.
-        var operatorOperation = operation == StudioAuthorizationOperation.PublishRequest
-            ? OperatorOperation.Publish
-            : OperatorOperation.Rollback;
+        var operatorOperation = operation switch
+        {
+            StudioAuthorizationOperation.PublishRequest => OperatorOperation.Publish,
+            StudioAuthorizationOperation.Generate => OperatorOperation.Execute,
+            _ => OperatorOperation.Rollback,
+        };
 
         if (isOwn && await HasOperatorGrantAsync(principal, operatorOperation, OwnResourceSentinel, cancellationToken).ConfigureAwait(false))
         {

--- a/src/Honua.Hosting/Features/Authentication/OperatorAuthorizationEvaluator.cs
+++ b/src/Honua.Hosting/Features/Authentication/OperatorAuthorizationEvaluator.cs
@@ -43,8 +43,7 @@ internal sealed class OperatorAuthorizationEvaluator(
             return AccessDecision.RequiresAuth("Authentication is required for operator resources.");
         }
 
-        var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier)
-                  ?? principal.FindFirstValue("sub");
+        var userId = ResolveGrantSubjectId(principal);
         var roleClaimType = rbacOptions.Value.EffectiveRoleClaimType;
         var checkStandardRoleClaim = !string.Equals(roleClaimType, ClaimTypes.Role, StringComparison.OrdinalIgnoreCase);
 
@@ -153,6 +152,43 @@ internal sealed class OperatorAuthorizationEvaluator(
             logger, userId, request.ResourceType, request.Operation, request.ResourceId);
         return AccessDecision.Forbidden(
             $"No matching operator permission for {request.ResourceType}.{request.Operation}.");
+    }
+
+    /// <summary>
+    /// Resolves the subject id used for role-store grant lookup and workspace ownership
+    /// comparison: <see cref="ClaimTypes.NameIdentifier"/>, then <c>sub</c>, then
+    /// <c>api_key_id</c>, then <c>api_key_name</c>.
+    /// </summary>
+    /// <remarks>
+    /// The API-key fallbacks mirror <c>StudioAuthorizationService.ResolveCallerId</c> so that
+    /// the id a caller owns content under is the same id an operator provisions grants
+    /// against. API-key principals carry neither <see cref="ClaimTypes.NameIdentifier"/> nor
+    /// <c>sub</c> (ApiKeyAuthenticationHandler stamps <c>api_key_id</c>/<c>api_key_name</c>
+    /// instead), so without these fallbacks every API-key caller collapsed onto the same
+    /// empty subject id and per-key grants could never match (#3023 review).
+    /// </remarks>
+    private static string? ResolveGrantSubjectId(ClaimsPrincipal principal)
+    {
+        var candidate = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!string.IsNullOrWhiteSpace(candidate))
+        {
+            return candidate;
+        }
+
+        candidate = principal.FindFirstValue("sub");
+        if (!string.IsNullOrWhiteSpace(candidate))
+        {
+            return candidate;
+        }
+
+        candidate = principal.FindFirstValue("api_key_id");
+        if (!string.IsNullOrWhiteSpace(candidate))
+        {
+            return candidate;
+        }
+
+        candidate = principal.FindFirstValue("api_key_name");
+        return string.IsNullOrWhiteSpace(candidate) ? null : candidate;
     }
 
     private bool MatchesOperatorGrant(PermissionGrant grant, OperatorAuthorizationRequest request)

--- a/src/Honua.Server/Features/Studio/StudioEndpointAuthorization.cs
+++ b/src/Honua.Server/Features/Studio/StudioEndpointAuthorization.cs
@@ -123,6 +123,7 @@ internal sealed class StudioEndpointAuthorization(
         StudioAuthorizationOperation.ReopenVersion => "reopen_version",
         StudioAuthorizationOperation.PublishRequest => "publish_request",
         StudioAuthorizationOperation.Rollback => "rollback",
+        StudioAuthorizationOperation.Generate => "generate",
         _ => operation.ToString(),
     };
 }

--- a/src/Honua.Server/Features/Studio/StudioPackageEndpoints.cs
+++ b/src/Honua.Server/Features/Studio/StudioPackageEndpoints.cs
@@ -120,11 +120,18 @@ internal static class StudioPackageEndpoints
             .WithDisplayName("Create Studio Rollback Request")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }));
 
+        // honua-server#3023: the generate routes intentionally rely on the group-level
+        // RequireStudioLifecycleAuthorization() gate (admin unconditionally; any authenticated
+        // principal once Studio:EndUserAuthorization:Enabled is on) instead of the former
+        // route-level RequireAdminAuthorization(). AI generation must not be implicitly
+        // widened by the end-user flag, so each handler additionally enforces the elevated
+        // StudioAuthorizationOperation.Generate check (StudioDraft/own/Execute operator grant
+        // for non-admins) before the request body is parsed. With the flag off this is exactly
+        // the prior admin-only posture.
         group.MapPost("/map-packages/generate", HandleGenerateMap)
             .WithDisplayName("Generate Studio Map Package")
             .WithSummary("Generate or refine a map package from a natural-language prompt.")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
-            .RequireAdminAuthorization()
             .Accepts<GenerateMapPackageRequest>("application/json")
             .Produces<MapGenerationResult>();
 
@@ -132,7 +139,6 @@ internal static class StudioPackageEndpoints
             .WithDisplayName("Generate Studio App Package")
             .WithSummary("Generate or refine a studio-app/v1 app package from a natural-language prompt.")
             .WithMetadata(new HttpMethodMetadata(new[] { HttpMethods.Post }))
-            .RequireAdminAuthorization()
             .Accepts<GenerateAppPackageRequest>("application/json")
             .Produces<AppGenerationResult>();
 
@@ -329,8 +335,15 @@ internal static class StudioPackageEndpoints
 
     private static async Task<IResult> HandleGenerateApp(
         HttpContext context,
-        [FromServices] IAppGenerationService generation)
+        [FromServices] IAppGenerationService generation,
+        [FromServices] StudioEndpointAuthorization authorization)
     {
+        var generateAuthResult = await EnsureGenerateAuthorizedAsync(authorization, context, "studio-app-generation").ConfigureAwait(false);
+        if (generateAuthResult is not null)
+        {
+            return generateAuthResult;
+        }
+
         GenerateAppPackageRequest? request;
         try
         {
@@ -377,8 +390,15 @@ internal static class StudioPackageEndpoints
 
     private static async Task<IResult> HandleGenerateMap(
         HttpContext context,
-        [FromServices] IMapGenerationService generation)
+        [FromServices] IMapGenerationService generation,
+        [FromServices] StudioEndpointAuthorization authorization)
     {
+        var generateAuthResult = await EnsureGenerateAuthorizedAsync(authorization, context, "studio-map-generation").ConfigureAwait(false);
+        if (generateAuthResult is not null)
+        {
+            return generateAuthResult;
+        }
+
         GenerateMapPackageRequest? request;
         try
         {
@@ -1582,6 +1602,25 @@ internal static class StudioPackageEndpoints
             return ServerError(context, "Studio rollback request could not be created.");
         }
     }
+
+    /// <summary>
+    /// Authorizes the AI generation endpoints (honua-server#3023): unlike the lifecycle
+    /// handlers, generation has no existing resource whose ownership can gate it, and it
+    /// consumes model resources — so it is an elevated operation. Admins pass unchanged;
+    /// with the end-user flag on, a non-admin needs a <c>StudioDraft</c> <c>Execute</c>
+    /// operator grant (the <c>own</c> sentinel form), keeping the group-level policy widening
+    /// from implicitly opening generation to every authenticated principal.
+    /// </summary>
+    private static Task<IResult?> EnsureGenerateAuthorizedAsync(
+        StudioEndpointAuthorization authorization,
+        HttpContext context,
+        string resourceType)
+        => EnsureAuthorizedAsync(
+            authorization, context,
+            StudioAuthorizationOperation.Generate,
+            resourceOwnerId: authorization.ResolveCallerId(context.User),
+            resourceType: resourceType,
+            resourceId: null);
 
     /// <summary>
     /// Authorizes a Studio package-lifecycle operation against the target resource's recorded

--- a/tests/dotnet/Honua.Core.Tests/Features/Studio/StudioAuthorizationServiceTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Studio/StudioAuthorizationServiceTests.cs
@@ -210,6 +210,29 @@ public sealed class StudioAuthorizationServiceTests
     }
 
     [UnitTest]
+    public async Task AuthorizeAsync_FlagOn_NonAdminOwnResource_GenerateUsesExecuteOperatorOperation()
+    {
+        // honua-server#3023: AI generation is elevated and maps to the Execute operator
+        // operation. A Publish or Rollback grant must not authorize generation -- each
+        // elevated operation is independently policy-gated.
+        var service = BuildService(enabled: true, out var evaluator);
+        evaluator.Allow(OperatorResourceType.StudioDraft, "own", OperatorOperation.Publish);
+        evaluator.Allow(OperatorResourceType.StudioDraft, "own", OperatorOperation.Rollback);
+
+        var denied = await service.AuthorizeAsync(
+            UserPrincipal(Alice), Alice, StudioAuthorizationOperation.Generate, resourceOwnerId: Alice);
+        Assert.False(denied.IsAllowed);
+        Assert.True(denied.IsElevated);
+        Assert.Equal(StudioAuthorizationService.ElevatedGrantRequiredCode, denied.Code);
+
+        evaluator.Allow(OperatorResourceType.StudioDraft, "own", OperatorOperation.Execute);
+        var allowed = await service.AuthorizeAsync(
+            UserPrincipal(Alice), Alice, StudioAuthorizationOperation.Generate, resourceOwnerId: Alice);
+        Assert.True(allowed.IsAllowed);
+        Assert.True(allowed.IsElevated);
+    }
+
+    [UnitTest]
     public async Task AuthorizeAsync_FlagOn_NonAdminCrossUser_ElevatedOperationAllowedWithDelegateGrant()
     {
         // A delegate scenario: an operator granted alice explicit publish rights on bob's

--- a/tests/dotnet/Honua.Server.Tests/Features/Authorization/OperatorAuthorizationEvaluatorTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Authorization/OperatorAuthorizationEvaluatorTests.cs
@@ -577,6 +577,116 @@ public sealed class OperatorAuthorizationEvaluatorTests
         decision.IsAllowed.Should().BeTrue();
     }
 
+    [UnitTest]
+    public async Task Evaluate_ApiKeyPrincipal_LooksUpGrantsUnderApiKeyId()
+    {
+        // PR #3024 review (P1): API-key principals carry neither NameIdentifier nor "sub"
+        // (ApiKeyAuthenticationHandler stamps Name/Role/api_key_id/api_key_name), so the
+        // evaluator used to collapse every API-key caller onto the same empty subject id --
+        // per-key grants could never match and a role-level grant authorized every scoped key.
+        // The grant-lookup subject must be the api_key_id, mirroring
+        // StudioAuthorizationService.ResolveCallerId so ownership ids and grant-subject ids
+        // agree.
+        _roleStore.AddGrant("scoped-api-key", "process", "*", "execute");
+        var principal = CreateApiKeyPrincipal("key-1111", "alice-key", "scoped-api-key");
+
+        var decision = await _evaluator.EvaluateAsync(principal, new OperatorAuthorizationRequest
+        {
+            ResourceType = OperatorResourceType.Process,
+            Operation = OperatorOperation.Execute,
+            ResourceId = "proc-1"
+        });
+
+        decision.IsAllowed.Should().BeTrue();
+        _roleStore.LastRequestedUserId.Should().Be("key-1111");
+    }
+
+    [UnitTest]
+    public async Task Evaluate_ApiKeyPrincipal_WithoutKeyId_FallsBackToApiKeyName()
+    {
+        _roleStore.AddGrant("scoped-api-key", "process", "*", "execute");
+        var principal = CreateApiKeyPrincipal(apiKeyId: null, apiKeyName: "alice-key", "scoped-api-key");
+
+        var decision = await _evaluator.EvaluateAsync(principal, new OperatorAuthorizationRequest
+        {
+            ResourceType = OperatorResourceType.Process,
+            Operation = OperatorOperation.Execute,
+            ResourceId = "proc-1"
+        });
+
+        decision.IsAllowed.Should().BeTrue();
+        _roleStore.LastRequestedUserId.Should().Be("alice-key");
+    }
+
+    [UnitTest]
+    public async Task Evaluate_NameIdentifierTakesPrecedenceOverApiKeyClaims()
+    {
+        _roleStore.AddGrant("operator", "process", "*", "execute");
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "user-1"),
+            new("api_key_id", "key-1111"),
+            new("roles", "operator")
+        };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestScheme"));
+
+        var decision = await _evaluator.EvaluateAsync(principal, new OperatorAuthorizationRequest
+        {
+            ResourceType = OperatorResourceType.Process,
+            Operation = OperatorOperation.Execute,
+            ResourceId = "proc-1"
+        });
+
+        decision.IsAllowed.Should().BeTrue();
+        _roleStore.LastRequestedUserId.Should().Be("user-1");
+    }
+
+    [UnitTest]
+    public async Task Evaluate_PersonalWorkspace_ApiKeyOwnerAllowed()
+    {
+        // The same resolved subject id is used for personal-workspace ownership, so an API-key
+        // principal can own a personal workspace under its api_key_id.
+        _roleStore.AddGrant("scoped-api-key", "workspace", "*", "read");
+        var principal = CreateApiKeyPrincipal("key-1111", "alice-key", "scoped-api-key");
+
+        var decision = await _evaluator.EvaluateAsync(principal, new OperatorAuthorizationRequest
+        {
+            ResourceType = OperatorResourceType.Workspace,
+            Operation = OperatorOperation.Read,
+            WorkspaceVisibility = WorkspaceVisibility.Personal,
+            WorkspaceOwnerId = "key-1111"
+        });
+
+        decision.IsAllowed.Should().BeTrue();
+    }
+
+    private static ClaimsPrincipal CreateApiKeyPrincipal(string? apiKeyId, string? apiKeyName, params string[] roles)
+    {
+        // Mirrors the claim shape ApiKeyAuthenticationHandler stamps for a scoped key:
+        // Name + role + api_key_id/api_key_name, and no NameIdentifier or "sub".
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Name, apiKeyName ?? "scoped-api-key")
+        };
+
+        if (apiKeyId is not null)
+        {
+            claims.Add(new Claim("api_key_id", apiKeyId));
+        }
+
+        if (apiKeyName is not null)
+        {
+            claims.Add(new Claim("api_key_name", apiKeyName));
+        }
+
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim("roles", role));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestScheme"));
+    }
+
     private static ClaimsPrincipal CreatePrincipalWithScopeClaim(string userId, string scopeGroup, params string[] roles)
     {
         var claims = new List<Claim>
@@ -647,6 +757,9 @@ public sealed class OperatorAuthorizationEvaluatorTests
     {
         private readonly Dictionary<string, List<PermissionGrant>> _roleGrants = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>The userId the evaluator passed to the most recent effective-permissions lookup.</summary>
+        public string? LastRequestedUserId { get; private set; }
+
         public void AddGrant(string roleName, string service, string layer, string operation)
         {
             if (!_roleGrants.TryGetValue(roleName, out var grants))
@@ -661,6 +774,7 @@ public sealed class OperatorAuthorizationEvaluatorTests
         public Task<EffectivePermissions> GetEffectivePermissionsAsync(
             string userId, IReadOnlyList<string> roles, CancellationToken cancellationToken = default)
         {
+            LastRequestedUserId = userId;
             var permissions = roles
                 .Where(r => _roleGrants.ContainsKey(r))
                 .SelectMany(r => _roleGrants[r])

--- a/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
@@ -923,16 +923,15 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
         var aliceOwnerId = aliceKey.Record.Id.ToString("D");
         var bobOwnerId = bobKey.Record.Id.ToString("D");
 
-        // OperatorAuthorizationEvaluator resolves its own grant-lookup "userId" from
-        // ClaimTypes.NameIdentifier/"sub" only -- claims an API-key principal never carries
-        // (ApiKeyAuthenticationHandler stamps Name/Role/api_key_id/permission instead), so it
-        // always resolves an empty user id for both Alice's and Bob's requests here. Grant
-        // under that same key rather than each principal's real (api_key_id-resolved)
-        // ownership id -- Bob's denial below rests entirely on the item-vs-version ownership
-        // boundary under test, not on this grant-lookup quirk (a real "own" grant existing for
-        // both callers, exactly as it would for two OIDC principals who each independently hold
-        // one, only matters once the item-ownership gate is already satisfied).
-        roleStore.Grant(string.Empty, StudioDraftOwnPublishAndRollbackGrants);
+        // OperatorAuthorizationEvaluator resolves its grant-lookup subject through the same
+        // chain as StudioAuthorizationService.ResolveCallerId (NameIdentifier -> sub ->
+        // api_key_id -> api_key_name; PR #3024 review), so each API-key principal's grants are
+        // provisioned under its own api_key_id -- the same id it owns content under. Both
+        // callers hold a real "own" grant, exactly as two OIDC principals each independently
+        // would: Bob's denial below rests entirely on the item-vs-version ownership boundary
+        // under test.
+        roleStore.Grant(aliceOwnerId, StudioDraftOwnPublishAndRollbackGrants);
+        roleStore.Grant(bobOwnerId, StudioDraftOwnPublishAndRollbackGrants);
 
         // Admin creates the item owned by Alice, then a second draft under the SAME item
         // explicitly owned by Bob -- the item's owner_id stays Alice (immutable), but the
@@ -980,16 +979,10 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
         var aliceOwnerId = aliceKey.Record.Id.ToString("D");
         var bobOwnerId = bobKey.Record.Id.ToString("D");
 
-        // OperatorAuthorizationEvaluator resolves its own grant-lookup "userId" from
-        // ClaimTypes.NameIdentifier/"sub" only -- claims an API-key principal never carries
-        // (ApiKeyAuthenticationHandler stamps Name/Role/api_key_id/permission instead), so it
-        // always resolves an empty user id for both Alice's and Bob's requests here. Grant
-        // under that same key rather than each principal's real (api_key_id-resolved)
-        // ownership id -- Bob's denial below rests entirely on the item-vs-version ownership
-        // boundary under test, not on this grant-lookup quirk (a real "own" grant existing for
-        // both callers, exactly as it would for two OIDC principals who each independently hold
-        // one, only matters once the item-ownership gate is already satisfied).
-        roleStore.Grant(string.Empty, StudioDraftOwnPublishAndRollbackGrants);
+        // Grants provisioned under each principal's real api_key_id-resolved subject id -- see
+        // PublishRequest_FlagOn_AuthorizesAgainstItemOwnerNotVersionOwner.
+        roleStore.Grant(aliceOwnerId, StudioDraftOwnPublishAndRollbackGrants);
+        roleStore.Grant(bobOwnerId, StudioDraftOwnPublishAndRollbackGrants);
 
         var (itemId, bobVersionId) = await CreateItemWithMixedOwnerVersionAsync(adminClient, aliceOwnerId, bobOwnerId);
 
@@ -1506,24 +1499,37 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
             services.AddSingleton<IRoleStore>(roleStore);
         });
         var apiKeyStore = fixture.Services.GetRequiredService<IAdminApiKeyStore>();
-        var userKey = await apiKeyStore.CreateAsync("generate-user", ["studio:enduser"], null, null, CancellationToken.None);
-        using var userClient = fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", userKey.Key));
+        var aliceKey = await apiKeyStore.CreateAsync("generate-alice", ["studio:enduser"], null, null, CancellationToken.None);
+        var bobKey = await apiKeyStore.CreateAsync("generate-bob", ["studio:enduser"], null, null, CancellationToken.None);
+        using var aliceClient = fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", aliceKey.Key));
+        using var bobClient = fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", bobKey.Key));
 
         // Without an Execute grant: denied at the authorization gate, for both generate routes.
-        var deniedMap = await userClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
+        var deniedMap = await aliceClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
         deniedMap.StatusCode.Should().Be(HttpStatusCode.Forbidden);
         var deniedProblem = JsonSerializer.Deserialize<JsonElement>(await deniedMap.Content.ReadAsStringAsync());
         deniedProblem.GetProperty("code").GetString().Should().Be("studio_authorization/elevated_grant_required");
 
-        var deniedApp = await userClient.PostAsync("/api/v1/studio/app-packages/generate", EmptyJson());
+        var deniedApp = await aliceClient.PostAsync("/api/v1/studio/app-packages/generate", EmptyJson());
         deniedApp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
 
-        // With the self-service "own"-sentinel Execute grant (granted under the evaluator's
-        // resolved empty user id -- see the round-5 tests for why): past the gate, into prompt
-        // validation.
-        roleStore.Grant(string.Empty, [new PermissionGrant { Service = "StudioDraft", Layer = "own", Operation = "Execute" }]);
-        var allowedMap = await userClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
+        // With the self-service "own"-sentinel Execute grant, provisioned under Alice's real
+        // api_key_id-resolved subject id (the evaluator mirrors
+        // StudioAuthorizationService.ResolveCallerId; PR #3024 review): past the gate, into
+        // prompt validation.
+        roleStore.Grant(
+            aliceKey.Record.Id.ToString("D"),
+            [new PermissionGrant { Service = "StudioDraft", Layer = "own", Operation = "Execute" }]);
+        var allowedMap = await aliceClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
         allowedMap.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Per-key isolation (PR #3024 review, P1): Alice's Execute grant must not authorize
+        // Bob's key -- previously every API-key principal resolved to the same empty subject
+        // id, so any one key's grant opened generation to all of them.
+        var bobDenied = await bobClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
+        bobDenied.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var bobProblem = JsonSerializer.Deserialize<JsonElement>(await bobDenied.Content.ReadAsStringAsync());
+        bobProblem.GetProperty("code").GetString().Should().Be("studio_authorization/elevated_grant_required");
 
         // Admin remains admitted with no grant.
         using var adminClient = fixture.CreateAdminClient();

--- a/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioPackageEndpointsTests.cs
@@ -464,6 +464,10 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
     [Endpoint("POST /api/v1/studio/app-packages/generate")]
     public async Task GeneratePackages_FlagOn_NonAdminScopedKeyDeniedBeforeHandler()
     {
+        // honua-server#3023: the end-user flag no longer hard-blocks non-admins at the route
+        // policy; instead each generate handler denies a grant-less non-admin at the elevated
+        // authorization gate, before the request body is parsed or any generation service is
+        // touched. Without a StudioDraft Execute operator grant the outcome stays 403.
         await using var endUserFixture = await CreateEndUserFixtureAsync();
         var apiKeyStore = endUserFixture.Services.GetRequiredService<IAdminApiKeyStore>();
         var endUserKey = await apiKeyStore.CreateAsync(
@@ -480,10 +484,10 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
 
         mapResponse.StatusCode.Should().Be(
             HttpStatusCode.Forbidden,
-            "end-user lifecycle access must not reach the potentially costly map-generation handler");
+            "end-user lifecycle access without a StudioDraft Execute grant must not reach the potentially costly map-generation path");
         appResponse.StatusCode.Should().Be(
             HttpStatusCode.Forbidden,
-            "end-user lifecycle access must not reach the potentially costly app-generation handler");
+            "end-user lifecycle access without a StudioDraft Execute grant must not reach the potentially costly app-generation path");
     }
 
     [IntegrationTest]
@@ -1483,6 +1487,48 @@ public sealed class StudioPackageEndpointsTests : IAsyncLifetime
         var response = await _client.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/studio/map-packages/generate")]
+    public async Task GenerateMapPackage_FlagOn_NonAdminRequiresExecuteGrant()
+    {
+        // PR #3018 review, round 7 (P1): the group-level end-user widening must not implicitly
+        // open the AI generation endpoints to every authenticated principal -- generation is an
+        // elevated operation requiring a StudioDraft Execute operator grant for non-admins.
+        // An empty JSON body is sufficient on both sides of the boundary: the authorization
+        // guard runs before body parsing, so "403 elevated_grant_required" proves the gate and
+        // "400 missing prompt" proves the caller got through it without invoking a real LLM.
+        var roleStore = new FakeGrantingRoleStore();
+        await using var fixture = await CreateEndUserFixtureAsync(services =>
+        {
+            services.RemoveAll<IRoleStore>();
+            services.AddSingleton<IRoleStore>(roleStore);
+        });
+        var apiKeyStore = fixture.Services.GetRequiredService<IAdminApiKeyStore>();
+        var userKey = await apiKeyStore.CreateAsync("generate-user", ["studio:enduser"], null, null, CancellationToken.None);
+        using var userClient = fixture.CreateClient(c => c.DefaultRequestHeaders.Add("X-API-Key", userKey.Key));
+
+        // Without an Execute grant: denied at the authorization gate, for both generate routes.
+        var deniedMap = await userClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
+        deniedMap.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var deniedProblem = JsonSerializer.Deserialize<JsonElement>(await deniedMap.Content.ReadAsStringAsync());
+        deniedProblem.GetProperty("code").GetString().Should().Be("studio_authorization/elevated_grant_required");
+
+        var deniedApp = await userClient.PostAsync("/api/v1/studio/app-packages/generate", EmptyJson());
+        deniedApp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        // With the self-service "own"-sentinel Execute grant (granted under the evaluator's
+        // resolved empty user id -- see the round-5 tests for why): past the gate, into prompt
+        // validation.
+        roleStore.Grant(string.Empty, [new PermissionGrant { Service = "StudioDraft", Layer = "own", Operation = "Execute" }]);
+        var allowedMap = await userClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
+        allowedMap.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Admin remains admitted with no grant.
+        using var adminClient = fixture.CreateAdminClient();
+        var adminResponse = await adminClient.PostAsync("/api/v1/studio/map-packages/generate", EmptyJson());
+        adminResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [IntegrationTest]


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #3023

## Summary
Grants non-admin end users a sanctioned, operator-provisioned path to the Studio AI generation endpoints. PR #3018 intentionally kept `POST /api/v1/studio/map-packages/generate` and `POST /api/v1/studio/app-packages/generate` admin-only even with `Studio:EndUserAuthorization:Enabled` on; this PR replaces that route-level admin gate with an elevated per-handler authorization check. Admins remain admitted unconditionally. With the flag on, a non-admin caller needs a `StudioDraft` `own` `Execute` operator grant and is otherwise denied `studio_authorization/elevated_grant_required` before the request body is parsed (no model provider is ever touched). With the flag off, both routes stay admin-only exactly as before. Elevated generation allows and denials flow through the existing `StudioEndpointAuthorization` audit seam.

## Changes Made
- Add `StudioAuthorizationOperation.Generate`, classified as elevated in `StudioAuthorizationService` alongside PublishRequest/Rollback and mapped to the `OperatorOperation.Execute` operator grant (the self-service `own`-sentinel form suffices — generation creates content the caller will own, so no concrete resource id exists at authorization time).
- Replace the route-level `RequireAdminAuthorization()` on both generate routes with an `EnsureGenerateAuthorizedAsync` guard in `StudioPackageEndpoints` that runs before body parsing in `HandleGenerateMap`/`HandleGenerateApp` (the routes keep the group-level `RequireStudioLifecycleAuthorization()` gate, so flag-off behavior is unchanged admin-only).
- Add the `generate` audit-operation snake_case mapping in `StudioEndpointAuthorization`.
- Docs: supersede the "AI generation remains admin-only" paragraph in `docs/internal/admin-api/studio-package-lifecycle.md` with the elevated-grant posture, including the grant an operator provisions for pilot users (`Service=StudioDraft`, `Layer=own`, `Operation=Execute`).
- Tests: new unit test `AuthorizeAsync_FlagOn_NonAdminOwnResource_GenerateUsesExecuteOperatorOperation` (Publish/Rollback grants must not authorize Generate; Execute does) and new integration test `GenerateMapPackage_FlagOn_NonAdminRequiresExecuteGrant` (non-admin denied `elevated_grant_required` on both routes without the grant, reaches prompt validation with it, admin unchanged); updated the #3018 `GeneratePackages_FlagOn_NonAdminScopedKeyDeniedBeforeHandler` wording to reflect the in-handler pre-body-parse denial.
- Regenerated `docs/gis/data/feature-catalog.json` and `docs/gis/data/capability-matrix.v1.json` (new proving test on the generate route family).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [x] Documentation updated
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None. Admin behavior and flag-off behavior are byte-for-byte unchanged; the only behavioral delta is that a flag-on non-admin with a `StudioDraft/own/Execute` grant can now generate (previously 403 in every non-admin case).

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [x] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
