### PR TITLE
feat(studio): bridge forms and analysis persistence into the package lifecycle

### DIFF
--- a/docs/gis/data/capability-matrix.v1.json
+++ b/docs/gis/data/capability-matrix.v1.json
@@ -21,7 +21,7 @@
       "category": "ControlPlane",
       "edition": "Community",
       "entryCount": 368,
-      "provingTestCount": 981,
+      "provingTestCount": 997,
       "maturity": {
         "implemented": 368
       },

--- a/docs/gis/data/feature-catalog.json
+++ b/docs/gis/data/feature-catalog.json
@@ -5229,6 +5229,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.AnalysisFamily_NativeContentRoundTripsWithJobAndArtifactLinks",
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.ListContentItemsAndDrafts_FiltersByFamilyOwnerAndState_JoinsPublicationBadge",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.ListContentItemsAndDrafts_WithoutAdmin_ReturnsUnauthorized",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.ListContentItems_FlagOn_ResponseIncludesOwnerId",
@@ -5246,6 +5248,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.AnalysisFamily_NativeContentRoundTripsWithJobAndArtifactLinks",
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.ListAndGetVersions_FlagOn_NonOwnerSeesOnlyThePublishedVersion",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.ListVersions_FlagOn_FiltersEachVersionByItsOwner",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback"
@@ -5262,6 +5266,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.ListAndGetVersions_FlagOn_NonOwnerSeesOnlyThePublishedVersion",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback"
       ],
@@ -5309,6 +5314,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.PackageFamilies_AdvertiseBridgedNativeFormats",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.AdminReadOnlyKey_CanReadButNotMutateStudio",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.AnonymousPolicyChallenge_IsAuditedExactlyOnceWithoutChangingTheResponse",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback",
@@ -16180,6 +16186,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.Rollback_FlagOn_AuthorizesAgainstItemOwnerNotVersionOwner",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback"
       ],
@@ -16210,6 +16217,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.AnalysisFamily_NativeContentRoundTripsWithJobAndArtifactLinks",
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.CreatePublishRequest_WithInvalidIntentOverride_ReturnsBadRequestProblem",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.EndUserAuthorization_FlagOn_OwnerCrudSucceeds_CrossUserDenied_ElevatedGatedOnGrant",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.PublishRequest_FlagOn_AuthorizesAgainstItemOwnerNotVersionOwner",
@@ -16227,6 +16236,8 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.AnalysisFamily_NativeContentRoundTripsWithJobAndArtifactLinks",
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback"
       ],
       "proof_ledger_surface": "studio-package-lifecycle",
@@ -16256,6 +16267,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_LifecycleCreatedPackageIsVisibleThroughNativeApi",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.AdminReadOnlyKey_CanReadButNotMutateStudio",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.CreateDraft_WithNullCollections_Returns201WithEmptyCollections",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.EndUserAuthorization_FlagOn_OwnerCrudSucceeds_CrossUserDenied_ElevatedGatedOnGrant",
@@ -16273,6 +16285,9 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.AnalysisFamily_NativeContentRoundTripsWithJobAndArtifactLinks",
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_LifecycleCreatedPackageIsVisibleThroughNativeApi",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.CreateVersion_FlagOn_MixedOwnerDraftCannotMoveAnotherOwnersCurrentPointer",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.EndUserAuthorization_FlagOn_OwnerCrudSucceeds_CrossUserDenied_ElevatedGatedOnGrant",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback"
@@ -20846,6 +20861,7 @@
       "protocol": "http-route-family",
       "code_location": "src/Honua.Server/EndpointRegistry.cs",
       "proving_tests": [
+        "Honua.Server.Tests.Features.Studio.StudioBridgedFamilyEndpointsTests.FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.EndUserAuthorization_FlagOn_OwnerCrudSucceeds_CrossUserDenied_ElevatedGatedOnGrant",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.StudioPackageLifecycleEndpoints_CreateVersionPublishReopenAndRollback",
         "Honua.Server.Tests.Features.Studio.StudioPackageEndpointsTests.UpdateDraft_WithStaleGeneration_ReturnsConflictProblem"

--- a/docs/internal/admin-api/studio-package-lifecycle.md
+++ b/docs/internal/admin-api/studio-package-lifecycle.md
@@ -246,13 +246,15 @@ families currently receive envelope-level validation and advertise
 
 Supported family strings are `query`, `analysis`, `map`, `dashboard`,
 `report`, `form`, `app`, `workflow`, `gp`, and `etl`. Every registered family
-advertises schema version `1.0`, `maxPackageBytes: 1048576`, preview support,
-publish support, and this package-family operation list in
-`GET /package-families`: `draft.create`, `draft.read`, `draft.update`,
-`validate`, `preview-plan`, `content-version.create`, `content-version.read`,
-`content-version.compare`, `publish-request.create`, `reopen`, and `rollback`.
-`DELETE /package-drafts/{draftId}` is available for cleanup, but draft delete is
-not advertised as a per-family capability operation.
+advertises schema version `1.0` and `maxPackageBytes: 1048576`. Non-bridged
+families advertise preview support, publish support, and this package-family
+operation list in `GET /package-families`: `draft.create`, `draft.read`,
+`draft.update`, `validate`, `preview-plan`, `content-version.create`,
+`content-version.read`, `content-version.compare`, `publish-request.create`,
+`reopen`, and `rollback`. The bridged `form` and `analysis` families (see
+[Bridged Families](#bridged-families-form-analysis)) advertise a reduced
+operation list. `DELETE /package-drafts/{draftId}` is available for cleanup,
+but draft delete is not advertised as a per-family capability operation.
 
 In Postgres-backed deployments, `durable` is `true`; `map` and `app` advertise
 `supportLevel: "supported"` because family-specific validators are active, while
@@ -260,6 +262,62 @@ the other families advertise `supportLevel: "limited"` with envelope validation.
 In-memory fallback deployments advertise `durable: false`,
 `persistenceMode: "in-memory"`, and a limitation noting that lifecycle data is
 not durable across server restarts.
+
+## Bridged Families (form, analysis)
+
+Tracked by issue **#3004**; decision record
+[ADR-0069](../contributor/adr/0069-studio-persistence-bridge-forms-analysis.md).
+The `form` and `analysis` families are **bridged, not migrated**: the lifecycle
+endpoints above are the single client-visible contract, but persistence
+delegates to each family's native store, which remains the source of truth.
+Content authored through the native console APIs
+(`/api/v1/admin/forms/packages`, `/api/v1/analysis/content`) is immediately
+enumerable/openable through the lifecycle, and lifecycle-authored
+drafts/versions are immediately visible through the native APIs — no flag-day,
+no data migration, no sync window.
+
+When the deployment registers the native stores, `GET /package-families`
+advertises the bridged native formats:
+
+| Family | `format` | Publish | Rollback | Native store |
+| --- | --- | --- | --- | --- |
+| `form` | `honua.form-package.v1` | yes (native validation gate) | no | forms package store |
+| `analysis` | `honua.analysis-content.v1` | no (use the Content Publication Registry) | no | analysis content store |
+
+Bridged semantics:
+
+- **Envelope `body` is the native document.** `form` bodies are
+  `honua.form-package.v1` documents serialized with the family's own contract
+  (JSON value kinds, `ruleId`s, and domain codes round-trip exactly as through
+  the native API); `analysis` bodies are the native analysis-package payload.
+- **Ids.** Native string ids project deterministically onto lifecycle GUIDs.
+  Lifecycle-created form packages use the item id as the native `formId`;
+  lifecycle-created analysis items use `analysis-content-{itemId:N}`.
+  `versionNumber` and `contentHash` are the native values.
+- **Drafts stay lifecycle-native** (mutable, `generation` concurrency). A
+  save-as-version writes through to the native store: forms append a **new
+  native draft version** (never an in-place overwrite, so console ETag/If-Match
+  editors are never clobbered — concurrent cross-surface edits produce distinct
+  native versions); analysis appends an immutable native version with the
+  native monotonic numbering and conflict retry. A form version saved through
+  the lifecycle therefore remains natively editable until published.
+- **Analysis job/artifact links** (`createdFromJobId`,
+  `createdFromArtifactIds`, `basedOnVersionId`) surface as the version's
+  `dependencies` sidecar (`kind: "job"` / `kind: "artifact"`) and are written
+  back to the native record on save.
+- **Publish.** A `form` publish-request runs the native publish validation
+  gate; invalid content persists a `rejected` request and the native version
+  stays draft. `analysis` publish-requests and all bridged rollbacks return
+  `409` with an explanatory problem.
+- **Authorization.** Bridged form items have no recorded owner and therefore
+  fail closed under `Studio:EndUserAuthorization:Enabled` (admin-only),
+  matching the native surface's admin-only posture; bridged analysis items
+  carry the native `ownerId` and follow the standard ownership rules above.
+- **Enumeration.** Bridged items appear in `GET /content-items` once first
+  saved (unsaved bridged drafts are listed by `GET /package-drafts`); at most
+  1,000 native rows per bridged family merge into the keyset-paginated listing.
+  Bridged rows carry no publication-registry badge join beyond the standard
+  `sourceContentId` convention.
 
 ## Request Semantics
 

--- a/docs/internal/contributor/adr/0069-studio-persistence-bridge-forms-analysis.md
+++ b/docs/internal/contributor/adr/0069-studio-persistence-bridge-forms-analysis.md
@@ -1,0 +1,166 @@
+# ADR-0069: Bridge forms and analysis persistence into the Studio package lifecycle
+
+## Status
+
+Accepted. Implements honua-server#3004 (studio-v0 adversarial review, P0-2).
+
+## Context
+
+Console's live editors persist through three different server surfaces:
+
+1. **Studio package lifecycle API** (`/api/v1/studio/*`, `IStudioPackageStore`,
+   `studio_*` tables): draft → immutable content version → publish-request →
+   rollback, with draft `generation` optimistic concurrency, item-level
+   current/published pointers, and the honua-server#3001/#3018 ownership +
+   fail-closed authorization model.
+2. **Forms package API** (`/api/v1/admin/forms/packages`, `IFormPackageStore`,
+   `form_packages` / `form_package_versions` tables): `honua.form-package.v1`
+   documents, monotonic integer versions with `draft`/`published`/`archived`
+   status, strong ETag + `If-Match` draft concurrency, a DB trigger that makes
+   published rows physically immutable, publish-time validation
+   (`FormPackageValidator`), offline compatibility manifests keyed by
+   content/policy hashes, and submission idempotency records keyed by
+   `(form_id, version)`.
+3. **Analysis content API** (`/api/v1/analysis/content` + artifacts + jobs,
+   `IAnalysisContentStore`, `analysis_content_*` tables): string `itm_*` item
+   ids, append-only immutable versions with server-assigned monotonic numbers,
+   job/artifact provenance links (`CreatedFromJobId`,
+   `CreatedFromArtifactIds`, `ResultArtifactRecord.Source*` back-links,
+   `AnalysisContentMetadataKeys` job metadata stamps), and retention-governed
+   artifacts that deliberately have **no** foreign keys and never cascade.
+
+The studio-v0 plan's "one JS Studio round-trips with console" claim only holds
+for lifecycle-native families. Without unification, the console retirement
+schedule for form/analysis editors (honua-console#324) has no persistence path.
+
+## Decision
+
+**Both families are BRIDGED, not migrated.** The Studio lifecycle API becomes
+the single client-visible contract for enumerating, opening, drafting, and
+saving form and analysis content, but it delegates persistence to each family's
+native store through a per-family adapter
+(`IStudioFamilyPersistenceBridge`, implemented by `FormStudioPackageBridge`
+and `AnalysisStudioPackageBridge`, composed by `BridgedStudioPackageStore`
+decorating whichever `IStudioPackageStore` is registered).
+
+### Why bridge and not migrate
+
+Migration into `studio_*` tables was rejected per family:
+
+- **Forms.** `form_package_versions` is load-bearing beyond authoring:
+  submission idempotency records reference `(form_id, version)`, offline
+  clients hold `ContentHash`/`PolicyHash` pairs consumed by the compatibility
+  manifest, the runtime submission path resolves the current *published*
+  version, and a DB trigger enforces immutability of published rows. Moving
+  rows into `studio_content_versions` would sever submission/idempotency
+  references, break offline compatibility manifests mid-flight, and require a
+  flag-day cutover of the console form builder — violating REQ-003 (no
+  flag-day) and NFR-001 (zero data loss).
+- **Analysis.** Artifact records back-reference `SourceItemId`/
+  `SourceVersionId` as loose strings, and running jobs carry
+  `analysis.content.*` metadata stamps that resolve against the analysis
+  store. A migration would orphan every artifact/job link for in-flight and
+  historical runs, and the geoprocessing terminal callback writes artifacts
+  back through `IAnalysisContentStore` — the native store must stay
+  authoritative.
+
+Because the native stores remain the single source of truth, there is **no
+data migration and no dual-write divergence risk**: the bridge reads native
+rows on demand and writes through the native stores' own APIs. Console's
+existing editors keep working unchanged throughout (REQ-003) because the
+native HTTP surfaces and stores are untouched.
+
+## The bridged contract
+
+Bridged families surface through the existing lifecycle endpoints and
+envelope; no new routes are added. Per family:
+
+| Concern | Form family | Analysis family |
+|---|---|---|
+| Native store | `IFormPackageStore` | `IAnalysisContentStore` (kind `analysisPackage`) |
+| Envelope `format` | `honua.form-package.v1` | `honua.analysis-content.v1` |
+| Envelope `body` | The native `FormPackageDocument`, serialized with the family's own `FormPackageJsonContext` | The native `AnalysisPackageContent`, serialized with `AnalysisContentJsonContext` |
+| Item id mapping | `formId` that parses as a GUID maps directly; otherwise a deterministic SHA-256-derived GUID with reverse lookup via `ListPackagesAsync` | `itm_{guid:N}` ids map directly; otherwise deterministic derived GUID with reverse lookup via `ListItemsAsync` |
+| Version id mapping | Deterministic GUID derived from `formId:version` | Deterministic GUID derived from the native `versionId` (`{itemId}:v{n}`) |
+| `versionNumber` | Native integer version | Native integer version |
+| `contentHash` | Native `ContentHash` | Native `ContentHash` |
+| Current pointer | Native `currentDraftVersion ?? currentPublishedVersion` | Native `CurrentVersion` |
+| Published pointer | Native `currentPublishedVersion` | None (analysis has no publish concept) |
+| Save-as-version | `IFormPackageStore.SaveDraftAsync` — always a **new** native draft version | `AddVersionAsync` (append-only, monotonic, conflict-retry) or `CreateItemAsync` for a new item |
+| Publish-request | Validates with the native `FormPackageValidator` then `PublishAsync`; invalid content yields a `rejected` request and no native publish | Not supported (`publishSupported: false`); route-level publication remains the Content Publication Registry's job |
+| Rollback | Not supported (published rows are DB-immutable; reopen + republish instead) | Not supported (append-only pointer only moves forward) |
+| Drafts | Studio-native (`IStudioPackageStore` drafts with `generation` concurrency); the native draft row is only touched on save | Same |
+| `ownerId` | `null` — forms has no ownership model → **fail-closed**: only admin can act on bridged form items under `Studio:EndUserAuthorization:Enabled`, matching the native surface's admin-only posture | Native `OwnerId`, enforced by the existing #3018 ownership checks |
+
+### Family-semantic preservation (REQ-002 / NFR-001)
+
+- **Form JSON-kind preservation, ruleId stability, unmodeled-field
+  round-trip:** the bridge deserializes/serializes envelope bodies with the
+  family's own source-generated `FormPackageJsonContext` — exactly the
+  serializer the native endpoint uses. `JsonElement`-typed fields
+  (`defaultValue`, domain `min`/`max`/`code`, rule `parameters`, conditional
+  `value`) round-trip with their JSON kinds intact, and `ruleId`s are copied
+  verbatim, byte-for-byte matching native behavior. The native contract has no
+  `[JsonExtensionData]`, so unmodeled fields are dropped **by the native
+  surface itself**; the bridge is exactly as lossless as the native API, which
+  is the NFR-001 bar (round-trip fixtures prove native-parity, not
+  better-than-native).
+- **Analysis artifact/job links:** `CreatedFromJobId` and
+  `CreatedFromArtifactIds` are projected into the envelope's `dependencies`
+  sidecar (`kind: "job"` / `kind: "artifact"`) on read and written back to the
+  native version record on save, so lifecycle-authored versions keep the same
+  provenance joins the artifacts/jobs APIs resolve.
+
+### Concurrency semantics
+
+- Studio drafts keep `generation` optimistic concurrency (Studio-side working
+  state, unchanged).
+- A lifecycle save **never** blind-overwrites a native form draft: it appends
+  a new native version via `SaveDraftAsync`, so a console editor concurrently
+  editing draft *N* with `If-Match` is never clobbered — cross-surface
+  concurrent edits produce distinct native versions instead of lost updates.
+  Analysis saves use the native append-only monotonic numbering with the same
+  conflict-retry the native service uses.
+
+### Documented divergences (also advertised via `GET /package-families` limitations)
+
+1. A form content version saved through the lifecycle is a native **draft**
+   version: it is immutable *through the lifecycle surface* but remains
+   editable through the native ETag surface until published. True immutability
+   attaches at publish (DB trigger).
+2. Bridged items appear in `GET /content-items` only once first saved;
+   unsaved bridged drafts are visible through `GET /package-drafts`.
+3. Bridged enumeration merges at most 1,000 native rows per family into the
+   keyset-paginated listing.
+4. Publish-request (analysis) and rollback (both) return `409` with an
+   explanatory message; the operations are omitted from the families'
+   advertised `supportedOperations`.
+5. Version `compare` uses the native content hashes; hashes are only
+   comparable within one family's hashing scheme (which is all the endpoint
+   ever compares).
+
+### Compatibility plan (REQ-003)
+
+- Native routes, DTOs, ETags, and stores are byte-for-byte unchanged; console
+  editors continue against them with no flag-day.
+- The lifecycle surface reads native state live, so content authored in
+  either surface is immediately visible in the other (dual-read by
+  construction; no background sync, no divergence window).
+- honua-console#324's form/analysis parity gates should reference this
+  contract: the lifecycle envelope (`family: form|analysis` + native-format
+  body) is the JS-Studio persistence path.
+
+## Consequences
+
+- `GET /package-families` now advertises `honua.form-package.v1` /
+  `honua.analysis-content.v1` as the `form`/`analysis` formats (previously the
+  placeholder `studio_form_package.v1` / `studio_analysis_package.v1`, which
+  nothing outside the registry referenced).
+- The saved-query (`query` family ↔ `AnalysisContentKind.SavedQuery`) bridge
+  is deliberately deferred; it reuses `AnalysisStudioPackageBridge`
+  parameterized by kind and is tracked as a follow-up.
+- Bridged reads add native-store probes on version/pointer resolution; this
+  surface is an admin/authoring control plane, not a runtime hot path.
+- When neither native store is registered (for example bare `Honua.Core`
+  hosts or MCP-only compositions), no bridge is registered and behavior is
+  unchanged.

--- a/docs/internal/contributor/adr/README.md
+++ b/docs/internal/contributor/adr/README.md
@@ -74,6 +74,7 @@ This folder contains Architecture Decision Records (ADRs) for the Honua greenfie
 | [0066](0066-mcp-evidence-vs-intelligence-boundary.md) | Evidence-vs-Intelligence Boundary for the Open MCP Surface (Rename to `McpDataAccessSurface`) | Accepted | 2026-07 |
 | [0067](0067-plugin-data-store-and-output-format-extension-points.md) | Plugin Data-Store and Output-Format Extension Points | Accepted | 2026-07 |
 | [0068](0068-optional-jwt-access-tokens-and-introspection.md) | Optional JWT Access Tokens and RFC 7662 Introspection | Accepted | 2026-06 |
+| [0069](0069-studio-persistence-bridge-forms-analysis.md) | Bridge Forms and Analysis Persistence into the Studio Package Lifecycle | Accepted | 2026-07 |
 
 ## Template
 

--- a/src/Honua.Core/Features/Studio/Abstractions/IStudioFamilyPersistenceBridge.cs
+++ b/src/Honua.Core/Features/Studio/Abstractions/IStudioFamilyPersistenceBridge.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.Studio.Domain;
+
+namespace Honua.Core.Features.Studio.Abstractions;
+
+/// <summary>
+/// Adapter that lets the Studio package lifecycle enumerate, open, and save one package family
+/// by delegating persistence to that family's native store instead of the Studio store
+/// (ADR-0069, honua-server#3004). The native store stays the single source of truth: reads are
+/// live projections of native rows and saves write through the native store's own API, so the
+/// family's domain semantics (form ETag/version model, analysis artifact/job links) are
+/// preserved and console's native editors keep working with no flag-day.
+/// </summary>
+public interface IStudioFamilyPersistenceBridge
+{
+    /// <summary>Package family served by this bridge.</summary>
+    StudioPackageFamily Family { get; }
+
+    /// <summary>Native package format advertised for the family (for example <c>honua.form-package.v1</c>).</summary>
+    string Format { get; }
+
+    /// <summary>Whether lifecycle publish-requests are supported for this family.</summary>
+    bool PublishSupported { get; }
+
+    /// <summary>Lifecycle operations supported for this family.</summary>
+    IReadOnlyList<StudioPackageOperation> SupportedOperations { get; }
+
+    /// <summary>Client-facing limitations advertised through <c>GET /package-families</c>.</summary>
+    IReadOnlyList<string> Limitations { get; }
+
+    /// <summary>
+    /// Lists native items as Studio content-item summaries. Implementations bound the result
+    /// (at most <see cref="StudioFamilyPersistenceBridgeDefaults.MaxEnumeratedItems"/> rows);
+    /// filtering, ordering, and cursor pagination are applied by the caller.
+    /// </summary>
+    Task<IReadOnlyList<StudioContentItemSummary>> ListItemSummariesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves current/published pointers for a bridged item, or <see langword="null"/> when
+    /// the item id does not map to a native record of this family.
+    /// </summary>
+    Task<StudioContentItemPointers?> GetPointersAsync(Guid itemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists native versions for a bridged item as immutable Studio content versions ordered by
+    /// version number. Returns an empty list when the item id does not map to a native record.
+    /// </summary>
+    Task<IReadOnlyList<StudioContentVersion>> ListVersionsAsync(Guid itemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets one native version projected as an immutable Studio content version, or
+    /// <see langword="null"/> when the item or version does not resolve.
+    /// </summary>
+    Task<StudioContentVersion?> GetVersionAsync(Guid itemId, Guid versionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes the draft's envelope through to the native store as a new native version and
+    /// returns its Studio content-version projection. Throws <see cref="ArgumentException"/>
+    /// when the envelope body is not a valid native document for the family.
+    /// </summary>
+    Task<StudioContentVersion> SaveVersionAsync(
+        StudioPackageDraft draft,
+        string? changeNote,
+        string? actorId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes a lifecycle publish-request against the native store. Implementations that do
+    /// not support publication throw <see cref="InvalidOperationException"/> (surfaced as
+    /// <c>409 Conflict</c>). Implementations that do support it return the stored request with
+    /// its final status (<c>accepted</c>, or <c>rejected</c> when native validation fails).
+    /// </summary>
+    Task<StudioPublicationRequest> PublishAsync(StudioPublicationRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Shared bounds for Studio family persistence bridges.
+/// </summary>
+public static class StudioFamilyPersistenceBridgeDefaults
+{
+    /// <summary>
+    /// Maximum native rows a bridge merges into content-item enumeration (documented
+    /// limitation, ADR-0069).
+    /// </summary>
+    public const int MaxEnumeratedItems = 1_000;
+}

--- a/src/Honua.Core/Features/Studio/Services/Bridging/AnalysisStudioPackageBridge.cs
+++ b/src/Honua.Core/Features/Studio/Services/Bridging/AnalysisStudioPackageBridge.cs
@@ -1,0 +1,384 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Core.Features.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Studio.Abstractions;
+using Honua.Core.Features.Studio.Domain;
+
+namespace Honua.Core.Features.Studio.Services.Bridging;
+
+/// <summary>
+/// Bridges the Studio <c>analysis</c> package family onto the native analysis content store
+/// (ADR-0069, honua-server#3004). Envelope bodies are native <see cref="AnalysisPackageContent"/>
+/// payloads serialized with the family's own <see cref="AnalysisContentJsonContext"/>, and the
+/// native job/artifact provenance links (<c>createdFromJobId</c>, <c>createdFromArtifactIds</c>,
+/// <c>basedOnVersionId</c>) are projected into the envelope's <c>dependencies</c> sidecar and
+/// written back on save, so lifecycle-authored versions keep the joins the analysis artifacts
+/// and jobs APIs resolve. Saves append immutable native versions with the same monotonic
+/// numbering and conflict-retry the native service uses.
+/// </summary>
+public sealed class AnalysisStudioPackageBridge : IStudioFamilyPersistenceBridge
+{
+    private const string IdNamespace = "analysis";
+    private const string VersionIdNamespace = "analysis-version";
+    private const string NativeIdPrefix = "analysis-content-";
+    private const int MaxVersionCreateAttempts = 3;
+
+    /// <summary>Native package format for bridged analysis content.</summary>
+    public const string NativeFormat = "honua.analysis-content.v1";
+
+    /// <summary>Dependency kind used for job provenance links.</summary>
+    public const string JobDependencyKind = "job";
+
+    /// <summary>Dependency kind used for artifact provenance links.</summary>
+    public const string ArtifactDependencyKind = "artifact";
+
+    private static readonly StudioPackageOperation[] Operations =
+    [
+        StudioPackageOperation.DraftCreate,
+        StudioPackageOperation.DraftRead,
+        StudioPackageOperation.DraftUpdate,
+        StudioPackageOperation.Validate,
+        StudioPackageOperation.PreviewPlan,
+        StudioPackageOperation.ContentVersionCreate,
+        StudioPackageOperation.ContentVersionRead,
+        StudioPackageOperation.ContentVersionCompare,
+        StudioPackageOperation.Reopen,
+    ];
+
+    private static readonly string[] BridgeLimitations =
+    [
+        "analysis packages persist through the native analysis content store (/api/v1/analysis/content); versions are append-only with server-assigned numbering",
+        "bridged analysis items appear in content-item enumeration once first saved; unsaved drafts are listed under /studio/package-drafts",
+        "content-item enumeration merges at most 1000 bridged analysis items",
+        "publish-request and rollback are not supported for the bridged analysis family; route publication is handled by the Content Publication Registry",
+    ];
+
+    private readonly IAnalysisContentStore _store;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initializes the analysis family bridge.</summary>
+    public AnalysisStudioPackageBridge(IAnalysisContentStore store, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _store = store;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public StudioPackageFamily Family => StudioPackageFamily.Analysis;
+
+    /// <inheritdoc />
+    public string Format => NativeFormat;
+
+    /// <inheritdoc />
+    public bool PublishSupported => false;
+
+    /// <inheritdoc />
+    public IReadOnlyList<StudioPackageOperation> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> Limitations => BridgeLimitations;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StudioContentItemSummary>> ListItemSummariesAsync(CancellationToken cancellationToken = default)
+    {
+        var page = await _store.ListItemsAsync(
+            new AnalysisContentItemQuery
+            {
+                Kind = AnalysisContentKind.AnalysisPackage,
+                Limit = StudioFamilyPersistenceBridgeDefaults.MaxEnumeratedItems,
+                Offset = 0,
+            },
+            cancellationToken).ConfigureAwait(false);
+        return page.Items.Select(ToSummary).ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentItemPointers?> GetPointersAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        var item = await ResolveItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (item is null)
+        {
+            return null;
+        }
+
+        return new StudioContentItemPointers
+        {
+            ItemId = itemId,
+            CurrentVersionId = VersionGuid(item.CurrentVersionId),
+            // The analysis surface has no publish concept; route publication is handled by the
+            // Content Publication Registry (ADR-0069 divergence).
+            PublishedVersionId = null,
+            OwnerId = item.OwnerId,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StudioContentVersion>> ListVersionsAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        var item = await ResolveItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (item is null)
+        {
+            return Array.Empty<StudioContentVersion>();
+        }
+
+        var versions = await _store.ListVersionsAsync(item.ItemId, cancellationToken).ConfigureAwait(false);
+        return versions
+            .Where(static version => version.Kind == AnalysisContentKind.AnalysisPackage)
+            .OrderBy(static version => version.Version)
+            .Select(version => ToContentVersion(itemId, item, version))
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentVersion?> GetVersionAsync(Guid itemId, Guid versionId, CancellationToken cancellationToken = default)
+    {
+        var item = await ResolveItemAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (item is null)
+        {
+            return null;
+        }
+
+        var versions = await _store.ListVersionsAsync(item.ItemId, cancellationToken).ConfigureAwait(false);
+        var match = versions.FirstOrDefault(version =>
+            version.Kind == AnalysisContentKind.AnalysisPackage && VersionGuid(version.VersionId) == versionId);
+        return match is null ? null : ToContentVersion(itemId, item, match);
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentVersion> SaveVersionAsync(
+        StudioPackageDraft draft,
+        string? changeNote,
+        string? actorId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+
+        if (draft.Envelope.Body is not { ValueKind: JsonValueKind.Object } body)
+        {
+            throw new ArgumentException("Analysis package body must be a honua.analysis-content.v1 JSON object.");
+        }
+
+        AnalysisPackageContent content;
+        try
+        {
+            content = JsonSerializer.Deserialize(body, AnalysisContentJsonContext.Default.AnalysisPackageContent)
+                ?? throw new ArgumentException("Analysis package body is not a valid analysis package document.");
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException("Analysis package body is not a valid analysis package document.", ex);
+        }
+
+        if (content.Plan is null)
+        {
+            throw new ArgumentException("Analysis package body must include an executable plan.");
+        }
+
+        var jobId = draft.Envelope.Dependencies
+            .FirstOrDefault(static dependency => string.Equals(dependency.Kind, JobDependencyKind, StringComparison.OrdinalIgnoreCase))
+            ?.Ref;
+        var artifactIds = draft.Envelope.Dependencies
+            .Where(static dependency => string.Equals(dependency.Kind, ArtifactDependencyKind, StringComparison.OrdinalIgnoreCase))
+            .Select(static dependency => dependency.Ref)
+            .ToArray();
+
+        var now = _timeProvider.GetUtcNow();
+        var existing = await ResolveItemAsync(draft.ItemId, cancellationToken).ConfigureAwait(false);
+        if (existing is null)
+        {
+            var nativeItemId = NativeIdForItem(draft.ItemId);
+            var version = BuildVersion(nativeItemId, 1, content, basedOnVersionId: null, jobId, artifactIds, actorId, now);
+            var item = new AnalysisContentItem
+            {
+                ItemId = nativeItemId,
+                Kind = AnalysisContentKind.AnalysisPackage,
+                Name = draft.PackageKey,
+                Title = null,
+                OwnerId = draft.OwnerId,
+                CurrentVersion = 1,
+                CurrentVersionId = version.VersionId,
+                CreatedAt = now,
+                UpdatedAt = now,
+                CreatedBy = actorId,
+            };
+            var createdItem = await _store.CreateItemAsync(item, version, cancellationToken).ConfigureAwait(false);
+            return ToContentVersion(draft.ItemId, createdItem, version) with
+            {
+                SourceDraftId = draft.DraftId,
+                ChangeNote = changeNote,
+                WorkspaceId = draft.WorkspaceId,
+            };
+        }
+
+        // Append with the same monotonic numbering + optimistic conflict retry the native
+        // analysis content service uses.
+        for (var attempt = 1; ; attempt++)
+        {
+            var latest = await _store.GetVersionAsync(existing.ItemId, version: null, cancellationToken).ConfigureAwait(false)
+                ?? throw new KeyNotFoundException("Analysis content item has no versions.");
+            var next = BuildVersion(existing.ItemId, latest.Version + 1, content, latest.VersionId, jobId, artifactIds, actorId, now);
+            try
+            {
+                var stored = await _store.AddVersionAsync(existing.ItemId, next, cancellationToken).ConfigureAwait(false);
+                return ToContentVersion(draft.ItemId, existing, stored) with
+                {
+                    SourceDraftId = draft.DraftId,
+                    BaseVersionId = draft.BaseVersionId,
+                    ChangeNote = changeNote,
+                    WorkspaceId = draft.WorkspaceId,
+                };
+            }
+            catch (AnalysisContentStoreConflictException) when (attempt < MaxVersionCreateAttempts)
+            {
+                // Another writer took this version number; re-read latest and retry.
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<StudioPublicationRequest> PublishAsync(StudioPublicationRequest request, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Publish-request is not supported for the bridged analysis family; use the Content Publication Registry for route publication.");
+
+    private async Task<AnalysisContentItem?> ResolveItemAsync(Guid itemId, CancellationToken cancellationToken)
+    {
+        // Fast paths: bridge-created ids embed the Studio item id; console-created ids follow
+        // the native "analysis-content-{guid:N}" convention whose embedded guid maps directly.
+        var direct = await _store.GetItemAsync(NativeIdForItem(itemId), cancellationToken).ConfigureAwait(false)
+            ?? await _store.GetItemAsync(itemId.ToString("D"), cancellationToken).ConfigureAwait(false);
+        if (direct is not null && direct.Kind == AnalysisContentKind.AnalysisPackage)
+        {
+            return direct;
+        }
+
+        // Slow path: custom native ids re-derive through the hash mapping.
+        var page = await _store.ListItemsAsync(
+            new AnalysisContentItemQuery
+            {
+                Kind = AnalysisContentKind.AnalysisPackage,
+                Limit = StudioFamilyPersistenceBridgeDefaults.MaxEnumeratedItems,
+                Offset = 0,
+            },
+            cancellationToken).ConfigureAwait(false);
+        return page.Items.FirstOrDefault(item => ItemGuid(item.ItemId) == itemId);
+    }
+
+    private static AnalysisContentVersion BuildVersion(
+        string nativeItemId,
+        int version,
+        AnalysisPackageContent content,
+        string? basedOnVersionId,
+        string? jobId,
+        IReadOnlyList<string> artifactIds,
+        string? actorId,
+        DateTimeOffset now)
+        => new()
+        {
+            VersionId = $"{nativeItemId}:v{version.ToString(CultureInfo.InvariantCulture)}",
+            ItemId = nativeItemId,
+            Version = version,
+            Kind = AnalysisContentKind.AnalysisPackage,
+            AnalysisPackage = content,
+            ContentHash = ComputeContentHash(content),
+            BasedOnVersionId = basedOnVersionId,
+            CreatedFromJobId = jobId,
+            CreatedFromArtifactIds = artifactIds,
+            CreatedAt = now,
+            CreatedBy = actorId,
+        };
+
+    private static string ComputeContentHash(AnalysisPackageContent content)
+    {
+        var payload = JsonSerializer.SerializeToUtf8Bytes(content, AnalysisContentJsonContext.Default.AnalysisPackageContent);
+        return Convert.ToHexString(SHA256.HashData(payload)).ToLowerInvariant();
+    }
+
+    private static string NativeIdForItem(Guid itemId) => $"{NativeIdPrefix}{itemId:N}";
+
+    private static Guid ItemGuid(string nativeId)
+    {
+        if (nativeId.StartsWith(NativeIdPrefix, StringComparison.Ordinal)
+            && Guid.TryParseExact(nativeId[NativeIdPrefix.Length..], "N", out var embedded))
+        {
+            return embedded;
+        }
+
+        return StudioBridgeIds.ForNativeId(IdNamespace, nativeId);
+    }
+
+    private static Guid VersionGuid(string nativeVersionId)
+        => StudioBridgeIds.Derive(VersionIdNamespace, nativeVersionId);
+
+    private static StudioContentItemSummary ToSummary(AnalysisContentItem item) => new()
+    {
+        ItemId = ItemGuid(item.ItemId),
+        PackageKey = SafePackageKey(item.Name, item.ItemId),
+        WorkspaceId = null,
+        Family = StudioPackageFamily.Analysis,
+        State = StudioContentItemState.Current,
+        CurrentVersionId = VersionGuid(item.CurrentVersionId),
+        PublishedVersionId = null,
+        OwnerId = item.OwnerId,
+        CreatedBy = item.CreatedBy,
+        UpdatedBy = null,
+        CreatedAt = item.CreatedAt,
+        UpdatedAt = item.UpdatedAt,
+    };
+
+    private static StudioContentVersion ToContentVersion(Guid itemId, AnalysisContentItem item, AnalysisContentVersion version)
+    {
+        var dependencies = new List<StudioPackageDependency>();
+        if (!string.IsNullOrWhiteSpace(version.CreatedFromJobId))
+        {
+            dependencies.Add(new StudioPackageDependency { Kind = JobDependencyKind, Ref = version.CreatedFromJobId, Required = false });
+        }
+
+        foreach (var artifactId in version.CreatedFromArtifactIds)
+        {
+            dependencies.Add(new StudioPackageDependency { Kind = ArtifactDependencyKind, Ref = artifactId, Required = false });
+        }
+
+        return new StudioContentVersion
+        {
+            ItemId = itemId,
+            PackageKey = SafePackageKey(item.Name, item.ItemId),
+            WorkspaceId = null,
+            OwnerId = item.OwnerId,
+            VersionId = VersionGuid(version.VersionId),
+            VersionNumber = version.Version,
+            ContentHash = version.ContentHash,
+            Envelope = new StudioPackageEnvelope
+            {
+                Family = StudioPackageFamily.Analysis,
+                SchemaVersion = "1.0",
+                Format = NativeFormat,
+                Body = JsonSerializer.SerializeToElement(version.AnalysisPackage, AnalysisContentJsonContext.Default.AnalysisPackageContent),
+                Dependencies = dependencies,
+                Validation = StudioValidationSummary.NotValidated,
+            },
+            Validation = StudioValidationSummary.NotValidated,
+            Dependencies = dependencies,
+            BaseVersionId = version.BasedOnVersionId is { } basedOn ? VersionGuid(basedOn) : null,
+            CreatedBy = version.CreatedBy,
+            CreatedAt = version.CreatedAt,
+        };
+    }
+
+    private static string SafePackageKey(string name, string nativeId)
+    {
+        var filtered = new string(name
+            .Where(static c => c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '-' or '_' or '.')
+            .Take(200)
+            .ToArray());
+        return filtered.Length > 0 ? filtered : ItemGuid(nativeId).ToString("D");
+    }
+}

--- a/src/Honua.Core/Features/Studio/Services/Bridging/BridgedStudioPackageStore.cs
+++ b/src/Honua.Core/Features/Studio/Services/Bridging/BridgedStudioPackageStore.cs
@@ -1,0 +1,253 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Linq;
+using Honua.Core.Features.Studio.Abstractions;
+using Honua.Core.Features.Studio.Domain;
+
+namespace Honua.Core.Features.Studio.Services.Bridging;
+
+/// <summary>
+/// <see cref="IStudioPackageStore"/> decorator that routes bridged families (ADR-0069,
+/// honua-server#3004) to their <see cref="IStudioFamilyPersistenceBridge"/> adapters while
+/// every other operation delegates to the inner Studio store. Drafts always live in the inner
+/// store (they are Studio working state with <c>generation</c> concurrency); immutable
+/// versions, item pointers, publication, and enumeration for bridged families read and write
+/// through the family's native store.
+/// </summary>
+public sealed class BridgedStudioPackageStore : IStudioPackageStore
+{
+    private static readonly StudioPackageFamily[] AllFamilies = Enum.GetValues<StudioPackageFamily>();
+
+    private readonly IStudioPackageStore _inner;
+    private readonly Dictionary<StudioPackageFamily, IStudioFamilyPersistenceBridge> _bridges;
+
+    /// <summary>Initializes the bridged store decorator.</summary>
+    public BridgedStudioPackageStore(IStudioPackageStore inner, IEnumerable<IStudioFamilyPersistenceBridge> bridges)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(bridges);
+        _inner = inner;
+        _bridges = bridges.ToDictionary(static bridge => bridge.Family);
+    }
+
+    /// <inheritdoc />
+    public StudioPackagePersistenceMode PersistenceMode => _inner.PersistenceMode;
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraft> CreateDraftAsync(StudioPackageDraft draft, CancellationToken cancellationToken = default)
+        => _inner.CreateDraftAsync(draft, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraft?> GetDraftAsync(Guid draftId, CancellationToken cancellationToken = default)
+        => _inner.GetDraftAsync(draftId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraft?> UpdateDraftAsync(StudioPackageDraft draft, CancellationToken cancellationToken = default)
+        => _inner.UpdateDraftAsync(draft, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<bool> DeleteDraftAsync(Guid draftId, CancellationToken cancellationToken = default)
+        => _inner.DeleteDraftAsync(draftId, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioContentVersion> CreateVersionAsync(
+        StudioPackageDraft draft,
+        string? changeNote,
+        string? actorId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        return _bridges.TryGetValue(draft.Family, out var bridge)
+            ? bridge.SaveVersionAsync(draft, changeNote, actorId, cancellationToken)
+            : _inner.CreateVersionAsync(draft, changeNote, actorId, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StudioContentVersion>> ListVersionsAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        foreach (var bridge in _bridges.Values)
+        {
+            var versions = await bridge.ListVersionsAsync(itemId, cancellationToken).ConfigureAwait(false);
+            if (versions.Count > 0)
+            {
+                return versions;
+            }
+        }
+
+        return await _inner.ListVersionsAsync(itemId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentVersion?> GetVersionAsync(Guid itemId, Guid versionId, CancellationToken cancellationToken = default)
+    {
+        foreach (var bridge in _bridges.Values)
+        {
+            var version = await bridge.GetVersionAsync(itemId, versionId, cancellationToken).ConfigureAwait(false);
+            if (version is not null)
+            {
+                return version;
+            }
+        }
+
+        return await _inner.GetVersionAsync(itemId, versionId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentItemPointers?> GetPointersAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        var bridged = await ResolveBridgedPointersAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (bridged is not null)
+        {
+            return bridged.Pointers;
+        }
+
+        return await _inner.GetPointersAsync(itemId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentItemListResult> ListContentItemsAsync(
+        StudioContentItemQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var requestedFamilies = query.Families is { Count: > 0 } families ? families : AllFamilies;
+        var innerFamilies = requestedFamilies.Where(family => !_bridges.ContainsKey(family)).ToArray();
+        var bridgedFamilies = requestedFamilies.Where(_bridges.ContainsKey).Distinct().ToArray();
+
+        // The inner store never lists bridged families: bridged items surface from their native
+        // stores below, and any inner shadow rows (created for lifecycle drafts before their
+        // first save) stay out of content-item enumeration (ADR-0069 documented divergence).
+        var innerResult = innerFamilies.Length > 0
+            ? await _inner.ListContentItemsAsync(query with { Families = innerFamilies }, cancellationToken).ConfigureAwait(false)
+            : new StudioContentItemListResult { Items = Array.Empty<StudioContentItemSummary>(), Total = 0, NextCursor = null };
+
+        if (bridgedFamilies.Length == 0)
+        {
+            return innerResult;
+        }
+
+        var bridgedMatches = new List<StudioContentItemSummary>();
+        foreach (var family in bridgedFamilies)
+        {
+            var summaries = await _bridges[family].ListItemSummariesAsync(cancellationToken).ConfigureAwait(false);
+            bridgedMatches.AddRange(summaries.Where(summary => MatchesQuery(summary, query)));
+        }
+
+        var total = innerResult.Total + bridgedMatches.Count;
+
+        IEnumerable<StudioContentItemSummary> bridgedPage = bridgedMatches;
+        if (StudioListCursor.TryDecode(query.Cursor, out var cursorUpdatedAt, out var cursorId))
+        {
+            bridgedPage = bridgedPage.Where(item =>
+                item.UpdatedAt < cursorUpdatedAt
+                || (item.UpdatedAt == cursorUpdatedAt && item.ItemId.CompareTo(cursorId) < 0));
+        }
+
+        // The inner page holds the top-N inner rows after the cursor and bridgedPage holds every
+        // bridged row after the cursor, so the merged top-N is the true top-N of the union.
+        var limit = query.Limit <= 0 ? 25 : query.Limit;
+        var merged = innerResult.Items
+            .Concat(bridgedPage)
+            .OrderByDescending(static item => item.UpdatedAt)
+            .ThenByDescending(static item => item.ItemId)
+            .ToList();
+
+        var hasMore = merged.Count > limit || innerResult.NextCursor is not null;
+        var page = merged.Take(limit).ToArray();
+        var nextCursor = hasMore && page.Length > 0
+            ? StudioListCursor.Encode(page[^1].UpdatedAt, page[^1].ItemId)
+            : null;
+
+        return new StudioContentItemListResult
+        {
+            Items = page,
+            Total = total,
+            NextCursor = nextCursor,
+        };
+    }
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraftListResult> ListDraftsAsync(StudioPackageDraftQuery query, CancellationToken cancellationToken = default)
+        => _inner.ListDraftsAsync(query, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<StudioPublicationRequest> CreatePublicationRequestAsync(
+        StudioPublicationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var bridged = await ResolveBridgedPointersAsync(request.ItemId, cancellationToken).ConfigureAwait(false);
+        if (bridged is not null)
+        {
+            return await bridged.Bridge.PublishAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await _inner.CreatePublicationRequestAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioRollbackRequest> RollbackAsync(
+        Guid itemId,
+        Guid targetVersionId,
+        StudioRollbackPointer target,
+        string? actorId,
+        string? reason,
+        CancellationToken cancellationToken = default)
+    {
+        var bridged = await ResolveBridgedPointersAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (bridged is not null)
+        {
+            throw new InvalidOperationException(
+                $"Rollback is not supported for the bridged {bridged.Bridge.Family} family; reopen the target version and save or republish instead.");
+        }
+
+        return await _inner.RollbackAsync(itemId, targetVersionId, target, actorId, reason, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<BridgedItem?> ResolveBridgedPointersAsync(Guid itemId, CancellationToken cancellationToken)
+    {
+        foreach (var bridge in _bridges.Values)
+        {
+            var pointers = await bridge.GetPointersAsync(itemId, cancellationToken).ConfigureAwait(false);
+            if (pointers is not null)
+            {
+                return new BridgedItem(bridge, pointers);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool MatchesQuery(StudioContentItemSummary item, StudioContentItemQuery query)
+    {
+        if (!string.IsNullOrWhiteSpace(query.WorkspaceId) &&
+            !string.Equals(item.WorkspaceId ?? string.Empty, query.WorkspaceId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.OwnerId) &&
+            !string.Equals(item.OwnerId ?? string.Empty, query.OwnerId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (query.States is { Count: > 0 } states && !states.Contains(item.State))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.SearchTerm) &&
+            !item.PackageKey.Contains(query.SearchTerm.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private sealed record BridgedItem(IStudioFamilyPersistenceBridge Bridge, StudioContentItemPointers Pointers);
+}

--- a/src/Honua.Core/Features/Studio/Services/Bridging/FormStudioPackageBridge.cs
+++ b/src/Honua.Core/Features/Studio/Services/Bridging/FormStudioPackageBridge.cs
@@ -1,0 +1,352 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Honua.Core.Features.Forms.Packages;
+using Honua.Core.Features.Studio.Abstractions;
+using Honua.Core.Features.Studio.Domain;
+
+namespace Honua.Core.Features.Studio.Services.Bridging;
+
+/// <summary>
+/// Bridges the Studio <c>form</c> package family onto the native forms package store
+/// (ADR-0069, honua-server#3004). Envelope bodies are native <c>honua.form-package.v1</c>
+/// documents serialized with the family's own <see cref="FormPackageJsonContext"/>, so JSON
+/// value kinds, <c>ruleId</c>s, and domain codes round-trip exactly as they do through
+/// <c>/api/v1/admin/forms/packages</c>. Saves append a new native draft version (never an
+/// in-place overwrite), so console editors using ETag/If-Match are never clobbered; publishes
+/// run the native <see cref="FormPackageValidator"/> publish gate.
+/// </summary>
+public sealed class FormStudioPackageBridge : IStudioFamilyPersistenceBridge
+{
+    private const string IdNamespace = "form";
+    private const string VersionIdNamespace = "form-version";
+
+    /// <summary>Native package format for bridged form packages.</summary>
+    public const string NativeFormat = "honua.form-package.v1";
+
+    private static readonly StudioPackageOperation[] Operations =
+    [
+        StudioPackageOperation.DraftCreate,
+        StudioPackageOperation.DraftRead,
+        StudioPackageOperation.DraftUpdate,
+        StudioPackageOperation.Validate,
+        StudioPackageOperation.PreviewPlan,
+        StudioPackageOperation.ContentVersionCreate,
+        StudioPackageOperation.ContentVersionRead,
+        StudioPackageOperation.ContentVersionCompare,
+        StudioPackageOperation.PublishRequestCreate,
+        StudioPackageOperation.Reopen,
+    ];
+
+    private static readonly string[] BridgeLimitations =
+    [
+        "form packages persist through the native forms package store (/api/v1/admin/forms/packages); a content version saved through the lifecycle is a native draft version and remains natively editable until published",
+        "bridged form items appear in content-item enumeration once first saved; unsaved drafts are listed under /studio/package-drafts",
+        "content-item enumeration merges at most 1000 bridged form packages",
+        "rollback is not supported for bridged form packages; reopen the target version and republish instead",
+    ];
+
+    private readonly IFormPackageStore _store;
+    private readonly FormPackageValidator _validator;
+
+    /// <summary>Initializes the form family bridge.</summary>
+    public FormStudioPackageBridge(IFormPackageStore store, FormPackageValidator validator)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(validator);
+        _store = store;
+        _validator = validator;
+    }
+
+    /// <inheritdoc />
+    public StudioPackageFamily Family => StudioPackageFamily.Form;
+
+    /// <inheritdoc />
+    public string Format => NativeFormat;
+
+    /// <inheritdoc />
+    public bool PublishSupported => true;
+
+    /// <inheritdoc />
+    public IReadOnlyList<StudioPackageOperation> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> Limitations => BridgeLimitations;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StudioContentItemSummary>> ListItemSummariesAsync(CancellationToken cancellationToken = default)
+    {
+        var packages = await _store.ListPackagesAsync(cancellationToken).ConfigureAwait(false);
+        return packages
+            .Take(StudioFamilyPersistenceBridgeDefaults.MaxEnumeratedItems)
+            .Select(ToSummary)
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentItemPointers?> GetPointersAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        var formId = await ResolveFormIdAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (formId is null)
+        {
+            return null;
+        }
+
+        var draft = await _store.GetCurrentVersionAsync(formId, FormPackageStatus.Draft, cancellationToken).ConfigureAwait(false);
+        var published = await _store.GetCurrentVersionAsync(formId, FormPackageStatus.Published, cancellationToken).ConfigureAwait(false);
+        var current = draft ?? published;
+        if (current is null)
+        {
+            return null;
+        }
+
+        return new StudioContentItemPointers
+        {
+            ItemId = itemId,
+            CurrentVersionId = VersionGuid(formId, current.Version),
+            PublishedVersionId = published is null ? null : VersionGuid(formId, published.Version),
+            // Forms has no ownership model; a null owner fails closed under the #3018
+            // authorization model (admin-only), matching the native surface's posture.
+            OwnerId = null,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<StudioContentVersion>> ListVersionsAsync(Guid itemId, CancellationToken cancellationToken = default)
+    {
+        var formId = await ResolveFormIdAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (formId is null)
+        {
+            return Array.Empty<StudioContentVersion>();
+        }
+
+        var versions = await _store.ListVersionsAsync(formId, cancellationToken).ConfigureAwait(false);
+        return versions
+            .OrderBy(static version => version.Version)
+            .Select(version => ToContentVersion(itemId, formId, version))
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentVersion?> GetVersionAsync(Guid itemId, Guid versionId, CancellationToken cancellationToken = default)
+    {
+        var resolved = await ResolveVersionAsync(itemId, versionId, cancellationToken).ConfigureAwait(false);
+        return resolved is not { } match ? null : ToContentVersion(itemId, match.FormId, match.Version);
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioContentVersion> SaveVersionAsync(
+        StudioPackageDraft draft,
+        string? changeNote,
+        string? actorId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+
+        if (draft.Envelope.Body is not { ValueKind: JsonValueKind.Object } body)
+        {
+            throw new ArgumentException("Form package body must be a honua.form-package.v1 JSON object.");
+        }
+
+        var existingFormId = await ResolveFormIdAsync(draft.ItemId, cancellationToken).ConfigureAwait(false);
+        var formId = existingFormId ?? draft.ItemId.ToString("D");
+
+        FormPackageDocument document;
+        try
+        {
+            // Stamp the server-resolved form id so the native record and the Studio item id stay
+            // one-to-one regardless of what the envelope body carried; everything else in the
+            // body round-trips through the family's own serializer contract.
+            var node = JsonNode.Parse(body.GetRawText()) ?? throw new ArgumentException("Form package body could not be parsed.");
+            node["formId"] = formId;
+            document = JsonSerializer.Deserialize(node, FormPackageJsonContext.Default.FormPackageDocument)
+                ?? throw new ArgumentException("Form package body is not a valid honua.form-package.v1 document.");
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException("Form package body is not a valid honua.form-package.v1 document.", ex);
+        }
+
+        var saved = await _store.SaveDraftAsync(document, actorId ?? "studio-lifecycle", cancellationToken).ConfigureAwait(false);
+        return ToContentVersion(draft.ItemId, saved.FormId, saved) with
+        {
+            SourceDraftId = draft.DraftId,
+            BaseVersionId = draft.BaseVersionId,
+            ChangeNote = changeNote,
+            WorkspaceId = draft.WorkspaceId,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<StudioPublicationRequest> PublishAsync(StudioPublicationRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resolved = await ResolveVersionAsync(request.ItemId, request.VersionId, cancellationToken).ConfigureAwait(false);
+        if (resolved is not { } match)
+        {
+            throw new KeyNotFoundException("Studio content version was not found.");
+        }
+
+        var validation = await _validator.ValidateForPublishAsync(match.Version.Package, cancellationToken).ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            _ = await _store.StoreValidationAsync(match.FormId, match.Version.Version, validation, cancellationToken).ConfigureAwait(false);
+            return request with
+            {
+                Status = StudioPublicationRequestStatus.Rejected,
+                Validation = MapValidation(validation),
+            };
+        }
+
+        var published = await _store.PublishAsync(
+            match.FormId,
+            match.Version.Version,
+            validation,
+            request.RequestedBy ?? "studio-lifecycle",
+            cancellationToken).ConfigureAwait(false);
+        if (published is null)
+        {
+            throw new InvalidOperationException("Only draft form package versions can be published; reopen the version to create a new draft.");
+        }
+
+        return request with
+        {
+            Status = StudioPublicationRequestStatus.Accepted,
+            Validation = MapValidation(validation),
+        };
+    }
+
+    private async Task<string?> ResolveFormIdAsync(Guid itemId, CancellationToken cancellationToken)
+    {
+        // Fast path: lifecycle-created packages use the Studio item id as the native form id.
+        var directId = itemId.ToString("D");
+        var directVersions = await _store.ListVersionsAsync(directId, cancellationToken).ConfigureAwait(false);
+        if (directVersions.Length > 0)
+        {
+            return directId;
+        }
+
+        // Console-created form ids are arbitrary strings; reverse-resolve by re-deriving.
+        var packages = await _store.ListPackagesAsync(cancellationToken).ConfigureAwait(false);
+        return packages.FirstOrDefault(package => ItemGuid(package.FormId) == itemId)?.FormId;
+    }
+
+    private async Task<(string FormId, FormPackageVersion Version)?> ResolveVersionAsync(
+        Guid itemId,
+        Guid versionId,
+        CancellationToken cancellationToken)
+    {
+        var formId = await ResolveFormIdAsync(itemId, cancellationToken).ConfigureAwait(false);
+        if (formId is null)
+        {
+            return null;
+        }
+
+        var versions = await _store.ListVersionsAsync(formId, cancellationToken).ConfigureAwait(false);
+        var match = versions.FirstOrDefault(version => VersionGuid(formId, version.Version) == versionId);
+        return match is null ? null : (formId, match);
+    }
+
+    private static Guid ItemGuid(string formId) => StudioBridgeIds.ForNativeId(IdNamespace, formId);
+
+    private static Guid VersionGuid(string formId, int version)
+        => StudioBridgeIds.Derive(VersionIdNamespace, $"{formId}:{version}");
+
+    private static StudioContentItemSummary ToSummary(FormPackageSummary package)
+    {
+        var currentVersion = package.CurrentDraftVersion ?? package.CurrentPublishedVersion;
+        return new StudioContentItemSummary
+        {
+            ItemId = ItemGuid(package.FormId),
+            PackageKey = SafePackageKey(package.FormId),
+            WorkspaceId = null,
+            Family = StudioPackageFamily.Form,
+            State = package.CurrentPublishedVersion is not null
+                ? StudioContentItemState.Published
+                : StudioContentItemState.Current,
+            CurrentVersionId = currentVersion is { } current ? VersionGuid(package.FormId, current) : null,
+            PublishedVersionId = package.CurrentPublishedVersion is { } published ? VersionGuid(package.FormId, published) : null,
+            OwnerId = null,
+            CreatedBy = null,
+            UpdatedBy = null,
+            CreatedAt = package.UpdatedAt,
+            UpdatedAt = package.UpdatedAt,
+        };
+    }
+
+    private static StudioContentVersion ToContentVersion(Guid itemId, string formId, FormPackageVersion version)
+    {
+        var validation = MapValidation(version.Validation);
+        return new StudioContentVersion
+        {
+            ItemId = itemId,
+            PackageKey = SafePackageKey(formId),
+            WorkspaceId = null,
+            OwnerId = null,
+            VersionId = VersionGuid(formId, version.Version),
+            VersionNumber = version.Version,
+            ContentHash = version.ContentHash,
+            Envelope = new StudioPackageEnvelope
+            {
+                Family = StudioPackageFamily.Form,
+                SchemaVersion = "1.0",
+                Format = NativeFormat,
+                Body = JsonSerializer.SerializeToElement(version.Package, FormPackageJsonContext.Default.FormPackageDocument),
+                Validation = validation,
+            },
+            Validation = validation,
+            BaseVersionId = version.ReopenedFromVersion is { } reopened ? VersionGuid(formId, reopened) : null,
+            CreatedBy = version.CreatedBy,
+            CreatedAt = version.CreatedAt,
+        };
+    }
+
+    private static StudioValidationSummary MapValidation(FormPackageValidationResult? validation)
+    {
+        if (validation is null)
+        {
+            return StudioValidationSummary.NotValidated;
+        }
+
+        var diagnostics = validation.Issues
+            .Select(static issue => new StudioValidationDiagnostic
+            {
+                Code = issue.Code,
+                Severity = issue.Severity.ToLowerInvariant() switch
+                {
+                    "error" => StudioPackageDiagnosticSeverity.Error,
+                    "warning" => StudioPackageDiagnosticSeverity.Warning,
+                    _ => StudioPackageDiagnosticSeverity.Info,
+                },
+                Path = issue.Path ?? issue.FieldId,
+                Message = issue.Message,
+            })
+            .ToArray();
+
+        var status = !validation.IsValid
+            ? StudioPackageValidationStatus.Invalid
+            : diagnostics.Any(static diagnostic => diagnostic.Severity == StudioPackageDiagnosticSeverity.Warning)
+                ? StudioPackageValidationStatus.Warning
+                : StudioPackageValidationStatus.Valid;
+
+        return new StudioValidationSummary
+        {
+            Status = status,
+            Diagnostics = diagnostics,
+            GeneratedAt = null,
+        };
+    }
+
+    private static string SafePackageKey(string nativeId)
+    {
+        var filtered = new string(nativeId
+            .Where(static c => c is (>= 'a' and <= 'z') or (>= 'A' and <= 'Z') or (>= '0' and <= '9') or '-' or '_' or '.')
+            .Take(200)
+            .ToArray());
+        return filtered.Length > 0 ? filtered : ItemGuid(nativeId).ToString("D");
+    }
+}

--- a/src/Honua.Core/Features/Studio/Services/Bridging/StudioBridgeIds.cs
+++ b/src/Honua.Core/Features/Studio/Services/Bridging/StudioBridgeIds.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Honua.Core.Features.Studio.Services.Bridging;
+
+/// <summary>
+/// Deterministic GUID derivation for bridged Studio item and version identifiers
+/// (ADR-0069). Native stores key content by strings (form ids, <c>itm_*</c> analysis ids,
+/// <c>{itemId}:v{n}</c> version ids); the Studio lifecycle keys everything by GUID. Ids that
+/// already round-trip as GUIDs map directly; anything else maps through a stable SHA-256
+/// derivation so the same native record always projects the same Studio id.
+/// </summary>
+public static class StudioBridgeIds
+{
+    /// <summary>
+    /// Derives a stable GUID from a namespaced native identifier. The derivation is one-way;
+    /// reverse resolution enumerates native ids and re-derives.
+    /// </summary>
+    /// <param name="ns">Bridge-specific namespace (for example <c>form</c>).</param>
+    /// <param name="nativeId">Native identifier.</param>
+    public static Guid Derive(string ns, string nativeId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(ns);
+        ArgumentNullException.ThrowIfNull(nativeId);
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"honua.studio.bridge:{ns}:{nativeId}"));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+
+        // Stamp RFC 4122 version 8 (custom) and variant bits so derived ids are well-formed
+        // and cannot collide with the version-4 ids the Studio store generates.
+        guidBytes[7] = (byte)((guidBytes[7] & 0x0F) | 0x80);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes, bigEndian: true);
+    }
+
+    /// <summary>
+    /// Maps a native string id to a Studio GUID: a native id that parses as a canonical GUID
+    /// maps directly (so lifecycle-created records round-trip losslessly); anything else uses
+    /// the deterministic derivation.
+    /// </summary>
+    public static Guid ForNativeId(string ns, string nativeId)
+        => Guid.TryParseExact(nativeId, "D", out var direct) ? direct : Derive(ns, nativeId);
+}

--- a/src/Honua.Core/Features/Studio/Services/Bridging/StudioFamilyPersistenceBridgeCatalog.cs
+++ b/src/Honua.Core/Features/Studio/Services/Bridging/StudioFamilyPersistenceBridgeCatalog.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using Honua.Core.Features.AnalysisContent.Abstractions;
+using Honua.Core.Features.Forms.Packages;
+using Honua.Core.Features.Studio.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Core.Features.Studio.Services.Bridging;
+
+/// <summary>
+/// Resolve-time composition of the available ADR-0069 family persistence bridges
+/// (honua-server#3004). Bridge availability is decided when the catalog is resolved — not when
+/// services are registered — because native stores (<see cref="IFormPackageStore"/>,
+/// <see cref="IAnalysisContentStore"/>) are registered at different points across hosts (the
+/// Postgres composition root, in-memory fallbacks, and test fixtures that rewire providers
+/// after the application's own registrations). A family whose native store is absent simply has
+/// no bridge and keeps today's Studio-store behavior.
+/// </summary>
+public sealed class StudioFamilyPersistenceBridgeCatalog
+{
+    /// <summary>
+    /// Composes the catalog from the current scope's registered native stores.
+    /// </summary>
+    public StudioFamilyPersistenceBridgeCatalog(IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        var bridges = new List<IStudioFamilyPersistenceBridge>(2);
+
+        var formStore = serviceProvider.GetService<IFormPackageStore>();
+        var formValidator = serviceProvider.GetService<FormPackageValidator>();
+        if (formStore is not null && formValidator is not null)
+        {
+            bridges.Add(new FormStudioPackageBridge(formStore, formValidator));
+        }
+
+        var analysisStore = serviceProvider.GetService<IAnalysisContentStore>();
+        if (analysisStore is not null)
+        {
+            bridges.Add(new AnalysisStudioPackageBridge(
+                analysisStore,
+                serviceProvider.GetService<TimeProvider>() ?? TimeProvider.System));
+        }
+
+        Bridges = bridges;
+    }
+
+    /// <summary>
+    /// Testing constructor composing an explicit bridge set.
+    /// </summary>
+    public StudioFamilyPersistenceBridgeCatalog(IReadOnlyList<IStudioFamilyPersistenceBridge> bridges)
+    {
+        ArgumentNullException.ThrowIfNull(bridges);
+        Bridges = bridges;
+    }
+
+    /// <summary>Available bridges, at most one per family.</summary>
+    public IReadOnlyList<IStudioFamilyPersistenceBridge> Bridges { get; }
+}

--- a/src/Honua.Core/Features/Studio/Services/StudioPackageFamilyRegistry.cs
+++ b/src/Honua.Core/Features/Studio/Services/StudioPackageFamilyRegistry.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using Honua.Core.Features.Studio.Abstractions;
 using Honua.Core.Features.Studio.Domain;
+using Honua.Core.Features.Studio.Services.Bridging;
 
 namespace Honua.Core.Features.Studio.Services;
 
@@ -29,14 +30,24 @@ public sealed class StudioPackageFamilyRegistry : IStudioPackageFamilyRegistry
     ];
 
     private readonly IStudioPackageStore _store;
+    private readonly Dictionary<StudioPackageFamily, IStudioFamilyPersistenceBridge> _bridges;
 
     /// <summary>
     /// Initializes a new family registry.
     /// </summary>
-    public StudioPackageFamilyRegistry(IStudioPackageStore store)
+    /// <param name="store">The Studio package store.</param>
+    /// <param name="bridgeCatalog">
+    /// Optional family persistence bridges (ADR-0069, honua-server#3004). Bridged families
+    /// advertise their native format, operation set, and bridge limitations.
+    /// </param>
+    public StudioPackageFamilyRegistry(
+        IStudioPackageStore store,
+        StudioFamilyPersistenceBridgeCatalog? bridgeCatalog = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         _store = store;
+        _bridges = (bridgeCatalog?.Bridges ?? Array.Empty<IStudioFamilyPersistenceBridge>())
+            .ToDictionary(static bridge => bridge.Family);
     }
 
     /// <inheritdoc />
@@ -67,12 +78,37 @@ public sealed class StudioPackageFamilyRegistry : IStudioPackageFamilyRegistry
     public StudioPackageFamilyDescriptor? GetDescriptor(StudioPackageFamily family)
         => GetCapabilities().Families.FirstOrDefault(descriptor => descriptor.Family == family);
 
-    private static StudioPackageFamilyDescriptor Build(
+    private StudioPackageFamilyDescriptor Build(
         StudioPackageFamily family,
         string format,
         string validationDepth,
         bool durable)
     {
+        // Bridged families (ADR-0069) advertise their native format, bridge-specific operation
+        // set, publish support, and bridge limitations; persistence delegates to the family's
+        // native store rather than the Studio store.
+        if (_bridges.TryGetValue(family, out var bridge))
+        {
+            var bridgeLimitations = new List<string>(bridge.Limitations);
+            if (!durable)
+            {
+                bridgeLimitations.Insert(0, "package lifecycle drafts are backed by in-memory storage and are not durable across server restarts");
+            }
+
+            return new StudioPackageFamilyDescriptor
+            {
+                Family = family,
+                CurrentSchemaVersion = "1.0",
+                Format = bridge.Format,
+                SupportLevel = StudioPackageSupportLevel.Limited,
+                SupportedOperations = bridge.SupportedOperations,
+                ValidationDepth = validationDepth,
+                Limitations = bridgeLimitations,
+                MaxPackageBytes = DefaultMaxPackageBytes,
+                PreviewSupported = true,
+                PublishSupported = bridge.PublishSupported,
+            };
+        }
         var supportLevel = durable
             ? validationDepth == "family-specific"
                 ? StudioPackageSupportLevel.Supported

--- a/src/Honua.Core/Features/Studio/Services/StudioPackageLifecycleService.cs
+++ b/src/Honua.Core/Features/Studio/Services/StudioPackageLifecycleService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using Honua.Core.Features.Studio.Abstractions;
 using Honua.Core.Features.Studio.Domain;
+using Honua.Core.Features.Studio.Services.Bridging;
 
 namespace Honua.Core.Features.Studio.Services;
 
@@ -26,17 +27,29 @@ public sealed class StudioPackageLifecycleService : IStudioPackageLifecycleServi
     /// <summary>
     /// Initializes a new Studio package lifecycle service.
     /// </summary>
+    /// <param name="store">The Studio package store.</param>
+    /// <param name="registry">The package-family registry.</param>
+    /// <param name="validator">The package envelope validator.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    /// <param name="bridgeCatalog">
+    /// Optional ADR-0069 family persistence bridges (honua-server#3004). When at least one
+    /// bridge is available, the store is wrapped with <see cref="BridgedStudioPackageStore"/>
+    /// so bridged families (form, analysis) read and write through their native stores.
+    /// </param>
     public StudioPackageLifecycleService(
         IStudioPackageStore store,
         IStudioPackageFamilyRegistry registry,
         IStudioPackageValidator validator,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        StudioFamilyPersistenceBridgeCatalog? bridgeCatalog = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(registry);
         ArgumentNullException.ThrowIfNull(validator);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        _store = store;
+        _store = bridgeCatalog is { Bridges.Count: > 0 }
+            ? new BridgedStudioPackageStore(store, bridgeCatalog.Bridges)
+            : store;
         _registry = registry;
         _validator = validator;
         _timeProvider = timeProvider;

--- a/src/Honua.Core/Features/Studio/StudioServiceCollectionExtensions.cs
+++ b/src/Honua.Core/Features/Studio/StudioServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using Honua.Core.Features.Authorization;
 using Honua.Core.Features.Studio.Abstractions;
 using Honua.Core.Features.Studio.Services;
+using Honua.Core.Features.Studio.Services.Bridging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -33,6 +34,12 @@ public static class StudioServiceCollectionExtensions
 
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<IStudioPackageStore, InMemoryStudioPackageStore>();
+        // ADR-0069 (honua-server#3004): the catalog decides at resolve time which family
+        // persistence bridges are available (native forms/analysis stores may be registered
+        // before or after this call depending on the host), and the lifecycle service and
+        // family registry consume it to route the form/analysis families through their native
+        // stores.
+        services.TryAddScoped<StudioFamilyPersistenceBridgeCatalog>();
         services.TryAddScoped<IStudioPackageFamilyRegistry, StudioPackageFamilyRegistry>();
         services.TryAddScoped<IStudioPackageValidator, StudioPackageValidator>();
         services.TryAddScoped<IStudioPackageLifecycleService, StudioPackageLifecycleService>();

--- a/src/Honua.Server/Features/Studio/StudioPackageEndpoints.cs
+++ b/src/Honua.Server/Features/Studio/StudioPackageEndpoints.cs
@@ -875,6 +875,12 @@ internal static class StudioPackageEndpoints
                 StudioApiJsonContext.Default.ApiResponseStudioContentVersion,
                 statusCode: StatusCodes.Status201Created);
         }
+        catch (ArgumentException ex)
+        {
+            // ADR-0069: a bridged family (form/analysis) rejects an envelope body that is not a
+            // valid native document before anything is persisted.
+            return BadRequest(context, ex.Message);
+        }
         catch (InvalidOperationException ex)
         {
             return Conflict(context, ex.Message);
@@ -1442,6 +1448,16 @@ internal static class StudioPackageEndpoints
         {
             return BadRequest(context, ex.Message);
         }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(context, "Studio content version was not found.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            // ADR-0069: bridged families surface unsupported or natively-refused publication
+            // (analysis has no publish concept; a form version must be a native draft) as 409.
+            return Conflict(context, ex.Message);
+        }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             StudioEndpointsLog.EndpointFailed(logger, "publish-request.create", ex);
@@ -1575,6 +1591,12 @@ internal static class StudioPackageEndpoints
         catch (ArgumentException ex)
         {
             return BadRequest(context, ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // ADR-0069: rollback is not supported for bridged families (forms' published rows
+            // are DB-immutable; analysis versions are append-only).
+            return Conflict(context, ex.Message);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/tests/dotnet/Honua.Core.Tests/Features/Studio/StudioFamilyPersistenceBridgeTests.cs
+++ b/tests/dotnet/Honua.Core.Tests/Features/Studio/StudioFamilyPersistenceBridgeTests.cs
@@ -1,0 +1,299 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Core.Features.Studio.Abstractions;
+using Honua.Core.Features.Studio.Domain;
+using Honua.Core.Features.Studio.Services;
+using Honua.Core.Features.Studio.Services.Bridging;
+using Honua.TestKit.Attributes;
+
+namespace Honua.Core.Tests.Features.Studio;
+
+/// <summary>
+/// Unit tests for the ADR-0069 family persistence bridge composition (honua-server#3004):
+/// deterministic id derivation, family-registry descriptor overrides, and
+/// <see cref="BridgedStudioPackageStore"/> routing/merging semantics.
+/// </summary>
+public sealed class StudioFamilyPersistenceBridgeTests
+{
+    [UnitTest]
+    public void BridgeIds_DeriveIsDeterministicAndNamespaced()
+    {
+        var first = StudioBridgeIds.Derive("form", "inspection-form");
+        var second = StudioBridgeIds.Derive("form", "inspection-form");
+        var otherNamespace = StudioBridgeIds.Derive("analysis", "inspection-form");
+        var otherId = StudioBridgeIds.Derive("form", "inspection-form-2");
+
+        Assert.Equal(first, second);
+        Assert.NotEqual(first, otherNamespace);
+        Assert.NotEqual(first, otherId);
+        Assert.NotEqual(Guid.Empty, first);
+    }
+
+    [UnitTest]
+    public void BridgeIds_NativeGuidIdsMapDirectly()
+    {
+        var native = Guid.NewGuid();
+        Assert.Equal(native, StudioBridgeIds.ForNativeId("form", native.ToString("D")));
+        Assert.NotEqual(native, StudioBridgeIds.ForNativeId("form", $"prefix-{native:N}"));
+    }
+
+    [UnitTest]
+    public void FamilyRegistry_BridgedFamilyAdvertisesNativeFormatOperationsAndLimitations()
+    {
+        var bridge = new StubBridge(StudioPackageFamily.Form)
+        {
+            FormatValue = "honua.form-package.v1",
+            PublishSupportedValue = true,
+            OperationsValue = [StudioPackageOperation.DraftCreate, StudioPackageOperation.ContentVersionCreate],
+            LimitationsValue = ["bridged to the native forms package store"],
+        };
+        var registry = new StudioPackageFamilyRegistry(
+            new InMemoryStudioPackageStore(),
+            new StudioFamilyPersistenceBridgeCatalog([bridge]));
+
+        var capabilities = registry.GetCapabilities();
+        Assert.Equal(10, capabilities.Families.Count);
+
+        var form = Assert.Single(capabilities.Families, descriptor => descriptor.Family == StudioPackageFamily.Form);
+        Assert.Equal("honua.form-package.v1", form.Format);
+        Assert.True(form.PublishSupported);
+        Assert.Equal(bridge.OperationsValue, form.SupportedOperations);
+        Assert.Contains("bridged to the native forms package store", form.Limitations);
+
+        // Non-bridged families are untouched.
+        var map = Assert.Single(capabilities.Families, descriptor => descriptor.Family == StudioPackageFamily.Map);
+        Assert.Equal("honua_map_package.v1", map.Format);
+    }
+
+    [UnitTest]
+    public async Task BridgedStore_RoutesVersionSaveAndPointersToBridge()
+    {
+        var inner = new InMemoryStudioPackageStore();
+        var bridge = new StubBridge(StudioPackageFamily.Form);
+        var store = new BridgedStudioPackageStore(inner, [bridge]);
+
+        var draft = BuildDraft(StudioPackageFamily.Form);
+        await store.CreateDraftAsync(draft);
+
+        var version = await store.CreateVersionAsync(draft, "note", "tester");
+        Assert.Equal(1, version.VersionNumber);
+        Assert.Single(bridge.SavedDrafts);
+
+        var pointers = await store.GetPointersAsync(draft.ItemId);
+        Assert.NotNull(pointers);
+        Assert.Equal(version.VersionId, pointers!.CurrentVersionId);
+
+        var versions = await store.ListVersionsAsync(draft.ItemId);
+        Assert.Single(versions);
+
+        var fetched = await store.GetVersionAsync(draft.ItemId, version.VersionId);
+        Assert.NotNull(fetched);
+
+        // Non-bridged families keep flowing to the inner store.
+        var queryDraft = BuildDraft(StudioPackageFamily.Query);
+        await store.CreateDraftAsync(queryDraft);
+        var queryVersion = await store.CreateVersionAsync(queryDraft, null, "tester");
+        Assert.DoesNotContain(bridge.SavedDrafts, saved => saved.DraftId == queryDraft.DraftId);
+        Assert.NotNull(await inner.GetVersionAsync(queryDraft.ItemId, queryVersion.VersionId));
+    }
+
+    [UnitTest]
+    public async Task BridgedStore_MergesBridgedItemsIntoEnumerationAndScopesByOwner()
+    {
+        var inner = new InMemoryStudioPackageStore();
+        var bridge = new StubBridge(StudioPackageFamily.Form);
+        var store = new BridgedStudioPackageStore(inner, [bridge]);
+
+        // One native (inner) query item.
+        var queryDraft = BuildDraft(StudioPackageFamily.Query);
+        await store.CreateDraftAsync(queryDraft);
+        await store.CreateVersionAsync(queryDraft, null, "tester");
+
+        // One bridged form item (owner-less, mirroring the native forms surface).
+        var formDraft = BuildDraft(StudioPackageFamily.Form);
+        await store.CreateDraftAsync(formDraft);
+        await store.CreateVersionAsync(formDraft, null, "tester");
+
+        var all = await store.ListContentItemsAsync(new StudioContentItemQuery { Limit = 10 });
+        Assert.Equal(2, all.Total);
+        Assert.Contains(all.Items, item => item.Family == StudioPackageFamily.Form);
+        Assert.Contains(all.Items, item => item.Family == StudioPackageFamily.Query);
+
+        var formsOnly = await store.ListContentItemsAsync(new StudioContentItemQuery
+        {
+            Families = [StudioPackageFamily.Form],
+            Limit = 10,
+        });
+        Assert.Equal(1, formsOnly.Total);
+        Assert.Single(formsOnly.Items);
+
+        // Owner scoping fails closed for owner-less bridged items (#3018 model).
+        var scoped = await store.ListContentItemsAsync(new StudioContentItemQuery
+        {
+            OwnerId = "somebody",
+            Families = [StudioPackageFamily.Form],
+            Limit = 10,
+        });
+        Assert.Empty(scoped.Items);
+        Assert.Equal(0, scoped.Total);
+    }
+
+    [UnitTest]
+    public async Task BridgedStore_RollbackAndUnsupportedPublishSurfaceInvalidOperation()
+    {
+        var inner = new InMemoryStudioPackageStore();
+        var bridge = new StubBridge(StudioPackageFamily.Analysis) { PublishSupportedValue = false };
+        var store = new BridgedStudioPackageStore(inner, [bridge]);
+
+        var draft = BuildDraft(StudioPackageFamily.Analysis);
+        await store.CreateDraftAsync(draft);
+        var version = await store.CreateVersionAsync(draft, null, "tester");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => store.RollbackAsync(
+            draft.ItemId,
+            version.VersionId,
+            StudioRollbackPointer.Current,
+            "tester",
+            reason: null));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => store.CreatePublicationRequestAsync(new StudioPublicationRequest
+        {
+            RequestId = Guid.NewGuid(),
+            ItemId = draft.ItemId,
+            VersionId = version.VersionId,
+            Status = StudioPublicationRequestStatus.Accepted,
+            CreatedAt = DateTimeOffset.UtcNow,
+        }));
+    }
+
+    private static StudioPackageDraft BuildDraft(StudioPackageFamily family)
+    {
+        using var body = JsonDocument.Parse("""{"title":"t"}""");
+        var now = DateTimeOffset.UtcNow;
+        return new StudioPackageDraft
+        {
+            DraftId = Guid.NewGuid(),
+            ItemId = Guid.NewGuid(),
+            PackageKey = $"pkg-{Guid.NewGuid():N}",
+            Family = family,
+            Envelope = new StudioPackageEnvelope
+            {
+                Family = family,
+                SchemaVersion = "1.0",
+                Format = "test-format",
+                Body = body.RootElement.Clone(),
+            },
+            Generation = 1,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+
+    /// <summary>
+    /// In-memory <see cref="IStudioFamilyPersistenceBridge"/> stub emulating a native store:
+    /// versions appended through <see cref="SaveVersionAsync"/> resolve through pointers,
+    /// listing, and item summaries; publish honors <see cref="PublishSupportedValue"/>.
+    /// </summary>
+    private sealed class StubBridge : IStudioFamilyPersistenceBridge
+    {
+        private readonly Dictionary<Guid, List<StudioContentVersion>> _versionsByItem = new();
+
+        public StubBridge(StudioPackageFamily family) => Family = family;
+
+        public List<StudioPackageDraft> SavedDrafts { get; } = [];
+
+        public string FormatValue { get; init; } = "native-format.v1";
+
+        public bool PublishSupportedValue { get; init; } = true;
+
+        public IReadOnlyList<StudioPackageOperation> OperationsValue { get; init; } =
+            [StudioPackageOperation.ContentVersionCreate, StudioPackageOperation.ContentVersionRead];
+
+        public IReadOnlyList<string> LimitationsValue { get; init; } = [];
+
+        public StudioPackageFamily Family { get; }
+
+        public string Format => FormatValue;
+
+        public bool PublishSupported => PublishSupportedValue;
+
+        public IReadOnlyList<StudioPackageOperation> SupportedOperations => OperationsValue;
+
+        public IReadOnlyList<string> Limitations => LimitationsValue;
+
+        public Task<IReadOnlyList<StudioContentItemSummary>> ListItemSummariesAsync(CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<StudioContentItemSummary> summaries = _versionsByItem
+                .Select(pair => new StudioContentItemSummary
+                {
+                    ItemId = pair.Key,
+                    PackageKey = pair.Value[^1].PackageKey,
+                    Family = Family,
+                    State = StudioContentItemState.Current,
+                    CurrentVersionId = pair.Value[^1].VersionId,
+                    OwnerId = null,
+                    CreatedAt = pair.Value[0].CreatedAt,
+                    UpdatedAt = pair.Value[^1].CreatedAt,
+                })
+                .ToArray();
+            return Task.FromResult(summaries);
+        }
+
+        public Task<StudioContentItemPointers?> GetPointersAsync(Guid itemId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_versionsByItem.TryGetValue(itemId, out var versions)
+                ? new StudioContentItemPointers
+                {
+                    ItemId = itemId,
+                    CurrentVersionId = versions[^1].VersionId,
+                    PublishedVersionId = null,
+                    OwnerId = null,
+                }
+                : null);
+
+        public Task<IReadOnlyList<StudioContentVersion>> ListVersionsAsync(Guid itemId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<StudioContentVersion>>(
+                _versionsByItem.TryGetValue(itemId, out var versions) ? versions.ToArray() : Array.Empty<StudioContentVersion>());
+
+        public Task<StudioContentVersion?> GetVersionAsync(Guid itemId, Guid versionId, CancellationToken cancellationToken = default)
+            => Task.FromResult(_versionsByItem.TryGetValue(itemId, out var versions)
+                ? versions.FirstOrDefault(version => version.VersionId == versionId)
+                : null);
+
+        public Task<StudioContentVersion> SaveVersionAsync(
+            StudioPackageDraft draft,
+            string? changeNote,
+            string? actorId,
+            CancellationToken cancellationToken = default)
+        {
+            SavedDrafts.Add(draft);
+            if (!_versionsByItem.TryGetValue(draft.ItemId, out var versions))
+            {
+                versions = [];
+                _versionsByItem[draft.ItemId] = versions;
+            }
+
+            var version = new StudioContentVersion
+            {
+                ItemId = draft.ItemId,
+                PackageKey = draft.PackageKey,
+                VersionId = Guid.NewGuid(),
+                VersionNumber = versions.Count + 1,
+                ContentHash = Guid.NewGuid().ToString("N"),
+                Envelope = draft.Envelope,
+                Validation = StudioValidationSummary.NotValidated,
+                ChangeNote = changeNote,
+                CreatedBy = actorId,
+                CreatedAt = DateTimeOffset.UtcNow,
+            };
+            versions.Add(version);
+            return Task.FromResult(version);
+        }
+
+        public Task<StudioPublicationRequest> PublishAsync(StudioPublicationRequest request, CancellationToken cancellationToken = default)
+            => PublishSupported
+                ? Task.FromResult(request with { Status = StudioPublicationRequestStatus.Accepted })
+                : throw new InvalidOperationException("Publish-request is not supported for this bridged family.");
+    }
+}

--- a/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioBridgedFamilyEndpointsTests.cs
+++ b/tests/dotnet/Honua.Server.Tests/Features/Studio/StudioBridgedFamilyEndpointsTests.cs
@@ -1,0 +1,514 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using FluentAssertions;
+using Honua.Ai.AnalysisContent;
+using Honua.Core.Features.AnalysisContent.Domain;
+using Honua.Core.Features.Forms.Packages;
+using Honua.Core.Features.Geoprocessing.Domain;
+using Honua.Core.Features.Licensing.Domain;
+using Honua.Core.Features.Publishing.Content.Abstractions;
+using Honua.Core.Features.Publishing.Content.Services;
+using Honua.Core.Features.Studio.Abstractions;
+using Honua.Core.Features.Studio.Domain;
+using Honua.Core.Features.Studio.Services;
+using Honua.Infrastructure.Models;
+using Honua.Server.Features.Studio.Models;
+using Honua.TestKit;
+using Honua.TestKit.Attributes;
+using Honua.TestKit.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Honua.Server.Tests.Features.Studio;
+
+/// <summary>
+/// ADR-0069 (honua-server#3004) round-trip coverage for the bridged <c>form</c> and
+/// <c>analysis</c> families: content created through the native APIs is enumerable and openable
+/// through the Studio lifecycle, and drafts/versions saved through the lifecycle are visible
+/// through the native APIs with family semantics (form JSON kinds, ruleIds, publish gate;
+/// analysis artifact/job links) intact.
+/// </summary>
+[Collection("Database")]
+[Protocol(TestProtocols.Studio)]
+[Operation(Operations.StudioLifecycle)]
+public sealed class StudioBridgedFamilyEndpointsTests : IAsyncLifetime
+{
+    private static readonly JsonSerializerOptions AnalysisJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private readonly WebAppFixture _fixture = new WebAppFixture()
+        .WithTestLicense(HonuaEdition.Pro)
+        .ConfigureServices(services =>
+        {
+            // Studio drafts and the publication-badge join use the in-memory stores (matching
+            // StudioPackageEndpointsTests: the studio/publication Postgres schema is not part of
+            // the fixture template). The BRIDGED families still hit the real Postgres-backed
+            // native stores (IFormPackageStore / IAnalysisContentStore), which is the surface
+            // under test here.
+            services.RemoveAll<IStudioPackageStore>();
+            services.AddSingleton<IStudioPackageStore, InMemoryStudioPackageStore>();
+            services.RemoveAll<IContentPublicationStore>();
+            services.AddSingleton<IContentPublicationStore, InMemoryContentPublicationStore>();
+        });
+
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+        _client = _fixture.Client;
+        await EnableEditingCapabilitiesAsync();
+    }
+
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/studio/package-families")]
+    public async Task PackageFamilies_AdvertiseBridgedNativeFormats()
+    {
+        var response = await _client.GetAsync("/api/v1/studio/package-families");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var capabilities = await ReadAsync<StudioPackageFamilyCapabilities>(
+            response,
+            StudioApiJsonContext.Default.ApiResponseStudioPackageFamilyCapabilities);
+
+        capabilities.Families.Should().HaveCount(10);
+
+        var form = capabilities.Families.Single(f => f.Family == StudioPackageFamily.Form);
+        form.Format.Should().Be("honua.form-package.v1");
+        form.PublishSupported.Should().BeTrue();
+        form.SupportedOperations.Should().Contain(StudioPackageOperation.PublishRequestCreate);
+        form.SupportedOperations.Should().NotContain(StudioPackageOperation.Rollback);
+        form.Limitations.Should().Contain(l => l.Contains("native forms package store"));
+
+        var analysis = capabilities.Families.Single(f => f.Family == StudioPackageFamily.Analysis);
+        analysis.Format.Should().Be("honua.analysis-content.v1");
+        analysis.PublishSupported.Should().BeFalse();
+        analysis.SupportedOperations.Should().NotContain(StudioPackageOperation.PublishRequestCreate);
+        analysis.SupportedOperations.Should().NotContain(StudioPackageOperation.Rollback);
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/studio/content-items")]
+    [Endpoint("GET /api/v1/studio/content-items/{itemId}/versions")]
+    [Endpoint("GET /api/v1/studio/content-items/{itemId}/versions/{versionId}")]
+    [Endpoint("POST /api/v1/studio/content-items/{itemId}/versions/{versionId}/reopen")]
+    [Endpoint("PUT /api/v1/studio/package-drafts/{draftId}")]
+    [Endpoint("POST /api/v1/studio/package-drafts/{draftId}/content-versions")]
+    [Endpoint("POST /api/v1/studio/content-items/{itemId}/versions/{versionId}/publish-requests")]
+    [Endpoint("POST /api/v1/studio/content-items/{itemId}/rollback-requests")]
+    public async Task FormFamily_ConsoleAuthoredPackageRoundTripsLosslesslyThroughLifecycle()
+    {
+        // Author a form through the NATIVE console surface, exercising the family semantics the
+        // bridge must preserve: a stable ruleId and JSON-kind-sensitive default value.
+        var document = CreateFormDocument("Bridged inspection");
+        var nativeDraft = await CreateNativeFormDraftAsync(document);
+        nativeDraft.Version.Should().Be(1);
+
+        // The native package is enumerable through the lifecycle content browser.
+        var listResponse = await _client.GetAsync($"/api/v1/studio/content-items?family=form&q={nativeDraft.FormId}");
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var list = await ReadAsync<StudioContentItemListResponse>(
+            listResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioContentItemListResponse);
+        var row = list.Items.Should().ContainSingle(item => item.PackageKey == nativeDraft.FormId).Subject;
+        row.Family.Should().Be(StudioPackageFamily.Form);
+        row.State.Should().Be(StudioContentItemState.Current);
+        row.CurrentVersionId.Should().NotBeNull();
+
+        // Open the version through the lifecycle: the envelope body must be the native document,
+        // byte-for-byte through the family's own serializer contract (REQ-002 / NFR-001).
+        var versionsResponse = await _client.GetAsync($"/api/v1/studio/content-items/{row.ItemId:D}/versions");
+        versionsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var versions = await ReadAsync<StudioContentVersionListResponse>(
+            versionsResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioContentVersionListResponse);
+        var version = versions.Versions.Should().ContainSingle().Subject;
+        version.VersionNumber.Should().Be(1);
+        version.Envelope.Format.Should().Be("honua.form-package.v1");
+        version.ContentHash.Should().Be(nativeDraft.ContentHash);
+
+        var nativeVersion = await GetNativeFormVersionAsync(nativeDraft.FormId, 1);
+        JsonNode.DeepEquals(
+                JsonNode.Parse(version.Envelope.Body!.Value.GetRawText()),
+                JsonNode.Parse(JsonSerializer.Serialize(nativeVersion.Package, FormPackageJsonContext.Default.FormPackageDocument)))
+            .Should().BeTrue("the lifecycle envelope body must round-trip the native form document losslessly");
+
+        // Reopen through the lifecycle, edit the title, and save a new version.
+        var reopenResponse = await _client.PostAsync(
+            $"/api/v1/studio/content-items/{row.ItemId:D}/versions/{version.VersionId:D}/reopen",
+            EmptyJson());
+        reopenResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var draft = await ReadAsync<StudioPackageDraft>(
+            reopenResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioPackageDraft);
+        draft.Family.Should().Be(StudioPackageFamily.Form);
+
+        var editedBody = JsonNode.Parse(draft.Envelope.Body!.Value.GetRawText())!;
+        editedBody["title"] = "Bridged inspection (edited)";
+        using var editedDocument = JsonDocument.Parse(editedBody.ToJsonString());
+        var updateResponse = await PutAsync(
+            $"/api/v1/studio/package-drafts/{draft.DraftId:D}",
+            new UpdateStudioPackageDraftRequest
+            {
+                PackageKey = draft.PackageKey,
+                Envelope = draft.Envelope with { Body = editedDocument.RootElement.Clone() },
+                Generation = draft.Generation,
+            },
+            StudioApiJsonContext.Default.UpdateStudioPackageDraftRequest);
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var saveResponse = await PostAsync(
+            $"/api/v1/studio/package-drafts/{draft.DraftId:D}/content-versions",
+            new SaveStudioContentVersionRequest { ChangeNote = "lifecycle edit" },
+            StudioApiJsonContext.Default.SaveStudioContentVersionRequest);
+        saveResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var saved = await ReadAsync<StudioContentVersion>(
+            saveResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioContentVersion);
+        saved.VersionNumber.Should().Be(2);
+        saved.ItemId.Should().Be(row.ItemId);
+
+        // The NATIVE surface sees the lifecycle-authored version with family semantics intact:
+        // new draft version, edited title, stable ruleId, and a numeric (not stringified)
+        // default value.
+        var nativeSaved = await GetNativeFormVersionAsync(nativeDraft.FormId, 2);
+        nativeSaved.Status.Should().Be(FormPackageStatus.Draft);
+        nativeSaved.Package.Title.Should().Be("Bridged inspection (edited)");
+        var severityField = nativeSaved.Package.Fields.Single(field => field.FieldId == "severity");
+        severityField.Validation.Single().RuleId.Should().Be("severity-range");
+        severityField.DefaultValue!.Value.ValueKind.Should().Be(JsonValueKind.Number);
+
+        // Publish through the lifecycle: runs the native publish validation gate and flips the
+        // native version to published.
+        var publishResponse = await _client.PostAsync(
+            $"/api/v1/studio/content-items/{row.ItemId:D}/versions/{saved.VersionId:D}/publish-requests",
+            EmptyJson());
+        publishResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var publication = await ReadAsync<StudioPublicationRequest>(
+            publishResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioPublicationRequest);
+        publication.Status.Should().Be(StudioPublicationRequestStatus.Accepted);
+
+        var nativePublished = await GetNativeFormVersionAsync(nativeDraft.FormId, 2);
+        nativePublished.Status.Should().Be(FormPackageStatus.Published);
+
+        // The lifecycle listing reflects the native published pointer.
+        var publishedList = await ReadAsync<StudioContentItemListResponse>(
+            await _client.GetAsync($"/api/v1/studio/content-items?family=form&q={nativeDraft.FormId}"),
+            StudioApiJsonContext.Default.ApiResponseStudioContentItemListResponse);
+        publishedList.Items.Single(item => item.PackageKey == nativeDraft.FormId)
+            .State.Should().Be(StudioContentItemState.Published);
+
+        // Rollback is a documented unsupported divergence for bridged forms.
+        var rollbackResponse = await PostAsync(
+            $"/api/v1/studio/content-items/{row.ItemId:D}/rollback-requests",
+            new CreateStudioRollbackRequest { TargetVersionId = version.VersionId },
+            StudioApiJsonContext.Default.CreateStudioRollbackRequest);
+        rollbackResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [IntegrationTest]
+    [Endpoint("POST /api/v1/studio/package-drafts")]
+    [Endpoint("POST /api/v1/studio/package-drafts/{draftId}/content-versions")]
+    public async Task FormFamily_LifecycleCreatedPackageIsVisibleThroughNativeApi()
+    {
+        using var body = JsonDocument.Parse(JsonSerializer.Serialize(
+            CreateFormDocument("Lifecycle-authored form"),
+            FormPackageJsonContext.Default.FormPackageDocument));
+        var createResponse = await PostAsync(
+            "/api/v1/studio/package-drafts",
+            new CreateStudioPackageDraftRequest
+            {
+                PackageKey = $"lifecycle-form-{Guid.NewGuid():N}",
+                Envelope = new StudioPackageEnvelope
+                {
+                    Family = StudioPackageFamily.Form,
+                    SchemaVersion = "1.0",
+                    Format = "honua.form-package.v1",
+                    Body = body.RootElement.Clone(),
+                },
+            },
+            StudioApiJsonContext.Default.CreateStudioPackageDraftRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var draft = await ReadAsync<StudioPackageDraft>(
+            createResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioPackageDraft);
+        draft.Validation.Status.Should().Be(StudioPackageValidationStatus.Valid);
+
+        var saveResponse = await PostAsync(
+            $"/api/v1/studio/package-drafts/{draft.DraftId:D}/content-versions",
+            new SaveStudioContentVersionRequest(),
+            StudioApiJsonContext.Default.SaveStudioContentVersionRequest);
+        saveResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var saved = await ReadAsync<StudioContentVersion>(
+            saveResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioContentVersion);
+        saved.VersionNumber.Should().Be(1);
+
+        // The lifecycle item id doubles as the native form id for lifecycle-created packages.
+        var nativeResponse = await _client.GetAsync($"/api/v1/admin/forms/packages/{saved.ItemId:D}");
+        nativeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var native = await ReadNativeJsonAsync(nativeResponse, FormPackageJsonContext.Default.FormPackageVersion);
+        native.Status.Should().Be(FormPackageStatus.Draft);
+        native.Package.Title.Should().Be("Lifecycle-authored form");
+    }
+
+    [IntegrationTest]
+    [Endpoint("GET /api/v1/studio/content-items")]
+    [Endpoint("GET /api/v1/studio/content-items/{itemId}/versions")]
+    [Endpoint("POST /api/v1/studio/content-items/{itemId}/versions/{versionId}/reopen")]
+    [Endpoint("POST /api/v1/studio/package-drafts/{draftId}/content-versions")]
+    [Endpoint("POST /api/v1/studio/content-items/{itemId}/versions/{versionId}/publish-requests")]
+    public async Task AnalysisFamily_NativeContentRoundTripsWithJobAndArtifactLinks()
+    {
+        // Author an analysis package through the NATIVE analysis content surface, then add a
+        // second version carrying job/artifact provenance links.
+        var name = $"bridged-analysis-{Guid.NewGuid():N}";
+        var content = CreateAnalysisPackageContent();
+        var createResponse = await _client.PostAsJsonAsync(
+            "/api/v1/analysis/content/items",
+            new CreateAnalysisContentItemRequest
+            {
+                Kind = AnalysisContentKind.AnalysisPackage,
+                Name = name,
+                AnalysisPackage = content,
+            },
+            AnalysisJsonOptions);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = (await createResponse.Content.ReadFromJsonAsync<AnalysisContentItemResponse>(AnalysisJsonOptions))!;
+
+        var addVersionResponse = await _client.PostAsJsonAsync(
+            $"/api/v1/analysis/content/items/{created.Item.ItemId}/versions",
+            new CreateAnalysisContentVersionRequest
+            {
+                AnalysisPackage = content,
+                CreatedFromJobId = "job-bridge-123",
+                CreatedFromArtifactIds = ["artifact-bridge-1"],
+            },
+            AnalysisJsonOptions);
+        addVersionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Enumerable and openable through the lifecycle.
+        var list = await ReadAsync<StudioContentItemListResponse>(
+            await _client.GetAsync($"/api/v1/studio/content-items?family=analysis&q={name}"),
+            StudioApiJsonContext.Default.ApiResponseStudioContentItemListResponse);
+        var row = list.Items.Should().ContainSingle(item => item.PackageKey == name).Subject;
+        row.Family.Should().Be(StudioPackageFamily.Analysis);
+
+        var versions = await ReadAsync<StudioContentVersionListResponse>(
+            await _client.GetAsync($"/api/v1/studio/content-items/{row.ItemId:D}/versions"),
+            StudioApiJsonContext.Default.ApiResponseStudioContentVersionListResponse);
+        versions.Versions.Should().HaveCount(2);
+        var second = versions.Versions.Single(v => v.VersionNumber == 2);
+        second.Envelope.Format.Should().Be("honua.analysis-content.v1");
+        second.Dependencies.Should().Contain(d => d.Kind == "job" && d.Ref == "job-bridge-123");
+        second.Dependencies.Should().Contain(d => d.Kind == "artifact" && d.Ref == "artifact-bridge-1");
+
+        // Reopen and save through the lifecycle: the native surface sees version 3 with the
+        // plan and provenance links preserved.
+        var reopenResponse = await _client.PostAsync(
+            $"/api/v1/studio/content-items/{row.ItemId:D}/versions/{second.VersionId:D}/reopen",
+            EmptyJson());
+        reopenResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var draft = await ReadAsync<StudioPackageDraft>(
+            reopenResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioPackageDraft);
+
+        var saveResponse = await PostAsync(
+            $"/api/v1/studio/package-drafts/{draft.DraftId:D}/content-versions",
+            new SaveStudioContentVersionRequest { ChangeNote = "lifecycle save" },
+            StudioApiJsonContext.Default.SaveStudioContentVersionRequest);
+        saveResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var saved = await ReadAsync<StudioContentVersion>(
+            saveResponse,
+            StudioApiJsonContext.Default.ApiResponseStudioContentVersion);
+        saved.VersionNumber.Should().Be(3);
+        saved.Dependencies.Should().Contain(d => d.Kind == "job" && d.Ref == "job-bridge-123");
+
+        var latestResponse = await _client.GetAsync($"/api/v1/analysis/content/items/{created.Item.ItemId}/versions/latest");
+        latestResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var latest = (await latestResponse.Content.ReadFromJsonAsync<AnalysisContentVersionResponse>(AnalysisJsonOptions))!;
+        latest.Version.Version.Should().Be(3);
+        latest.Version.CreatedFromJobId.Should().Be("job-bridge-123");
+        latest.Version.CreatedFromArtifactIds.Should().ContainSingle(id => id == "artifact-bridge-1");
+        latest.Version.AnalysisPackage!.Plan.PlanId.Should().Be(content.Plan.PlanId);
+
+        // Publish-request is a documented unsupported divergence for the bridged analysis
+        // family (route publication belongs to the Content Publication Registry).
+        var publishResponse = await _client.PostAsync(
+            $"/api/v1/studio/content-items/{row.ItemId:D}/versions/{saved.VersionId:D}/publish-requests",
+            EmptyJson());
+        publishResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    private async Task EnableEditingCapabilitiesAsync()
+    {
+        // Mirrors FormPackageEndpointsTests: the form publish gate validates the target
+        // service's editing capabilities through the Metadata v2 graph.
+        await _fixture.Postgres.ApplyGlobalSeedSqlAsync("""
+            UPDATE honua.services
+            SET capabilities = ARRAY['Query', 'Extract', 'Create', 'Update', 'Delete']
+            WHERE service_name = 'test';
+            """, _fixture.CurrentSchema);
+        _fixture.EnableV2ServiceEditingCapabilities(
+            "test",
+            ["Query", "Extract", "Create", "Update", "Delete"]);
+    }
+
+    private async Task<FormPackageVersion> CreateNativeFormDraftAsync(FormPackageDocument document)
+    {
+        var response = await _client.PostAsync(
+            "/api/v1/admin/forms/packages",
+            new StringContent(
+                JsonSerializer.Serialize(document, FormPackageJsonContext.Default.FormPackageDocument),
+                Encoding.UTF8,
+                "application/json"));
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        return await ReadNativeJsonAsync(response, FormPackageJsonContext.Default.FormPackageVersion);
+    }
+
+    private async Task<FormPackageVersion> GetNativeFormVersionAsync(string formId, int version)
+    {
+        var response = await _client.GetAsync($"/api/v1/admin/forms/packages/{formId}/versions/{version}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return await ReadNativeJsonAsync(response, FormPackageJsonContext.Default.FormPackageVersion);
+    }
+
+    private static FormPackageDocument CreateFormDocument(string title) => new()
+    {
+        Title = title,
+        Target = new FormTargetDefinition
+        {
+            ServiceId = WebAppFixture.TestServiceId,
+            LayerId = WebAppFixture.TestLayerId,
+        },
+        Sections =
+        [
+            new FormSectionDefinition { SectionId = "main", Label = "Main", FieldIds = ["name", "severity"] },
+        ],
+        Fields =
+        [
+            new FormFieldDefinition
+            {
+                FieldId = "name",
+                Label = "Name",
+                Type = "text",
+                TargetField = "name",
+                Required = true,
+                SectionId = "main",
+            },
+            new FormFieldDefinition
+            {
+                FieldId = "severity",
+                Label = "Severity",
+                Type = "number",
+                TargetField = "rating",
+                SectionId = "main",
+                DefaultValue = ParseElement("3"),
+                Validation =
+                [
+                    new FormValidationRule
+                    {
+                        RuleId = "severity-range",
+                        Type = "max",
+                        Message = "Severity must be 5 or lower.",
+                        Parameters = ParseElement("""{"max":5}"""),
+                    },
+                ],
+            },
+        ],
+        SubmitPolicy = new FormSubmitPolicy
+        {
+            AllowedOperations = [FormSubmissionOperations.Create],
+            RequiresGeometry = true,
+        },
+        OfflinePolicy = new FormOfflinePolicy { Enabled = true },
+    };
+
+    private static AnalysisPackageContent CreateAnalysisPackageContent() => new()
+    {
+        Intent = new AnalysisIntent
+        {
+            IntentId = "intent-bridge",
+            Goal = "buffer incidents",
+            RequestedOutputs = [ArtifactKind.FeatureLayer],
+        },
+        Plan = new AnalysisPlan
+        {
+            PlanId = "plan-bridge",
+            IntentId = "intent-bridge",
+            Steps =
+            [
+                new AnalysisPlanStep
+                {
+                    StepId = "query-1",
+                    Kind = AnalysisPlanStepKind.QueryFeatures,
+                    Inputs = new Dictionary<string, string>
+                    {
+                        ["layerId"] = WebAppFixture.TestLayerId.ToString(CultureInfo.InvariantCulture),
+                    },
+                },
+                new AnalysisPlanStep
+                {
+                    StepId = "buffer-1",
+                    Kind = AnalysisPlanStepKind.Geoprocess,
+                    ProcessId = "geometry.buffer",
+                    Inputs = new Dictionary<string, string> { ["distance"] = "10" },
+                    DependsOn = ["query-1"],
+                },
+            ],
+            Outputs = [ArtifactKind.FeatureLayer],
+        },
+        RequestedArtifacts = [ArtifactKind.FeatureLayer],
+        SpatialReferenceId = 4326,
+        Units = "meters",
+    };
+
+    private static JsonElement ParseElement(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private async Task<HttpResponseMessage> PostAsync<T>(string path, T body, JsonTypeInfo<T> typeInfo)
+        => await _client.PostAsync(path, JsonContent(body, typeInfo));
+
+    private async Task<HttpResponseMessage> PutAsync<T>(string path, T body, JsonTypeInfo<T> typeInfo)
+        => await _client.PutAsync(path, JsonContent(body, typeInfo));
+
+    private static StringContent JsonContent<T>(T body, JsonTypeInfo<T> typeInfo)
+        => new(JsonSerializer.Serialize(body, typeInfo), Encoding.UTF8, "application/json");
+
+    private static StringContent EmptyJson()
+        => new("{}", Encoding.UTF8, "application/json");
+
+    private static async Task<T> ReadAsync<T>(HttpResponseMessage response, JsonTypeInfo<ApiResponse<T>> typeInfo)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var envelope = JsonSerializer.Deserialize(json, typeInfo);
+        envelope.Should().NotBeNull();
+        envelope!.Success.Should().BeTrue();
+        envelope.Data.Should().NotBeNull();
+        return envelope.Data!;
+    }
+
+    private static async Task<T> ReadNativeJsonAsync<T>(HttpResponseMessage response, JsonTypeInfo<T> typeInfo)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        var value = JsonSerializer.Deserialize(json, typeInfo);
+        value.Should().NotBeNull();
+        return value!;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link
Closes #3004

## Summary
Bridges the `form` and `analysis` package families into the Studio package lifecycle (ADR-0069). The lifecycle API (`/api/v1/studio/*`) becomes the single client-visible contract for enumerating, opening, drafting, versioning, and (for forms) publishing form and analysis content, while persistence delegates to each family's native store — the forms package store (`/api/v1/admin/forms/packages`, `honua.form-package.v1`, ETag/If-Match) and the analysis content store (`/api/v1/analysis/content` + artifacts + jobs) — which remain the source of truth. Bridge, not migration: no data moves, console's native editors keep working with no flag-day, and family semantics (form JSON-kind/ruleId round-trip and publish validation gate; analysis artifact/job provenance links and append-only monotonic versioning) are preserved by construction.

## Changes Made
- ADR-0069 (`docs/internal/contributor/adr/0069-studio-persistence-bridge-forms-analysis.md`): chooses BRIDGE over migration per family, with the id-mapping, concurrency, compatibility, and divergence analysis (REQ-001).
- `IStudioFamilyPersistenceBridge` + `FormStudioPackageBridge` + `AnalysisStudioPackageBridge` (Honua.Core/Features/Studio/Services/Bridging): per-family adapters projecting native records as lifecycle items/versions and writing lifecycle saves through the native stores. Deterministic native-id ↔ GUID mapping via `StudioBridgeIds`.
- `BridgedStudioPackageStore`: `IStudioPackageStore` decorator routing bridged families to their adapters (drafts stay Studio-native with `generation` concurrency); merges bridged items into keyset-paginated content-item enumeration with owner/state/search filters applied.
- `StudioFamilyPersistenceBridgeCatalog`: resolve-time bridge availability (native stores register at different points across hosts/fixtures); no bridge registered → behavior unchanged.
- `StudioPackageFamilyRegistry`: bridged families advertise their native format (`honua.form-package.v1`, `honua.analysis-content.v1`), reduced operation set, publish support, and bridge limitations through `GET /package-families` (REQ-002).
- `StudioPackageEndpoints`: maps bridged `ArgumentException` (invalid native body) to 400 and unsupported bridged publish/rollback (`InvalidOperationException`) to 409.
- Form publish-requests run the native `FormPackageValidator` publish gate and flip the native version to published; invalid content yields a `rejected` request. Analysis publish/rollback are documented 409 divergences (route publication stays with the Content Publication Registry).
- Authorization consistent with the merged #3018 model: bridged form items are owner-less and fail closed (admin-only, matching the native admin-only posture); bridged analysis items carry the native `ownerId` through the standard ownership checks (fail-closed, audited).
- Contract docs: new "Bridged Families" section in `docs/internal/admin-api/studio-package-lifecycle.md`; ADR index updated.
- Regenerated `docs/gis/data/feature-catalog.json` and `docs/gis/data/capability-matrix.v1.json`.
- Tests: `StudioFamilyPersistenceBridgeTests` (Core unit: id derivation, registry overrides, store routing/merging/fail-closed scoping) and `StudioBridgedFamilyEndpointsTests` (integration round-trips on production-shaped fixtures against the real Postgres-backed native stores: console-authored form opens/edits/saves/publishes losslessly through the lifecycle with ruleId + JSON-kind preservation and ETag semantics intact; analysis round-trips with job/artifact links preserved; lifecycle-created form visible natively; capability advertisement) (REQ-003/NFR-001).

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Architecture tests pass
- [ ] Manual testing performed

## Gate Impact
- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact
- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact
- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow

## Breaking Changes
None. The `form`/`analysis` family `format` strings advertised by `GET /package-families` change from the placeholder `studio_form_package.v1`/`studio_analysis_package.v1` to the native formats; nothing outside the registry referenced the placeholders and no envelopes of those families could previously round-trip anywhere.

## Deferred Follow-Ups
- `query` family ↔ `AnalysisContentKind.SavedQuery` bridging (same adapter parameterized by kind).
- A Studio-level published pointer (or Content Publication Registry integration) for the analysis family, if lifecycle-native publish semantics are later needed.
- Publication-registry badge joins for bridged rows beyond the existing `sourceContentId` convention.

---

## Pre-PR Checklist
- [x] Ran `scripts/ci/pre-pr-check.sh` and all checks passed
- [x] Commit messages follow conventional format: `type: description (#issue)`
- [x] PR title matches main commit message
- [x] Issue number linked above
- [x] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
